### PR TITLE
feat(auth): add audit events for OAuth authentication

### DIFF
--- a/src/distillery/mcp/__main__.py
+++ b/src/distillery/mcp/__main__.py
@@ -151,6 +151,29 @@ def main(argv: list[str] | None = None) -> int:
                 )
 
             server = create_server(config=config, auth=auth)
+
+            # Wire up audit logging for auth events.  The callback lazily
+            # reads the store from the server's shared state so it works
+            # even though the store is only initialised at first request.
+            _shared_ref = server._distillery_shared  # type: ignore[attr-defined]
+
+            async def _auth_audit_cb(
+                user_id: str,
+                operation: str,
+                entry_id: str,
+                action: str,
+                outcome: str,
+            ) -> None:
+                store = _shared_ref.get("store")
+                if store is None:
+                    return
+                await store.write_audit_log(user_id, operation, entry_id, action, outcome)
+
+            # Attach callback to auth provider (if org-restricted).
+            from distillery.mcp.auth import OrgRestrictedGitHubProvider
+
+            if isinstance(auth, OrgRestrictedGitHubProvider):
+                auth._audit_callback = _auth_audit_cb
             http_app = server.http_app(
                 path="/mcp",
                 transport="streamable-http",
@@ -168,6 +191,7 @@ def main(argv: list[str] | None = None) -> int:
                 max_body_bytes=rl.max_body_bytes,
                 trust_proxy=rl.trust_proxy,
                 org_checker=org_checker,
+                audit_callback=_auth_audit_cb,
             )
 
             from starlette.types import ASGIApp, Receive, Scope, Send

--- a/src/distillery/mcp/auth.py
+++ b/src/distillery/mcp/auth.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import fnmatch
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -31,6 +32,9 @@ from distillery.config import DistilleryConfig, parse_env_allowed_orgs
 from distillery.mcp.org_membership import OrgMembershipChecker
 
 logger = logging.getLogger(__name__)
+
+# Callback signature: (user_id, operation, entry_id, action, outcome) -> awaitable
+AuditCallback = Callable[[str, str, str, str, str], Awaitable[None]]
 
 
 class OrgRestrictedGitHubProvider(GitHubProvider):
@@ -51,6 +55,7 @@ class OrgRestrictedGitHubProvider(GitHubProvider):
         client_id: str,
         client_secret: str,
         base_url: str,
+        audit_callback: AuditCallback | None = None,
     ) -> None:
         super().__init__(
             client_id=client_id,
@@ -58,11 +63,13 @@ class OrgRestrictedGitHubProvider(GitHubProvider):
             base_url=base_url,
         )
         self._org_checker = org_checker
+        self._audit_callback = audit_callback
 
     async def _extract_upstream_claims(self, idp_tokens: dict[str, Any]) -> dict[str, Any] | None:
         """Extract GitHub user identity and store the token for org checks."""
         access_token = idp_tokens.get("access_token")
         if not access_token or not isinstance(access_token, str):
+            await self._audit("unknown", "auth_login_failed", "missing_or_invalid_access_token")
             return None
 
         try:
@@ -79,6 +86,11 @@ class OrgRestrictedGitHubProvider(GitHubProvider):
                         "Failed to fetch GitHub user info during OAuth exchange: %d",
                         resp.status_code,
                     )
+                    await self._audit(
+                        "unknown",
+                        "auth_login_failed",
+                        f"github_api_status_{resp.status_code}",
+                    )
                     return None
 
                 user_data = resp.json()
@@ -87,6 +99,7 @@ class OrgRestrictedGitHubProvider(GitHubProvider):
                     self._org_checker.store_user_token(login, access_token)
                     logger.debug("Stored user token for %s", login)
 
+                await self._audit(login or "unknown", "auth_login", "success")
                 return {
                     "login": login,
                     "name": user_data.get("name"),
@@ -94,7 +107,17 @@ class OrgRestrictedGitHubProvider(GitHubProvider):
                 }
         except Exception:
             logger.warning("Error extracting upstream claims", exc_info=True)
+            await self._audit("unknown", "auth_login_failed", "exception_during_claims_extraction")
             return None
