### PR TITLE
build(docker): multi-stage build for Svelte dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,37 @@
+# syntax=docker/dockerfile:1.7
+
+# ──────────────────────────────────────────────────────────────────────
+# Stage 1: build the Svelte dashboard
+#
+# The Distillery MCP server exposes the dashboard as a ui:// resource
+# (src/distillery/mcp/resources.py) that inlines dashboard/dist/index.html
+# at read time. Without this stage, the final image ships without
+# dashboard/dist/, the resource falls through to a stub HTML page, and
+# the Explore tab never renders. We build the dashboard in an isolated
+# Node stage and copy only the dist/ output into the Python runtime,
+# keeping the final image free of Node, npm, and the ~200 MB of
+# node_modules.
+# ──────────────────────────────────────────────────────────────────────
+FROM node:22-alpine AS dashboard-builder
+
+WORKDIR /build
+
+# Leverage Docker layer caching: copy package manifests first, install,
+# then copy sources. Changes to dashboard sources will reuse the
+# npm ci layer as long as package.json and package-lock.json don't change.
+COPY dashboard/package.json dashboard/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY dashboard/ ./
+RUN npm run build
+
+# Sanity check: fail the build here (not silently at runtime with a
+# fallback HTML stub) if Vite didn't produce the expected entry point.
+RUN test -f /build/dist/index.html || (echo "Dashboard build did not produce dist/index.html" && exit 1)
+
+# ──────────────────────────────────────────────────────────────────────
+# Stage 2: Python runtime
+# ──────────────────────────────────────────────────────────────────────
 FROM cgr.dev/chainguard/wolfi-base:latest
 
 WORKDIR /app
@@ -16,6 +50,12 @@ RUN adduser --disabled-password --uid 10001 appuser
 
 # Copy the full repo (build context is repo root)
 COPY . .
+
+# Replace any locally-committed dashboard/dist/ with the freshly built
+# artifacts from stage 1. This makes the image build reproducible
+# regardless of whether a developer committed stale dist output.
+RUN rm -rf /app/dashboard/dist
+COPY --from=dashboard-builder /build/dist/ /app/dashboard/dist/
 
 # Install the package (production only, no dev deps)
 RUN uv pip install --system --no-cache .


### PR DESCRIPTION
## Summary

Fixes a packaging bug discovered during Phase 3 staging smoke testing of #218. The \`ui://distillery/dashboard\` MCP resource was returning the fallback stub HTML instead of the real Svelte dashboard because the container image had no JavaScript build step — dashboard/dist/ was never produced during \`docker build\`.

## Root cause

\`src/distillery/mcp/resources.py::_build_inline_html\` reads \`dashboard/dist/index.html\` at resource-read time:

\`\`\`python
if not index_path.exists():
    raise FileNotFoundError(
        f"Dashboard not built: {index_path} not found. "
        "Run 'make dashboard' to build the Svelte app."
    )
\`\`\`

\`register_dashboard_resource\` catches that and returns \`_fallback_html()\` — so the resource URI is registered, but clients reading it get a stub page instead of the real dashboard.

The distillery \`Dockerfile\` on this PR branch is unchanged from main:

\`\`\`dockerfile
FROM cgr.dev/chainguard/wolfi-base:latest
RUN apk add --no-cache python-3.13
...
COPY . .
RUN uv pip install --system --no-cache .
\`\`\`

No \`node\`, no \`npm\`, no \`npm run build\`. \`COPY . .\` copies the \`dashboard/\` source directory but \`dashboard/dist/\` doesn't exist at build time unless the developer happens to have run Vite locally first.

## Observed on staging

Deployed \`pr-218-sha-0505b4a\` to \`https://distillery-mcp-dev.fly.dev\` via the new comment-trigger staging pipeline. Claude.ai web connected successfully, but the MCP resource list either doesn't include \`distillery_dashboard\` in a form the user can interact with, and reading the resource would return the fallback stub regardless. Staging exposed exactly the kind of defect it was built to catch.

## Fix — two-stage Dockerfile

**Stage 1** (\`node:22-alpine\`):
- \`npm ci\` against \`dashboard/package-lock.json\`
- \`npm run build\` (\`vite build\`, produces \`/build/dist/\`)
- Sanity check: \`test -f /build/dist/index.html\` — fail the build loudly if Vite ever stops producing the expected entry point, rather than letting the fallback stub mask the problem at runtime.

**Stage 2** (unchanged \`cgr.dev/chainguard/wolfi-base:latest\`):
- \`COPY . .\` as before
- \`RUN rm -rf /app/dashboard/dist\` then \`COPY --from=dashboard-builder /build/dist/ /app/dashboard/dist/\` — replaces any locally-committed dist output with the fresh build, keeping the image reproducible regardless of developer local state
- Everything after is unchanged (uv, DuckDB VSS, appuser, EXPOSE 8000, CMD)

Stage 1's \`node_modules\` (~200 MB) stays in the builder layer and is discarded. Final image gains only the built \`dist/\` tree (a few hundred KB).

Layer caching: \`package.json\` + \`package-lock.json\` are copied before the rest of \`dashboard/\`, so source-only changes reuse the \`npm ci\` layer.

## Why target \`feature/dashboard-explore\` not \`main\`

This change only becomes necessary once \`feature/dashboard-explore\` adds the dashboard source + \`resources.py\` that references \`dashboard/dist/\`. Landing it on this feature branch keeps main's Dockerfile unchanged until #218 is ready to merge.

## Test plan

- [ ] Merge this PR into \`feature/dashboard-explore\`
- [ ] Re-comment \`/deploy-staging\` on #218 — the new head SHA will trigger a fresh staging image build with the multi-stage Dockerfile
- [ ] After deploy, check staging logs for absence of \"Dashboard assets not found\" warnings when the dashboard resource is read
- [ ] Connect claude.ai to \`https://distillery-mcp-dev.fly.dev/mcp\` and ask Claude to read the \`distillery_dashboard\` resource — expect the real Svelte dashboard to render, not the stub
- [ ] Verify Explore tab functionality: search, result detail, investigate, working set