### PR TITLE
docs: update all docs for 18-tool post-consolidation surface

### DIFF
--- a/.claude-plugin/skills/README.md
+++ b/.claude-plugin/skills/README.md
@@ -11,6 +11,11 @@ Each skill is located in its own subdirectory:
 - **`pour/`** — `/pour` — Multi-entry synthesis and deep dives
 - **`bookmark/`** — `/bookmark` — Store and summarize URLs
 - **`minutes/`** — `/minutes` — Create and update meeting notes
+- **`classify/`** — `/classify` — Classify entries and manage the review queue
+- **`watch/`** — `/watch` — Add, remove, or list monitored feed sources
+- **`radar/`** — `/radar` — Generate ambient intelligence digests
+- **`tune/`** — `/tune` — Adjust feed relevance thresholds at runtime
+- **`setup/`** — `/setup` — Onboarding wizard for MCP connectivity
 
 ## Getting Started
 
@@ -71,17 +76,16 @@ To create a new skill:
 
 ## MCP Tools Available
 
-The Distillery MCP server provides these tools:
+The Distillery MCP server provides 18 tools:
 
-- `distillery_metrics` — Server health, usage stats, and search quality (use `scope="summary"` for health check)
-- `distillery_store` — Store a new knowledge entry
-- `distillery_search` — Semantic search for entries
-- `distillery_find_similar` — Find duplicate entries
-- `distillery_get` — Retrieve an entry by ID
-- `distillery_update` — Partially update an entry
-- `distillery_list` — List entries with filtering
+**CRUD:** `distillery_store`, `distillery_get`, `distillery_update`, `distillery_list`
+**Discovery:** `distillery_search`, `distillery_find_similar`, `distillery_aggregate`, `distillery_stale`, `distillery_tag_tree`
+**Classification:** `distillery_classify`, `distillery_resolve_review`
+**Observability:** `distillery_metrics` (scopes: `"summary"`, `"full"`, `"search_quality"`)
+**Feeds:** `distillery_watch`, `distillery_poll`, `distillery_rescore`, `distillery_interests`
+**Configuration:** `distillery_configure`, `distillery_type_schemas`
 
-See `/docs/mcp-setup.md` for full tool documentation.
+See `/docs/getting-started/mcp-setup.md` for full tool documentation.
 
 ## Debugging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Webhook Endpoints (PR #94)
+
+- REST webhook API (`/api/poll`, `/api/rescore`, `/api/maintenance`) with bearer token auth
+- Per-endpoint cooldowns persisted in DuckDB, rate limiting, audit logging
+- ASGI dispatcher routing `/api/*` to webhooks, all other paths to MCP
+- GitHub Actions webhook scheduler integration for `/setup` skill
+
+### Eval Supplement (PR #102)
+
+- promptfoo PR CI gate (`eval-pr.yml`) with 10 smoke-test scenarios
+- RAGAS retrieval quality metrics (`retrieval_scorer.py`) with golden dataset
+- 13 adversarial/edge-case eval scenarios (malformed input, empty store, boundaries)
+- Per-run cost tracking with `--compare-cost` flag and per-skill breakdown
+
+### Promotion Readiness (PR #103)
+
+- README badges (PyPI, License, Python), demo GIF, `.env.example`
+- `SECURITY.md` with GitHub Security Advisories disclosure policy
+
+### Plugin Audit (PR #105)
+
+- `allowed-tools` on all 10 skills, `disable-model-invocation` on write skills
+- Skill descriptions rewritten from trigger-phrase lists to purpose statements
+- `context: fork` on `/pour` and `/radar`, `effort` hints on all skills
+- `userConfig` in `plugin.json` with `sensitive: true` for API keys
+
+### MCP Server Refactor (PR #106)
+
+- Split `server.py` (4,041 lines) into 7 domain modules under `mcp/tools/`
+- Standardized error codes (`INVALID_PARAMS`, `NOT_FOUND`, `CONFLICT`, `INTERNAL`)
+- Extracted validation helpers (`validate_limit`, `validate_required`, `tool_error`)
+- Configurable defaults (`defaults.dedup_threshold`, `dedup_limit`, `stale_days`) in `distillery.yaml`
+- Full middleware test coverage (rate limiting, body size, org membership)
+- Tests for all 22 tool handlers; `mcp/` package at 95%+ coverage
+
+### Skill UX Improvements (PR #115)
+
+- Dedup standardization: `/minutes` and `/radar` now call `distillery_find_similar(dedup_action=true)`
+- `--project` filtering on `/classify --inbox`, `/minutes --list`, `/radar`
+- Confirmation format template and entry types table in CONVENTIONS.md
+- `/radar` defaults to display-only (requires `--store` to persist)
+- `distillery_configure` MCP tool for runtime threshold changes (`/tune` no longer requires manual YAML editing)
+- Progressive disclosure: `/setup` references extracted to `references/` subdirectory
+
+### Tool Consolidation (PR #118)
+
+- Consolidated 22 MCP tools down to 18 by merging overlapping tools:
+  - `distillery_metrics` absorbs `distillery_status` and `distillery_quality` (via `scope` parameter)
+  - `distillery_find_similar` absorbs `distillery_check_dedup` and `distillery_check_conflicts` (via `dedup_action` and `conflict_check` parameters)
+  - `distillery_list` absorbs `distillery_review_queue` (via `output_mode="review"`)
+  - `distillery_interests` absorbs `distillery_suggest_sources` (via `suggest_sources` parameter)
+- All skills, eval scenarios, and tests updated to use consolidated tool names
+- 18 MCP tools total, 1600+ tests
+
+### Remaining Audit (PRs #120, #121)
+
+- SessionStart hook for review queue notifications
+- `distillery-researcher` custom agent for `/pour` and `/radar` workflows
+- `X-Request-ID` middleware for HTTP request correlation
+- Model hints on `/recall` and `/tune` skills
+- Stale tool reference cleanup across skills and cron payloads
+
 ### Spec 05 — Developer Experience
 
 - Fixed `distillery` CLI entry point with `status` and `health` subcommands