+
+    async def _audit(self, user: str, operation: str, outcome: str) -> None:
+        """Fire audit callback (best-effort, never raises)."""
+        if self._audit_callback is None:
+            return
+        try:
+            await self._audit_callback(user, operation, "", operation, outcome)
+        except Exception:  # noqa: BLE001
+            logger.debug("auth audit_log write failed (ignored)", exc_info=True)
 
 
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
@@ -185,6 +208,7 @@ def _patch_cimd_localhost_redirect() -> None:
 def build_github_auth(
     config: DistilleryConfig,
     org_checker: OrgMembershipChecker | None = None,
+    audit_callback: AuditCallback | None = None,
 ) -> GitHubProvider:
     """Build a :class:`~fastmcp.server.auth.providers.github.GitHubProvider`.
 
@@ -249,6 +273,7 @@ def build_github_auth(
             client_id=client_id,
             client_secret=client_secret,
             base_url=base_url,
+            audit_callback=audit_callback,
         )
 
     return GitHubProvider(

--- a/src/distillery/mcp/auth.py
+++ b/src/distillery/mcp/auth.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import fnmatch
 import logging
 import os
-from collections.abc import Awaitable, Callable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -30,11 +29,9 @@ from fastmcp.server.auth.providers.github import GitHubProvider
 
 from distillery.config import DistilleryConfig, parse_env_allowed_orgs
 from distillery.mcp.org_membership import OrgMembershipChecker
+from distillery.mcp.types import AuditCallback
 
 logger = logging.getLogger(__name__)
-
-# Callback signature: (user_id, operation, entry_id, action, outcome) -> awaitable
-AuditCallback = Callable[[str, str, str, str, str], Awaitable[None]]
 
 
 class OrgRestrictedGitHubProvider(GitHubProvider):
@@ -111,7 +108,27 @@ class OrgRestrictedGitHubProvider(GitHubProvider):
             return None
 
     async def _audit(self, user: str, operation: str, outcome: str) -> None:
-        """Fire audit callback (best-effort, never raises)."""
+        """Fire the audit callback for an authentication event.
+
+        Emits a best-effort audit log entry for login success or failure.
+        Exceptions from the callback are caught and logged at DEBUG level
+        so that audit infrastructure issues never block the auth flow.
+
+        Args:
+            user: GitHub login of the authenticating user, or ``"unknown"``
+                when identity cannot be determined.
+            operation: Audit operation name (e.g. ``"auth_login"``,
+                ``"auth_login_failed"``).
+            outcome: Free-text outcome descriptor (e.g. ``"success"``,
+                ``"github_api_status_401"``).
+
+        Note:
+            Token refresh (``auth_refresh``) is handled entirely within
+            FastMCP's ``OAuthProxy`` layer, which does not expose a hook
+            for subclasses.  GitHub OAuth tokens are long-lived and do not
+            use refresh tokens, so this event is not emitted here.
+            See issue #139 for background.
+        """
         if self._audit_callback is None:
             return
         try:

--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -16,19 +16,18 @@ import logging
 import time
 import uuid
 from collections import deque
-from collections.abc import Awaitable, Callable, MutableMapping
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any
 
 from starlette.datastructures import Headers
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from distillery.mcp.types import AuditCallback
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from distillery.mcp.org_membership import OrgMembershipChecker
-
-# Callback signature: (user_id, operation, entry_id, action, outcome) -> awaitable
-AuditCallback = Callable[[str, str, str, str, str], Awaitable[None]]
 
 # ---------------------------------------------------------------------------
 # Type aliases
@@ -413,7 +412,16 @@ class OrgMembershipMiddleware:
         await self._send_403(send, "<unknown>", list(self.checker.allowed_orgs))
 
     async def _audit_org_denied(self, username: str) -> None:
-        """Fire audit callback for org membership denial (best-effort)."""
+        """Fire the audit callback when a user is denied by org membership check.
+
+        Emits a best-effort audit log entry with operation ``auth_org_denied``.
+        Exceptions from the callback are caught and logged at DEBUG level so
+        that audit infrastructure issues never block the 403 response.
+
+        Args:
+            username: GitHub login of the denied user, or ``"<unknown>"``
+                when the JWT does not contain an identifiable claim.
+        """
         if self._audit_callback is None:
             return
         try:

--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -16,7 +16,7 @@ import logging
 import time
 import uuid
 from collections import deque
-from collections.abc import MutableMapping
+from collections.abc import Awaitable, Callable, MutableMapping
 from typing import TYPE_CHECKING, Any
 
 from starlette.datastructures import Headers
@@ -26,6 +26,9 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from distillery.mcp.org_membership import OrgMembershipChecker
+
+# Callback signature: (user_id, operation, entry_id, action, outcome) -> awaitable
+AuditCallback = Callable[[str, str, str, str, str], Awaitable[None]]
 
 # ---------------------------------------------------------------------------
 # Type aliases
@@ -363,9 +366,11 @@ class OrgMembershipMiddleware:
         self,
         app: ASGIApp,
         checker: OrgMembershipChecker,
+        audit_callback: AuditCallback | None = None,
     ) -> None:
         self.app = app
         self.checker = checker
+        self._audit_callback = audit_callback
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or not self.checker.enabled:
@@ -396,6 +401,7 @@ class OrgMembershipMiddleware:
             username = raw.strip() if isinstance(raw, str) else ""
             if username:
                 if not await self.checker.is_allowed(username):
+                    await self._audit_org_denied(username)
                     await self._send_403(send, username, list(self.checker.allowed_orgs))
                     return
                 await self.app(scope, receive, send)
@@ -403,7 +409,19 @@ class OrgMembershipMiddleware:
 
         # Cannot identify the user (opaque token or JWT without
         # login/sub claim) — fail closed.
+        await self._audit_org_denied("<unknown>")
         await self._send_403(send, "<unknown>", list(self.checker.allowed_orgs))
+
+    async def _audit_org_denied(self, username: str) -> None:
+        """Fire audit callback for org membership denial (best-effort)."""
+        if self._audit_callback is None:
+            return
+        try:
+            await self._audit_callback(
+                username, "auth_org_denied", "", "auth_org_denied", "denied"
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("org-denied audit_log write failed (ignored)", exc_info=True)
 
     @staticmethod
     async def _send_403(send: Send, username: str, orgs: list[str]) -> None:
@@ -442,6 +460,7 @@ def apply_http_middleware(
     max_body_bytes: int = 1_048_576,
     trust_proxy: bool = False,
     org_checker: OrgMembershipChecker | None = None,
+    audit_callback: AuditCallback | None = None,
 ) -> ASGIApp:
     """Wrap *app* with rate-limit, body-size, request-ID, and org-membership middleware.
 
