### PR TITLE
ci(staging): use startsWith for command match to stop self-triggering teardown

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -46,10 +46,15 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   resolve:
     name: Resolve PR head SHA
+    # startsWith (NOT contains) is load-bearing: any bot comment whose
+    # body mentions the command string in prose (e.g. the staging
+    # success comment's help text "Comment /deploy-staging ...") will
+    # otherwise self-trigger this workflow via the issue_comment event
+    # on that same comment. Commands must begin at column 0.
     if: >
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
-      contains(github.event.comment.body, '/deploy-staging') &&
+      startsWith(github.event.comment.body, '/deploy-staging') &&
       (
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
@@ -192,10 +197,17 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   teardown_comment:
     name: Dispatch staging teardown (comment)
+    # startsWith (NOT contains) — see the `resolve` job above. The
+    # distill_ops staging-deploy success comment intentionally no
+    # longer contains the literal "/teardown-staging" in its help
+    # text, but defence in depth: a prefix check means *only* a
+    # bare-command comment starting with "/teardown-staging" fires
+    # the teardown. Any prose that mentions the command in-line does
+    # nothing.
     if: >
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
-      contains(github.event.comment.body, '/teardown-staging') &&
+      startsWith(github.event.comment.body, '/teardown-staging') &&
       (
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||


### PR DESCRIPTION
## Summary

Phase 3 end-to-end smoke test on norrietaylor/distillery#223 **succeeded in deploying** — but then the staging environment tore itself down ~10 seconds later. Sequence:

\`\`\`
02:35:31  distill_ops posts success comment on PR #223:
          "✅ Staging deployed from 0505b4a
           URL: https://distillery-mcp-dev.fly.dev
           ...
           Comment /teardown-staging or close the PR to tear down."
                   ^^^^^^^^^^^^^^^^^^
02:35:35  This very workflow fires an issue_comment event on that
          same comment. The teardown_comment job's condition:
              contains(body, '/teardown-staging') → true
          Author_association check passes — the PAT maps to
          @norrietaylor, an OWNER.
02:35:40  Teardown dispatch fires to distill_ops.
02:35:51  Machine + volume destroyed.
\`\`\`

The upside: this proves the entire end-to-end path is wired up correctly. Deploy worked, success comment landed, teardown fired on command, teardown executed cleanly. We just didn't mean for it to fire.

## Root cause

\`contains(github.event.comment.body, '/teardown-staging')\` is a substring match. Any comment body — including bot help text — that mentions the literal command string triggers the job. Author_association is not a sufficient gate because the bot-side PATs are owned by collaborators.

## Fix

Swap \`contains()\` for \`startsWith()\` on both command matches:

| Job | Condition before | Condition after |
|---|---|---|
| \`resolve\` (/deploy-staging) | \`contains(body, '/deploy-staging')\` | \`startsWith(body, '/deploy-staging')\` |
| \`teardown_comment\` (/teardown-staging) | \`contains(body, '/teardown-staging')\` | \`startsWith(body, '/teardown-staging')\` |

Slash commands must begin at column 0 of the comment body. Prose that mentions the command in-line (including bot-authored help text) does nothing.

## Companion change needed

Follow-up PR on **distill_ops** will reword the staging-deploy success comment to not contain the literal \"/teardown-staging\" in its help text. The \`startsWith\` fix on this side makes that comment-rewording strictly unnecessary (defence in depth), but removing the literal eliminates confusion for humans reading the comment who might wonder why the help text looks \"off\".

## Test plan

- [ ] Merge this PR
- [ ] Re-comment \`/deploy-staging\` on norrietaylor/distillery#223
- [ ] Approve the \`staging-deploy\` environment
- [ ] Verify the distillery build job runs, distill_ops deploy runs, success comment lands
- [ ] Verify the workflow does NOT self-trigger a teardown this time — machine and volume should persist
- [ ] Then explicitly comment \`/teardown-staging\` to exercise the teardown path on purpose
- [ ] Verify teardown runs and destroys the machine + volume