### PR TITLE
fix(hooks): scope-aware hook config via /setup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -41,12 +41,6 @@
         "command": "echo '[Distillery v0.3.0] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
       }
     ],
-    "UserPromptSubmit": [
-      {
-        "type": "command",
-        "command": "bash -c 'J=$(cat); S=$(echo \"$J\" | grep -o \"session_id[^,}]*\" | grep -o \"[^:]*$\" | tr -d \" \\\"\"); [ -z \"$S\" ] && exit 0; F=/tmp/distillery-prompt-count-$S; N=0; [ -f \"$F\" ] && N=$(cat \"$F\" 2>/dev/null); case \"$N\" in *[!0-9]*) N=0;; esac; N=$((N+1)); echo \"$N\" > \"$F\"; if [ $((N % 30)) -eq 0 ]; then echo \"[Distillery] You have exchanged $N messages this session. Consider whether any decisions, insights, or corrections should be stored with /distill.\"; fi; exit 0'"
-      }
-    ],
     "Stop": [
       {
         "type": "command",

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -2,12 +2,21 @@
 
 This directory contains Claude Code hook scripts for Distillery integration.
 
-## distillery-hooks.sh (recommended)
+## Automatic Setup (recommended)
+
+Run `/setup` after installing the Distillery plugin. It detects your plugin
+installation scope (user or project) and configures hooks in the appropriate
+`settings.json` automatically.
+
+> **Why not plugin.json?** Plugin manifest hooks only support `SessionStart`
+> and `Stop` events. `UserPromptSubmit` is silently ignored by the plugin
+> system, so these hooks must be registered in `settings.json`.
+
+## distillery-hooks.sh
 
 A single **dispatcher script** that routes all Claude Code hook events to the
 appropriate Distillery handler. Register this one script for `UserPromptSubmit`,
-`PreCompact`, and `SessionStart` in `~/.claude/settings.json` — no need to
-manage multiple hook entries.
+`PreCompact`, and `SessionStart` — no need to manage multiple hook entries.
 
 ### Hook Events
 
@@ -22,13 +31,15 @@ manage multiple hook entries.
 - Distillery MCP server running with **HTTP transport** (`distillery-mcp --transport http`)
   (required only for the `SessionStart` briefing; the `UserPromptSubmit` nudge works offline)
 - `curl` available on the system PATH (for `SessionStart` briefing)
-- Claude Code with hook support (`~/.claude/settings.json`)
+- Claude Code with hook support
 
 > **Note:** The SessionStart handler targets the HTTP MCP transport, not stdio.
 > Hooks run as shell commands outside of an MCP session, so they must
 > communicate with the server over HTTP.
 
-### Setup
+### Manual Setup
+
+If you prefer not to use `/setup`, configure hooks manually.
 
 **1. Make the dispatcher executable** (already done if cloned from the repo):
 
@@ -36,27 +47,33 @@ manage multiple hook entries.
 chmod +x /path/to/distillery/scripts/hooks/distillery-hooks.sh
 ```
 
-**2. Register the dispatcher in `~/.claude/settings.json`:**
+**2. Register the dispatcher in your settings.json:**
+
+Choose the appropriate file based on desired scope:
+- **User scope** (all projects): `~/.claude/settings.json`
+- **Project scope** (this project only): `.claude/settings.json`
 
 ```json
 {
   "hooks": {
     "UserPromptSubmit": [
       {
-        "type": "command",
-        "command": "/absolute/path/to/distillery/scripts/hooks/distillery-hooks.sh"
-      }
-    ],
-    "PreCompact": [
-      {
-        "type": "command",
-        "command": "/absolute/path/to/distillery/scripts/hooks/distillery-hooks.sh"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /absolute/path/to/distillery/scripts/hooks/distillery-hooks.sh"
+          }
+        ]
       }
     ],
     "SessionStart": [
       {
-        "type": "command",
-        "command": "/absolute/path/to/distillery/scripts/hooks/distillery-hooks.sh"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /absolute/path/to/distillery/scripts/hooks/distillery-hooks.sh"
+          }
+        ]
       }
     ]
   }
