### PR TITLE
docs: add demo server warning to README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Then run the onboarding wizard in Claude Code:
 
 This verifies MCP connectivity, detects your transport, and configures auto-poll for ambient intelligence.
 
+> **Demo Server:** The plugin defaults to `distillery-mcp.fly.dev`, which is a demo server for evaluation only. Do not store sensitive or confidential data. For production use, [deploy your own instance](https://norrietaylor.github.io/distillery/team/fly/) or run locally.
+
 ### Local Setup
 
 ```bash


### PR DESCRIPTION
## Summary
- Add demo server warning after /setup in README quick start, matching docs pages

## Test plan
- [ ] Warning renders correctly in GitHub README view

🤖 Generated with [Claude Code](https://claude.com/claude-code)