### PR TITLE
fix: cherry-pick hotfixes #214 and #215 to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Install git-cliff
         env:
@@ -38,6 +39,7 @@ jobs:
       - name: Create changelog PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: update changelog for ${{ github.event.release.tag_name }}"
           title: "docs: update changelog for ${{ github.event.release.tag_name }}"
           body: "Auto-generated changelog update from release ${{ github.event.release.tag_name }}."

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -332,7 +332,7 @@ async def _handle_store(
                         "entry_id": result.entry.id,
                         "content_preview": preview,
                         "similarity_score": round(result.score, 4),
-                        "conflict_reasoning": prompt,
+                        "conflict_prompt": prompt,
                     }
                 )
             if conflicts:

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -397,7 +397,9 @@ class TestMCPStoreConflictDetection:
         assert "entry_id" in conflict
         assert "content_preview" in conflict
         assert "similarity_score" in conflict
-        assert "conflict_reasoning" in conflict
+        assert "conflict_prompt" in conflict
+        # conflict_reasoning must NOT be present (it leaked the system prompt — #200)
+        assert "conflict_reasoning" not in conflict
 
     async def test_store_no_conflicts_when_no_similar(
         self,


### PR DESCRIPTION
## Summary
- Cherry-picks fix commits from develop PRs #214 and #215 into main
- **#214** `fix(mcp)`: stop leaking conflict-detector system prompt in store response (#200)
- **#215** `fix(ci)`: resolve duplicate Authorization header in changelog workflow

## Test plan
- [ ] CI passes on cherry-picked commits
- [ ] Verify conflict-detector prompt no longer leaks in store responses
- [ ] Verify changelog workflow doesn't produce duplicate Authorization headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow authentication handling for improved security.
  * Refined internal response structure for conflict detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->