### PR TITLE
ci(staging): dispatch distill_ops via gh workflow run

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -162,14 +162,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DISTILL_OPS_DEPLOY_TOKEN }}
         run: |
-          gh api \
-            --method POST \
-            repos/norrietaylor/distill_ops/dispatches \
-            -f "event_type=staging-deploy" \
-            --field "client_payload[image_tag]=${{ needs.resolve.outputs.image_tag }}" \
-            --field "client_payload[pr_number]=${{ needs.resolve.outputs.pr_number }}" \
-            --field "client_payload[head_sha]=${{ needs.resolve.outputs.head_sha }}" \
-            --field "client_payload[repo]=${{ github.repository }}"
+          # `gh workflow run` triggers a workflow_dispatch event on the
+          # target workflow. This requires only actions:write on the
+          # target repo (same scope supply-chain.yml already uses to
+          # trigger prod fly-deploy.yml). We previously used
+          # `gh api .../dispatches` which fires a repository_dispatch
+          # event and needs contents:write — a scope the existing
+          # DISTILL_OPS_DEPLOY_TOKEN PAT doesn't carry. Switching to
+          # gh workflow run lets us reuse the existing token without
+          # broadening its permissions.
+          gh workflow run staging-deploy.yml \
+            --repo norrietaylor/distill_ops \
+            --ref main \
+            -f "image_tag=${{ needs.resolve.outputs.image_tag }}" \
+            -f "pr_number=${{ needs.resolve.outputs.pr_number }}" \
+            -f "head_sha=${{ needs.resolve.outputs.head_sha }}"
 
       - name: Comment dispatch confirmation
         env:
@@ -212,13 +219,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DISTILL_OPS_DEPLOY_TOKEN }}
         run: |
-          gh api \
-            --method POST \
-            repos/norrietaylor/distill_ops/dispatches \
-            -f "event_type=staging-teardown" \
-            --field "client_payload[pr_number]=${{ github.event.issue.number }}" \
-            --field "client_payload[repo]=${{ github.repository }}" \
-            --field "client_payload[reason]=comment"
+          # See the deploy job above for why we use `gh workflow run`
+          # instead of `gh api .../dispatches`.
+          # Note: the distill_ops staging-teardown workflow_dispatch
+          # input surface is (pr_number,) only — reason and repo fall
+          # through to their defaults ('manual' and
+          # norrietaylor/distillery). Minor fidelity loss vs. the old
+          # repository_dispatch path: the PR comment will say
+          # "reason: manual" instead of "reason: comment" / "pr-closed".
+          gh workflow run staging-teardown.yml \
+            --repo norrietaylor/distill_ops \
+            --ref main \
+            -f "pr_number=${{ github.event.issue.number }}"
 
   # ──────────────────────────────────────────────────────────────────
   # Job 3: Teardown on PR close (any close — merged or not)
@@ -234,10 +246,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DISTILL_OPS_DEPLOY_TOKEN }}
         run: |
-          gh api \
-            --method POST \
-            repos/norrietaylor/distill_ops/dispatches \
-            -f "event_type=staging-teardown" \
-            --field "client_payload[pr_number]=${{ github.event.pull_request.number }}" \
-            --field "client_payload[repo]=${{ github.repository }}" \
-            --field "client_payload[reason]=pr-closed"
+          gh workflow run staging-teardown.yml \
+            --repo norrietaylor/distill_ops \
+            --ref main \
+            -f "pr_number=${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

Fixes the first Phase 3 end-to-end failure — \`/deploy-staging\` on norrietaylor/distillery#223 successfully built and pushed the image but failed at the cross-repo dispatch step:

\`\`\`
gh: Resource not accessible by personal access token (HTTP 403)
POST /repos/norrietaylor/distill_ops/dispatches
\`\`\`

Failing run: [24272287949](https://github.com/norrietaylor/distillery/actions/runs/24272287949/job/70879550009).

## Root cause

The existing \`DISTILL_OPS_DEPLOY_TOKEN\` PAT carries \`actions:write\` on distill_ops (sufficient for \`gh workflow run\`, which \`supply-chain.yml\` uses today to trigger prod \`fly-deploy.yml\`), but it does **not** carry \`contents:write\`, which the \`POST /repos/{o}/{r}/dispatches\` endpoint used by \`repository_dispatch\` events requires. Two different GitHub API surfaces, two different permission requirements.

## Fix

Rather than broaden the PAT, switch all three cross-repo dispatch calls from \`gh api .../dispatches\` to \`gh workflow run\`:

1. \`build\` job — deploy dispatch → \`gh workflow run staging-deploy.yml\`
2. \`teardown_comment\` job → \`gh workflow run staging-teardown.yml\`
3. \`teardown_on_close\` job → \`gh workflow run staging-teardown.yml\`

Both target workflows on distill_ops already declare \`workflow_dispatch\` with inputs matching what we were sending via \`client_payload\`. **No changes required on the distill_ops side.**

## Minor fidelity loss

The \`staging-teardown.yml\` workflow on distill_ops currently accepts only \`pr_number\` as a dispatch input, so the reason discrimination (\`comment\` vs \`pr-closed\` vs \`manual\`) flattens to \`manual\` on the distill_ops side. The teardown PR comment will no longer distinguish the trigger source. Acceptable for now; can be restored in a follow-up by adding optional \`reason\` and \`repo\` inputs to \`staging-teardown.yml\` on distill_ops.

## Unchanged

The two remaining \`gh api\` calls in this workflow are comment-reaction POSTs (\`🔭 eyes\`) against the running repo using the default \`GITHUB_TOKEN\`. Those hit \`/repos/{o}/{r}/issues/comments/{id}/reactions\` — a different endpoint with different scopes — and are not affected by the dispatch problem.

## Test plan

- [ ] Merge this PR
- [ ] Comment \`/deploy-staging\` on PR #223 again, verify:
  - [ ] \`resolve\` job posts pending-review comment
  - [ ] \`staging-deploy\` environment approval gate fires
  - [ ] After approval, build-and-push succeeds
  - [ ] **Dispatch step succeeds (this is the fix)** — triggers a new run of \`norrietaylor/distill_ops/staging-deploy.yml\`
  - [ ] distill_ops deploy succeeds end-to-end, success comment lands on PR #223
- [ ] Comment \`/teardown-staging\` on PR #223, verify teardown workflow dispatches and completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal deployment workflow trigger mechanisms for staging environments to improve workflow dispatch efficiency and streamline the deployment and teardown processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->