@@ -463,13 +482,16 @@ def apply_http_middleware(
         org_checker: Optional org membership checker.  When provided and
             :attr:`~distillery.mcp.org_membership.OrgMembershipChecker.enabled`
             is ``True``, :class:`OrgMembershipMiddleware` is added.
+        audit_callback: Optional async callback for writing audit log entries
+            when org membership checks deny access.  Signature:
+            ``(user_id, operation, entry_id, action, outcome) -> Awaitable[None]``.
 
     Returns:
         A new ASGI app with all requested middleware layers applied.
     """
     app = BodySizeLimitMiddleware(app, max_bytes=max_body_bytes)
     if org_checker is not None and org_checker.enabled:
-        app = OrgMembershipMiddleware(app, org_checker)
+        app = OrgMembershipMiddleware(app, org_checker, audit_callback=audit_callback)
     app = RateLimitMiddleware(
         app,
         requests_per_minute=requests_per_minute,

--- a/src/distillery/mcp/types.py
+++ b/src/distillery/mcp/types.py
@@ -1,0 +1,8 @@
+"""Shared type aliases for the ``distillery.mcp`` package."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+# Callback signature: (user_id, operation, entry_id, action, outcome) -> awaitable
+AuditCallback = Callable[[str, str, str, str, str], Awaitable[None]]

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -196,3 +197,157 @@ class TestBuildOrgCheckerIntegration:
         checker = build_org_checker(config)
         assert isinstance(checker, OrgMembershipChecker)
         assert "env-company" in checker._allowed_orgs
+
+
+# ---------------------------------------------------------------------------
+# Tests: Audit events on OrgRestrictedGitHubProvider
+# ---------------------------------------------------------------------------
+
+
+class TestAuthAuditEvents:
+    """Verify audit callbacks are fired for login success/failure."""
+
+    def _make_provider(
+        self, audit_cb: AsyncMock | None = None
+    ) -> OrgRestrictedGitHubProvider:
+        from distillery.mcp.org_membership import OrgMembershipChecker
+
+        checker = OrgMembershipChecker(allowed_orgs=["acme"])
+        return OrgRestrictedGitHubProvider(
+            org_checker=checker,
+            client_id="fake-id",
+            client_secret="fake-secret",
+            base_url="https://example.com",
+            audit_callback=audit_cb,
+        )
+
+    async def test_audit_login_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Successful login fires audit callback with auth_login operation."""
+        from unittest.mock import MagicMock
+
+        cb = AsyncMock()
+        provider = self._make_provider(audit_cb=cb)
+
+        # Mock httpx to return a successful user response.
+        import httpx
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "login": "testuser",
+            "name": "Test User",
+            "email": "test@example.com",
+        }
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: mock_client)
+
+        result = await provider._extract_upstream_claims({"access_token": "tok123"})
+        assert result is not None
+        assert result["login"] == "testuser"
+
+        cb.assert_awaited_once_with("testuser", "auth_login", "", "auth_login", "success")
+
+    async def test_audit_login_failed_bad_token(self) -> None:
+        """Missing access token fires audit with auth_login_failed."""
+        cb = AsyncMock()
+        provider = self._make_provider(audit_cb=cb)
+
+        result = await provider._extract_upstream_claims({})
+        assert result is None
+
+        cb.assert_awaited_once()
+        args = cb.call_args[0]
+        assert args[0] == "unknown"
+        assert args[1] == "auth_login_failed"
+
+    async def test_audit_login_failed_github_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-200 GitHub API response fires audit with auth_login_failed."""
+        from unittest.mock import MagicMock
+
+        cb = AsyncMock()
+        provider = self._make_provider(audit_cb=cb)
+
+        import httpx
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: mock_client)
+
+        result = await provider._extract_upstream_claims({"access_token": "bad"})
+        assert result is None
+
+        cb.assert_awaited_once()
+        args = cb.call_args[0]
+        assert args[0] == "unknown"
+        assert args[1] == "auth_login_failed"
+        assert "401" in args[4]
+
+    async def test_audit_login_failed_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exception during claims extraction fires audit with auth_login_failed."""
+        cb = AsyncMock()
+        provider = self._make_provider(audit_cb=cb)
+
+        import httpx
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("network down"))
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: mock_client)
+
+        result = await provider._extract_upstream_claims({"access_token": "tok"})
+        assert result is None
+
+        cb.assert_awaited_once()
+        args = cb.call_args[0]
+        assert args[1] == "auth_login_failed"
+        assert "exception" in args[4]
+
+    async def test_audit_callback_failure_does_not_break_auth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failing audit callback must not prevent a successful login."""
+        from unittest.mock import MagicMock
+
+        cb = AsyncMock(side_effect=RuntimeError("audit db down"))
+        provider = self._make_provider(audit_cb=cb)
+
+        import httpx
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"login": "user1", "name": "U", "email": "u@e.com"}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: mock_client)
+
+        result = await provider._extract_upstream_claims({"access_token": "tok"})
+        # Auth succeeds despite audit failure.
+        assert result is not None
+        assert result["login"] == "user1"
+
+    async def test_no_audit_callback_is_safe(self) -> None:
+        """Provider with no audit callback does not error."""
+        provider = self._make_provider(audit_cb=None)
+        result = await provider._extract_upstream_claims({})
+        assert result is None  # no crash

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -515,6 +515,63 @@ class TestOrgMembershipMiddleware:
         # the OrgMembershipChecker itself handles caching internally.
         assert checker.is_allowed.await_count == 3
 
