### PR TITLE
fix(readme): use static license badge instead of GitHub API badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 <p align="center">
   <a href="https://pypi.org/project/distillery/"><img src="https://img.shields.io/pypi/v/distillery" alt="PyPI version"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/norrietaylor/distillery" alt="License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11%2B-blue" alt="Python version"></a>
 </p>
 


### PR DESCRIPTION
GitHub's license detection API can't identify the license file. Switch to a static shields.io badge showing "Apache 2.0".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the license badge in README to use a static Apache 2.0 badge design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->