### PR TITLE
fix(security): resolve 5 open findings from security review (#112)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ classifiers = [
 
 dependencies = [
     "duckdb~=1.5.0",
-    "pyyaml>=6.0",
-    "httpx>=0.24.0",
-    "fastmcp>=2.12.0",
-    "defusedxml>=0.7.0",
+    "pyyaml>=6.0,<7.0",
+    "httpx>=0.24.0,<1.0",
+    "fastmcp>=2.12.0,<4.0",
+    "defusedxml>=0.7.0,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -236,6 +236,8 @@ class RateLimitConfig:
     embedding_budget_daily: int = 500
     max_db_size_mb: int = 900
     warn_db_size_pct: int = 80
+    search_logging_enabled: bool = True
+    search_log_retention_days: int = 90
 
 
 @dataclass
@@ -282,6 +284,7 @@ class HttpRateLimitConfig:
     requests_per_hour: int = 600
     max_body_bytes: int = 1_048_576  # 1 MB
     trust_proxy: bool = False
+    cors_allowed_origins: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/distillery/embedding/jina.py
+++ b/src/distillery/embedding/jina.py
@@ -149,7 +149,7 @@ class JinaEmbeddingProvider:
 
         for attempt in range(_MAX_RETRIES):
             try:
-                with httpx.Client(timeout=60.0) as client:
+                with httpx.Client(timeout=60.0, verify=True) as client:
                     response = client.post(_JINA_API_URL, json=payload, headers=headers)
                     response.raise_for_status()
 

--- a/src/distillery/embedding/openai.py
+++ b/src/distillery/embedding/openai.py
@@ -64,7 +64,7 @@ class OpenAIEmbeddingProvider:
         self._model = model
         self._dimensions = dimensions
         self._api_key = resolved_key
-        self._client = httpx.Client(timeout=30.0)
+        self._client = httpx.Client(timeout=30.0, verify=True)
 
     # ------------------------------------------------------------------
     # EmbeddingProvider protocol implementation

--- a/src/distillery/feeds/github.py
+++ b/src/distillery/feeds/github.py
@@ -256,7 +256,7 @@ class GitHubAdapter:
 
         logger.debug("GitHubAdapter: fetching %s", api_url)
 
-        with httpx.Client(timeout=_REQUEST_TIMEOUT, follow_redirects=True) as client:
+        with httpx.Client(timeout=_REQUEST_TIMEOUT, follow_redirects=True, verify=True) as client:
             response = client.get(api_url, params=params, headers=headers)
             response.raise_for_status()
 

--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -271,7 +271,7 @@ class GitHubSyncAdapter:
 
         should_close = client is None
         if client is None:
-            client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, follow_redirects=True)
+            client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, follow_redirects=True, verify=True)
         try:
             all_issues: list[dict[str, Any]] = []
             page = 1
@@ -309,7 +309,7 @@ class GitHubSyncAdapter:
 
         should_close = client is None
         if client is None:
-            client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, follow_redirects=True)
+            client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, follow_redirects=True, verify=True)
         try:
             response = await self._request_with_retry(client, api_url, params)
             result: list[dict[str, Any]] = response.json()

--- a/src/distillery/feeds/rss.py
+++ b/src/distillery/feeds/rss.py
@@ -394,7 +394,7 @@ class RSSAdapter:
         headers = {"User-Agent": "Distillery/0.1 (RSS adapter)"}
         headers.update(self._extra_headers)
 
-        with httpx.Client(timeout=_REQUEST_TIMEOUT) as client:
+        with httpx.Client(timeout=_REQUEST_TIMEOUT, verify=True) as client:
             response = client.get(
                 self._fetch_url,
                 headers=headers,

--- a/src/distillery/mcp/__main__.py
+++ b/src/distillery/mcp/__main__.py
@@ -192,6 +192,7 @@ def main(argv: list[str] | None = None) -> int:
                 trust_proxy=rl.trust_proxy,
                 org_checker=org_checker,
                 audit_callback=_auth_audit_cb,
+                cors_allowed_origins=rl.cors_allowed_origins,
             )
 
             from starlette.types import ASGIApp, Receive, Scope, Send

