### PR TITLE
fix(deploy): persist OAuth tokens across Fly.io restarts

### DIFF
--- a/deploy/fly/Dockerfile
+++ b/deploy/fly/Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /app
 ARG BUILD_SHA=unknown
 ENV DISTILLERY_BUILD_SHA=${BUILD_SHA}
 
+# Persist FastMCP OAuth state (client registrations, tokens) on the Fly volume
+# so tokens survive machine autostop/restart cycles.
+ENV FASTMCP_HOME=/data/fastmcp
+
 RUN useradd --create-home --uid 10001 appuser
 
 # Copy the full repo (build context is repo root)


### PR DESCRIPTION
## Summary

- Fix OAuth reauth forced on every Fly.io machine scale-to-zero restart
- Set `FASTMCP_HOME=/data/fastmcp` so OAuth state persists on the Fly volume

## Root cause

FastMCP stores OAuth state (client registrations, upstream tokens, auth codes) as Fernet-encrypted files under `$FASTMCP_HOME/oauth-proxy/`. The default path (`~/.local/share/fastmcp`) is on the ephemeral root filesystem, which is wiped every time Fly.io autostops and restarts the machine. This forces every connected client to re-authenticate.

## Fix

One line: `ENV FASTMCP_HOME=/data/fastmcp` in the Dockerfile. The `/data` volume is persistent across restarts.

## Test plan

- [ ] Deploy to Fly.io
- [ ] Authenticate via OAuth
- [ ] Wait for machine to autostop (or `flyctl machine stop`)
- [ ] Send a new MCP request — should succeed without reauth
- [ ] Verify `/data/fastmcp/oauth-proxy/` contains encrypted state files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to establish a dedicated storage location for application state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->