+    async def test_org_denied_fires_audit_callback(self) -> None:
+        """Org membership denial fires the audit callback."""
+        checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)
+        audit_cb = AsyncMock()
+        mw = OrgMembershipMiddleware(_dummy_app, checker, audit_callback=audit_cb)
+
+        token = _make_jwt({"login": "baduser"})
+        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        cap = _ResponseCapture()
+        await mw(scope, _noop_receive, cap)
+        assert cap.status == 403
+
+        audit_cb.assert_awaited_once_with(
+            "baduser", "auth_org_denied", "", "auth_org_denied", "denied"
+        )
+
+    async def test_org_denied_unknown_user_fires_audit(self) -> None:
+        """Opaque token (unknown user) denial fires audit callback."""
+        checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
+        audit_cb = AsyncMock()
+        mw = OrgMembershipMiddleware(_dummy_app, checker, audit_callback=audit_cb)
+
+        scope = _make_scope(headers=[(b"authorization", b"Bearer opaque-token-no-dots")])
+        cap = _ResponseCapture()
+        await mw(scope, _noop_receive, cap)
+        assert cap.status == 403
+
+        audit_cb.assert_awaited_once_with(
+            "<unknown>", "auth_org_denied", "", "auth_org_denied", "denied"
+        )
+
+    async def test_audit_callback_failure_does_not_break_403(self) -> None:
+        """A failing audit callback must not prevent the 403 response."""
+        checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)
+        audit_cb = AsyncMock(side_effect=RuntimeError("db down"))
+        mw = OrgMembershipMiddleware(_dummy_app, checker, audit_callback=audit_cb)
+
+        token = _make_jwt({"login": "baduser"})
+        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        cap = _ResponseCapture()
+        await mw(scope, _noop_receive, cap)
+        # 403 is still sent despite audit failure.
+        assert cap.status == 403
+
+    async def test_no_audit_callback_on_allowed_user(self) -> None:
+        """Audit callback is NOT fired when user is allowed."""
+        checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
+        audit_cb = AsyncMock()
+        mw = OrgMembershipMiddleware(_dummy_app, checker, audit_callback=audit_cb)
+
+        token = _make_jwt({"login": "gooduser"})
+        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        cap = _ResponseCapture()
+        await mw(scope, _noop_receive, cap)
+        assert cap.status == 200
+        audit_cb.assert_not_awaited()
+
 
 # ===================================================================
 # _client_ip helper