@@ -148,43 +165,10 @@ requiring a manual `/briefing` invocation.
 
 - Distillery MCP server running with **HTTP transport** (`distillery-mcp --transport http`)
 - `curl` available on the system PATH
-- Claude Code with hook support (`~/.claude/settings.json`)
 
 > **Note:** The hook targets the HTTP MCP transport, not stdio. Hooks run as
 > shell commands outside of an MCP session, so they must communicate with the
 > server over HTTP.
-
-### Setup
-
-**1. Make the script executable** (already done if cloned from the repo):
-
-```bash
-chmod +x /path/to/distillery/scripts/hooks/session-start-briefing.sh
-```
-
-**2. Register the hook in `~/.claude/settings.json`:**
-
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "type": "command",
-        "command": "/absolute/path/to/distillery/scripts/hooks/session-start-briefing.sh"
-      }
-    ]
-  }
-}
-```
-
-Replace `/absolute/path/to/distillery` with the actual path to your Distillery
-installation.
-
-**3. Start the Distillery MCP server with HTTP transport:**
-
-```bash
-distillery-mcp --transport http --port 8000
-```
 
 ### Configuration
 
@@ -202,12 +186,6 @@ Example — custom port and more entries:
 ```bash
 export DISTILLERY_MCP_URL="http://localhost:9000/mcp"
 export DISTILLERY_BRIEFING_LIMIT="10"
-```
-
-Example — with OAuth bearer token:
-
-```bash
-export DISTILLERY_BEARER_TOKEN="your-token-here"
 ```
 
 > **Security note:** Do not commit `DISTILLERY_BEARER_TOKEN` or other secrets

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -5,6 +5,9 @@ allowed-tools:
   - "mcp__*__distillery_metrics"
   - "CronCreate"
   - "RemoteTrigger"
+  - "Bash(mkdir:*)"
+  - "Bash(cp:*)"
+  - "Bash(chmod:*)"
 effort: low
 ---
 
@@ -57,7 +60,7 @@ MCP server connected.
 
 Proceed to Step 2.
 
-**State: Needs Authentication** — Server entry found but `distillery_metrics(scope="summary")` is unavailable or fails (including auth-related failures). See `references/transport-detection.md` for display instructions. Skip to Step 5 with `MCP Server: needs authentication`.
+**State: Needs Authentication** — Server entry found but `distillery_metrics(scope="summary")` is unavailable or fails (including auth-related failures). See `references/transport-detection.md` for display instructions. Skip to Step 6 with `MCP Server: needs authentication`.
 
 ---
 
@@ -90,7 +93,7 @@ Then restart Claude Code and run /setup again.
 Full guide: https://norrietaylor.github.io/distillery/getting-started/local-setup/
 ```
 
-Skip to Step 5 with `MCP Server: not connected`.
+Skip to Step 6 with `MCP Server: not connected`.
 
 ### Step 2: Detect Transport Mode
 
