### PR TITLE
build(docker): set DISTILLERY_DASHBOARD_DIR so installed package finds dashboard/dist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,25 @@ COPY . .
 RUN rm -rf /app/dashboard/dist
 COPY --from=dashboard-builder /build/dist/ /app/dashboard/dist/
 
+# Point the dashboard resource loader at the in-container path.
+#
+# src/distillery/mcp/resources.py::_DEFAULT_DIST_DIR walks
+# Path(__file__).resolve().parents[3] / "dashboard" / "dist" to find
+# the Svelte build output. In a source checkout that resolves to
+# <repo>/dashboard/dist; in an installed package (like this image,
+# where uv pip install drops the code into /usr/lib/python3.13/
+# site-packages/distillery/...) it resolves to
+# /usr/lib/python3.13/dashboard/dist, which doesn't exist — and the
+# resource handler silently falls back to a stub HTML page.
+#
+# _find_dist_dir() checks DISTILLERY_DASHBOARD_DIR first, so setting
+# the env var here bypasses the broken ancestor walk without
+# requiring a code change in resources.py. The underlying packaging
+# bug in resources.py should be fixed separately (ideally by
+# bundling dashboard/dist/ as Python package data so importlib.
+# resources can find it without filesystem walking).
+ENV DISTILLERY_DASHBOARD_DIR=/app/dashboard/dist
+
 # Install the package (production only, no dev deps)
 RUN uv pip install --system --no-cache .
 


### PR DESCRIPTION
## Summary

Completes the dashboard packaging fix started in #226. Without this follow-up, the Svelte dashboard is in the image at \`/app/dashboard/dist/\` but the Python runtime can't find it, so \`register_dashboard_resource\` silently serves the fallback stub HTML.

## Root cause

\`src/distillery/mcp/resources.py::_DEFAULT_DIST_DIR\` resolves via:

\`\`\`python
_DEFAULT_DIST_DIR = Path(__file__).resolve().parents[3] / "dashboard" / "dist"
\`\`\`

| Install layout | \`__file__\` | \`parents[3]\` | Default dist path |
|---|---|---|---|
| **Source checkout** | \`/repo/src/distillery/mcp/resources.py\` | \`/repo\` | \`/repo/dashboard/dist\` ✓ |
| **Installed package** (this container) | \`/usr/lib/python3.13/site-packages/distillery/mcp/resources.py\` | \`/usr/lib/python3.13\` | \`/usr/lib/python3.13/dashboard/dist\` ✗ |

The ancestor-walk convention only works from a source checkout. Any \`pip install\` — in a container, in a venv, in a wheel — puts the code at \`site-packages/\` and the walk points at the wrong place.

## Evidence (via \`fly ssh\` on staging)

```
>>> from distillery.mcp.resources import _find_dist_dir, _build_inline_html
>>> dist = _find_dist_dir()
>>> dist
PosixPath('/usr/lib/python3.13/dashboard/dist')
>>> _build_inline_html(dist)
FileNotFoundError: Dashboard not built:
/usr/lib/python3.13/dashboard/dist/index.html not found.
Run 'make dashboard' to build the Svelte app.
```

Meanwhile \`/app/dashboard/dist/index.html\` exists and is a valid Vite-built entry point (404 bytes, references \`/assets/index-dKF8H8Uv.js\` and \`/assets/index-oi584UL6.css\`).

## Fix

Set \`ENV DISTILLERY_DASHBOARD_DIR=/app/dashboard/dist\` in the Dockerfile. \`_find_dist_dir()\` already honours that env var as an override:

\`\`\`python
def _find_dist_dir() -> Path:
    override = os.environ.get("DISTILLERY_DASHBOARD_DIR")
    if override:
        return Path(override)
    return _DEFAULT_DIST_DIR
\`\`\`

So this bypasses the broken ancestor walk without requiring any code change in \`resources.py\`.

## Follow-up work (out of scope for this PR)

The underlying packaging bug in \`resources.py\` should be fixed properly. The canonical Python pattern is:

1. Bundle \`dashboard/dist/\` as Python package data via \`pyproject.toml\`:
   \`\`\`toml
   [tool.setuptools.package-data]
   \"distillery.mcp\" = [\"dashboard/**\"]
   \`\`\`
2. Use \`importlib.resources\` to load it:
   \`\`\`python
   from importlib.resources import files
   dist_dir = files(\"distillery.mcp\") / \"dashboard\" / \"dist\"
   \`\`\`

That works in source checkouts, wheels, zipapps, and containerised installs without any filesystem walking. But it's a bigger change and requires directory layout shuffling, so I'm leaving it as a follow-up issue.

## Test plan

- [ ] Merge into \`feature/dashboard-explore\`
- [ ] Re-deploy staging from PR #218 (via \`/deploy-staging\` comment)
- [ ] SSH into staging and verify \`_find_dist_dir()\` returns \`/app/dashboard/dist\` instead of \`/usr/lib/...\`
- [ ] Connect from a client that supports MCP \`resources/read\` and confirm the resource returns the real inlined HTML (script + style tags present, no \`/assets/\` references remaining)