### PR TITLE
ci(registry): add MCP Registry and Smithery automated publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -82,3 +82,46 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry & Smithery
+    needs: publish-pypi
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set version in server.json
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          jq --arg v "$VERSION" '
+            .version = $v |
+            .packages[].version = $v
+          ' server.json > server.tmp && mv server.tmp server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "lts/*"
+
+      - name: Install Smithery CLI
+        run: npm install -g @smithery/cli
+
+      - name: Publish to Smithery
+        run: smithery mcp publish "https://github.com/norrietaylor/distillery" -n norrietaylor/distillery-mcp
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 <h1 align="center">Distillery</h1>
 
+<!-- mcp-name: io.github.norrietaylor/distillery-mcp -->
+
 <p align="center">
   <strong>Team Knowledge, Distilled</strong>
   <br>

--- a/server.json
+++ b/server.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.norrietaylor/distillery-mcp",
+  "title": "Distillery",
+  "description": "A configurable embedding system with DuckDB storage and MCP server integration",
+  "version": "0.1.1",
+  "repository": {
+    "url": "https://github.com/norrietaylor/distillery",
+    "source": "github",
+    "id": "norrietaylor/distillery"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "distillery-mcp",
+      "version": "0.1.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "JINA_API_KEY",
+          "description": "API key for Jina embedding provider",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "OPENAI_API_KEY",
+          "description": "API key for OpenAI embedding provider (alternative to Jina)",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    },
+    {
+      "registryType": "pypi",
+      "identifier": "distillery-mcp",
+      "version": "0.1.1",
+      "transport": {
+        "type": "streamable-http"
+      },
+      "environmentVariables": [
+        {
+          "name": "JINA_API_KEY",
+          "description": "API key for Jina embedding provider",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "OPENAI_API_KEY",
+          "description": "API key for OpenAI embedding provider (alternative to Jina)",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-11-25/server.schema.json",
   "name": "io.github.norrietaylor/distillery-mcp",
   "title": "Distillery",
   "description": "A configurable embedding system with DuckDB storage and MCP server integration",


### PR DESCRIPTION
## Summary

- Add `server.json` for the official MCP Registry with PyPI package metadata, both stdio and streamable-http transports, and environment variable declarations for embedding API keys
- Add `publish-mcp-registry` job to the release workflow that runs after PyPI publish succeeds, authenticates via GitHub OIDC (no secrets needed), and publishes to both the MCP Registry and Smithery
- Add `<!-- mcp-name: ... -->` verification comment to README.md (required by the MCP Registry for PyPI package ownership proof)

## Notes

- **MCP Registry auth**: Uses GitHub OIDC — no additional secrets required. The job needs `id-token: write` permission which is already scoped to the job.
- **Smithery auth**: Requires a `SMITHERY_API_KEY` secret to be added to the repository settings. Obtain an API key from [smithery.ai](https://smithery.ai) and add it as a repository secret.
- **Version sync**: The workflow automatically updates the version in `server.json` from the release tag (strips the `v` prefix), so the committed version is just a placeholder.
- The job only runs on `release` events (not `workflow_dispatch`), and only after `publish-pypi` succeeds.

## Test plan

- [ ] Verify `server.json` validates against the MCP Registry schema
- [ ] Create a test release and confirm the `publish-mcp-registry` job runs after PyPI publish
- [ ] Confirm OIDC auth succeeds with `mcp-publisher login github-oidc`
- [ ] Add `SMITHERY_API_KEY` secret and verify Smithery publish step
- [ ] Verify the `mcp-name` comment appears in the PyPI package description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated publishing to the MCP Registry to run after release publications.
  * Added a server manifest registering the MCP server and two package transport options (stdio and streamable HTTP).
  * Embedded MCP metadata into the project README for discovery and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->