### PR TITLE
feat(mcp): add version and build SHA to status response

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -22,6 +22,6 @@ jobs:
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - run: flyctl deploy -c deploy/fly/fly.toml --remote-only
+      - run: flyctl deploy -c deploy/fly/fly.toml --remote-only --build-arg BUILD_SHA=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/deploy/fly/Dockerfile
+++ b/deploy/fly/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
+ARG BUILD_SHA=unknown
+ENV DISTILLERY_BUILD_SHA=${BUILD_SHA}
+
 RUN useradd --create-home --uid 10001 appuser
 
 # Copy the full repo (build context is repo root)

--- a/src/distillery/__init__.py
+++ b/src/distillery/__init__.py
@@ -1,3 +1,6 @@
 """Distillery: Team knowledge storage and retrieval system."""
 
+import os
+
 __version__ = "0.1.0"
+__build_sha__ = os.environ.get("DISTILLERY_BUILD_SHA", "dev")

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1316,8 +1316,12 @@ def _sync_gather_stats(
             "calls used."
         )
 
+    from distillery import __build_sha__, __version__
+
     result: dict[str, Any] = {
         "status": "ok",
+        "version": __version__,
+        "build_sha": __build_sha__,
         "total_entries": total_entries,
         "entries_by_type": entries_by_type,
         "entries_by_status": entries_by_status,


### PR DESCRIPTION
## Summary

- Add `version` and `build_sha` fields to the `distillery_status` MCP tool response
- Inject git commit SHA at Docker build time via `DISTILLERY_BUILD_SHA` env var
- Local/dev runs default to `"dev"` as the build SHA

## Changes

- `src/distillery/__init__.py` — export `__build_sha__` from env var
- `src/distillery/mcp/server.py` — include `version` and `build_sha` in status response
- `deploy/fly/Dockerfile` — accept `BUILD_SHA` build arg, set as env var
- `.github/workflows/fly-deploy.yml` — pass `--build-arg BUILD_SHA=${{ github.sha }}` to flyctl

## Test plan

- [ ] `distillery_status` returns `"build_sha": "dev"` locally
- [ ] After Fly deploy, `distillery_status` returns the full commit SHA
- [ ] Existing status fields unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now reports version and build information in system status diagnostics.

* **Chores**
  * Updated build and deployment configuration to capture and expose build identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->