### PR TITLE
release: v0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "distillery",
       "source": "./",
       "description": "Knowledge base skills — capture, search, and synthesize project knowledge",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings"],
       "category": "knowledge-management"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "distillery",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Knowledge base skills for Claude Code — capture, search, and synthesize project knowledge",
   "author": {
     "name": "norrietaylor",
@@ -38,7 +38,7 @@
     "SessionStart": [
       {
         "type": "command",
-        "command": "echo '[Distillery v0.3.0] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+        "command": "echo '[Distillery v0.3.1] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
       }
     ],
     "Stop": [

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   changelog:
@@ -34,7 +35,11 @@ jobs:
       - name: Generate changelog
         run: git-cliff --output CHANGELOG.md
 
-      - name: Commit changelog
+      - name: Create changelog PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -44,5 +49,12 @@ jobs:
             echo "No changelog changes to commit"
             exit 0
           fi
-          git commit -m "docs: update changelog for ${{ github.event.release.tag_name }}"
-          git push origin HEAD:${{ github.event.repository.default_branch }}
+          BRANCH="docs/changelog-${TAG_NAME}"
+          git checkout -b "$BRANCH"
+          git commit -m "docs: update changelog for ${TAG_NAME}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "docs: update changelog for ${TAG_NAME}" \
+            --body "Auto-generated changelog update from release ${TAG_NAME}." \
+            --base "$DEFAULT_BRANCH" \
+            --head "$BRANCH"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,7 @@ GitHub Release (tag: vX.Y.Z)
   │   └─ Publish to Smithery
   └─ changelog.yml
       ├─ Generate CHANGELOG.md via git-cliff
-      └─ Commit to main
+      └─ Open PR to main (branch protection prevents direct push)
 ```
 
 Users install the server via `pip install distillery-mcp` or `uvx distillery-mcp`, both pulling from PyPI.
@@ -128,7 +128,7 @@ This triggers pypi-publish.yml and changelog.yml automatically.
 1. **PyPI**: Check https://pypi.org/project/distillery-mcp/ for the new version
 2. **Install**: `pip install distillery-mcp==X.Y.Z` or `uvx distillery-mcp --version`
 3. **MCP Registry**: Verify the server listing is updated
-4. **Changelog**: Check that CHANGELOG.md was auto-committed to main
+4. **Changelog**: Merge the auto-generated changelog PR (created by changelog.yml)
 
 ## Deploying the Hosted Server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distillery-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "A configurable embedding system with DuckDB storage and MCP server integration"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.norrietaylor/distillery-mcp",
   "title": "Distillery",
   "description": "Knowledge base system for Claude Code with semantic search, feed intelligence, and team collaboration",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "repository": {
     "url": "https://github.com/norrietaylor/distillery",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "transport": {
         "type": "streamable-http",
         "url": "https://distillery-mcp.fly.dev/mcp"

--- a/src/distillery/__init__.py
+++ b/src/distillery/__init__.py
@@ -2,5 +2,5 @@
 
 import os
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __build_sha__ = os.environ.get("DISTILLERY_BUILD_SHA", "dev")

--- a/uv.lock
+++ b/uv.lock
@@ -719,7 +719,7 @@ wheels = [
 
 [[package]]
 name = "distillery-mcp"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

- Bump all version references from 0.3.0 to 0.3.1

## Context

Patch release to get MCP Registry publishing working. The v0.3.0 release published to PyPI successfully but the MCP Registry step failed due to a stale `server.json` schema. The schema fix landed via #204 but couldn't be re-published against the existing v0.3.0 tag (PyPI versions are immutable).

## Changes since v0.3.0

- fix(ci): update server.json to MCP Registry schema 2025-12-11 (#204)
- fix(hooks): scope-aware hook config via /setup (#202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.3.1 across all plugin and package manifests, including startup messages and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->