### PR TITLE
fix(readme): replace em dash with hyphen in Mermaid subgraph label

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ graph TD
 
     skills -->|invoke| mcp
 
-    subgraph MCP Server — 17 tools
+    subgraph MCP Server - 17 tools
         mcp["FastMCP (stdio / HTTP)"]
     end
 


### PR DESCRIPTION
Mermaid cannot parse the em dash character in subgraph titles, causing GitHub to show "Unable to render rich display".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture diagram formatting in the README for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->