### PR TITLE
fix(plugin): use correct hook format with matcher and nested hooks array

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -37,14 +37,24 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "echo '[Distillery v0.3.2] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '[Distillery v0.3.2] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+          }
+        ]
       }
     ],
     "Stop": [
       {
-        "type": "command",
-        "command": "echo '[Distillery] If this response produced decisions or insights, run /distill to capture them. If it surfaced interesting URLs, use /watch to add as a feed source or /bookmark to save as an entry.'"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '[Distillery] If this response produced decisions or insights, run /distill to capture them. If it surfaced interesting URLs, use /watch to add as a feed source or /bookmark to save as an entry.'"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Plugin manifest hooks require {matcher, hooks[]} structure, not flat {type, command}. The flat format causes "hooks: Invalid input" validation error on plugin load.