### PR TITLE
fix(plugin): fix hooks not firing at session start/stop

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -39,9 +39,8 @@
       {
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Call distillery_metrics with scope 'summary'. If there are pending_review entries, print a one-line reminder: '[Distillery] N entries pending review — run /classify to process them.' If there are no pending entries or the call fails, say nothing.",
-            "timeout": 10
+            "type": "command",
+            "command": "echo '[Distillery] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
           }
         ]
       }
@@ -51,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '[Distillery] If this session produced decisions or insights, run /distill to capture them in the knowledge base.'"
+            "command": "echo '[Distillery] If this response produced decisions or insights, run /distill to capture them. If it surfaced interesting URLs, use /watch to add as a feed source or /bookmark to save as an entry.'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Change SessionStart hook from `prompt` to `command` type — prompt hooks crash at startup because `ToolUseContext` isn't initialized yet (Claude Code bug)
- Update SessionStart message to remind the model of all key skills: /recall, /pour, /distill, /classify, /radar
- Update Stop message to suggest /watch and /bookmark for interesting URLs

Note: command hook stdout is injected as model context (system-reminder), not displayed in the terminal. Both hooks now serve as silent model nudges.

## Test plan
- [ ] Start a new session — verify no `ToolUseContext` error in debug logs
- [ ] Confirm SessionStart hook output appears in system-reminder
- [ ] Complete a model response — verify Stop hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Revised plugin session initialization to announce available commands (`/recall`, `/pour`, `/distill`, `/classify`, `/radar`) and knowledge base status instead of pending review metrics.
  * Improved session conclusion messaging to guide users on extracting insights with distillation commands and handling URLs via dedicated operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->