@@ -215,7 +218,114 @@ Weekly maintenance enabled: Mondays at 07:<minute> UTC (cron job <job_id>)
   Stores: weekly digest entry for tracking trends
 ```
 
-### Step 5: Summary
+### Step 5: Configure Session Hooks
+
+Plugin manifest hooks do not support `UserPromptSubmit` events — only `SessionStart` works from `plugin.json`. To enable the memory nudge (every 30 prompts) and session lifecycle hooks, the dispatcher script must be configured in the appropriate settings.json based on plugin installation scope.
+
+**5a. Detect plugin installation scope:**
+
+Check which settings file contains the Distillery plugin in `enabledPlugins`:
+
+1. `~/.claude/settings.json` → **user scope** (hooks apply to all projects)
+2. `.claude/settings.json` → **project scope** (hooks apply to this project only)
+3. `.claude/settings.local.json` → **local scope** (treat as project scope)
+
+If the plugin isn't found in any file (e.g., running from the Distillery repo itself), default to **project scope**.
+
+Set `SCOPE_FILE` to the matching settings file and `SCOPE_LABEL` to "user" or "project".
+
+**5b. Locate the hook scripts:**
+
+The hook scripts ship with the plugin under `scripts/hooks/`. Determine the absolute path:
+
+1. If `scripts/hooks/distillery-hooks.sh` exists relative to cwd → use that path
+2. Otherwise, check `~/.claude/plugins/cache/` for a `distillery-*/scripts/hooks/` directory
+
+Required files:
+- `distillery-hooks.sh` — main dispatcher (routes events to handlers)
+- `session-start-briefing.sh` — SessionStart briefing handler (called by dispatcher)
+
+If the scripts cannot be found, display:
+
+```text
+Session hooks: skipped (hook scripts not found)
+  Run /setup from inside the Distillery repo to install hooks.
+```
+
+Skip to Step 6.
+
+**5c. Check existing hooks:**
+
+Read `SCOPE_FILE` and check if `hooks.UserPromptSubmit` already references `distillery-hooks.sh`.
+
+If already configured:
+
+```text
+Session hooks: active (<SCOPE_LABEL> scope)
+  Memory nudge:  every 30 prompts
+  Session start: briefing context injection
+```
+
+Skip to Step 6.
+
+**5d. Install hooks:**
+
+Ask the user:
+
+```text
+Enable session hooks? This configures hooks in <SCOPE_FILE> (<SCOPE_LABEL> scope).
+  • Memory nudge — reminder to /distill every 30 prompts
+  • Session start — briefing context injection
+(yes / no)
+```
+
+If yes, merge the following hooks into `SCOPE_FILE` (do not overwrite other settings). Use the absolute path to the dispatcher script found in 5b:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash <absolute-path-to>/scripts/hooks/distillery-hooks.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash <absolute-path-to>/scripts/hooks/distillery-hooks.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Display:
+
+```text
+Session hooks installed:
+  Config:        <SCOPE_FILE> (<SCOPE_LABEL> scope)
+  Dispatcher:    <absolute-path-to>/scripts/hooks/distillery-hooks.sh
+  Memory nudge:  every 30 prompts
+  Session start: briefing context injection
+```
+
+If no:
+
+```text
+Session hooks: skipped
+  Enable later by running /setup again.
+```
+
+### Step 6: Summary
 
 Always display the configuration summary, regardless of which steps were completed or skipped.
 
@@ -232,6 +342,10 @@ Distillery Setup Complete
     Feed rescore:  <active (daily 06:XX UTC) | inactive | managed by GitHub Actions>
     KB maintenance:<active (weekly Mon 07:XX UTC) | inactive | managed by GitHub Actions>
 
+  Session Hooks:   <SCOPE_LABEL> scope
+    Memory nudge:  <active (every 30 prompts) | inactive | skipped>
+    Session start: <active | inactive | skipped>
+
 Available skills:
   /distill   — capture knowledge      /recall   — search knowledge
   /bookmark  — save URLs              /pour     — synthesize topics
@@ -244,13 +358,18 @@ Run /watch add <url> to start monitoring feeds.
 
 ## Output Format
 
-The setup wizard uses a sequential, conversational format. Each step prints its result before proceeding to the next. The summary in Step 5 is always shown — even when MCP is unavailable or steps are skipped.
+The setup wizard uses a sequential, conversational format. Each step prints its result before proceeding to the next. The summary in Step 6 is always shown — even when MCP is unavailable or steps are skipped.
 
 ## Rules
 
 - Always start by checking MCP availability — distinguish between "not configured", "needs authentication", and "connected"
 - When an MCP server entry exists but tools are unavailable, treat this as "needs authentication" — guide the user through the OAuth flow
-- Always show the Step 5 summary — even on early exits (MCP unavailable, auth needed)
+- Always show the Step 6 summary — even on early exits (MCP unavailable, auth needed)
+- Session hooks are installed to the same scope as the plugin (user or project) — detect via `enabledPlugins`
+- Merge hook config into the scope-appropriate settings file — never overwrite other settings
+- If hook scripts can't be found (not in repo or plugin cache), skip gracefully
+- The dispatcher uses `BASH_SOURCE[0]` to find sibling scripts — both files must be in the same directory
+- Use absolute paths to the dispatcher script in hook commands
 - For hosted/team transport, skip local cron creation — scheduling is handled by GitHub Actions
 - Never create duplicate cron jobs — always check `CronList` first for each job type (poll, rescore, maintenance)
 - Pick an off-peak cron minute (not :00 or :30) for all schedules; use different random minutes for each job

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -5,6 +5,11 @@ allowed-tools:
   - "mcp__*__distillery_metrics"
   - "CronCreate"
   - "RemoteTrigger"
+  - "Bash(test:*)"
+  - "Bash(cat:*)"
+  - "Bash(find:*)"
+  - "Bash(ls:*)"
+  - "Bash(jq:*)"
   - "Bash(mkdir:*)"
   - "Bash(cp:*)"
   - "Bash(chmod:*)"
@@ -220,7 +225,7 @@ Weekly maintenance enabled: Mondays at 07:<minute> UTC (cron job <job_id>)
 
 ### Step 5: Configure Session Hooks
 
-Plugin manifest hooks do not support `UserPromptSubmit` events — only `SessionStart` works from `plugin.json`. To enable the memory nudge (every 30 prompts) and session lifecycle hooks, the dispatcher script must be configured in the appropriate settings.json based on plugin installation scope.
+Plugin manifest hooks do not support `UserPromptSubmit` events. Manifest hooks support `SessionStart` and `Stop`, so `UserPromptSubmit` must be configured in `settings.json`. To enable the memory nudge (every 30 prompts) and full session lifecycle hooks via the dispatcher, the script must be configured in the appropriate settings.json based on plugin installation scope.
 
 **5a. Detect plugin installation scope:**
 
@@ -256,9 +261,9 @@ Skip to Step 6.
 
 **5c. Check existing hooks:**
 
-Read `SCOPE_FILE` and check if `hooks.UserPromptSubmit` already references `distillery-hooks.sh`.
+Read `SCOPE_FILE` and check whether **both** `hooks.UserPromptSubmit` and `hooks.SessionStart` reference `distillery-hooks.sh` (same dispatcher path).
 
-If already configured:
+If both are already configured:
 
 ```text
 Session hooks: active (<SCOPE_LABEL> scope)


