### PR TITLE
fix(plugin): correct hook format in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -37,14 +37,24 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "echo '[Distillery v0.3.2] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '[Distillery v0.3.2] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+          }
+        ]
       }
     ],
     "Stop": [
       {
-        "type": "command",
-        "command": "echo '[Distillery] If this response produced decisions or insights, run /distill to capture them. If it surfaced interesting URLs, use /watch to add as a feed source or /bookmark to save as an entry.'"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '[Distillery] If this response produced decisions or insights, run /distill to capture them. If it surfaced interesting URLs, use /watch to add as a feed source or /bookmark to save as an entry.'"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

- Fix plugin.json hooks to use `{matcher, hooks[]}` format instead of flat `{type, command}`
- Fixes: `hooks: Invalid input` validation error on plugin load

## Context

Plugin manifest hooks require the nested structure with `matcher` and `hooks` array. The flat format was accepted by older Claude Code versions but is rejected by current versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin hook configuration structure to improve extensibility and system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->