### PR TITLE
feat(feeds): filter low-value GitHub event types at adapter level

### DIFF
--- a/src/distillery/feeds/github.py
+++ b/src/distillery/feeds/github.py
@@ -31,6 +31,20 @@ _DEFAULT_PER_PAGE = 30
 # Request timeout in seconds.
 _REQUEST_TIMEOUT = 30.0
 
+# Event types that typically carry meaningful content (issue/PR bodies, comments,
+# release notes, commit messages).  Low-value events like WatchEvent, ForkEvent,
+# and bare CreateEvent/DeleteEvent are excluded by default because they have
+# very short content that dominates BM25 keyword matching (#171).
+_DEFAULT_INCLUDE_EVENT_TYPES: frozenset[str] = frozenset({
+    "IssuesEvent",
+    "IssueCommentEvent",
+    "PullRequestEvent",
+    "PullRequestReviewEvent",
+    "PullRequestReviewCommentEvent",
+    "PushEvent",
+    "ReleaseEvent",
+})
+
 # Pattern that matches a bare "owner/repo" slug so callers may pass either
 # the full URL or the short slug form.
 _SLUG_RE = re.compile(r"^[\w.\-]+/[\w.\-]+$")
@@ -185,11 +199,15 @@ class GitHubAdapter:
         url: str,
         token: str | None = None,
         per_page: int = _DEFAULT_PER_PAGE,
+        include_event_types: frozenset[str] | None = None,
     ) -> None:
         self._owner, self._repo = _parse_github_url(url)
         self._source_url = url
         self._token = token or os.environ.get("GITHUB_TOKEN", "")
         self._per_page = max(1, min(per_page, 100))
+        self._include_event_types = (
+            include_event_types if include_event_types is not None else _DEFAULT_INCLUDE_EVENT_TYPES
+        )
         self.last_polled_at: datetime | None = None
 
     # ------------------------------------------------------------------
@@ -248,9 +266,16 @@ class GitHubAdapter:
             return []
 
         items: list[FeedItem] = []
+        skipped = 0
         for event in events:
+            event_type = str(event.get("type", ""))
+            if self._include_event_types and event_type not in self._include_event_types:
+                skipped += 1
+                continue
             try:
                 items.append(_event_to_feed_item(event, self._source_url))
             except Exception:
                 logger.exception("GitHubAdapter: failed to convert event %r", event.get("id"))
+        if skipped:
+            logger.debug("GitHubAdapter: skipped %d low-value events", skipped)
         return items

--- a/src/distillery/feeds/github.py
+++ b/src/distillery/feeds/github.py
@@ -268,14 +268,17 @@ class GitHubAdapter:
         items: list[FeedItem] = []
         skipped = 0
         for event in events:
-            event_type = str(event.get("type", ""))
-            if self._include_event_types and event_type not in self._include_event_types:
-                skipped += 1
-                continue
             try:
+                if not isinstance(event, dict):
+                    skipped += 1
+                    continue
+                event_type = str(event.get("type", ""))
+                if self._include_event_types and event_type not in self._include_event_types:
+                    skipped += 1
+                    continue
                 items.append(_event_to_feed_item(event, self._source_url))
             except Exception:
-                logger.exception("GitHubAdapter: failed to convert event %r", event.get("id"))
+                logger.exception("GitHubAdapter: failed to convert event %r", event.get("id") if isinstance(event, dict) else event)
         if skipped:
             logger.debug("GitHubAdapter: skipped %d low-value events", skipped)
         return items

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -262,6 +262,119 @@ class TestGitHubAdapter:
         # Token should have been picked up from the environment
         assert adapter._token == "ghp_testtoken"  # noqa: SLF001
 
