### PR TITLE
docs: plugin install points to /setup instead of distillery_status

### DIFF
--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -14,11 +14,13 @@ claude plugin install distillery
 
 This installs the skill definitions globally and configures the MCP server connection to the hosted Distillery instance.
 
-After installation, restart Claude Code and verify by calling the `distillery_status` MCP tool:
+After installation, restart Claude Code and run the onboarding wizard:
 
 ```text
-distillery_status
+/setup
 ```
+
+This verifies MCP connectivity, detects your transport, and configures auto-poll for ambient intelligence.
 
 !!! note "Claude Desktop"
     The Claude desktop app does not support Claude Code skills or the plugin install system. Desktop users can connect the MCP server directly (all 22 tools are available) but slash commands like `/distill` and `/recall` are CLI-only features.


### PR DESCRIPTION
## Summary
- Replace `distillery_status` MCP tool call with `/setup` onboarding wizard in plugin install quick start

## Test plan
- [ ] `mkdocs build --strict` passes
- [ ] Plugin install page shows `/setup` as the post-install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the post-install verification workflow to use the `/setup` onboarding wizard. The wizard verifies connectivity, detects transport configuration, and configures auto-poll settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->