### PR DESCRIPTION
## Summary

- Add audit logging for OAuth authentication events: successful logins, failed logins (bad tokens, GitHub API errors, exceptions), and org membership denials
- Use a best-effort callback pattern (`AuditCallback`) so the auth/middleware modules don't depend directly on the store — the callback is wired up in `__main__.py` via the server's shared state
- Audit failures are silently caught and never block the auth flow

Closes #139

## Changes

- **`src/distillery/mcp/auth.py`**: `OrgRestrictedGitHubProvider` accepts an optional `audit_callback` and fires it at each auth outcome (success, failure, exception)
- **`src/distillery/mcp/middleware.py`**: `OrgMembershipMiddleware` accepts an optional `audit_callback` and fires it when org membership is denied
- **`src/distillery/mcp/__main__.py`**: Wires up the audit callback using a closure over the server's `_distillery_shared` dict (lazy store access)
- **`tests/test_mcp_auth.py`**: 6 new tests covering login success/failure audit events and callback resilience
- **`tests/test_middleware.py`**: 4 new tests covering org-denied audit events and callback resilience

## Test plan

- [x] All 1464 existing tests pass (266 eval/e2e skipped)
- [x] Audit callback fires on successful OAuth login
- [x] Audit callback fires on failed login (missing token, bad GitHub API response, exception)
- [x] Audit callback fires on org membership denial (known and unknown users)
- [x] Failing audit callback does not break auth flow or 403 responses
- [x] No audit callback (None) is safe — no errors raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit logging for authentication events (successful logins, failed attempts, upstream API errors) and for organization-membership denials.
  * Audit callbacks are best-effort and non-blocking so they won’t disrupt normal auth flows.
* **Tests**
  * Added unit tests covering audit callback behavior, success/failure cases, denial events, and callback resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->