### PR TITLE
fix(deps): add types-PyYAML for mypy strict CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "mypy>=1.0",
     "ruff>=0.1.0",
     "pytest-cov>=4.0",
+    "types-PyYAML>=6.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Add `types-PyYAML>=6.0` to dev dependencies
- Fixes CI failure: `mypy --strict` errors on `import yaml` without stubs

## Test plan
- [ ] CI passes (mypy --strict no longer errors on yaml import)


🤖 Generated with [Claude Code](https://claude.com/claude-code)