@@ -27,7 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `distillery_metrics` tool: comprehensive usage dashboard (entries, activity, search, quality, staleness, storage)
 - `ConflictChecker` class for LLM-based contradiction detection
 - Config extensions: `feedback_window_minutes`, `stale_days`, `conflict_threshold`
-- 15 MCP tools total
+- 15 MCP tools total (later consolidated to 18)
 
 ### Spec 07 — FastMCP Migration
 
@@ -47,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TagsConfig` in `distillery.yaml`: `enforce_namespaces`, `reserved_prefixes`
 - DuckDB concurrent initialization retry with `INSERT OR IGNORE` for meta bootstrap
 - Updated `/distill` and `/bookmark` skills with hierarchical tag suggestions
-- 17 MCP tools total, 600+ tests
+- 17 MCP tools total (later consolidated to 18), 600+ tests
 
 ### Spec 09 — CLI Eval Runner
 
@@ -71,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `distillery poll` CLI command for cron-based scheduling
 - `FeedsConfig` in `distillery.yaml` with sources (each with per-source `trust_weight`) and thresholds
 - MotherDuck backend (`md:distillery`) for persistent storage across container restarts
-- 21 MCP tools total, 1000+ tests
+- 21 MCP tools total (later consolidated to 18), 1000+ tests
 
 ### Spec 10b — GitHub Team OAuth
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Distillery
 
-Distillery is a knowledge-base system for Claude Code. It stores, searches, and classifies knowledge entries using DuckDB with vector similarity search (VSS/HNSW). It includes ambient intelligence features that poll external feeds (GitHub, RSS) and score relevance using embeddings. It exposes functionality via an MCP server (stdio or streamable-HTTP transport) with 16 tools, orchestrated by 10 Claude Code skills (`/distill`, `/recall`, `/pour`, `/bookmark`, `/minutes`, `/classify`, `/watch`, `/radar`, `/tune`, `/setup`). HTTP transport supports GitHub OAuth for team access. REST webhook endpoints (`/api/poll`, `/api/rescore`, `/api/maintenance`) run alongside the MCP server for automated scheduling via GitHub Actions cron.
+Distillery is a knowledge-base system for Claude Code. It stores, searches, and classifies knowledge entries using DuckDB with vector similarity search (VSS/HNSW). It includes ambient intelligence features that poll external feeds (GitHub, RSS) and score relevance using embeddings. It exposes functionality via an MCP server (stdio or streamable-HTTP transport) with 18 tools, orchestrated by 10 Claude Code skills (`/distill`, `/recall`, `/pour`, `/bookmark`, `/minutes`, `/classify`, `/watch`, `/radar`, `/tune`, `/setup`). HTTP transport supports GitHub OAuth for team access. REST webhook endpoints (`/api/poll`, `/api/rescore`, `/api/maintenance`) run alongside the MCP server for automated scheduling via GitHub Actions cron.
 
 ## Commands
 
@@ -51,7 +51,7 @@ Four-layer design:
 ```text
 Skills (.claude-plugin/skills/<name>/SKILL.md)  →  slash commands users invoke
     ↓