+    def test_fetch_filters_low_value_events(self) -> None:
+        events = [
+            {
+                "id": "1",
+                "type": "IssuesEvent",
+                "actor": {"login": "alice"},
+                "repo": {"name": "owner/repo"},
+                "payload": {"body": "Bug report details"},
+                "created_at": "2024-03-25T09:00:00Z",
+            },
+            {
+                "id": "2",
+                "type": "WatchEvent",
+                "actor": {"login": "bob"},
+                "repo": {"name": "owner/repo"},
+                "payload": {},
+                "created_at": "2024-03-25T09:01:00Z",
+            },
+            {
+                "id": "3",
+                "type": "ForkEvent",
+                "actor": {"login": "carol"},
+                "repo": {"name": "owner/repo"},
+                "payload": {},
+                "created_at": "2024-03-25T09:02:00Z",
+            },
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = events
+        mock_response.raise_for_status.return_value = None
+
+        with patch("distillery.feeds.github.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            adapter = GitHubAdapter("owner/repo")
+            items = adapter.fetch()
+
+        # Only IssuesEvent should pass the default filter
+        assert len(items) == 1
+        assert items[0].item_id == "1"
+
+    def test_fetch_no_filter_when_empty_set(self) -> None:
+        events = [
+            {
+                "id": "1",
+                "type": "WatchEvent",
+                "actor": {"login": "bob"},
+                "repo": {"name": "owner/repo"},
+                "payload": {},
+                "created_at": "2024-03-25T09:00:00Z",
+            },
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = events
+        mock_response.raise_for_status.return_value = None
+
+        with patch("distillery.feeds.github.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            # Pass empty frozenset to disable filtering
+            adapter = GitHubAdapter("owner/repo", include_event_types=frozenset())
+            items = adapter.fetch()
+
+        # All events should pass when filter is empty
+        assert len(items) == 1
+
+    def test_fetch_custom_event_types(self) -> None:
+        events = [
+            {
+                "id": "1",
+                "type": "WatchEvent",
+                "actor": {"login": "bob"},
+                "repo": {"name": "owner/repo"},
+                "payload": {},
+                "created_at": "2024-03-25T09:00:00Z",
+            },
+            {
+                "id": "2",
+                "type": "PushEvent",
+                "actor": {"login": "alice"},
+                "repo": {"name": "owner/repo"},
+                "payload": {"commits": [{"message": "fix"}]},
+                "created_at": "2024-03-25T09:01:00Z",
+            },
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = events
+        mock_response.raise_for_status.return_value = None
+
+        with patch("distillery.feeds.github.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            # Only allow WatchEvent
+            adapter = GitHubAdapter(
+                "owner/repo", include_event_types=frozenset({"WatchEvent"})
+            )
+            items = adapter.fetch()
+
+        assert len(items) == 1
+        assert items[0].item_id == "1"
+
 
 # ---------------------------------------------------------------------------
 # parse_feed_xml — RSS 2.0


### PR DESCRIPTION
## Summary
Add configurable event type filtering to `GitHubAdapter`. By default, only high-value event types are ingested:

**Included:** IssuesEvent, IssueCommentEvent, PullRequestEvent, PullRequestReviewEvent, PullRequestReviewCommentEvent, PushEvent, ReleaseEvent

**Excluded:** WatchEvent, ForkEvent, CreateEvent, DeleteEvent, MemberEvent, PublicEvent, GollumEvent

This prevents short-content events (e.g., "WatchEvent by X on duckdb/duckdb") from dominating BM25 keyword search results (#170).

Closes #171

## API
- Default: `_DEFAULT_INCLUDE_EVENT_TYPES` frozenset applied automatically
- Override: `GitHubAdapter(url, include_event_types=frozenset({"WatchEvent"}))` for custom filtering
- Disable: `GitHubAdapter(url, include_event_types=frozenset())` to accept all events

## Test plan
- [x] `test_fetch_filters_low_value_events` — WatchEvent and ForkEvent excluded, IssuesEvent passes
- [x] `test_fetch_no_filter_when_empty_set` — empty frozenset disables filtering
- [x] `test_fetch_custom_event_types` — custom set overrides defaults
- [x] Existing tests pass (PushEvent is in default set)
- [x] Full suite: 1,795 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub integration adds customizable event filtering so you control which activities appear in feeds.
  * Default behavior filters out low-value events (watches, forks) while keeping issues, PRs, pushes, and releases.
  * Filtering can be customized or fully disabled.

* **Tests**
  * Added unit tests verifying default, disabled, and custom filtering behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->