### PR TITLE
fix(mcp): ASGI dispatcher for webhook routing (lifespan fix)

### DIFF
--- a/src/distillery/mcp/__main__.py
+++ b/src/distillery/mcp/__main__.py
@@ -172,30 +172,45 @@ def main(argv: list[str] | None = None) -> int:
                 org_checker=org_checker,
             )
 
-            from starlette.types import ASGIApp
+            from starlette.types import ASGIApp, Receive, Scope, Send
 
             final_app: ASGIApp = wrapped_app
             if config.server.webhooks.enabled and os.environ.get(
                 config.server.webhooks.secret_env
             ):
-                from starlette.applications import Starlette
-                from starlette.routing import Mount
-
                 from distillery.mcp.middleware import BodySizeLimitMiddleware
                 from distillery.mcp.webhooks import create_webhook_app
 
-                webhook_app = create_webhook_app(server._distillery_shared, config)  # type: ignore[attr-defined]
-                # Apply the same body-size guard as the MCP endpoint.
-                webhook_app = BodySizeLimitMiddleware(webhook_app, max_bytes=rl.max_body_bytes)  # type: ignore[assignment]
-                # Propagate the MCP http_app's lifespan to the parent so
-                # FastMCP's session manager initialises on startup.
-                final_app = Starlette(
-                    routes=[
-                        Mount("/api", app=webhook_app),
-                        Mount("/", app=wrapped_app),
-                    ],
-                    lifespan=http_app.router.lifespan_context,
+                webhook_app: ASGIApp = create_webhook_app(
+                    server._distillery_shared, config  # type: ignore[attr-defined]
                 )
+                # Apply the same body-size guard as the MCP endpoint.
+                webhook_app = BodySizeLimitMiddleware(
+                    webhook_app, max_bytes=rl.max_body_bytes
+                )
+
+                # Route /api/* to webhooks, everything else to MCP.
+                # Uses a thin ASGI dispatcher instead of Starlette Mount so
+                # that lifespan events propagate naturally to wrapped_app
+                # (which contains the FastMCP lifespan via middleware chain).
+                _mcp_app = wrapped_app
+
+                async def _combined_app(
+                    scope: Scope, receive: Receive, send: Send
+                ) -> None:
+                    if scope["type"] == "http" and scope.get("path", "").startswith(
+                        "/api/"
+                    ):
+                        # Strip /api prefix for the webhook app's routes.
+                        scope = dict(scope)
+                        scope["path"] = scope["path"][4:]  # /api/poll -> /poll
+                        raw = scope.get("root_path", "")
+                        scope["root_path"] = raw + "/api"
+                        await webhook_app(scope, receive, send)
+                    else:
+                        await _mcp_app(scope, receive, send)
+
+                final_app = _combined_app
 
             import uvicorn as _uvicorn
 


### PR DESCRIPTION
## Summary

- The Starlette `Mount()` approach for webhook routing broke FastMCP's lifespan — Starlette doesn't propagate lifespan events to mounted apps
- Replaces with a thin ASGI dispatcher that routes `/api/*` to webhooks and everything else to the MCP middleware chain
- Fixes the 502 errors from the scheduler workflow

## Root cause

`Starlette(routes=[Mount("/api", webhook_app), Mount("/", mcp_app)], lifespan=...)` — the lifespan parameter expects `async def lifespan(app: Starlette)` but FastMCP's lifespan expects a `FastMCP` server object. The ASGI dispatcher approach lets lifespan events flow naturally through the middleware chain to FastMCP's http_app.

## Test plan

- [ ] `pytest tests/test_webhooks.py -v` — all 12 tests pass
- [ ] `mypy --strict src/distillery/mcp/__main__.py` — clean
- [ ] Deploy to Fly.io and verify `/api/poll` returns 200
- [ ] Re-run scheduler workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized HTTP request routing and path handling. Improved request delegation and separation between API and webhook processing. Enhanced routing architecture provides better performance, reliability, and stability across service endpoints. Refined request processing ensures improved efficiency when handling mixed request types and concurrent integration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->