### PR DESCRIPTION
## Summary

- Remove `UserPromptSubmit` from `plugin.json` — plugin manifest hooks silently ignore this event (confirmed by testing; only `SessionStart` fires)
- Add Step 5 to `/setup` skill that configures session hooks in the correct settings.json based on plugin installation scope:
  - User-scoped plugin → `~/.claude/settings.json`
  - Project-scoped plugin → `.claude/settings.json`
  - Detects scope by checking `enabledPlugins` in each settings file
- Hooks point at the existing `scripts/hooks/distillery-hooks.sh` dispatcher from #198

## Context

The inlined `UserPromptSubmit` hook in `plugin.json` never fired. Plugin hooks only support `SessionStart` and `Stop` events. The `/setup` onboarding wizard now handles hook installation, matching the scope to where the plugin was installed.

## Test plan

- [ ] Install plugin at user scope → `/setup` configures hooks in `~/.claude/settings.json`
- [ ] Install plugin at project scope → `/setup` configures hooks in `.claude/settings.json`
- [ ] `/setup` detects existing hooks and skips reconfiguration
- [ ] `UserPromptSubmit` counter increments after hook installation
- [ ] `/setup` skips gracefully when hook scripts are not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session hook setup integrated into the installer with automatic scope detection, safer merging into user settings, and updated setup flow for early-exit paths.

* **Chores**
  * Removed the automatic per-message counting and periodic reminder behavior.

* **Documentation**
  * Setup and README rewritten to recommend automatic setup, streamlined manual options, and updated hook registration guidance.
* **Misc**
  * Expanded allowed shell operations for setup (file and permission management).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->