### PR TITLE
fix(mcp): stop leaking conflict-detector prompt in store response

### DIFF
--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -332,7 +332,7 @@ async def _handle_store(
                         "entry_id": result.entry.id,
                         "content_preview": preview,
                         "similarity_score": round(result.score, 4),
-                        "conflict_reasoning": prompt,
+                        "conflict_prompt": prompt,
                     }
                 )
             if conflicts:

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -397,7 +397,9 @@ class TestMCPStoreConflictDetection:
         assert "entry_id" in conflict
         assert "content_preview" in conflict
         assert "similarity_score" in conflict
-        assert "conflict_reasoning" in conflict
+        assert "conflict_prompt" in conflict
+        # conflict_reasoning must NOT be present (it leaked the system prompt — #200)
+        assert "conflict_reasoning" not in conflict
 
     async def test_store_no_conflicts_when_no_similar(
         self,


### PR DESCRIPTION
## Summary

- Fixes #200 — `distillery_store` was returning the full LLM system prompt in `conflict_reasoning` instead of actual reasoning
- Renamed field from `conflict_reasoning` to `conflict_prompt` in the store response's conflict candidates, matching the existing pattern in `run_conflict_discovery` (quality.py)
- Added regression test asserting `conflict_reasoning` is absent from store conflict candidates

## Root cause

`crud.py:335` assigned `"conflict_reasoning": prompt` where `prompt` was the output of `conflict_checker.build_prompt()` — the raw system prompt template with content interpolated. The field name implied LLM output but contained LLM input.

## Test plan

- [x] All 51 conflict tests pass (`test_conflict.py` + `test_mcp_conflicts.py`)
- [x] mypy --strict passes on `crud.py`
- [x] Regression test: `assert "conflict_reasoning" not in conflict` in `TestMCPStoreConflictDetection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Consolidated MCP tool surface from 20 to 12 tools; removed `aggregate`, `metrics`, `stale`, `tag_tree`, `type_schemas`, `interests`, `poll`, and `rescore` tools
* Extended `list` tool with `stale_days`, `group_by`, and `output="stats"` parameters for filtering and aggregation
* Moved `poll` and `rescore` to dedicated webhook endpoints (`/hooks/poll`, `/hooks/rescore`)
* Added new `/hooks/classify-batch` webhook endpoint supporting LLM and heuristic classification modes
* Added `distillery://schemas/entry-types` MCP resource for entry type schemas
* Added CLI `distillery maintenance classify` command

## Documentation
* Updated API documentation and skill guides to reflect new consolidated tool surface and endpoint paths

## Chores
* Added CVE-2026-31790 suppression for OpenSSL vulnerability in base image

<!-- end of auto-generated comment: release notes by coderabbit.ai -->