### PR TITLE
chore: pin plugin version to release tag

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '[Distillery] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+            "command": "echo '[Distillery v0.2.1] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
           }
         ]
       }

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -102,11 +102,15 @@ jobs:
             .version = $v |
             .packages[].version = $v
           ' server.json > server.tmp && mv server.tmp server.json
-          jq --arg v "$VERSION" '.version = $v' \
-            .claude-plugin/plugin.json > .claude-plugin/plugin.tmp && \
+          jq --arg v "$VERSION" '
+            .version = $v |
+            .hooks.SessionStart[0].hooks[0].command = (.hooks.SessionStart[0].hooks[0].command | gsub("v[0-9]+\\.[0-9]+\\.[0-9]+"; "v" + $v))
+          ' .claude-plugin/plugin.json > .claude-plugin/plugin.tmp && \
             mv .claude-plugin/plugin.tmp .claude-plugin/plugin.json
-          jq --arg v "$VERSION" '.plugins[0].version = $v' \
-            .claude-plugin/marketplace.json > .claude-plugin/marketplace.tmp && \
+          jq --arg v "$VERSION" '
+            .metadata.version = $v |
+            .plugins[0].version = $v
+          ' .claude-plugin/marketplace.json > .claude-plugin/marketplace.tmp && \
             mv .claude-plugin/marketplace.tmp .claude-plugin/marketplace.json
 
       - name: Install mcp-publisher

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -95,13 +95,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set version in server.json
+      - name: Set version in server.json and plugin manifests
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           jq --arg v "$VERSION" '
             .version = $v |
             .packages[].version = $v
           ' server.json > server.tmp && mv server.tmp server.json
