### PR TITLE
ci(staging): print staging endpoint URL in PR comments

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -105,7 +105,13 @@ jobs:
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           gh pr comment "${{ steps.pr.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
-            --body "⏳ Staging deploy pending review — resolved head SHA \`${{ steps.pr.outputs.head_sha }}\`. A repo collaborator must approve the \`staging-deploy\` environment before the image is built: ${RUN_URL}"
+            --body "⏳ Staging deploy pending review — resolved head SHA \`${{ steps.pr.outputs.head_sha }}\`. A repo collaborator must approve the \`staging-deploy\` environment before the image is built: ${RUN_URL}
+
+          Once deployed, staging will be reachable at:
+          - Web / claude.ai: \`https://distillery-mcp-dev.fly.dev/mcp\`
+          - Health check: \`https://distillery-mcp-dev.fly.dev/.well-known/oauth-authorization-server\`
+
+          (note the \`/mcp\` path — the bare hostname returns 404)"
 
   # ──────────────────────────────────────────────────────────────────
   # Job 1b: Build and push the staging image.
@@ -190,7 +196,13 @@ jobs:
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           gh pr comment "${{ needs.resolve.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
-            --body "🚀 Staging deploy dispatched — image \`${{ needs.resolve.outputs.image_tag }}\` pushed. Build log: ${RUN_URL}. Fly deploy is handled in [distill_ops staging-deploy](https://github.com/norrietaylor/distill_ops/actions/workflows/staging-deploy.yml); it will comment back with the URL when the app is up."
+            --body "🚀 Staging deploy dispatched — image \`${{ needs.resolve.outputs.image_tag }}\` pushed. Build log: ${RUN_URL}. Fly deploy is handled in [distill_ops staging-deploy](https://github.com/norrietaylor/distill_ops/actions/workflows/staging-deploy.yml); it will comment back when the app is healthy.
+
+          **Staging endpoint** (once healthy):
+          - MCP URL: \`https://distillery-mcp-dev.fly.dev/mcp\`  ← use this to connect from Claude Code / claude.ai
+          - Health check: https://distillery-mcp-dev.fly.dev/.well-known/oauth-authorization-server
+
+          The \`/mcp\` path suffix is required — the bare hostname returns 404."
 
   # ──────────────────────────────────────────────────────────────────
   # Job 2: /teardown-staging via comment


### PR DESCRIPTION
## Summary

Every comment the staging-deploy workflow posts on the source PR now includes the exact URL the user needs to connect to the staging deployment from Claude Code or claude.ai.

Previously the user had to remember (or hunt through notes for) \`https://distillery-mcp-dev.fly.dev/mcp\` every time. We hit this exact UX problem during Phase 3 smoke testing — the user tried connecting to the bare hostname and got a confusing \"Authorization with the MCP server failed\" error from claude.ai (which was actually just a 404 on the root path because MCP lives at \`/mcp\`).

## Changes

- **\"⏳ pending review\"** comment (posted by the \`resolve\` job): now includes the staging MCP URL + OAuth discovery URL. User can queue up the connection while waiting for environment approval.
- **\"🚀 dispatched\"** comment (posted by the \`build\` job after image push): repeats the URL with explicit \"use this to connect\" framing.

Both comments call out the \`/mcp\` path suffix explicitly, since the bare hostname returns 404.

## Example comment body after this change

> 🚀 Staging deploy dispatched — image \`pr-218-sha-2edd583\` pushed. Build log: ...
> 
> **Staging endpoint** (once healthy):
> - MCP URL: \`https://distillery-mcp-dev.fly.dev/mcp\` ← use this to connect from Claude Code / claude.ai
> - Health check: https://distillery-mcp-dev.fly.dev/.well-known/oauth-authorization-server
> 
> The \`/mcp\` path suffix is required — the bare hostname returns 404.

## Test plan

- [ ] Merge
- [ ] Comment \`/deploy-staging\` on any PR
- [ ] Verify both comments (pending review + dispatched) include the staging URL and call out the \`/mcp\` suffix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced staging deployment notifications with connectivity details, including explicit MCP interface and health check endpoint URLs for the staging environment, plus clarification that the `/mcp` path is required for proper access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->