-MCP Server (src/distillery/mcp/server.py)  →  16 tools over stdio or HTTP (FastMCP 2.x/3.x)
+MCP Server (src/distillery/mcp/server.py)  →  18 tools over stdio or HTTP (FastMCP 2.x/3.x)
 Webhook API (src/distillery/mcp/webhooks.py) →  /api/poll, /api/rescore, /api/maintenance (bearer auth)
     ↓
 Core Protocols (store/protocol.py, embedding/protocol.py)  →  typed Protocol interfaces

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ DuckDB (local persistent storage)
 | Layer | Description | Key types |
 |-------|-------------|-----------|
 | **Skills** | `/distill`, `/recall`, `/pour`, `/bookmark`, `/minutes`, `/classify`, `/watch`, `/radar`, `/tune` — SKILL.md files that orchestrate MCP tool calls | — |
-| **MCP Server** | FastMCP server exposing 21 tools over stdio/HTTP transport | `mcp/server.py` |
+| **MCP Server** | FastMCP server exposing 18 tools over stdio/HTTP transport | `mcp/server.py` |
 | **Core protocols** | `DistilleryStore`, `EmbeddingProvider`, `ClassificationEngine` — typed `Protocol` interfaces | `store/protocol.py`, `embedding/protocol.py`, `classification/engine.py` |
 | **DuckDB backend** | `DuckDBStore` implements `DistilleryStore`; vector similarity search via VSS extension | `store/duckdb.py` |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ Distillery is built as a 4-layer system where skills (SKILL.md files) drive all 
   <!-- Layer 2: MCP Server -->
   <rect class="d-amber-bg" x="30" y="104" width="700" height="52" rx="10"/>
   <text class="d-white" x="380" y="128" text-anchor="middle">MCP Server</text>
