### PR TITLE
fix(ci): resolve duplicate Authorization header in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Install git-cliff
         env:
@@ -38,6 +39,7 @@ jobs:
       - name: Create changelog PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: update changelog for ${{ github.event.release.tag_name }}"
           title: "docs: update changelog for ${{ github.event.release.tag_name }}"
           body: "Auto-generated changelog update from release ${{ github.event.release.tag_name }}."


### PR DESCRIPTION
## Summary

- Adds `persist-credentials: false` to `actions/checkout` in the changelog workflow
- Explicitly passes `token: ${{ secrets.GITHUB_TOKEN }}` to `peter-evans/create-pull-request`

## Root cause

`actions/checkout` persists an `http.*.extraheader` Authorization config by default. When `create-pull-request` injects its own token for git operations (`git remote prune origin`), Git sends **two Authorization headers**, and GitHub returns HTTP 400 (`Duplicate header: "Authorization"`).

## Test plan

- [ ] Trigger a release and verify the changelog PR is created without the HTTP 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to improve authentication handling in automated changelog updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->