### PR TITLE
fix(mcp): use lambda replacement in re.sub to survive \u in CSS/JS bundles

### DIFF
--- a/src/distillery/mcp/resources.py
+++ b/src/distillery/mcp/resources.py
@@ -57,6 +57,15 @@ def _build_inline_html(dist_dir: Path) -> str:
     assets_dir = dist_dir / "assets"
 
     # Inline CSS: replace <link rel="stylesheet" ... href="/assets/X.css">
+    #
+    # Note: the replacement argument to re.sub() is parsed for regex
+    # escape sequences (\1, \g<name>, etc.), and unrecognised
+    # backslash-letter sequences — including \u — raise
+    # `re.PatternError: bad escape \u`. CSS and JS bundles routinely
+    # contain Unicode escape sequences like `content: "\u2605"`, so
+    # passing raw bundle text as a replacement string is unsafe.
+    # Using a lambda as the replacement avoids escape parsing
+    # entirely — the function's return value is substituted literally.
     if assets_dir.exists():
         for css_file in sorted(assets_dir.glob("*.css")):
             css_content = css_file.read_text(encoding="utf-8")
@@ -67,7 +76,7 @@ def _build_inline_html(dist_dir: Path) -> str:
                 safe_css = css_content.replace("</style>", "<\\/style>")
                 pattern = rf'<link[^>]*href="/assets/{re.escape(css_file.name)}"[^>]*/?\s*>'
                 replacement = f"<style>{safe_css}</style>"
-                html = re.sub(pattern, replacement, html, flags=re.IGNORECASE)
+                html = re.sub(pattern, lambda _m, r=replacement: r, html, flags=re.IGNORECASE)
 
         # Inline JS: replace <script type="module" ... src="/assets/X.js">
         for js_file in sorted(assets_dir.glob("*.js")):
@@ -77,7 +86,7 @@ def _build_inline_html(dist_dir: Path) -> str:
                 safe_js = js_content.replace("</script>", "<\\/script>")
                 pattern = rf'<script[^>]*src="/assets/{re.escape(js_name)}"[^>]*>\s*</script>'
                 replacement = f'<script type="module">{safe_js}</script>'
-                html = re.sub(pattern, replacement, html, flags=re.IGNORECASE)
+                html = re.sub(pattern, lambda _m, r=replacement: r, html, flags=re.IGNORECASE)
 
     return html
 


### PR DESCRIPTION
## Summary

Third bug in the dashboard packaging chain surfaced by Phase 3 staging smoke testing. After #226 (multi-stage Dockerfile) and #228 (DISTILLERY_DASHBOARD_DIR env var) both landed, staging finally had dashboard/dist/ in the right place and the resource handler could find it — at which point the next step, \`_build_inline_html\`, crashed with:

\`\`\`
re.PatternError: bad escape \u at position 39563
  File \"/usr/lib/python3.13/site-packages/distillery/mcp/resources.py\", line 80
    html = re.sub(pattern, replacement, html, flags=re.IGNORECASE)
\`\`\`

## Root cause

\`re.sub(pattern, replacement, string)\` parses the \`replacement\` argument for regex escape sequences: \`\\1\`, \`\\2\`, \`\\g<name>\`, etc. Unknown escapes raise \`re.PatternError\`. The \`\\u\` sequence, commonly used in CSS for Unicode code-point literals (\`content: \"\\u2605\"\` for a star, \`\\u203a\` for a chevron, etc.), is not a valid re.sub replacement escape.

\`_build_inline_html\` was passing raw Vite-built CSS and JS bundle text as the replacement argument:

\`\`\`python
# resources.py line 70
replacement = f\"<style>{safe_css}</style>\"
html = re.sub(pattern, replacement, html, flags=re.IGNORECASE)
\`\`\`

Any Vite build that includes a CSS bundle with a Unicode escape sequence — which is most production builds — hits this.

## Fix

Pass a lambda as the replacement. re.sub skips escape parsing on function replacements and uses the return value literally.

\`\`\`python
# before
html = re.sub(pattern, replacement, html, flags=re.IGNORECASE)
# after
html = re.sub(pattern, lambda _m, r=replacement: r, html, flags=re.IGNORECASE)
\`\`\`

Applies to both CSS and JS inliner loops (the JS bundle has the same problem class).

The default-argument \`r=replacement\` captures the current loop iteration's value. This is defensive — since each re.sub call runs synchronously inside the loop, late-binding closures would work here too, but explicit capture is clearer to readers and immune to future refactors that move the loop body elsewhere.

## Minimal repro

\`\`\`python
>>> import re
>>> html = '<link href=\"/assets/test.css\">'
>>> css = r'.star::before { content: \"\\u2605\"; }'
>>> pattern = r'<link[^>]*href=\"/assets/test\\.css\"[^>]*/?\\s*>'
>>> re.sub(pattern, f'<style>{css}</style>', html)
re.PatternError: bad escape \\u at position 33
>>> re.sub(pattern, lambda _m: f'<style>{css}</style>', html)
'<style>.star::before { content: \"\\\\u2605\"; }</style>'
\`\`\`

## Full chain of packaging fixes for PR #218

Closing out with this PR, all three latent bugs in the dashboard packaging chain are fixed:

1. **#226** — multi-stage Dockerfile builds dashboard/dist/ into the image (image packaging)
2. **#228** — ENV DISTILLERY_DASHBOARD_DIR=/app/dashboard/dist so the installed package finds it (runtime discovery)
3. **This PR** — lambda replacement in re.sub so the inliner doesn't crash on \\u in bundles (inline serialisation)

None of these show up in a local \`npm run dev\` loop — they only manifest in containerised deployment. Staging caught all three.

## Test plan

- [ ] Merge into \`feature/dashboard-explore\`
- [ ] Re-deploy staging via \`/deploy-staging\` on #218
- [ ] SSH into staging and run:
  \`\`\`python
  from distillery.mcp.resources import _find_dist_dir, _build_inline_html
  html = _build_inline_html(_find_dist_dir())
  assert 'Dashboard not built' not in html
  assert '<script type=\"module\">' in html
  assert '<style>' in html
  assert html.count('/assets/') == 0  # nothing left referencing external assets
  \`\`\`
- [ ] From a client that supports MCP \`resources/read\`, fetch \`ui://distillery/dashboard\` and confirm the real Svelte dashboard is returned (not the fallback stub)

## Longer-term follow-up

\`resources.py\` still has the underlying packaging bug in \`_DEFAULT_DIST_DIR\` (from #228 context) where \`parents[3]\` only works in source checkouts. The env var escape hatch is a workaround, not a fix. Filing a follow-up issue to migrate to \`importlib.resources\` + \`pyproject.toml\` package-data declarations would make this robust across all install layouts.