-  <text class="d-white-sub" x="380" y="144" text-anchor="middle">FastMCP 2.x/3.x  ·  stdio + streamable-HTTP  ·  22 tools  ·  REST webhooks (/api/*)</text>
+  <text class="d-white-sub" x="380" y="144" text-anchor="middle">FastMCP 2.x/3.x  ·  stdio + streamable-HTTP  ·  18 tools  ·  REST webhooks (/api/*)</text>
 
   <!-- Connector: MCP to Auth + Protocols -->
   <line class="d-line" x1="380" y1="156" x2="380" y2="168"/>
@@ -140,7 +140,7 @@ Distillery is built as a 4-layer system where skills (SKILL.md files) drive all 
 | Layer | What it does | Key files |
 |-------|-------------|-----------|
 | **Skills** | 10 SKILL.md files — portable, version-controlled slash commands. Not Python code. | `.claude-plugin/skills/*/SKILL.md` |
-| **MCP Server** | 22 tools exposed over stdio (local) or streamable-HTTP (team). Built on FastMCP 2.x/3.x with `@server.tool` decorators. | `src/distillery/mcp/server.py` |
+| **MCP Server** | 18 tools exposed over stdio (local) or streamable-HTTP (team). Built on FastMCP 2.x/3.x with `@server.tool` decorators. | `src/distillery/mcp/server.py` |
 | **Webhook API** | REST endpoints (`/api/poll`, `/api/rescore`, `/api/maintenance`) for automated scheduling. Bearer token auth, per-endpoint cooldowns persisted to DuckDB. Mounted alongside MCP in HTTP mode. | `src/distillery/mcp/webhooks.py` |
 | **Auth** | MCP: GitHub OAuth with org-restricted access. Webhooks: bearer token via `DISTILLERY_WEBHOOK_SECRET`. Middleware handles logging, rate limiting, security headers, budget tracking. | `src/distillery/mcp/auth.py`, `middleware.py`, `budget.py` |
 | **Core Protocols** | Typed `Protocol` interfaces (structural subtyping, not ABCs). All storage operations are async. | `src/distillery/store/protocol.py`, `embedding/protocol.py` |
@@ -219,7 +219,7 @@ distillery/
 │   │   ├── engine.py        # ClassificationEngine
 │   │   └── dedup.py         # DeduplicationChecker
 │   ├── mcp/
-│   │   ├── server.py        # MCP server (22 tools, FastMCP 2.x)
+│   │   ├── server.py        # MCP server (18 tools, FastMCP 2.x)
 │   │   ├── webhooks.py      # REST webhook endpoints (/api/poll, /api/rescore, /api/maintenance)
 │   │   ├── auth.py          # GitHub OAuth via FastMCP GitHubProvider
 │   │   ├── middleware.py     # Request logging, rate limiting, security headers
@@ -231,7 +231,7 @@ distillery/
 │       ├── scorer.py        # Embedding-based relevance scorer
 │       ├── poller.py        # Background feed poller
 │       └── interests.py     # Interest extractor for source suggestions
-├── tests/                   # 1100+ tests (unit + integration)
+├── tests/                   # 1600+ tests (unit + integration)
 ├── deploy/
 │   ├── fly/                 # Fly.io deployment (persistent DuckDB)
 │   └── prefect/             # Prefect Horizon deployment (MotherDuck)

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -44,7 +44,7 @@
   <!-- Layer 2: MCP Server -->
   <rect class="d-amber-bg" x="30" y="104" width="700" height="52" rx="10"/>
   <text class="d-white" x="380" y="128" text-anchor="middle">MCP Server</text>
-  <text class="d-white-sub" x="380" y="144" text-anchor="middle">FastMCP 2.x/3.x  ·  stdio + streamable-HTTP  ·  22 tools  ·  @server.tool decorators</text>
+  <text class="d-white-sub" x="380" y="144" text-anchor="middle">FastMCP 2.x/3.x  ·  stdio + streamable-HTTP  ·  18 tools  ·  @server.tool decorators</text>
 
   <line class="d-line" x1="380" y1="156" x2="380" y2="168"/>
   <line class="d-line" x1="190" y1="168" x2="570" y2="168"/>

--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -88,7 +88,7 @@ Or use the installed entry point:
 Restart Claude Code and verify:
 
 ```text
-distillery_status
+distillery_metrics(scope="summary")
 ```
 
 ## Embedding Providers

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -1,6 +1,6 @@
 # MCP Server Reference
 
-Complete reference for the Distillery MCP server — all 22 tools, configuration options, and troubleshooting.
+Complete reference for the Distillery MCP server — all 18 tools, configuration options, and troubleshooting.
 
 ## Starting the Server
 
@@ -42,35 +42,37 @@ See [`distillery.yaml.example`](https://github.com/norrietaylor/distillery/blob/
 
 | Tool | Description |
 |------|-------------|
-| `distillery_status` | Database stats: total entries, breakdown by type/status, embedding model |
-| `distillery_store` | Store a new knowledge entry with duplicate and conflict checks |
+| **CRUD** | |
+| `distillery_store` | Store a new knowledge entry with content, tags, and metadata |
 | `distillery_get` | Retrieve a single entry by UUID |
-| `distillery_update` | Partially update an existing entry (with metadata re-validation) |
+| `distillery_update` | Partially update an existing entry (tags, status, metadata) |
+| `distillery_list` | List entries with filtering, pagination, and optional review-queue enrichment (`output_mode="review"`) |
+| **Discovery** | |
 | `distillery_search` | Semantic search using cosine similarity; returns ranked results |
-| `distillery_find_similar` | Find entries similar to given text (for deduplication) |
-| `distillery_list` | List entries with optional filtering and pagination |
-| `distillery_classify` | Classify an entry by type with LLM-based confidence scoring |
-| `distillery_review_queue` | List entries pending manual review |
-| `distillery_resolve_review` | Resolve a pending review entry (accept/reject/reclassify) |
-| `distillery_check_dedup` | Check content for duplicates against existing entries |
-| `distillery_check_conflicts` | Detect semantic contradictions with existing entries |
-| `distillery_metrics` | Usage dashboard: entries, activity, search, quality, staleness |
-| `distillery_quality` | Aggregate retrieval quality metrics from implicit feedback |
+| `distillery_find_similar` | Find similar entries — supports dedup mode (`dedup_action=true`) and conflict detection (`conflict_check=true`) |
+| `distillery_aggregate` | Group entry counts by field (type, status, project, author) |
 | `distillery_stale` | Surface entries not accessed within a configurable time window |
 | `distillery_tag_tree` | Nested tree of all tags in use with entry counts |
-| `distillery_type_schemas` | Metadata schema registry for all entry types |
-| `distillery_watch` | List, add, or remove monitored feed sources |
+| **Classification** | |
+| `distillery_classify` | Classify an entry by type with LLM-based confidence scoring |
+| `distillery_resolve_review` | Resolve a pending review entry (accept/reject/reclassify) |
+| **Observability** | |
+| `distillery_metrics` | Usage dashboard with configurable scope: `"summary"` (health check), `"full"` (all metrics), or `"search_quality"` (retrieval stats) |
+| **Feeds** | |
+| `distillery_watch` | List, add, or remove monitored feed sources (RSS, GitHub) |
 | `distillery_poll` | Trigger a feed poll cycle (fetch, score, store) |
-| `distillery_interests` | Return user's interest profile (top tags, domains, repos) |
-| `distillery_suggest_sources` | Interest profile with suggestion context for source discovery |
 | `distillery_rescore` | Re-score feed entries against current interest profile |
+| `distillery_interests` | User's interest profile (top tags/domains); optionally includes source suggestions (`suggest_sources=true`) |
+| **Configuration** | |
+| `distillery_configure` | Update runtime configuration (thresholds, settings) and persist to `distillery.yaml` |
+| `distillery_type_schemas` | Metadata schema registry for all entry types |
 
 ## Verifying the Server
 
-Call the `distillery_status` MCP tool from within Claude Code:
+Call the `distillery_metrics` MCP tool from within Claude Code:
 
 ```text
-distillery_status
+distillery_metrics(scope="summary")
 ```
 
 Expected response:

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -26,7 +26,7 @@ This verifies MCP connectivity, detects your transport, and configures auto-poll
     The plugin defaults to the hosted instance at `distillery-mcp.fly.dev`, which is a **demo server** for evaluation only. Do not store sensitive or confidential data. For production use, [deploy your own instance](../team/fly.md) or use [local setup](local-setup.md).
 
 !!! note "Claude Desktop"
-    The Claude desktop app does not support Claude Code skills or the plugin install system. Desktop users can connect the MCP server directly (all 22 tools are available) but slash commands like `/distill` and `/recall` are CLI-only features.
+    The Claude desktop app does not support Claude Code skills or the plugin install system. Desktop users can connect the MCP server directly (all 18 tools are available) but slash commands like `/distill` and `/recall` are CLI-only features.
 
 ## Manual Install (Copy Skills)
 
@@ -134,10 +134,10 @@ You should see your feed sources and a note about the active remote trigger.
 
 ## Verifying the Setup
 
-After saving the settings file, restart Claude Code or reload MCP servers, then check connectivity by calling the `distillery_status` MCP tool:
+After saving the settings file, restart Claude Code or reload MCP servers, then check connectivity by calling the `distillery_metrics` MCP tool:
 
 ```text
-distillery_status
+distillery_metrics(scope="summary")
 ```
 
 You should see a JSON response with `"status": "ok"`.

--- a/docs/presentation.html
+++ b/docs/presentation.html
@@ -806,7 +806,7 @@
       </div>
     </div>
     <div class="demo-buttons">
-      <button class="demo-btn" id="demo-btn-status">distillery_status()</button>
+      <button class="demo-btn" id="demo-btn-status">distillery_metrics()</button>
       <button class="demo-btn" id="demo-btn-search">distillery_search("caching strategy")</button>
       <button class="demo-btn" id="demo-btn-recent">distillery_list(limit=5)</button>
     </div>
@@ -949,7 +949,7 @@ Options:
       </div>
       <div class="arch-mcp">
         <div class="arch-mcp-title">MCP Server</div>
-        <div class="arch-mcp-sub">FastMCP 2.x/3.x &middot; stdio + streamable-HTTP &middot; 22 tools &middot; REST webhooks</div>
+        <div class="arch-mcp-sub">FastMCP 2.x/3.x &middot; stdio + streamable-HTTP &middot; 18 tools &middot; REST webhooks</div>
       </div>
     </div>
     <div class="arch-connector">
@@ -1294,8 +1294,8 @@ $ distillery-mcp --transport http --port 8000
 
   /* Pre-recorded fallbacks shown when the hosted MCP is unreachable */
   var FALLBACK = {
-    distillery_status: [
-      ['prompt', '> distillery_status()'],
+    distillery_metrics: [
+      ['prompt', '> distillery_metrics()'],
       ['plain',  ''],
       ['label',  '● Distillery Knowledge Base'],
       ['plain',  ''],
@@ -1485,7 +1485,7 @@ $ distillery-mcp --transport http --port 8000
     panel.addEventListener('keydown', function (e) { e.stopPropagation(); });
 
     document.getElementById('demo-btn-status').addEventListener('click', function () {
-      runAction('distillery_status', {}, outputEl, null);
+      runAction('distillery_metrics', {}, outputEl, null);
     });
     document.getElementById('demo-btn-search').addEventListener('click', function () {
       runAction('distillery_search', { query: 'caching strategy', limit: 5 }, outputEl, 'caching strategy');

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@
 - [x] DuckDB backend with VSS extension and HNSW index (cosine similarity)
 - [x] Configurable embedding providers (Jina v3 default, OpenAI adapter)
 - [x] Embedding model lock via `_meta` table — prevents mixed-model corruption
-- [x] MCP server with 22 tools over stdio and streamable-HTTP
+- [x] MCP server with 18 tools over stdio and streamable-HTTP
 - [x] `distillery.yaml` config system with validation
 
 ### Core Skills
@@ -25,9 +25,9 @@
 - [x] `/classify` skill — classify by ID, batch inbox, review queue triage
 
 ### Quality & Observability
-- [x] Implicit retrieval feedback + `distillery_quality` tool
+- [x] Implicit retrieval feedback + quality metrics (now via `distillery_metrics(scope="search_quality")`)
 - [x] Stale entry detection — `distillery_stale` tool
-- [x] Conflict detection — `distillery_check_conflicts` tool
+- [x] Conflict detection (now via `distillery_find_similar(conflict_check=true)`)
 - [x] Usage metrics dashboard — `distillery_metrics` tool
 
 ### Infrastructure

--- a/docs/skills/radar.md
+++ b/docs/skills/radar.md
@@ -64,7 +64,7 @@ Digest stored: m3n4o5p6
 2. Groups entries by source tag or topic
 3. Synthesizes 2-4 sentence summaries per group with bullet points
 4. Generates a cross-group overall summary
-5. If `--suggest` is enabled, calls `distillery_suggest_sources` for recommendations
+5. If `--suggest` is enabled, calls `distillery_interests` (with `suggest_sources=true`) for recommendations
 6. Stores the digest as an entry (type `digest`) unless `--no-store` is specified
 
 ## Tips

--- a/docs/team/fly.md
+++ b/docs/team/fly.md
@@ -143,7 +143,7 @@ The flow (handled by FastMCP's `GitHubProvider`):
 |-------|---------|---------|
 | `embedding_budget_daily` | 500 | Max Jina API calls/day (0 = unlimited) |
 | `max_db_size_mb` | 900 | Reject writes above this DB size |
-| `warn_db_size_pct` | 80 | Warn in `distillery_status` at this % |
+| `warn_db_size_pct` | 80 | Warn in `distillery_metrics` at this % |
 
 Budget counters are stored in DuckDB's `_meta` table and survive scale-to-zero restarts.
 


### PR DESCRIPTION
## Summary
- Fix tool count references across 7 files (22/21/16 → 18)
- Rewrite MCP setup tool table with current 18 tools grouped by category
- Replace all stale tool name references (`distillery_status`, `distillery_suggest_sources`, `distillery_check_dedup`, etc.)
- Update test count (1100+ → 1600+)
- Update skills README with all 10 skills and full tool inventory
- Add CHANGELOG entries for PRs #94-#121

## Files changed (13)
CLAUDE.md, CONTRIBUTING.md, CHANGELOG.md, docs/architecture.md, docs/assets/architecture.svg, docs/getting-started/local-setup.md, docs/getting-started/mcp-setup.md, docs/getting-started/plugin-install.md, docs/presentation.html, docs/roadmap.md, docs/skills/radar.md, docs/team/fly.md, .claude-plugin/skills/README.md

## Test plan
- [x] `mkdocs build --strict` passes
- [x] No stale tool names in docs/ or skills/README.md
- [x] No wrong tool counts (22/21/16) outside specs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP server tool reference from 22 to 18 tools with reorganized capabilities and descriptions.
  * Changed system verification command from `distillery_status` to `distillery_metrics(scope="summary")`.
  * Expanded test suite documentation to reflect 1600+ tests.
  * Updated getting-started and installation guides with consolidated tool descriptions and new parameter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->