+          jq --arg v "$VERSION" '.version = $v' \
+            .claude-plugin/plugin.json > .claude-plugin/plugin.tmp && \
+            mv .claude-plugin/plugin.tmp .claude-plugin/plugin.json
+          jq --arg v "$VERSION" '.plugins[0].version = $v' \
+            .claude-plugin/marketplace.json > .claude-plugin/marketplace.tmp && \
+            mv .claude-plugin/marketplace.tmp .claude-plugin/marketplace.json
 
       - name: Install mcp-publisher
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,130 @@
+# Releasing Distillery
+
+This document describes the release process for the Distillery MCP server and plugin.
+
+## Release Chain
+
+Creating a GitHub release triggers three automated workflows:
+
+```text
+GitHub Release (tag: vX.Y.Z)
+  ├─ pypi-publish.yml
+  │   ├─ Build sdist + wheel
+  │   ├─ Publish to PyPI (distillery-mcp)
+  │   ├─ Stamp version in server.json, plugin.json, marketplace.json
+  │   ├─ Publish to MCP Registry
+  │   └─ Publish to Smithery
+  └─ changelog.yml
+      ├─ Generate CHANGELOG.md via git-cliff
+      └─ Commit to main
+```
+
+Users install the server via `pip install distillery-mcp` or `uvx distillery-mcp`, both pulling from PyPI.
+
+## Pre-Release Checklist
+
+1. **Version bump** — Update `version` in `pyproject.toml`:
+
+   ```bash
+   # Edit pyproject.toml [project] section
+   version = "X.Y.Z"
+   ```
+
+2. **Version consistency** — Ensure these files match (the release workflow stamps plugin manifests and server.json automatically, but pyproject.toml is the source of truth):
+
+   | File | Field | Updated by |
+   |------|-------|-----------|
+   | `pyproject.toml` | `version` | Manual (pre-release) |
+   | `.claude-plugin/plugin.json` | `version` | Release workflow |
+   | `.claude-plugin/marketplace.json` | `plugins[0].version` | Release workflow |
+   | `server.json` | `version`, `packages[].version` | Release workflow |
+
+3. **Merge all PRs** — Ensure all feature branches for this release are merged to `main`.
+
+4. **Tests pass** — Verify CI is green on `main`:
+
+   ```bash
+   pytest --cov=src/distillery --cov-fail-under=80
+   mypy --strict src/distillery/
+   ruff check src/ tests/
+   ```
+
+5. **Skill compatibility** — If new MCP tools were added, ensure skills that use them have `min_server_version` in their frontmatter.
+
+## Cutting the Release
+
+### Step 1: Create and push the tag
+
+```bash
+# IMPORTANT: Tag format is vX.Y.Z (no extra dots, no prefix other than 'v')
+# The release workflow extracts the version with: ${GITHUB_REF#refs/tags/v}
+# Wrong: v.0.2.1 → extracts ".0.2.1"
+# Right: v0.2.1  → extracts "0.2.1"
+
+git checkout main
+git pull origin main
+git tag v0.2.1
+git push origin v0.2.1
+```
+
+### Step 2: Create the GitHub release
+
+```bash
+gh release create v0.2.1 \
+  --title "v0.2.1 — Short Description" \
+  --generate-notes
+```
+
+Or create via the GitHub UI at `https://github.com/norrietaylor/distillery/releases/new`.
+
+This triggers pypi-publish.yml and changelog.yml automatically.
+
+### Step 3: Verify
+
+1. **PyPI**: Check https://pypi.org/project/distillery-mcp/ for the new version
+2. **Install**: `pip install distillery-mcp==X.Y.Z` or `uvx distillery-mcp --version`
+3. **MCP Registry**: Verify the server listing is updated
+4. **Changelog**: Check that CHANGELOG.md was auto-committed to main
+
+## Deploying the Hosted Server
+
+The hosted MCP server at `distillery-mcp.fly.dev` is deployed separately via the [distill_ops](https://github.com/norrietaylor/distill_ops) repo. After a PyPI release:
+
+```bash
+# In the distill_ops repo
+fly deploy --app distillery-mcp
+```
+
+## Versioning
+
+Follow [Semantic Versioning](https://semver.org/):
+
+- **Patch** (0.2.1 → 0.2.2): Bug fixes, doc updates, no new MCP tools or skills
+- **Minor** (0.2.x → 0.3.0): New MCP tools, new skills, new store methods, migration additions
+- **Major** (0.x → 1.0): Breaking protocol changes, migration format changes, removed tools
+
+## Tag Format
+
+**The tag MUST be `vX.Y.Z`** — exactly `v` followed by semver digits.
+
+The release workflow extracts the version number using `${GITHUB_REF#refs/tags/v}`, which strips the leading `v`. Any deviation (e.g., `v.0.2.1`, `ver0.2.1`) produces a malformed version string that breaks PyPI metadata, MCP Registry publishing, and plugin manifest stamping.
+
+## Fixing a Bad Tag
+
+If a tag was created with the wrong format:
+
+```bash
+# Delete the bad tag locally and remotely
+git tag -d v.0.2.1
+git push origin :refs/tags/v.0.2.1
+
+# Delete the GitHub release (if created)
+gh release delete v.0.2.1 --yes
+
+# Create the correct tag
+git tag v0.2.1 <commit-sha>
+git push origin v0.2.1
+
+# Re-create the release
+gh release create v0.2.1 --title "v0.2.1 — Description" --generate-notes
+```

--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -10,6 +10,7 @@ All skills follow the same structure for consistency and clarity:
 ---
 name: <skill-name>
 description: "Description of the skill's purpose and trigger phrases (case-insensitive: e.g., 'use when user says ...', 'triggered by ...')"
+min_server_version: "0.3.0"  # optional — minimum MCP server version required
 ---
 
 # <Skill Name> — Purpose/Tagline
@@ -102,6 +103,15 @@ Setup: see docs/mcp-setup.md
 Stop immediately if MCP is unavailable.
 
 **Authentication errors** (HTTP transport with OAuth): If `distillery_metrics(scope="summary")` returns an authentication error rather than a connection failure, direct the user to run `/setup` or complete the OAuth flow via the MCP server menu.
+
+### Server Version Compatibility
+
+Skills that require MCP tools added in a specific server version should declare `min_server_version` in their frontmatter. During the MCP health check, if `distillery_metrics(scope="summary")` succeeds, compare the returned `version` field against `min_server_version`. If the server version is older, display:
+
+```
+Warning: This skill requires Distillery MCP server >= {min_server_version}.
+Your server is running {actual_version}. Update with: pip install --upgrade distillery-mcp
+```
 
 ## Canonical Dedup Flow
 

--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -108,7 +108,7 @@ Stop immediately if MCP is unavailable.
 
 Skills that require MCP tools added in a specific server version should declare `min_server_version` in their frontmatter. During the MCP health check, if `distillery_metrics(scope="summary")` succeeds, compare the returned `version` field against `min_server_version`. If the server version is older, display:
 
-```
+```text
 Warning: This skill requires Distillery MCP server >= {min_server_version}.
 Your server is running {actual_version}. Update with: pip install --upgrade distillery-mcp
 ```

--- a/src/distillery/mcp/tools/analytics.py
+++ b/src/distillery/mcp/tools/analytics.py
@@ -330,7 +330,7 @@ def _sync_gather_summary(
         ``status``, ``total_entries``, ``entries_by_type``, ``entries_by_status``,
         ``database_size_bytes``, ``embedding_model``, ``embedding_dimensions``,
         ``database_path``, ``embedding_usage_today``, ``embedding_budget_daily``,
-        and optionally ``warnings``.
+        ``version``, and optionally ``warnings``.
     """
     import contextlib
 
@@ -397,8 +397,11 @@ def _sync_gather_summary(
             "calls used."
         )
 
+    from distillery import __version__
+
     result: dict[str, Any] = {
         "status": "ok",
+        "version": __version__,
         "total_entries": total_entries,
         "entries_by_type": entries_by_type,
         "entries_by_status": entries_by_status,


### PR DESCRIPTION
## Summary

- Sync `plugin.json` and `marketplace.json` versions from git tag during release (extends the existing `server.json` pattern in pypi-publish.yml)
- Add `min_server_version` frontmatter convention to `skills/CONVENTIONS.md` so skills can declare which server version they require
- Add server version compatibility check to the MCP health check flow — warns users if their server is too old for a skill

This prevents skill/server version drift: skills pulled from the repo can declare their minimum server version, and the health check warns before failing with "unknown tool" errors.

## Context

Needed before merging #189 (team-skills) — the new `/gh-sync` and `/investigate` skills require `distillery_relations`, a tool that only exists in the server code from that PR. Without this, users on older server versions would get confusing errors.

## Test plan

- [x] Workflow syntax valid (jq commands tested)
- [x] CONVENTIONS.md documents the new frontmatter field and check flow
- [ ] On next release, verify plugin.json and marketplace.json versions are updated by the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skills can declare a minimum server version; the app shows compatibility warnings when the server is older.
  * Health/analytics summaries now include the running product version.

* **Chores**
  * Version label updated to include specific version numbers.
  * Release workflow now synchronizes plugin and server version metadata across manifests.

* **Documentation**
  * Added a comprehensive release guide for tagging, publishing, and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->