--- a/src/distillery/mcp/auth.py
+++ b/src/distillery/mcp/auth.py
@@ -70,7 +70,7 @@ class OrgRestrictedGitHubProvider(GitHubProvider):
             return None
 
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
+            async with httpx.AsyncClient(timeout=10, verify=True) as client:
                 resp = await client.get(
                     "https://api.github.com/user",
                     headers={

--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -467,17 +467,19 @@ def apply_http_middleware(
     trust_proxy: bool = False,
     org_checker: OrgMembershipChecker | None = None,
     audit_callback: AuditCallback | None = None,
+    cors_allowed_origins: list[str] | None = None,
 ) -> ASGIApp:
-    """Wrap *app* with rate-limit, body-size, request-ID, and org-membership middleware.
+    """Wrap *app* with CORS, rate-limit, body-size, request-ID, and org-membership middleware.
 
     Middleware is applied in outermost-to-innermost order:
     1. :class:`RequestIDMiddleware` (outermost — echoes ``X-Request-ID`` on
        *all* responses, including 429/403/413 rejections)
-    2. :class:`RateLimitMiddleware` (counts every request so denied requests
+    2. :class:`CORSMiddleware` (handles preflight and CORS headers)
+    3. :class:`RateLimitMiddleware` (counts every request so denied requests
        still consume quota)
-    3. :class:`OrgMembershipMiddleware` (when *org_checker* is provided and
+    4. :class:`OrgMembershipMiddleware` (when *org_checker* is provided and
        enabled — blocks non-members before body is read)
-    4. :class:`BodySizeLimitMiddleware` (innermost — rejects oversized bodies)
+    5. :class:`BodySizeLimitMiddleware` (innermost — rejects oversized bodies)
 
     Args:
         app: The ASGI application to wrap.
@@ -491,10 +493,14 @@ def apply_http_middleware(
         audit_callback: Optional async callback for writing audit log entries
             when org membership checks deny access.  Signature:
             ``(user_id, operation, entry_id, action, outcome) -> Awaitable[None]``.
+        cors_allowed_origins: List of allowed CORS origins.  When empty or
+            ``None``, no origins are permitted (restrictive default).
 
     Returns:
         A new ASGI app with all requested middleware layers applied.
     """
+    from starlette.middleware.cors import CORSMiddleware
+
     app = BodySizeLimitMiddleware(app, max_bytes=max_body_bytes)
     if org_checker is not None and org_checker.enabled:
         app = OrgMembershipMiddleware(app, org_checker, audit_callback=audit_callback)
@@ -503,6 +509,14 @@ def apply_http_middleware(
         requests_per_minute=requests_per_minute,
         requests_per_hour=requests_per_hour,
         trust_proxy=trust_proxy,
+    )
+    origins = cors_allowed_origins or []
+    app = CORSMiddleware(
+        app=app,
+        allow_origins=origins,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "X-Request-ID"],
+        allow_credentials=True,
     )
     app = RequestIDMiddleware(app)
     return app

--- a/src/distillery/mcp/org_membership.py
+++ b/src/distillery/mcp/org_membership.py
@@ -243,7 +243,7 @@ class OrgMembershipChecker:
             headers["Authorization"] = f"Bearer {token}"
 
         try:
-            async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
+            async with httpx.AsyncClient(timeout=10.0, follow_redirects=False, verify=True) as client:
                 resp = await client.get(
                     f"{GITHUB_API}/orgs/{org}/members/{username}",
                     headers=headers,
@@ -297,7 +297,7 @@ class OrgMembershipChecker:
         # Cap at 50 pages (5 000 orgs) to avoid infinite loops.
         max_pages = 50
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            async with httpx.AsyncClient(timeout=10.0, verify=True) as client:
                 for page in range(1, max_pages + 1):
                     resp = await client.get(
                         f"{GITHUB_API}/user/orgs",

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -569,6 +569,10 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         confidence (0–1) determines the updated entry status.
         """
         c = _lc(ctx)
+        user = _get_authenticated_user()
+        err = await _own(c, user, entry_id, "distillery_classify")
+        if err:
+            return err
         args: dict[str, Any] = dict(
             entry_id=entry_id,
             entry_type=entry_type,

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -87,7 +87,8 @@ async def _handle_search(
     results = [{"score": round(sr.score, 6), "entry": sr.entry.to_dict()} for sr in search_results]
 
     # Log the search event to search_log for later implicit-feedback correlation.
-    if search_results:
+    search_logging = cfg is None or cfg.rate_limit.search_logging_enabled
+    if search_results and search_logging:
         result_entry_ids = [sr.entry.id for sr in search_results]
         result_scores = [sr.score for sr in search_results]
         try:

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -525,6 +525,32 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
         "ok": False, "error": classify_body.get("error", "classify-batch failed")
     }
 
+    # 4. Search log retention — prune old search_log rows.
+    retention_result: dict[str, Any] = {"ok": True, "deleted": 0}
+    config = state.get("config")
+    if config is not None and config.rate_limit.search_log_retention_days > 0:
+        store = state["store"]
+        retention_days = config.rate_limit.search_log_retention_days
+        try:
+            import asyncio
+
+            def _prune() -> int:
+                conn = store.connection
+                result = conn.execute(
+                    "DELETE FROM search_log WHERE timestamp < "
+                    "current_timestamp - INTERVAL ? DAY RETURNING id",
+                    [retention_days],
+                ).fetchall()
+                return len(result)
+
+            deleted = await asyncio.to_thread(_prune)
+            retention_result = {"ok": True, "deleted": deleted}
+            if deleted:
+                logger.info("Maintenance: pruned %d search_log rows older than %d days", deleted, retention_days)
+        except Exception as exc:  # noqa: BLE001
+            retention_result = {"ok": False, "error": f"search_log retention failed: {exc}"}
+            logger.warning("Maintenance: search_log retention failed: %s", exc)
+
     logger.info(
         "Webhook maintenance: completed — poll_ok=%s rescore_ok=%s classify_ok=%s",
         poll_body.get("ok"),
@@ -538,6 +564,7 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
                 "poll": poll_result,
                 "rescore": rescore_result,
                 "classify_batch": classify_result,
+                "search_log_retention": retention_result,
             },
         }
     )


### PR DESCRIPTION
## Summary

Closes all 5 remaining open findings from the security review (#112).

- **P1 (MEDIUM)** — Explicit `verify=True` on all 9 httpx Client/AsyncClient instantiations
- **P2 (MEDIUM)** — Extended ownership checks to `distillery_classify` (was missing vs update/correct/resolve_review)
- **P3 (MEDIUM)** — Added CORS middleware with configurable `cors_allowed_origins` (restrictive default: empty list)
- **P4 (LOW)** — Pinned upper bounds on pyyaml (<7), httpx (<1), fastmcp (<4), defusedxml (<1)
- **P5 (LOW)** — Added `search_logging_enabled` and `search_log_retention_days` config; wired retention cleanup into maintenance webhook

## Test plan
- [x] 143 relevant tests pass
- [x] `mypy --strict` passes on all changed files
- [ ] CI pipeline

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)