### PR TITLE
feat: add distillery-dev.yaml for Prefect Horizon dev/test environment

### DIFF
--- a/distillery-dev.yaml
+++ b/distillery-dev.yaml
@@ -1,0 +1,16 @@
+storage:
+  backend: duckdb
+  database_path: "/tmp/distillery-dev.db"
+
+embedding:
+  provider: jina
+  model: jina-embeddings-v3
+  dimensions: 1024
+  api_key_env: JINA_API_KEY
+
+team:
+  name: distillery-dev
+
+server:
+  auth:
+    provider: none            # open access for dev testing


### PR DESCRIPTION
Adds `distillery-dev.yaml` for the Prefect Horizon Lambda deployment:

- DuckDB at `/tmp/distillery-dev.db`
- Jina embeddings (`jina-embeddings-v3`, 1024-dim)
- No auth gate (open access for dev testing)

Point the Lambda at this config via `DISTILLERY_CONFIG=distillery-dev.yaml` and set `JINA_API_KEY` in the environment.

Closes #45

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development configuration file to support local testing and development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->