### PR TITLE
docs: comprehensive v0.3 documentation update

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 Distillery is built as a 4-layer system where skills (SKILL.md files) drive all user interaction, the MCP server mediates all storage access, and backends are swappable through typed Protocol interfaces.
 
 <div markdown="0">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 560" font-family="Inter, -apple-system, system-ui, sans-serif" style="max-width: 760px; width: 100%; height: auto;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 584" font-family="Inter, -apple-system, system-ui, sans-serif" style="max-width: 760px; width: 100%; height: auto;">
   <defs>
     <style>
       .d-bg { fill: #0f0f0f; }
@@ -29,11 +29,11 @@ Distillery is built as a 4-layer system where skills (SKILL.md files) drive all 
   </defs>
 
   <!-- Background -->
-  <rect class="d-bg" width="760" height="560" rx="16"/>
+  <rect class="d-bg" width="760" height="584" rx="16"/>
 
   <!-- Layer 1: Skills -->
-  <rect class="d-layer" x="30" y="16" width="700" height="72" rx="12"/>
-  <text class="d-label" x="50" y="36">10 Claude Code Skills</text>
+  <rect class="d-layer" x="30" y="16" width="700" height="96" rx="12"/>
+  <text class="d-label" x="50" y="36">14 Claude Code Skills</text>
   <rect class="d-pill" x="50" y="44" width="62" height="26" rx="6"/><text class="d-pill-text" x="81" y="61" text-anchor="middle">/distill</text>
   <rect class="d-pill" x="120" y="44" width="56" height="26" rx="6"/><text class="d-pill-text" x="148" y="61" text-anchor="middle">/recall</text>
   <rect class="d-pill" x="184" y="44" width="50" height="26" rx="6"/><text class="d-pill-text" x="209" y="61" text-anchor="middle">/pour</text>
@@ -44,94 +44,99 @@ Distillery is built as a 4-layer system where skills (SKILL.md files) drive all 
   <rect class="d-pill" x="538" y="44" width="54" height="26" rx="6"/><text class="d-pill-text" x="565" y="61" text-anchor="middle">/radar</text>
   <rect class="d-pill" x="600" y="44" width="50" height="26" rx="6"/><text class="d-pill-text" x="625" y="61" text-anchor="middle">/tune</text>
   <rect class="d-pill" x="658" y="44" width="54" height="26" rx="6"/><text class="d-pill-text" x="685" y="61" text-anchor="middle">/setup</text>
+  <!-- Row 2: Team skills -->
+  <rect class="d-pill" x="50" y="76" width="56" height="26" rx="6"/><text class="d-pill-text" x="78" y="93" text-anchor="middle">/digest</text>
+  <rect class="d-pill" x="114" y="76" width="70" height="26" rx="6"/><text class="d-pill-text" x="149" y="93" text-anchor="middle">/gh-sync</text>
+  <rect class="d-pill" x="192" y="76" width="86" height="26" rx="6"/><text class="d-pill-text" x="235" y="93" text-anchor="middle">/investigate</text>
+  <rect class="d-pill" x="286" y="76" width="68" height="26" rx="6"/><text class="d-pill-text" x="320" y="93" text-anchor="middle">/briefing</text>
 
   <!-- Connector -->
-  <line class="d-line" x1="380" y1="88" x2="380" y2="104"/>
+  <line class="d-line" x1="380" y1="112" x2="380" y2="128"/>
 
   <!-- Layer 2: MCP Server -->
-  <rect class="d-amber-bg" x="30" y="104" width="700" height="52" rx="10"/>
-  <text class="d-white" x="380" y="128" text-anchor="middle">MCP Server</text>
-  <text class="d-white-sub" x="380" y="144" text-anchor="middle">FastMCP 2.x/3.x  ·  stdio + streamable-HTTP  ·  tools  ·  REST webhooks (/api/*)</text>
+  <rect class="d-amber-bg" x="30" y="128" width="700" height="52" rx="10"/>
+  <text class="d-white" x="380" y="152" text-anchor="middle">MCP Server</text>
+  <text class="d-white-sub" x="380" y="168" text-anchor="middle">FastMCP 2.x/3.x  ·  stdio + streamable-HTTP  ·  tools  ·  REST webhooks (/api/*)</text>
 
   <!-- Connector: MCP to Auth + Protocols -->
-  <line class="d-line" x1="380" y1="156" x2="380" y2="168"/>
-  <line class="d-line" x1="190" y1="168" x2="570" y2="168"/>
-  <line class="d-line" x1="190" y1="168" x2="190" y2="180"/>
-  <line class="d-line" x1="380" y1="168" x2="380" y2="180"/>
-  <line class="d-line" x1="570" y1="168" x2="570" y2="180"/>
+  <line class="d-line" x1="380" y1="180" x2="380" y2="192"/>
+  <line class="d-line" x1="190" y1="192" x2="570" y2="192"/>
+  <line class="d-line" x1="190" y1="192" x2="190" y2="204"/>
+  <line class="d-line" x1="380" y1="192" x2="380" y2="204"/>
+  <line class="d-line" x1="570" y1="192" x2="570" y2="204"/>
 
   <!-- Layer 3a: Auth -->
-  <rect class="d-auth" x="30" y="180" width="220" height="64" rx="8"/>
-  <text class="d-auth-title" x="140" y="202" text-anchor="middle">GitHub OAuth</text>
-  <text class="d-box-sub" x="140" y="218" text-anchor="middle">OrgRestrictedGitHubProvider</text>
-  <text class="d-box-sub" x="140" y="232" text-anchor="middle">Middleware · Budget · Rate limits</text>
+  <rect class="d-auth" x="30" y="204" width="220" height="64" rx="8"/>
+  <text class="d-auth-title" x="140" y="226" text-anchor="middle">GitHub OAuth</text>
+  <text class="d-box-sub" x="140" y="242" text-anchor="middle">OrgRestrictedGitHubProvider</text>
+  <text class="d-box-sub" x="140" y="256" text-anchor="middle">Middleware · Budget · Rate limits</text>
 
   <!-- Layer 3b: Core Protocols -->
-  <rect class="d-box" x="268" y="180" width="224" height="64" rx="8"/>
-  <text class="d-box-title" x="380" y="202" text-anchor="middle">Core Protocols</text>
-  <text class="d-box-sub" x="380" y="218" text-anchor="middle">DistilleryStore · EmbeddingProvider</text>
-  <text class="d-box-sub" x="380" y="232" text-anchor="middle">Typed Protocol interfaces (async)</text>
+  <rect class="d-box" x="268" y="204" width="224" height="64" rx="8"/>
+  <text class="d-box-title" x="380" y="226" text-anchor="middle">Core Protocols</text>
+  <text class="d-box-sub" x="380" y="242" text-anchor="middle">DistilleryStore · EmbeddingProvider</text>
+  <text class="d-box-sub" x="380" y="256" text-anchor="middle">Typed Protocol interfaces (async)</text>
 
   <!-- Layer 3c: Feeds -->
-  <rect class="d-feed" x="510" y="180" width="220" height="64" rx="8"/>
-  <text class="d-feed-title" x="620" y="202" text-anchor="middle">Feed System</text>
-  <text class="d-box-sub" x="620" y="218" text-anchor="middle">GitHub · RSS/Atom · Auto-tagging</text>
-  <text class="d-box-sub" x="620" y="232" text-anchor="middle">Poller · Scorer · Interests</text>
+  <rect class="d-feed" x="510" y="204" width="220" height="64" rx="8"/>
+  <text class="d-feed-title" x="620" y="226" text-anchor="middle">Feed System</text>
+  <text class="d-box-sub" x="620" y="242" text-anchor="middle">GitHub · RSS/Atom · Auto-tagging</text>
+  <text class="d-box-sub" x="620" y="256" text-anchor="middle">Poller · Scorer · Interests</text>
 
   <!-- Connector: Protocols to Backends -->
-  <line class="d-line" x1="380" y1="244" x2="380" y2="256"/>
-  <line class="d-line" x1="140" y1="256" x2="620" y2="256"/>
-  <line class="d-line" x1="140" y1="256" x2="140" y2="268"/>
-  <line class="d-line" x1="285" y1="256" x2="285" y2="268"/>
-  <line class="d-line" x1="475" y1="256" x2="475" y2="268"/>
-  <line class="d-line" x1="620" y1="256" x2="620" y2="268"/>
+  <line class="d-line" x1="380" y1="268" x2="380" y2="280"/>
+  <line class="d-line" x1="140" y1="280" x2="620" y2="280"/>
+  <line class="d-line" x1="140" y1="280" x2="140" y2="292"/>
+  <line class="d-line" x1="285" y1="280" x2="285" y2="292"/>
+  <line class="d-line" x1="475" y1="280" x2="475" y2="292"/>
+  <line class="d-line" x1="620" y1="280" x2="620" y2="292"/>
 
   <!-- Layer 4: Backends -->
-  <rect class="d-box" x="30" y="268" width="210" height="72" rx="8"/>
-  <text class="d-box-title" x="135" y="290" text-anchor="middle">DuckDB + VSS + FTS</text>
-  <text class="d-box-sub" x="135" y="306" text-anchor="middle">HNSW + BM25 hybrid (RRF)</text>
-  <text class="d-box-sub" x="135" y="320" text-anchor="middle">Vector + keyword search</text>
+  <rect class="d-box" x="30" y="292" width="210" height="72" rx="8"/>
+  <text class="d-box-title" x="135" y="314" text-anchor="middle">DuckDB + VSS + FTS</text>
+  <text class="d-box-sub" x="135" y="330" text-anchor="middle">HNSW + BM25 hybrid (RRF)</text>
+  <text class="d-box-sub" x="135" y="344" text-anchor="middle">Vector + keyword search</text>
 
-  <rect class="d-box" x="254" y="268" width="152" height="72" rx="8"/>
-  <text class="d-box-title" x="330" y="290" text-anchor="middle">Embedding</text>
-  <text class="d-box-sub" x="330" y="306" text-anchor="middle">Jina v3 / OpenAI</text>
-  <text class="d-box-sub" x="330" y="320" text-anchor="middle">Configurable provider</text>
+  <rect class="d-box" x="254" y="292" width="152" height="72" rx="8"/>
+  <text class="d-box-title" x="330" y="314" text-anchor="middle">Embedding</text>
+  <text class="d-box-sub" x="330" y="330" text-anchor="middle">Jina v3 / OpenAI</text>
+  <text class="d-box-sub" x="330" y="344" text-anchor="middle">Configurable provider</text>
 
-  <rect class="d-box" x="420" y="268" width="160" height="72" rx="8"/>
-  <text class="d-box-title" x="500" y="290" text-anchor="middle">Classification</text>
-  <text class="d-box-sub" x="500" y="306" text-anchor="middle">LLM engine + Dedup</text>
-  <text class="d-box-sub" x="500" y="320" text-anchor="middle">Conflicts + Tag validation</text>
+  <rect class="d-box" x="420" y="292" width="160" height="72" rx="8"/>
+  <text class="d-box-title" x="500" y="314" text-anchor="middle">Classification</text>
+  <text class="d-box-sub" x="500" y="330" text-anchor="middle">LLM engine + Dedup</text>
+  <text class="d-box-sub" x="500" y="344" text-anchor="middle">Conflicts + Tag validation</text>
 
-  <rect class="d-box" x="594" y="268" width="136" height="72" rx="8"/>
-  <text class="d-box-title" x="662" y="290" text-anchor="middle">Config</text>
-  <text class="d-box-sub" x="662" y="306" text-anchor="middle">distillery.yaml</text>
-  <text class="d-box-sub" x="662" y="320" text-anchor="middle">Security · Validation</text>
+  <rect class="d-box" x="594" y="292" width="136" height="72" rx="8"/>
+  <text class="d-box-title" x="662" y="314" text-anchor="middle">Config</text>
+  <text class="d-box-sub" x="662" y="330" text-anchor="middle">distillery.yaml</text>
+  <text class="d-box-sub" x="662" y="344" text-anchor="middle">Security · Validation</text>
 
   <!-- Entry Types -->
-  <text class="d-label" x="50" y="370">12 Entry Types</text>
-  <rect class="d-pill" x="50" y="380" width="56" height="22" rx="5"/><text class="d-type-text" x="78" y="395" text-anchor="middle">session</text>
-  <rect class="d-pill" x="114" y="380" width="66" height="22" rx="5"/><text class="d-type-text" x="147" y="395" text-anchor="middle">bookmark</text>
-  <rect class="d-pill" x="188" y="380" width="58" height="22" rx="5"/><text class="d-type-text" x="217" y="395" text-anchor="middle">minutes</text>
-  <rect class="d-pill" x="254" y="380" width="60" height="22" rx="5"/><text class="d-type-text" x="284" y="395" text-anchor="middle">meeting</text>
-  <rect class="d-pill" x="322" y="380" width="66" height="22" rx="5"/><text class="d-type-text" x="355" y="395" text-anchor="middle">reference</text>
-  <rect class="d-pill" x="396" y="380" width="38" height="22" rx="5"/><text class="d-type-text" x="415" y="395" text-anchor="middle">idea</text>
-  <rect class="d-pill" x="442" y="380" width="42" height="22" rx="5"/><text class="d-type-text" x="463" y="395" text-anchor="middle">inbox</text>
-  <rect class="d-pill" x="492" y="380" width="52" height="22" rx="5"/><text class="d-type-text" x="518" y="395" text-anchor="middle">person</text>
-  <rect class="d-pill" x="552" y="380" width="52" height="22" rx="5"/><text class="d-type-text" x="578" y="395" text-anchor="middle">project</text>
-  <rect class="d-pill" x="612" y="380" width="48" height="22" rx="5"/><text class="d-type-text" x="636" y="395" text-anchor="middle">digest</text>
-  <rect class="d-pill" x="668" y="380" width="48" height="22" rx="5"/><text class="d-type-text" x="692" y="395" text-anchor="middle">github</text>
-  <rect class="d-pill" x="50" y="408" width="40" height="22" rx="5"/><text class="d-type-text" x="70" y="423" text-anchor="middle">feed</text>
+  <text class="d-label" x="50" y="394">12 Entry Types</text>
+  <rect class="d-pill" x="50" y="404" width="56" height="22" rx="5"/><text class="d-type-text" x="78" y="419" text-anchor="middle">session</text>
+  <rect class="d-pill" x="114" y="404" width="66" height="22" rx="5"/><text class="d-type-text" x="147" y="419" text-anchor="middle">bookmark</text>
+  <rect class="d-pill" x="188" y="404" width="58" height="22" rx="5"/><text class="d-type-text" x="217" y="419" text-anchor="middle">minutes</text>
+  <rect class="d-pill" x="254" y="404" width="60" height="22" rx="5"/><text class="d-type-text" x="284" y="419" text-anchor="middle">meeting</text>
+  <rect class="d-pill" x="322" y="404" width="66" height="22" rx="5"/><text class="d-type-text" x="355" y="419" text-anchor="middle">reference</text>
+  <rect class="d-pill" x="396" y="404" width="38" height="22" rx="5"/><text class="d-type-text" x="415" y="419" text-anchor="middle">idea</text>
+  <rect class="d-pill" x="442" y="404" width="42" height="22" rx="5"/><text class="d-type-text" x="463" y="419" text-anchor="middle">inbox</text>
+  <rect class="d-pill" x="492" y="404" width="52" height="22" rx="5"/><text class="d-type-text" x="518" y="419" text-anchor="middle">person</text>
+  <rect class="d-pill" x="552" y="404" width="52" height="22" rx="5"/><text class="d-type-text" x="578" y="419" text-anchor="middle">project</text>
+  <rect class="d-pill" x="612" y="404" width="48" height="22" rx="5"/><text class="d-type-text" x="636" y="419" text-anchor="middle">digest</text>
+  <rect class="d-pill" x="668" y="404" width="48" height="22" rx="5"/><text class="d-type-text" x="692" y="419" text-anchor="middle">github</text>
+  <rect class="d-pill" x="50" y="432" width="40" height="22" rx="5"/><text class="d-type-text" x="70" y="447" text-anchor="middle">feed</text>
 
   <!-- Dedup Thresholds -->
-  <text class="d-label" x="50" y="456">Dedup Thresholds</text>
-  <rect class="d-pill" x="50" y="466" width="140" height="22" rx="5"/><text class="d-type-text" x="120" y="481" text-anchor="middle">skip >= 0.95</text>
-  <rect class="d-pill" x="200" y="466" width="140" height="22" rx="5"/><text class="d-type-text" x="270" y="481" text-anchor="middle">merge >= 0.80</text>
-  <rect class="d-pill" x="350" y="466" width="140" height="22" rx="5"/><text class="d-type-text" x="420" y="481" text-anchor="middle">link >= 0.60</text>
-  <rect class="d-pill" x="500" y="466" width="140" height="22" rx="5"/><text class="d-type-text" x="570" y="481" text-anchor="middle">unique &lt; 0.60</text>
+  <text class="d-label" x="50" y="480">Dedup Thresholds</text>
+  <rect class="d-pill" x="50" y="490" width="140" height="22" rx="5"/><text class="d-type-text" x="120" y="505" text-anchor="middle">skip >= 0.95</text>
+  <rect class="d-pill" x="200" y="490" width="140" height="22" rx="5"/><text class="d-type-text" x="270" y="505" text-anchor="middle">merge >= 0.80</text>
+  <rect class="d-pill" x="350" y="490" width="140" height="22" rx="5"/><text class="d-type-text" x="420" y="505" text-anchor="middle">link >= 0.60</text>
+  <rect class="d-pill" x="500" y="490" width="140" height="22" rx="5"/><text class="d-type-text" x="570" y="505" text-anchor="middle">unique &lt; 0.60</text>
 
   <!-- Tag Namespaces -->
-  <text class="d-label" x="50" y="516">Hierarchical Tags</text>
-  <text class="d-tag-text" x="50" y="536">project/distillery/sessions  ·  domain/storage  ·  source/bookmark/duckdb-org  ·  team/distillery</text>
+  <text class="d-label" x="50" y="540">Hierarchical Tags</text>
+  <text class="d-tag-text" x="50" y="560">project/distillery/sessions  ·  domain/storage  ·  source/bookmark/duckdb-org  ·  team/distillery</text>
 </svg>
 </div>
 
@@ -139,7 +144,7 @@ Distillery is built as a 4-layer system where skills (SKILL.md files) drive all 
 
 | Layer | What it does | Key files |
 |-------|-------------|-----------|
-| **Skills** | 10 SKILL.md files — portable, version-controlled slash commands. Not Python code. | `skills/*/SKILL.md` |
+| **Skills** | 14 SKILL.md files — portable, version-controlled slash commands. Not Python code. | `skills/*/SKILL.md` |
 | **MCP Server** | Tools exposed over stdio (local) or streamable-HTTP (team). Built on FastMCP 2.x/3.x with `@server.tool` decorators. | `src/distillery/mcp/server.py` |
 | **Webhook API** | REST endpoints (`/api/poll`, `/api/rescore`, `/api/maintenance`) for automated scheduling. Bearer token auth, per-endpoint cooldowns persisted to DuckDB. Mounted alongside MCP in HTTP mode. | `src/distillery/mcp/webhooks.py` |
 | **Auth** | MCP: GitHub OAuth with org-restricted access. Webhooks: bearer token via `DISTILLERY_WEBHOOK_SECRET`. Middleware handles logging, rate limiting, security headers, budget tracking. | `src/distillery/mcp/auth.py`, `middleware.py`, `budget.py` |
@@ -177,7 +182,7 @@ The `Entry` dataclass (`src/distillery/models.py`) is the fundamental unit of kn
 | `id` | str (UUID4) | Unique identifier |
 | `content` | str | The knowledge content |
 | `entry_type` | EntryType | session, bookmark, minutes, meeting, reference, idea, inbox, person, project, digest, github, feed |
-| `source` | EntrySource | claude_code, manual, import |
+| `source` | EntrySource | claude_code, manual, import, inference, documentation, external |
 | `status` | EntryStatus | active, pending_review, archived |
 | `tags` | list[str] | Hierarchical tags (`project/distillery/decisions`) |
 | `metadata` | dict | Type-specific fields (validated per entry type) |
@@ -185,6 +190,9 @@ The `Entry` dataclass (`src/distillery/models.py`) is the fundamental unit of kn
 | `author` | str | Who created the entry |
 | `project` | str \| None | Which project context |
 | `created_at` | datetime | Creation timestamp |
+| `session_id` | str \| None | Session grouping identifier |
+| `verification` | VerificationStatus | Unverified, Testing, or Verified |
+| `expires_at` | datetime \| None | Optional expiration timestamp |
 | `updated_at` | datetime | Last modification |
 
 ## Project Structure
@@ -202,6 +210,10 @@ distillery/
 │   ├── radar/SKILL.md
 │   ├── tune/SKILL.md
 │   ├── setup/SKILL.md
+│   ├── digest/SKILL.md
+│   ├── gh-sync/SKILL.md
+│   ├── investigate/SKILL.md
+│   ├── briefing/SKILL.md
 │   └── CONVENTIONS.md
 ├── src/distillery/
 │   ├── models.py            # Entry, SearchResult, enums

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -26,7 +26,7 @@ This verifies MCP connectivity, detects your transport, and configures auto-poll
     The plugin defaults to the hosted instance at `distillery-mcp.fly.dev`, which is a **demo server** for evaluation only. Do not store sensitive or confidential data. For production use, [deploy your own instance](../team/deployment.md) or use [local setup](local-setup.md).
 
 !!! note "Claude Desktop"
-    The Claude Desktop app does not support Claude Code skills or the plugin install system. Desktop users can connect the MCP server directly (all 19 tools are available) but slash commands like `/distill` and `/recall` are CLI-only features.
+    The Claude Desktop app does not support Claude Code skills or the plugin install system. Desktop users can connect the MCP server directly (all 20 tools are available) but slash commands like `/distill` and `/recall` are CLI-only features.
 
 ## Manual Install (Copy Skills)
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -32,6 +32,10 @@ Distillery provides 14 Claude Code slash commands:
 | [`/radar`](skills/radar.md) | Ambient feed digest with source suggestions | `/radar --days 7` |
 | [`/tune`](skills/tune.md) | Adjust feed relevance thresholds | `/tune --digest 0.40` |
 | [`/setup`](skills/setup.md) | Onboarding wizard for MCP connectivity and config | `/setup` |
+| [`/digest`](skills/digest.md) | Team activity summary from internal entries | `/digest --days 7` |
+| [`/gh-sync`](skills/gh-sync.md) | Sync GitHub issues/PRs into the knowledge base | `/gh-sync owner/repo` |
+| [`/investigate`](skills/investigate.md) | Deep context builder with relationship traversal | `/investigate authentication flow` |
+| [`/briefing`](skills/briefing.md) | Knowledge dashboard (solo and team mode) | `/briefing --project distillery` |
 
 ## Quick Start
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,8 +59,31 @@
 - [x] Recency decay — configurable time-weighted scoring (90-day window, 0.5 min weight)
 - [x] Graceful degradation — falls back to vector-only if FTS extension unavailable
 
+### Team Skills
+- [x] `/digest` — team activity summaries over configurable time windows
+- [x] `/gh-sync` — sync GitHub issues/PRs into the knowledge base as searchable entries
+- [x] `/investigate` — deep context builder with 4-phase retrieval and relationship traversal
+- [x] `/briefing` — knowledge dashboard with solo mode (5 sections) and team mode (8 sections)
+
+### Entry Relations & Corrections
+- [x] `entry_relations` table with backfill migration
+- [x] `distillery_correct` tool for structured corrections
+- [x] `distillery_relations` tool for managing entry links
+
+### New Entry Fields
+- [x] `expires_at` — time-limited entries with UTC normalization
+- [x] `verification` — orthogonal quality tracking (Unverified, Testing, Verified)
+- [x] `session_id` — first-class field for session-scoped entries
+- [x] Extended `EntrySource` — added inference, documentation, external provenance values
+
+### Session Hooks
+- [x] Hook dispatcher script (`distillery-hooks.sh`) — routes UserPromptSubmit, SessionStart, PreCompact
+- [x] Memory nudge — periodic reminder to `/distill` every 30 prompts
+- [x] SessionStart briefing — automatic context injection via HTTP MCP
+- [x] Scope-aware `/setup` hook configuration — detects plugin install scope (user/project)
+
 ### Onboarding
-- [x] `/setup` skill — MCP connectivity wizard, auto-poll configuration
+- [x] `/setup` skill — MCP connectivity wizard, auto-poll configuration, session hook setup
 - [x] uvx-first setup — `uvx distillery-mcp` as recommended first-time path
 
 ---
@@ -69,16 +92,11 @@
 
 ### New Skills
 - [ ] `/whois` — evidence-backed expertise map
-- [ ] `/investigate` — deep domain context builder
-- [ ] `/digest` — team activity summaries
-- [ ] `/briefing` — team knowledge dashboard
 - [ ] `/process` — batch classify + digest + stale detection pipeline
-- [ ] `/gh-sync` — GitHub issue/PR knowledge tracking
 
 ### Infrastructure
-- [ ] RRF score normalization — hybrid search scores cluster near 1.0 (#170)
-- [ ] GitHub event content filtering — skip low-value WatchEvent/ForkEvent (#171)
 - [ ] Access control — team/private visibility flag (#149)
+- [ ] PreCompact auto-extraction — capture knowledge before context compression
 
 ---
 

--- a/docs/skills/briefing.md
+++ b/docs/skills/briefing.md
@@ -1,0 +1,64 @@
+# /briefing — Knowledge Dashboard
+
+Produces a single-command knowledge dashboard: recent entries, pending corrections, soon-to-expire items, stale knowledge, and unresolved work — all scoped to your project. When multiple authors are detected (or `--team` is passed), team sections are added automatically.
+
+## Usage
+
+```text
+/briefing
+/briefing --project distillery
+/briefing --team
+```
+
+**Trigger phrases:** "briefing", "knowledge dashboard", "project overview", "my briefing", "team briefing"
+
+## When to Use
+
+- Starting a work session to orient yourself
+- Checking the state of your knowledge base at a glance
+- Getting a project-scoped overview of what needs attention
+- Viewing team activity and cross-author context
+
+## What It Does
+
+### Solo Mode (default)
+
+Displays 5 sections scoped to your project:
+
+| Section | What it shows |
+|---------|--------------|
+| **Recent entries** | Latest knowledge captured (configurable limit) |
+| **Corrections** | Entries with pending corrections via `entry_relations` |
+| **Expiring soon** | Entries with `expires_at` approaching |
+| **Stale knowledge** | Entries not updated in 30+ days |
+| **Unresolved** | Items in `pending_review` status |
+
+### Team Mode (`--team`)
+
+Adds 3 additional sections:
+
+| Section | What it shows |
+|---------|--------------|
+| **Team activity** | Recent entries from all authors |
+| **Related entries** | Entries from teammates on overlapping topics |
+| **Review queue** | Items awaiting classification review |
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--project NAME` | Scope to a specific project |
+| `--team` | Enable team sections (auto-detected when multiple authors exist) |
+
+## Session Start Hook
+
+The `/setup` wizard can configure a `SessionStart` hook that automatically injects a condensed briefing at the start of every Claude Code session. This gives Claude awareness of recent knowledge and stale items without requiring a manual `/briefing` invocation.
+
+See the [/setup docs](setup.md) for configuration details.
+
+## Tips
+
+- Run at the start of each work session to catch up on what needs attention
+- Combine with `/digest` for full context — `/briefing` shows current state, `/digest` shows recent activity
+- The `expires_at` section helps you stay on top of time-sensitive knowledge
+- Corrections section surfaces entries that may need updating based on newer information

--- a/docs/skills/digest.md
+++ b/docs/skills/digest.md
@@ -1,0 +1,60 @@
+# /digest — Team Activity Summaries
+
+Generates structured summaries of internal team knowledge activity over a configurable time window. Unlike `/radar` (which surfaces external feed signals), Digest focuses on what the team itself has captured — sessions, bookmarks, meeting notes, ideas, and references.
+
+## Usage
+
+```text
+/digest
+/digest --days 14
+/digest --project distillery
+/digest --store
+```
+
+**Trigger phrases:** "team digest", "activity summary", "what did the team capture", "weekly digest"
+
+## When to Use
+
+- Weekly or periodic team activity reviews
+- Tracking knowledge growth across the team
+- Scoping activity to a specific project
+- Storing the summary as a knowledge entry for longitudinal tracking
+
+## What It Does
+
+1. **Retrieves entries** from the configured time window (default: 7 days)
+2. **Groups by author and type** to show who captured what
+3. **Identifies themes** across the activity using tag and content analysis
+4. **Generates a structured summary** with sections for each author and cross-cutting themes
+5. **Optionally stores** the digest as a `digest` entry for future reference
+
+## Output Format
+
+```text
+Team Activity Digest (7 days)
+Project: distillery
+
+Authors: 3 active
+  norrie: 12 entries (sessions, bookmarks)
+  alex: 5 entries (minutes, references)
+  sam: 3 entries (ideas, sessions)
+
+Themes: DuckDB migration, auth refactor, feed scoring
+New entries: 20 | Updated: 4
+
+[Full narrative summary with per-author highlights]
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--days N` | Time window in days (default: 7) |
+| `--project NAME` | Scope to a specific project |
+| `--store` | Save the digest as a knowledge entry |
+
+## Tips
+
+- Combine with `/briefing` for a complete picture — `/briefing` shows current state, `/digest` shows recent activity
+- Stored digests create a longitudinal record of team knowledge growth
+- Use `--days 1` for a daily standup summary

--- a/docs/skills/gh-sync.md
+++ b/docs/skills/gh-sync.md
@@ -1,0 +1,45 @@
+# /gh-sync — GitHub Issue/PR Sync
+
+Syncs GitHub issues and pull requests from a repository into the Distillery knowledge base as searchable `github` entries. Each issue or PR becomes a knowledge entry with full metadata, cross-reference relations, and incremental sync support.
+
+## Usage
+
+```text
+/gh-sync owner/repo
+/gh-sync owner/repo --issues
+/gh-sync owner/repo --prs
+/gh-sync owner/repo --since 2026-01-01
+```
+
+**Trigger phrases:** "sync GitHub", "import issues", "sync repo issues", "capture PR history"
+
+## When to Use
+
+- Capturing GitHub issues and PRs alongside session notes for traceable decisions
+- Making issue discussions and PR context searchable via `/recall` and `/pour`
+- Syncing only issues or only PRs for focused imports
+- Incrementally updating after previous syncs (only fetches items updated since last run)
+
+## What It Does
+
+1. **Fetches issues/PRs** from the GitHub API (respects rate limits)
+2. **Checks for existing entries** to avoid duplicates (incremental sync)
+3. **Creates `github` entries** with structured metadata (labels, assignees, state, milestone)
+4. **Adds relations** between related issues/PRs (cross-references, parent issues)
+5. **Tags entries** with `source/github/owner/repo` and label-derived tags
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--issues` | Sync only issues (skip PRs) |
+| `--prs` | Sync only pull requests (skip issues) |
+| `--since DATE` | Only sync items updated after this date |
+| `--limit N` | Maximum number of items to sync |
+
+## Tips
+
+- Run incrementally — subsequent syncs only fetch items updated since the last run
+- Synced entries are searchable via `/recall` and synthesizable via `/pour`
+- Use `/investigate` to follow relationship chains across synced issues
+- Combine with `/watch add github:owner/repo` for ongoing event monitoring (different from `/gh-sync` which imports full issue/PR content)

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,6 +1,6 @@
 # Skills Overview
 
-Distillery provides 10 Claude Code slash commands organized into three categories: knowledge capture, knowledge retrieval, and ambient intelligence.
+Distillery provides 14 Claude Code slash commands organized into five categories: knowledge capture, knowledge retrieval, ambient intelligence, team skills, and onboarding.
 
 ## Knowledge Capture
 
@@ -26,11 +26,20 @@ Distillery provides 10 Claude Code slash commands organized into three categorie
 | [`/radar`](radar.md) | Generate a digest of recent feed activity |
 | [`/tune`](tune.md) | Adjust feed relevance thresholds |
 
+## Team
+
+| Skill | Purpose |
+|-------|---------|
+| [`/digest`](digest.md) | Team activity summary from internal entries |
+| [`/gh-sync`](gh-sync.md) | Sync GitHub issues/PRs into the knowledge base |
+| [`/investigate`](investigate.md) | Deep context builder with relationship traversal |
+| [`/briefing`](briefing.md) | Knowledge dashboard with metrics (solo and team mode) |
+
 ## Onboarding
 
 | Skill | Purpose |
 |-------|---------|
-| [`/setup`](setup.md) | First-time configuration wizard |
+| [`/setup`](setup.md) | First-time configuration wizard with session hook setup |
 
 ## How Skills Work
 

--- a/docs/skills/investigate.md
+++ b/docs/skills/investigate.md
@@ -1,0 +1,66 @@
+# /investigate — Deep Context Builder
+
+Compiles comprehensive context on a topic by executing a 4-phase retrieval: seed search, relationship expansion, tag expansion, and gap filling. Combines semantic search with explicit relationship traversal to surface context that keyword search alone misses.
+
+## Usage
+
+```text
+/investigate authentication flow
+/investigate --entry <uuid>
+/investigate DuckDB migration --depth 3
+```
+
+**Trigger phrases:** "investigate", "deep context", "what do we know about", "trace connections", "follow relationships"
+
+## When to Use
+
+- Deep research on a topic spanning multiple entries and relationships
+- Starting from a specific entry and following its connections
+- Understanding how entries relate across sessions, issues, and meeting notes
+- Discovering knowledge gaps before a decision or discussion
+
+## What It Does
+
+### Phase 1: Seed Search
+Performs semantic search for the topic, collecting the initial set of relevant entries.
+
+### Phase 2: Relationship Expansion
+Follows explicit relations (corrections, references, parent/child) from seed entries to discover connected knowledge.
+
+### Phase 3: Tag Expansion
+Uses shared tags to find entries in the same topic space that weren't surfaced by semantic search.
+
+### Phase 4: Gap Filling
+Identifies areas where knowledge is thin and reports gaps — topics mentioned but not well-covered.
+
+## Output Format
+
+```text
+Investigation: authentication flow
+Sources: 12 entries across 4 phases
+
+[Structured narrative organized by theme]
+
+Relationships:
+  entry-A --corrects--> entry-B
+  entry-C --references--> entry-D
+
+Knowledge Gaps:
+  - OAuth refresh token handling (mentioned but no dedicated entry)
+  - Rate limiting strategy (referenced in 2 entries, no decision recorded)
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--entry UUID` | Start from a specific entry instead of a topic search |
+| `--depth N` | Maximum relationship traversal depth (default: 2) |
+| `--project NAME` | Scope to a specific project |
+
+## Tips
+
+- More thorough than `/recall` — follows relationships and identifies gaps
+- Use before important decisions to ensure you have full context
+- The gap analysis helps identify what to capture next with `/distill`
+- Works well with `/gh-sync` entries — follow issue chains and PR discussions

--- a/docs/skills/setup.md
+++ b/docs/skills/setup.md
@@ -19,7 +19,7 @@ Walks through first-time Distillery configuration: verifying MCP connectivity, d
 
 ## What It Does
 
-The wizard runs through up to 5 steps, showing a summary at the end regardless of how far it gets.
+The wizard runs through up to 6 steps, showing a summary at the end regardless of how far it gets.
 
 ### Step 1: Check MCP Availability
 
@@ -64,7 +64,26 @@ Scheduling depends on your transport:
 - Checks for existing jobs before creating (no duplicates)
 - If no feed sources exist, poll/rescore are skipped but weekly maintenance is still offered
 
-### Step 5: Summary
+### Step 5: Configure Session Hooks
+
+Configures session lifecycle hooks in the appropriate `settings.json` based on your plugin installation scope.
+
+!!! note "Plugin Hooks Limitation"
+    Plugin manifest hooks (`plugin.json`) support `SessionStart` and `Stop` events but **not** `UserPromptSubmit`. To enable the memory nudge and full session lifecycle hooks, they must be configured in `settings.json` via `/setup`.
+
+The wizard:
+
+1. **Detects plugin scope** — checks `enabledPlugins` in user (`~/.claude/settings.json`) or project (`.claude/settings.json`) settings
+2. **Locates the dispatcher** — finds `scripts/hooks/distillery-hooks.sh` in the repo or plugin cache
+3. **Checks existing hooks** — skips if both `UserPromptSubmit` and `SessionStart` already reference the dispatcher
+4. **Installs hooks** — merges hook config into the scope-appropriate settings file
+
+| Hook | Behaviour |
+|------|-----------|
+| **UserPromptSubmit** | Memory nudge every 30 prompts — reminds you to `/distill` |
+| **SessionStart** | Injects a condensed briefing with recent entries and stale items |
+
+### Step 6: Summary
 
 Always displayed, even if the wizard exits early:
 
@@ -83,7 +102,8 @@ Always displayed, even if the wizard exits early:
 
 ### Available Skills
 /distill, /recall, /pour, /bookmark, /minutes,
-/classify, /watch, /radar, /tune
+/classify, /watch, /radar, /tune, /digest,
+/gh-sync, /investigate, /briefing
 ```
 
 ## Tips

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,10 @@ nav:
     - /radar: skills/radar.md
     - /tune: skills/tune.md
     - /setup: skills/setup.md
+    - /digest: skills/digest.md
+    - /gh-sync: skills/gh-sync.md
+    - /investigate: skills/investigate.md
+    - /briefing: skills/briefing.md
   - Team Access:
     - Team Member Guide: team/team-setup.md
     - Operator Deployment: team/deployment.md


### PR DESCRIPTION
## Summary

- Add 4 new skill doc pages: `/digest`, `/gh-sync`, `/investigate`, `/briefing`
- Update architecture SVG with 14 skills (second row for team skills), new entry fields
- Update skills index with Team category (was 3 categories, now 5)
- Update roadmap: move 4 completed skills + corrections + hooks from Planned to Complete
- Update `/setup` docs with Step 5 session hooks
- Fix tool count on plugin install page (20, was 19)

## Files Changed (11)

| File | Change |
|------|--------|
| `docs/skills/digest.md` | New |
| `docs/skills/gh-sync.md` | New |
| `docs/skills/investigate.md` | New |
| `docs/skills/briefing.md` | New |
| `docs/architecture.md` | SVG (14 skills), data model (3 new fields), project tree |
| `docs/skills/index.md` | Team category, count fix |
| `docs/skills/setup.md` | Step 5 session hooks, skills list |
| `docs/home.md` | Team skills in table |
| `docs/roadmap.md` | Moved completed, added new sections |
| `docs/getting-started/plugin-install.md` | Tool count fix |
| `mkdocs.yml` | 4 new nav entries |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new Claude Code slash commands: `/digest` for team activity summaries, `/gh-sync` for GitHub issue/PR syncing, `/investigate` for deep context building with relationship traversal, and `/briefing` for knowledge dashboards
  * Extended Entry model with session tracking, verification status, and expiration support
  * Increased available tools from 19 to 20

* **Documentation**
  * Added comprehensive skill guides for all four new commands
  * Updated setup wizard with session lifecycle hook configuration
  * Expanded Entry source documentation and project structure references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->