### PR TITLE
feat(mcp): harden MCP interface — descriptions, handlers, error codes, validation (#245)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1079,12 +1079,12 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         distillery_tag_tree (to explore tag structure)
         """
         c = _lc(ctx)
-        args: dict[str, Any] = dict(
-            recency_days=recency_days,
-            top_n=top_n,
-            suggest_sources=suggest_sources,
-            max_suggestions=max_suggestions,
-        )
+        args: dict[str, Any] = {
+            "recency_days": recency_days,
+            "top_n": top_n,
+            "suggest_sources": suggest_sources,
+            "max_suggestions": max_suggestions,
+        }
         return await _handle_interests(store=c["store"], config=c["config"], arguments=args)
 
     @server.resource("distillery://schemas/entry-types")

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -285,15 +285,34 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     ) -> list[types.TextContent]:
         """Store a new knowledge entry and return its ID with dedup/conflict information.
 
-        entry_type must be one of: session, bookmark, minutes, meeting, reference,
-        idea, inbox, github, person, project, digest, feed.
-        source: claude-code (default), manual, import, inference,
-        documentation, or external. session_id: opaque session identifier for grouping.
-        dedup_threshold (0–1) controls near-duplicate warnings.
-        verification: unverified, testing, or verified (default: unverified).
-        expires_at accepts ISO 8601 datetime; entries past expiry appear in stale results.
-        output_mode: "full" (default) or "summary". Use "summary" for bulk imports
-        to skip dedup/conflict checks and return only {"entry_id": "..."}.
+        USE WHEN: capturing a new piece of knowledge (session notes, bookmarks,
+        meeting minutes, ideas, etc.) into the Distillery store.
+
+        PARAMS:
+          - content (str, required): The knowledge content to store.
+          - entry_type (str, required): Entry classification. Valid: [session, bookmark,
+            minutes, meeting, reference, idea, inbox, github, person, project, digest, feed].
+          - author (str, required): Who authored this entry.
+          - project (str, optional): Project scope for the entry.
+          - tags (list[str], optional): Tags for categorisation; supports namespaced tags (e.g. "topic/ai").
+          - metadata (dict, optional): Arbitrary key-value metadata.
+          - source (str, optional, default="claude-code"): Origin of the entry.
+            Valid: [claude-code, manual, import, inference, documentation, external].
+          - session_id (str, optional): Opaque session identifier for grouping related entries.
+          - dedup_threshold (float, optional, default=config): Cosine similarity threshold (0-1)
+            for near-duplicate warnings.
+          - dedup_limit (int, optional, default=config): Max duplicates to report.
+          - verification (str, optional, default="unverified"): Verification status.
+            Valid: [unverified, testing, verified].
+          - expires_at (str, optional): ISO 8601 datetime; entries past expiry appear in stale results.
+          - output_mode (str, optional, default="full"): Response verbosity.
+            Valid: [full, summary]. Use "summary" for bulk imports to skip dedup/conflict checks.
+
+        RETURNS (success): { entry_id: str, warnings?: list, conflict_candidates?: list }
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_find_similar (for pre-store dedup checks),
+        distillery_correct (to supersede an existing entry)
         """
         c = _lc(ctx)
         user = _get_authenticated_user()
@@ -324,7 +343,20 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
 
     @server.tool
     async def distillery_get(ctx: Context, entry_id: str) -> list[types.TextContent]:
-        """Retrieve a knowledge entry by ID; returns NOT_FOUND error if missing."""
+        """Retrieve a single knowledge entry by its unique ID.
+
+        USE WHEN: fetching the full content and metadata of a specific entry
+        (e.g. after finding its ID via search or list).
+
+        PARAMS:
+          - entry_id (str, required): UUID of the entry to retrieve.
+
+        RETURNS (success): { id: str, content: str, entry_type: str, ... }
+        RETURNS (error): { error: true, code: "NOT_FOUND" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_search (to find entries by content),
+        distillery_list (to browse entries by filters)
+        """
         c = _lc(ctx)
         return await _handle_get(
             store=c["store"], arguments={"entry_id": entry_id}, config=c["config"]
@@ -347,11 +379,28 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     ) -> list[types.TextContent]:
         """Update one or more fields on an existing knowledge entry.
 
-        At least one field must be provided. status: active, pending_review, or
-        archived. entry_type: session, bookmark, minutes, meeting, reference,
-        idea, or inbox. verification: unverified, testing, or verified.
-        session_id: opaque session identifier for grouping.
-        expires_at accepts ISO 8601 datetime; pass null to clear.
+        USE WHEN: modifying an entry's content, type, tags, status, or other
+        mutable fields. At least one updatable field must be provided.
+
+        PARAMS:
+          - entry_id (str, required): UUID of the entry to update.
+          - content (str, optional): Replacement content.
+          - entry_type (str, optional): New type. Valid: [session, bookmark, minutes,
+            meeting, reference, idea, inbox, github, person, project, digest, feed].
+          - author (str, optional): New author.
+          - project (str, optional): New project scope.
+          - tags (list[str], optional): Replacement tag list.
+          - status (str, optional): New status. Valid: [active, pending_review, archived].
+          - verification (str, optional): New verification. Valid: [unverified, testing, verified].
+          - metadata (dict, optional): Replacement metadata dict.
+          - session_id (str, optional): Session identifier for grouping.
+          - expires_at (str, optional): ISO 8601 datetime; pass null to clear.
+
+        RETURNS (success): { id: str, content: str, entry_type: str, ... } (full updated entry)
+        RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "FORBIDDEN" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_correct (to supersede rather than edit),
+        distillery_get (to read before updating)
         """
         c = _lc(ctx)
         user = _get_authenticated_user()
@@ -391,9 +440,25 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     ) -> list[types.TextContent]:
         """Store a correction that supersedes an existing entry.
 
-        The original entry is archived and a 'corrects' relation is created
-        linking the new entry to the original. Fields (entry_type, author,
-        project, tags) are inherited from the original when not provided.
+        USE WHEN: an existing entry contains wrong information and you want to
+        replace it with corrected content while preserving the audit trail.
+
+        PARAMS:
+          - wrong_entry_id (str, required): UUID of the entry being corrected.
+          - content (str, required): The corrected content.
+          - entry_type (str, optional): Override type; inherited from original if omitted.
+            Valid: [session, bookmark, minutes, meeting, reference, idea, inbox,
+            github, person, project, digest, feed].
+          - author (str, optional): Override author; inherited from original if omitted.
+          - project (str, optional): Override project; inherited from original if omitted.
+          - tags (list[str], optional): Override tags; inherited from original if omitted.
+          - metadata (dict, optional): Additional metadata for the correction entry.
+
+        RETURNS (success): { correction_entry_id: str, archived_entry_id: str }
+        RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "FORBIDDEN" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_update (for non-breaking edits),
+        distillery_relations (to view the 'corrects' relation)
         """
         c = _lc(ctx)
         user = _get_authenticated_user()
@@ -449,16 +514,41 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     ) -> list[types.TextContent]:
         """List knowledge entries with optional filters and pagination (newest first).
 
-        date_from/date_to accept ISO 8601. verification: unverified, testing, or verified.
-        source: filter by entry source (claude-code, manual, import, inference, documentation, external).
-        session_id: filter by session identifier.
-        output_mode: "full" (default), "summary", "ids",
-        or "review" (filters to pending_review and enriches with confidence/classification_reasoning).
-        stale_days: restrict to entries not accessed in the last N days (>= 1).
-        group_by: return grouped counts instead of entries; one of entry_type, status, author,
-        project, source, tags. Mutually exclusive with output="stats".
-        output: "stats" returns aggregate statistics (entries_by_type, entries_by_status,
-        total_entries, storage_bytes). Mutually exclusive with group_by.
+        USE WHEN: browsing or filtering entries without a semantic query.
+        Use distillery_search instead when you have a natural-language question.
+
+        PARAMS:
+          - entry_type (str, optional): Filter by type. Valid: [session, bookmark, minutes,
+            meeting, reference, idea, inbox, github, person, project, digest, feed].
+          - author (str, optional): Filter by author.
+          - project (str, optional): Filter by project scope.
+          - tags (list[str], optional): Filter by tags (AND match).
+          - status (str, optional): Filter by status. Valid: [active, pending_review, archived].
+          - verification (str, optional): Filter by verification. Valid: [unverified, testing, verified].
+          - source (str, optional): Filter by origin. Valid: [claude-code, manual, import,
+            inference, documentation, external].
+          - session_id (str, optional): Filter by session identifier.
+          - date_from (str, optional): ISO 8601 lower bound on created_at.
+          - date_to (str, optional): ISO 8601 upper bound on created_at.
+          - limit (int, optional, default=20): Max entries to return (1-500).
+          - offset (int, optional, default=0): Pagination offset.
+          - tag_prefix (str, optional): Filter tags by namespace prefix.
+          - output_mode (str, optional, default="full"): Response shape.
+            Valid: [full, summary, ids, review]. "review" filters to pending_review
+            and enriches with confidence/classification_reasoning.
+          - content_max_length (int, optional): Truncate content to N chars (full mode only).
+          - stale_days (int, optional): Restrict to entries not accessed in N days (>= 1).
+          - group_by (str, optional): Return grouped counts instead of entries.
+            Valid: [entry_type, status, author, project, source, tags].
+            Mutually exclusive with output="stats".
+          - output (str, optional): Set to "stats" for aggregate statistics.
+            Mutually exclusive with group_by.
+
+        RETURNS (success): { entries: list, count: int, total_count: int, limit: int, offset: int }
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_search (for semantic search),
+        distillery_aggregate (for count-by-group analytics)
         """
         c = _lc(ctx)
         args: dict[str, Any] = dict(
@@ -501,10 +591,30 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         limit: int = 10,
         tag_prefix: str | None = None,
     ) -> list[types.TextContent]:
-        """Search the knowledge store using semantic similarity (cosine, ranked descending).
+        """Search knowledge entries using semantic similarity (cosine distance, ranked descending).
 
-        limit 1–200. date_from/date_to accept ISO 8601. tag_prefix filters by namespace.
-        source: filter by entry source. session_id: filter by session identifier.
+        USE WHEN: finding entries that match a natural-language question or topic.
+        Each result includes a similarity score (0-1, higher is more relevant).
+
+        PARAMS:
+          - query (str, required): Natural-language search query.
+          - entry_type (str, optional): Filter by type.
+          - author (str, optional): Filter by author.
+          - project (str, optional): Filter by project scope.
+          - tags (list[str], optional): Filter by tags (AND match).
+          - status (str, optional): Filter by status.
+          - source (str, optional): Filter by origin.
+          - session_id (str, optional): Filter by session identifier.
+          - date_from (str, optional): ISO 8601 lower bound.
+          - date_to (str, optional): ISO 8601 upper bound.
+          - limit (int, optional, default=10): Max results (1-200).
+          - tag_prefix (str, optional): Filter tags by namespace prefix.
+
+        RETURNS (success): { results: [{ score: float, entry: {...} }], count: int }
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_list (for filter-based browsing without semantic ranking),
+        distillery_find_similar (to compare against arbitrary text)
         """
         c = _lc(ctx)
         args: dict[str, Any] = dict(
@@ -535,12 +645,29 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         conflict_check: bool = False,
         llm_responses: list[dict[str, Any]] | None = None,
     ) -> list[types.TextContent]:
-        """Find stored entries similar to the given text. threshold: cosine cutoff (0-1). limit 1-200.
+        """Find stored entries similar to the given text (cosine similarity).
 
-        Optional modes (progressive disclosure):
-          dedup_action: when true, includes dedup check with action (create/skip/merge/link).
-          conflict_check: when true, includes conflict candidates with LLM prompts.
-          llm_responses: with conflict_check=true, evaluates [{entry_id, is_conflict, reasoning}].
+        USE WHEN: checking for duplicates or conflicts before storing, or finding
+        entries related to arbitrary text. Supports progressive disclosure modes.
+
+        PARAMS:
+          - content (str, required): Text to compare against stored entries.
+          - threshold (float, optional, default=0.8): Cosine similarity cutoff (0-1).
+          - limit (int, optional, default=10): Max results (1-200).
+          - dedup_action (bool, optional, default=false): When true, includes dedup
+            check with recommended action (create/skip/merge/link).
+          - conflict_check (bool, optional, default=false): When true, includes
+            conflict candidates with LLM evaluation prompts.
+          - llm_responses (list[dict], optional): With conflict_check=true, evaluates
+            LLM conflict verdicts. Each item: { entry_id: str, is_conflict: bool, reasoning: str }.
+
+        RETURNS (success): { results: [{ score: float, entry: {...} }], count: int, threshold: float,
+          dedup?: { action: str, similar_entries: list },
+          conflict_candidates?: list, conflict_evaluation?: dict }
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_store (stores with automatic dedup/conflict checks),
+        distillery_search (for natural-language queries)
         """
         c = _lc(ctx)
         args: dict[str, Any] = dict(
@@ -565,8 +692,24 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     ) -> list[types.TextContent]:
         """Apply a pre-computed classification to an existing entry.
 
-        entry_type: session, bookmark, minutes, meeting, reference, idea, or inbox.
-        confidence (0–1) determines the updated entry status.
+        USE WHEN: you have determined an entry's type and confidence via LLM
+        or heuristic analysis and want to persist the classification result.
+
+        PARAMS:
+          - entry_id (str, required): UUID of the entry to classify.
+          - entry_type (str, required): Assigned type. Valid: [session, bookmark, minutes,
+            meeting, reference, idea, inbox, github, person, project, digest, feed].
+          - confidence (float, required): Classification confidence (0-1). Entries below
+            the configured threshold (default 0.6) go to pending_review.
+          - reasoning (str, optional): Explanation of the classification decision.
+          - suggested_tags (list[str], optional): Tags to merge onto the entry.
+          - suggested_project (str, optional): Project to assign if entry has none.
+
+        RETURNS (success): { id: str, entry_type: str, status: str, ... } (full updated entry)
+        RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_resolve_review (to act on pending_review entries),
+        distillery_list (with output_mode="review" to see the review queue)
         """
         c = _lc(ctx)
         args: dict[str, Any] = dict(
@@ -589,9 +732,24 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         new_entry_type: str | None = None,
         reviewer: str | None = None,
     ) -> list[types.TextContent]:
-        """Resolve a pending-review entry: action is "approve", "reclassify", or "archive".
+        """Resolve a pending-review entry by approving, reclassifying, or archiving it.
 
-        new_entry_type required when action is "reclassify".
+        USE WHEN: acting on entries in the review queue (entries with
+        status=pending_review from low-confidence classifications).
+
+        PARAMS:
+          - entry_id (str, required): UUID of the pending-review entry.
+          - action (str, required): Resolution action. Valid: [approve, reclassify, archive].
+          - new_entry_type (str, optional): Required when action="reclassify".
+            Valid: [session, bookmark, minutes, meeting, reference, idea, inbox,
+            github, person, project, digest, feed].
+          - reviewer (str, optional): Reviewer identity for audit metadata.
+
+        RETURNS (success): { id: str, status: str, ... } (full updated entry)
+        RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "FORBIDDEN" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_classify (to classify entries),
+        distillery_list (with output_mode="review" to see the queue)
         """
         c = _lc(ctx)
         user = _get_authenticated_user()
@@ -618,9 +776,26 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         poll_interval_minutes: int | None = None,
         trust_weight: float | None = None,
     ) -> list[types.TextContent]:
-        """Manage monitored feed sources: action is "list", "add", or "remove".
+        """Manage monitored feed sources for ambient intelligence.
 
-        add requires url and source_type (rss or github). remove requires url.
+        USE WHEN: listing, adding, or removing RSS/GitHub feed sources
+        that Distillery polls for new content.
+
+        PARAMS:
+          - action (str, required): Operation to perform. Valid: [list, add, remove].
+          - url (str, required for add/remove): Feed URL or GitHub owner/repo slug.
+          - source_type (str, required for add): Feed type. Valid: [rss, github].
+          - label (str, optional): Human-readable label for the source.
+          - poll_interval_minutes (int, optional, default=60): Polling frequency in minutes.
+          - trust_weight (float, optional, default=1.0): Source trust weight (0-1).
+
+        RETURNS (success): { sources: list, count: int } (list) or
+          { added: dict, sources: list } (add) or
+          { removed_url: str, removed: bool, sources: list } (remove)
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "CONFLICT" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_interests (to discover sources to watch),
+        distillery_configure (to adjust feed thresholds)
         """
         c = _lc(ctx)
         return await _handle_watch(
@@ -648,11 +823,29 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         direction: str = "both",
         relation_id: str | None = None,
     ) -> list[types.TextContent]:
-        """Manage typed relations between knowledge entries: action is "add", "get", or "remove".
+        """Manage typed relations between knowledge entries.
 
-        add requires from_id, to_id, and relation_type (e.g. "link", "blocks", "related").
-        get requires entry_id; accepts optional relation_type and direction ("outgoing", "incoming", "both").
-        remove requires relation_id.
+        USE WHEN: linking entries together (e.g. marking one as blocking another,
+        citing a reference, or flagging duplicates).
+
+        PARAMS:
+          - action (str, required): Operation. Valid: [add, get, remove].
+          - from_id (str, required for add): Source entry UUID.
+          - to_id (str, required for add): Target entry UUID.
+          - relation_type (str, required for add, optional for get): Relation type.
+            Valid: [link, corrects, supersedes, related, blocks, depends_on, citation, duplicate].
+          - entry_id (str, required for get): Entry UUID to query relations for.
+          - direction (str, optional for get, default="both"): Filter direction.
+            Valid: [outgoing, incoming, both].
+          - relation_id (str, required for remove): UUID of the relation to delete.
+
+        RETURNS (success): { relation_id: str, from_id: str, to_id: str, relation_type: str } (add) or
+          { entry_id: str, relations: list, count: int } (get) or
+          { relation_id: str, removed: bool } (remove)
+        RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_correct (creates 'corrects' relations automatically),
+        distillery_find_similar (to discover related entries)
         """
         c = _lc(ctx)
         return await _handle_relations(
@@ -679,11 +872,25 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     ) -> list[types.TextContent]:
         """Update a runtime configuration value and persist it to distillery.yaml.
 
-        Accepts an allowlisted (section, key) pair and validates ranges and
-        cross-field constraints before applying.  Returns previous and new values.
+        USE WHEN: adjusting thresholds, classification settings, or feed
+        parameters at runtime without editing the config file directly.
 
-        section examples: "feeds.thresholds", "defaults", "classification".
-        key examples: "alert", "digest", "dedup_threshold", "confidence_threshold".
+        PARAMS:
+          - section (str, required): Config section path (dotted notation).
+            Valid: [feeds.thresholds, defaults, classification].
+          - key (str, required): Config key within the section.
+            Valid keys by section: feeds.thresholds: [alert, digest];
+            defaults: [dedup_threshold, dedup_limit, stale_days];
+            classification: [confidence_threshold, mode].
+          - value (str | int | float, required): New value. Must satisfy type and
+            range constraints for the given key.
+
+        RETURNS (success): { changed: bool, section: str, key: str, previous_value: any,
+          new_value: any, disk_written: bool, message: str }
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_watch (to manage feed sources),
+        distillery_metrics (to review current system state)
         """
         c = _lc(ctx)
         return await _handle_configure(

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -237,7 +237,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             existing = await lc["store"].get(eid)
         except Exception as exc:  # noqa: BLE001
             logger.exception("Ownership pre-check failed for entry %s", eid)
-            return error_response("STORE_ERROR", f"Failed to read entry: {exc}")
+            return error_response("INTERNAL", f"Failed to read entry: {exc}")
         if existing is None:
             await lc["store"].write_audit_log(user, op, eid, op, "not_found")
             return error_response("NOT_FOUND", f"No entry found with id={eid!r}.")

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1,13 +1,12 @@
-"""MCP server for Distillery — 12 tools over stdio or HTTP.
+"""MCP server for Distillery — 17 tools over stdio or HTTP.
 
 Handlers live in ``src/distillery/mcp/tools/`` (crud, search, classify, quality,
 analytics, feeds, configure, meta). This module owns: FastMCP app creation,
 lifespan, shared-state init, tool registration wrappers, and middleware
 composition.
 
-Analytics tools (stale, aggregate, tag_tree, metrics, interests, type_schemas)
-and feed-management tools (poll, rescore) have been moved to REST webhook
-endpoints or MCP resources — they are no longer registered as MCP tools.
+Feed-management tools (poll, rescore) have been moved to REST webhook
+endpoints. Type schemas are exposed as an MCP resource.
 """
 
 from __future__ import annotations
@@ -897,6 +896,196 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             config=c["config"],
             arguments={"section": section, "key": key, "value": value},
         )
+
+    @server.tool
+    async def distillery_aggregate(
+        ctx: Context,
+        group_by: str,
+        limit: int = 50,
+        entry_type: str | None = None,
+        author: str | None = None,
+        project: str | None = None,
+        status: str | None = None,
+        source: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> list[types.TextContent]:
+        """Count entries grouped by a field, without fetching full payloads.
+
+        USE WHEN: getting a quick overview of how entries are distributed
+        across types, statuses, authors, projects, or sources.
+
+        PARAMS:
+          - group_by (str, required): Field to group by.
+            Valid: [entry_type, status, author, project, source,
+            metadata.source_url, metadata.source_type].
+          - limit (int, optional, default=50): Max groups to return (1-500).
+          - entry_type (str, optional): Filter by type.
+          - author (str, optional): Filter by author.
+          - project (str, optional): Filter by project.
+          - status (str, optional): Filter by status.
+          - source (str, optional): Filter by origin.
+          - date_from (str, optional): ISO 8601 lower bound.
+          - date_to (str, optional): ISO 8601 upper bound.
+
+        RETURNS (success): { group_by: str, groups: dict, total_entries: int, total_groups: int }
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_list (for entry-level browsing),
+        distillery_metrics (for comprehensive system metrics)
+        """
+        c = _lc(ctx)
+        args: dict[str, Any] = dict(
+            group_by=group_by,
+            limit=limit,
+            **_omit_none(
+                entry_type=entry_type,
+                author=author,
+                project=project,
+                status=status,
+                source=source,
+                date_from=date_from,
+                date_to=date_to,
+            ),
+        )
+        return await _handle_aggregate(store=c["store"], arguments=args)
+
+    @server.tool
+    async def distillery_metrics(
+        ctx: Context,
+        scope: str = "full",
+        period_days: int = 30,
+        entry_type: str | None = None,
+        date_from: str | None = None,
+        user: str | None = None,
+    ) -> list[types.TextContent]:
+        """Aggregate usage, quality, and audit metrics from the Distillery instance.
+
+        USE WHEN: reviewing system health, search quality, staleness, or
+        audit trails. Supports scoped views for different use cases.
+
+        PARAMS:
+          - scope (str, optional, default="full"): Metrics view.
+            Valid: [summary, full, search_quality, audit].
+          - period_days (int, optional, default=30): Lookback window in days (>= 1, full scope only).
+          - entry_type (str, optional): Filter by type (search_quality scope only).
+          - date_from (str, optional): ISO 8601 lower bound (audit scope only).
+          - user (str, optional): Filter by user (audit scope only).
+
+        RETURNS (success): varies by scope — summary: counts + storage;
+          full: entries + activity + search + quality + staleness + storage;
+          search_quality: totals + feedback rates; audit: logins + operations.
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_aggregate (for count-by-group breakdowns),
+        distillery_stale (for detailed stale entry listing)
+        """
+        c = _lc(ctx)
+        args: dict[str, Any] = dict(
+            scope=scope,
+            period_days=period_days,
+            **_omit_none(
+                entry_type=entry_type,
+                date_from=date_from,
+                user=user,
+            ),
+        )
+        return await _handle_metrics(
+            store=c["store"],
+            config=c["config"],
+            embedding_provider=c["embedding_provider"],
+            arguments=args,
+        )
+
+    @server.tool
+    async def distillery_stale(
+        ctx: Context,
+        days: int | None = None,
+        limit: int = 20,
+        entry_type: str | None = None,
+    ) -> list[types.TextContent]:
+        """List entries not accessed within a staleness window, plus expired entries.
+
+        USE WHEN: identifying knowledge that may need refreshing, archiving,
+        or reviewing due to age or expiration.
+
+        PARAMS:
+          - days (int, optional, default=config.defaults.stale_days): Staleness
+            threshold in days (>= 1).
+          - limit (int, optional, default=20): Max entries to return.
+          - entry_type (str, optional): Filter by type.
+
+        RETURNS (success): { days_threshold: int, stale_count: int, expired_count: int,
+          entries: [{ id: str, content_preview: str, reason: "stale" | "expired", ... }] }
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_metrics (for staleness aggregates),
+        distillery_list (with stale_days filter)
+        """
+        c = _lc(ctx)
+        args: dict[str, Any] = dict(
+            limit=limit,
+            **_omit_none(days=days, entry_type=entry_type),
+        )
+        return await _handle_stale(store=c["store"], config=c["config"], arguments=args)
+
+    @server.tool
+    async def distillery_tag_tree(
+        ctx: Context,
+        prefix: str | None = None,
+    ) -> list[types.TextContent]:
+        """Build a nested tag hierarchy from active entries.
+
+        USE WHEN: exploring the tag namespace structure, understanding how
+        entries are categorised, or discovering tag conventions.
+
+        PARAMS:
+          - prefix (str, optional): Root the tree at this tag prefix (e.g. "topic").
+
+        RETURNS (success): { tree: { count: int, children: { ... } }, prefix: str | null }
+        RETURNS (error): { error: true, code: "INTERNAL", message: "..." }
+
+        RELATED: distillery_list (with tag_prefix filter),
+        distillery_aggregate (for flat tag counts)
+        """
+        c = _lc(ctx)
+        return await _handle_tag_tree(store=c["store"], arguments={"prefix": prefix})
+
+    @server.tool
+    async def distillery_interests(  # noqa: PLR0913
+        ctx: Context,
+        recency_days: int = 90,
+        top_n: int = 20,
+        suggest_sources: bool = False,
+        max_suggestions: int = 5,
+    ) -> list[types.TextContent]:
+        """Build an interest profile from stored entries, optionally suggesting feed sources.
+
+        USE WHEN: understanding what topics and repositories are tracked, or
+        discovering new feed sources to watch based on existing knowledge.
+
+        PARAMS:
+          - recency_days (int, optional, default=90): How far back to look for entries.
+          - top_n (int, optional, default=20): Max top tags to include in the profile.
+          - suggest_sources (bool, optional, default=false): When true, includes
+            heuristic feed source suggestions based on the profile.
+          - max_suggestions (int, optional, default=5): Max suggestions to return.
+
+        RETURNS (success): { top_tags: list, bookmark_domains: list, tracked_repos: list,
+          expertise_areas: list, entry_count: int, suggestions?: list }
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_watch (to act on suggested sources),
+        distillery_tag_tree (to explore tag structure)
+        """
+        c = _lc(ctx)
+        args: dict[str, Any] = dict(
+            recency_days=recency_days,
+            top_n=top_n,
+            suggest_sources=suggest_sources,
+            max_suggestions=max_suggestions,
+        )
+        return await _handle_interests(store=c["store"], config=c["config"], arguments=args)
 
     @server.resource("distillery://schemas/entry-types")
     async def entry_type_schemas() -> str:

--- a/src/distillery/mcp/tools/_common.py
+++ b/src/distillery/mcp/tools/_common.py
@@ -102,6 +102,9 @@ def success_response(data: dict[str, Any]) -> list[types.TextContent]:
 def validate_required(arguments: dict[str, Any], *fields: str) -> str | None:
     """Return an error message if any required field is missing from *arguments*.
 
+    A field is considered missing if it is absent, ``None``, or (for strings)
+    empty.  Values such as ``0`` and ``False`` are **not** treated as missing.
+
     Args:
         arguments: The tool argument dict.
         *fields: Field names that must be present and non-empty.
@@ -110,7 +113,12 @@ def validate_required(arguments: dict[str, Any], *fields: str) -> str | None:
         An error message string if validation fails, or ``None`` if all fields
         are present.
     """
-    missing = [f for f in fields if not arguments.get(f)]
+    missing = [
+        f
+        for f in fields
+        if arguments.get(f) is None
+        or (isinstance(arguments.get(f), str) and not arguments.get(f))
+    ]
     if missing:
         return f"Missing required fields: {', '.join(missing)}"
     return None
@@ -134,3 +142,49 @@ def validate_type(
     if value is not None and not isinstance(value, expected_type):
         return f"Field '{field}' must be a {label}"
     return None
+
+
+def validate_enum(
+    arguments: dict[str, Any], field: str, valid_values: set[str], label: str = ""
+) -> str | None:
+    """Return an error message if *field* is not one of *valid_values*.
+
+    Args:
+        arguments: The tool argument dict.
+        field: Key to check.
+        valid_values: Allowed string values.
+        label: Human-readable description for the error message
+            (defaults to *field* when empty).
+
+    Returns:
+        An error message string or ``None``.
+    """
+    val = arguments.get(field)
+    if val is not None and val not in valid_values:
+        desc = label or field
+        return f"Invalid {desc} {val!r}. Must be one of: {', '.join(sorted(valid_values))}."
+    return None
+
+
+def validate_positive_int(
+    arguments: dict[str, Any], field: str, default: int | None = None
+) -> int | tuple[str, str]:
+    """Validate and return a positive integer from *arguments*.
+
+    Args:
+        arguments: The tool argument dict.
+        field: Key to check.
+        default: Default value if *field* is absent.
+
+    Returns:
+        On success: the validated positive integer.
+        On failure: a ``(code, message)`` tuple suitable for ``error_response()``.
+    """
+    from distillery.mcp.tools._errors import ToolErrorCode
+
+    raw = arguments.get(field, default)
+    if raw is None:
+        return (ToolErrorCode.INVALID_PARAMS.value, f"Field '{field}' is required.")
+    if not isinstance(raw, int) or raw < 1:
+        return (ToolErrorCode.INVALID_PARAMS.value, f"Field '{field}' must be a positive integer.")
+    return raw

--- a/src/distillery/mcp/tools/_errors.py
+++ b/src/distillery/mcp/tools/_errors.py
@@ -20,20 +20,35 @@ class ToolErrorCode(StrEnum):
     Attributes:
         INVALID_PARAMS: Request parameters fail validation (e.g., missing
             required fields, wrong types, values out of range). This replaces
-            both ``INVALID_INPUT`` and ``VALIDATION_ERROR`` to provide
-            consistency across all handlers.
+            ``INVALID_INPUT``, ``VALIDATION_ERROR``, ``MISSING_FIELD``,
+            ``INVALID_FIELD``, ``INVALID_ACTION``, ``INVALID_SOURCE_TYPE``,
+            ``INVALID_STATE``, and ``RESERVED_PREFIX`` to provide consistency
+            across all handlers.
         NOT_FOUND: The requested resource does not exist (e.g., entry ID not
             found, user not found).
         CONFLICT: The operation conflicts with existing state (e.g.,
-            deduplication detected, concurrent modification).
+            deduplication detected, duplicate feed source).
         INTERNAL: An unexpected server-side error occurred (e.g., database
-            connection failure, embedding service timeout).
+            connection failure, embedding service timeout). This replaces
+            ``STORE_ERROR``, ``SEARCH_ERROR``, ``FIND_SIMILAR_ERROR``,
+            ``WATCH_ERROR``, ``RELATIONS_ERROR``, ``LIST_ERROR``,
+            ``AGGREGATE_ERROR``, ``METRICS_ERROR``, ``TAG_TREE_ERROR``,
+            ``STALE_ERROR``, ``POLL_ERROR``, ``RESCORE_ERROR``,
+            ``DEDUP_ERROR``, ``CONFLICT_ERROR``, and ``EXTRACTION_ERROR``.
+        FORBIDDEN: The authenticated user is not allowed to perform the
+            operation (e.g., ownership violation).
+        BUDGET_EXCEEDED: A rate-limit or budget has been exhausted (e.g.,
+            daily embedding budget, database size limit).
+        RATE_LIMITED: The request was rejected due to rate limiting.
     """
 
     INVALID_PARAMS = "INVALID_PARAMS"
     NOT_FOUND = "NOT_FOUND"
     CONFLICT = "CONFLICT"
     INTERNAL = "INTERNAL"
+    FORBIDDEN = "FORBIDDEN"
+    BUDGET_EXCEEDED = "BUDGET_EXCEEDED"
+    RATE_LIMITED = "RATE_LIMITED"
 
 
 def tool_error(code: ToolErrorCode | str, message: str) -> tuple[ToolErrorCode | str, str]:

--- a/src/distillery/mcp/tools/analytics.py
+++ b/src/distillery/mcp/tools/analytics.py
@@ -150,7 +150,7 @@ async def _handle_tag_tree(
         tree = _build_tree_from_vocab(vocab, prefix)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error in distillery_tag_tree")
-        return error_response("TAG_TREE_ERROR", f"Failed to build tag tree: {exc}")
+        return error_response("INTERNAL", f"Failed to build tag tree: {exc}")
 
     return success_response({"tree": tree, "prefix": prefix})
 
@@ -246,7 +246,7 @@ async def _handle_metrics(
             return success_response(result)
         except Exception as exc:  # noqa: BLE001
             logger.exception("Error gathering quality metrics")
-            return error_response("METRICS_ERROR", f"Failed to gather quality metrics: {exc}")
+            return error_response("INTERNAL", f"Failed to gather quality metrics: {exc}")
 
     # --- scope=audit -----------------------------------------------------------
     if scope == "audit":
@@ -276,7 +276,7 @@ async def _handle_metrics(
             return success_response(result_audit)
         except Exception as exc:  # noqa: BLE001
             logger.exception("Error gathering audit metrics")
-            return error_response("METRICS_ERROR", f"Failed to gather audit metrics: {exc}")
+            return error_response("INTERNAL", f"Failed to gather audit metrics: {exc}")
 
     # --- scope=summary delegates to _sync_gather_summary --------------------
     if scope == "summary":
@@ -287,7 +287,7 @@ async def _handle_metrics(
             return success_response(result_summary)
         except Exception as exc:  # noqa: BLE001
             logger.exception("Error gathering summary metrics")
-            return error_response("METRICS_ERROR", f"Failed to gather summary: {exc}")
+            return error_response("INTERNAL", f"Failed to gather summary: {exc}")
 
     # --- scope=full (default) -----------------------------------------------
     # --- validate period_days -----------------------------------------------
@@ -306,7 +306,7 @@ async def _handle_metrics(
         return success_response(metrics)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error gathering metrics")
-        return error_response("METRICS_ERROR", f"Failed to gather metrics: {exc}")
+        return error_response("INTERNAL", f"Failed to gather metrics: {exc}")
 
 
 def _sync_gather_summary(
@@ -966,7 +966,7 @@ async def _handle_stale(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error gathering stale entries")
-        return error_response("STALE_ERROR", f"Failed to gather stale entries: {exc}")
+        return error_response("INTERNAL", f"Failed to gather stale entries: {exc}")
 
 
 def _sync_gather_stale(
@@ -1173,12 +1173,12 @@ async def _handle_interests(
         recency_days = int(recency_days_raw)
     except (TypeError, ValueError):
         return error_response(
-            "INVALID_FIELD",
+            "INVALID_PARAMS",
             f"recency_days must be an integer, got: {recency_days_raw!r}",
         )
     if recency_days <= 0:
         return error_response(
-            "INVALID_FIELD",
+            "INVALID_PARAMS",
             f"recency_days must be a positive integer, got: {recency_days}",
         )
 
@@ -1187,19 +1187,19 @@ async def _handle_interests(
         top_n = int(top_n_raw)
     except (TypeError, ValueError):
         return error_response(
-            "INVALID_FIELD",
+            "INVALID_PARAMS",
             f"top_n must be an integer, got: {top_n_raw!r}",
         )
     if top_n <= 0:
         return error_response(
-            "INVALID_FIELD",
+            "INVALID_PARAMS",
             f"top_n must be a positive integer, got: {top_n}",
         )
 
     suggest_sources_raw = arguments.get("suggest_sources", False)
     if not isinstance(suggest_sources_raw, bool):
         return error_response(
-            "INVALID_FIELD",
+            "INVALID_PARAMS",
             f"suggest_sources must be a boolean, got: {suggest_sources_raw!r}",
         )
     suggest_sources: bool = suggest_sources_raw
@@ -1209,12 +1209,12 @@ async def _handle_interests(
         max_suggestions = int(max_suggestions_raw)
     except (TypeError, ValueError):
         return error_response(
-            "INVALID_FIELD",
+            "INVALID_PARAMS",
             f"max_suggestions must be an integer, got: {max_suggestions_raw!r}",
         )
     if max_suggestions <= 0:
         return error_response(
-            "INVALID_FIELD",
+            "INVALID_PARAMS",
             f"max_suggestions must be a positive integer, got: {max_suggestions}",
         )
 
@@ -1227,7 +1227,7 @@ async def _handle_interests(
         profile = await extractor.extract()
     except Exception as exc:  # noqa: BLE001
         logger.exception("distillery_interests: extraction failed")
-        return error_response("EXTRACTION_ERROR", f"Interest extraction failed: {exc}")
+        return error_response("INTERNAL", f"Interest extraction failed: {exc}")
 
     payload: dict[str, Any] = {
         "top_tags": [[tag, weight] for tag, weight in profile.top_tags],

--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -88,7 +88,7 @@ async def _handle_classify(
         entry = await store.get(entry_id)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error fetching entry id=%s for classify", entry_id)
-        return error_response("STORE_ERROR", f"Failed to retrieve entry: {exc}")
+        return error_response("INTERNAL", f"Failed to retrieve entry: {exc}")
 
     if entry is None:
         return error_response(
@@ -151,7 +151,7 @@ async def _handle_classify(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error updating entry id=%s during classify", entry_id)
-        return error_response("STORE_ERROR", f"Failed to update entry: {exc}")
+        return error_response("INTERNAL", f"Failed to update entry: {exc}")
 
     return success_response(updated_entry.to_dict())
 
@@ -205,7 +205,7 @@ async def _handle_resolve_review(
         entry = await store.get(entry_id)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error fetching entry id=%s for resolve_review", entry_id)
-        return error_response("STORE_ERROR", f"Failed to retrieve entry: {exc}")
+        return error_response("INTERNAL", f"Failed to retrieve entry: {exc}")
 
     if entry is None:
         return error_response(
@@ -266,7 +266,7 @@ async def _handle_resolve_review(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error updating entry id=%s during resolve_review", entry_id)
-        return error_response("STORE_ERROR", f"Failed to update entry: {exc}")
+        return error_response("INTERNAL", f"Failed to update entry: {exc}")
 
     return success_response(updated_entry.to_dict())
 

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -201,7 +201,7 @@ async def _handle_store(
                 top = tag.split("/")[0]
                 if top in cfg.tags.reserved_prefixes:
                     return error_response(
-                        "RESERVED_PREFIX",
+                        "INVALID_PARAMS",
                         f"Tag {tag!r} uses reserved prefix {top!r}. "
                         "Only internal sources may use this namespace.",
                     )
@@ -214,7 +214,7 @@ async def _handle_store(
                 size_mb = Path(db_path).stat().st_size / (1024 * 1024)
                 if size_mb >= cfg.rate_limit.max_db_size_mb:
                     return error_response(
-                        "DB_SIZE_EXCEEDED",
+                        "BUDGET_EXCEEDED",
                         f"Database size ({size_mb:.1f} MB) exceeds limit "
                         f"({cfg.rate_limit.max_db_size_mb} MB). "
                         "Delete old entries or increase rate_limit.max_db_size_mb.",
@@ -286,7 +286,7 @@ async def _handle_store(
         entry_id = await store.store(entry)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error storing entry")
-        return error_response("STORE_ERROR", f"Failed to store entry: {exc}")
+        return error_response("INTERNAL", f"Failed to store entry: {exc}")
 
     # --- summary mode: skip dedup/conflict, return early --------------------
     if output_mode == "summary":
@@ -416,7 +416,7 @@ async def _handle_get(
         entry = await store.get(entry_id)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error fetching entry id=%s", entry_id)
-        return error_response("STORE_ERROR", f"Failed to retrieve entry: {exc}")
+        return error_response("INTERNAL", f"Failed to retrieve entry: {exc}")
 
     if entry is None:
         return error_response(
@@ -590,7 +590,7 @@ async def _handle_update(
         return error_response("INVALID_PARAMS", str(exc))
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error updating entry id=%s", entry_id)
-        return error_response("STORE_ERROR", f"Failed to update entry: {exc}")
+        return error_response("INTERNAL", f"Failed to update entry: {exc}")
 
     return success_response(updated_entry.to_dict())
 
@@ -729,7 +729,7 @@ async def _handle_list(
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("Error in distillery_list (group_by mode)")
-            return error_response("LIST_ERROR", f"list_entries failed: {exc}")
+            return error_response("INTERNAL", f"list_entries failed: {exc}")
         return success_response(result)
 
     # --- stats mode ----------------------------------------------------------
@@ -744,7 +744,7 @@ async def _handle_list(
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("Error in distillery_list (stats mode)")
-            return error_response("LIST_ERROR", f"list_entries failed: {exc}")
+            return error_response("INTERNAL", f"list_entries failed: {exc}")
         return success_response(result)
 
     # --- default list mode ---------------------------------------------------
@@ -757,7 +757,7 @@ async def _handle_list(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error in distillery_list")
-        return error_response("LIST_ERROR", f"list_entries failed: {exc}")
+        return error_response("INTERNAL", f"list_entries failed: {exc}")
 
     try:
         total_count = await store.count_entries(filters=filters)
@@ -892,7 +892,7 @@ async def _handle_correct(
         original = await store.get(wrong_entry_id)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error fetching entry id=%s for correction", wrong_entry_id)
-        return error_response("STORE_ERROR", f"Failed to retrieve original entry: {exc}")
+        return error_response("INTERNAL", f"Failed to retrieve original entry: {exc}")
 
     if original is None:
         return error_response(
@@ -903,7 +903,7 @@ async def _handle_correct(
 
     if original.status == EntryStatus.ARCHIVED:
         return error_response(
-            "INVALID_STATE",
+            "INVALID_PARAMS",
             "Cannot correct an archived entry.",
             details={"wrong_entry_id": wrong_entry_id, "status": original.status.value},
         )
@@ -935,7 +935,7 @@ async def _handle_correct(
             top = tag.split("/")[0]
             if top in cfg.tags.reserved_prefixes:
                 return error_response(
-                    "RESERVED_PREFIX",
+                    "INVALID_PARAMS",
                     f"Tag {tag!r} uses reserved prefix {top!r}. "
                     "Only internal sources may use this namespace.",
                 )
@@ -969,7 +969,7 @@ async def _handle_correct(
                 size_mb = Path(db_path).stat().st_size / (1024 * 1024)
                 if size_mb >= cfg.rate_limit.max_db_size_mb:
                     return error_response(
-                        "DB_SIZE_EXCEEDED",
+                        "BUDGET_EXCEEDED",
                         f"Database size ({size_mb:.1f} MB) exceeds limit "
                         f"({cfg.rate_limit.max_db_size_mb} MB). "
                         "Delete old entries or increase rate_limit.max_db_size_mb.",
@@ -990,7 +990,7 @@ async def _handle_correct(
         new_entry_id = await store.apply_correction(new_entry, wrong_entry_id)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error applying correction for entry id=%s", wrong_entry_id)
-        return error_response("STORE_ERROR", f"Failed to apply correction: {exc}")
+        return error_response("INTERNAL", f"Failed to apply correction: {exc}")
 
     return success_response(
         {

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -57,14 +57,14 @@ async def _handle_watch(
     action_raw = arguments.get("action")
     if action_raw is None or not isinstance(action_raw, str):
         return error_response(
-            "INVALID_ACTION",
+            "INVALID_PARAMS",
             f"action must be a non-null string, got: {action_raw!r}",
         )
     action = action_raw.strip().lower()
 
     if action not in ("list", "add", "remove"):
         return error_response(
-            "INVALID_ACTION",
+            "INVALID_PARAMS",
             f"action must be one of 'list', 'add', 'remove'; got: {action!r}",
         )
 
@@ -73,7 +73,7 @@ async def _handle_watch(
             db_sources = await store.list_feed_sources()
         except Exception as exc:  # noqa: BLE001
             logger.exception("distillery_watch: failed to list feed sources")
-            return error_response("WATCH_ERROR", f"Failed to list feed sources: {exc}")
+            return error_response("INTERNAL", f"Failed to list feed sources: {exc}")
         return success_response(
             {
                 "sources": db_sources,
@@ -85,24 +85,24 @@ async def _handle_watch(
         url_raw = arguments.get("url")
         if url_raw is not None and not isinstance(url_raw, str):
             return error_response(
-                "INVALID_FIELD", f"url must be a string, got: {type(url_raw).__name__}"
+                "INVALID_PARAMS", f"url must be a string, got: {type(url_raw).__name__}"
             )
         url = str(url_raw or "").strip()
         if not url:
-            return error_response("MISSING_FIELD", "url is required for action='add'")
+            return error_response("INVALID_PARAMS", "url is required for action='add'")
 
         source_type_raw = arguments.get("source_type")
         if source_type_raw is not None and not isinstance(source_type_raw, str):
             return error_response(
-                "INVALID_FIELD",
+                "INVALID_PARAMS",
                 f"source_type must be a string, got: {type(source_type_raw).__name__}",
             )
         source_type = str(source_type_raw or "").strip()
         if not source_type:
-            return error_response("MISSING_FIELD", "source_type is required for action='add'")
+            return error_response("INVALID_PARAMS", "source_type is required for action='add'")
         if source_type not in _VALID_SOURCE_TYPES:
             return error_response(
-                "INVALID_SOURCE_TYPE",
+                "INVALID_PARAMS",
                 f"source_type must be one of {sorted(_VALID_SOURCE_TYPES)}, got: {source_type!r}",
             )
 
@@ -113,12 +113,12 @@ async def _handle_watch(
             poll_interval = int(poll_interval_raw)
         except (TypeError, ValueError):
             return error_response(
-                "INVALID_FIELD",
+                "INVALID_PARAMS",
                 f"poll_interval_minutes must be an integer, got: {poll_interval_raw!r}",
             )
         if poll_interval <= 0:
             return error_response(
-                "INVALID_FIELD",
+                "INVALID_PARAMS",
                 f"poll_interval_minutes must be a positive integer, got: {poll_interval}",
             )
 
@@ -127,12 +127,12 @@ async def _handle_watch(
             trust_weight = float(trust_weight_raw)
         except (TypeError, ValueError):
             return error_response(
-                "INVALID_FIELD",
+                "INVALID_PARAMS",
                 f"trust_weight must be a float, got: {trust_weight_raw!r}",
             )
         if not (0.0 <= trust_weight <= 1.0):
             return error_response(
-                "INVALID_FIELD",
+                "INVALID_PARAMS",
                 f"trust_weight must be between 0.0 and 1.0, got: {trust_weight}",
             )
 
@@ -147,12 +147,12 @@ async def _handle_watch(
             db_sources = await store.list_feed_sources()
         except ValueError:
             return error_response(
-                "DUPLICATE_SOURCE",
+                "CONFLICT",
                 f"Source with URL {url!r} is already registered.",
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("distillery_watch: failed to add feed source")
-            return error_response("WATCH_ERROR", f"Failed to add feed source: {exc}")
+            return error_response("INTERNAL", f"Failed to add feed source: {exc}")
 
         return success_response(
             {
@@ -164,14 +164,14 @@ async def _handle_watch(
     # action == "remove"
     url = str(arguments.get("url", "")).strip()
     if not url:
-        return error_response("MISSING_FIELD", "url is required for action='remove'")
+        return error_response("INVALID_PARAMS", "url is required for action='remove'")
 
     try:
         removed = await store.remove_feed_source(url)
         db_sources = await store.list_feed_sources()
     except Exception as exc:  # noqa: BLE001
         logger.exception("distillery_watch: failed to remove feed source")
-        return error_response("WATCH_ERROR", f"Failed to remove feed source: {exc}")
+        return error_response("INTERNAL", f"Failed to remove feed source: {exc}")
     return success_response(
         {
             "removed_url": url,
@@ -238,7 +238,7 @@ async def _handle_poll(
         summary = await poller.poll(source_url=source_url)
     except Exception as exc:  # noqa: BLE001
         logger.exception("distillery_poll: unexpected error during poll cycle")
-        return error_response("POLL_ERROR", f"Poll cycle failed: {exc}")
+        return error_response("INTERNAL", f"Poll cycle failed: {exc}")
 
     return success_response(
         {
@@ -285,7 +285,7 @@ async def _handle_rescore(
         limit = int(limit_raw)
     except (TypeError, ValueError):
         return error_response(
-            "INVALID_FIELD",
+            "INVALID_PARAMS",
             f"limit must be an integer, got: {limit_raw!r}",
         )
 
@@ -295,7 +295,7 @@ async def _handle_rescore(
         return success_response(stats)
     except Exception as exc:  # noqa: BLE001
         logger.exception("distillery_rescore: unexpected error")
-        return error_response("RESCORE_ERROR", f"Rescore failed: {exc}")
+        return error_response("INTERNAL", f"Rescore failed: {exc}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -25,6 +25,17 @@ logger = logging.getLogger(__name__)
 
 _VALID_DIRECTIONS = {"outgoing", "incoming", "both"}
 
+_VALID_RELATION_TYPES = {
+    "link",
+    "corrects",
+    "supersedes",
+    "related",
+    "blocks",
+    "depends_on",
+    "citation",
+    "duplicate",
+}
+
 
 async def _handle_relations(
     store: Any,
@@ -80,6 +91,12 @@ async def _handle_relations(
         relation_type = relation_type_raw.strip()
         if not relation_type:
             return error_response("INVALID_PARAMS", "relation_type must be a non-empty string")
+        if relation_type not in _VALID_RELATION_TYPES:
+            return error_response(
+                "INVALID_PARAMS",
+                f"Invalid relation_type {relation_type!r}. "
+                f"Must be one of: {', '.join(sorted(_VALID_RELATION_TYPES))}.",
+            )
 
         try:
             relation_id = await store.add_relation(from_id, to_id, relation_type)

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -45,14 +45,14 @@ async def _handle_relations(
     action_raw = arguments.get("action")
     if action_raw is None or not isinstance(action_raw, str):
         return error_response(
-            "INVALID_ACTION",
+            "INVALID_PARAMS",
             f"action must be a non-null string, got: {action_raw!r}",
         )
     action = action_raw.strip().lower()
 
     if action not in ("add", "get", "remove"):
         return error_response(
-            "INVALID_ACTION",
+            "INVALID_PARAMS",
             f"action must be one of 'add', 'get', 'remove'; got: {action!r}",
         )
 
@@ -62,24 +62,24 @@ async def _handle_relations(
     if action == "add":
         from_id_raw = arguments.get("from_id")
         if from_id_raw is None or not isinstance(from_id_raw, str):
-            return error_response("MISSING_FIELD", "from_id is required for action='add'")
+            return error_response("INVALID_PARAMS", "from_id is required for action='add'")
         from_id = from_id_raw.strip()
         if not from_id:
-            return error_response("MISSING_FIELD", "from_id must be a non-empty string")
+            return error_response("INVALID_PARAMS", "from_id must be a non-empty string")
 
         to_id_raw = arguments.get("to_id")
         if to_id_raw is None or not isinstance(to_id_raw, str):
-            return error_response("MISSING_FIELD", "to_id is required for action='add'")
+            return error_response("INVALID_PARAMS", "to_id is required for action='add'")
         to_id = to_id_raw.strip()
         if not to_id:
-            return error_response("MISSING_FIELD", "to_id must be a non-empty string")
+            return error_response("INVALID_PARAMS", "to_id must be a non-empty string")
 
         relation_type_raw = arguments.get("relation_type")
         if relation_type_raw is None or not isinstance(relation_type_raw, str):
-            return error_response("MISSING_FIELD", "relation_type is required for action='add'")
+            return error_response("INVALID_PARAMS", "relation_type is required for action='add'")
         relation_type = relation_type_raw.strip()
         if not relation_type:
-            return error_response("MISSING_FIELD", "relation_type must be a non-empty string")
+            return error_response("INVALID_PARAMS", "relation_type must be a non-empty string")
 
         try:
             relation_id = await store.add_relation(from_id, to_id, relation_type)
@@ -90,7 +90,7 @@ async def _handle_relations(
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("distillery_relations add: unexpected error")
-            return error_response("RELATIONS_ERROR", f"Failed to add relation: {exc}")
+            return error_response("INTERNAL", f"Failed to add relation: {exc}")
 
         return success_response(
             {
@@ -107,21 +107,21 @@ async def _handle_relations(
     if action == "get":
         entry_id_raw = arguments.get("entry_id")
         if entry_id_raw is None or not isinstance(entry_id_raw, str):
-            return error_response("MISSING_FIELD", "entry_id is required for action='get'")
+            return error_response("INVALID_PARAMS", "entry_id is required for action='get'")
         entry_id = entry_id_raw.strip()
         if not entry_id:
-            return error_response("MISSING_FIELD", "entry_id must be a non-empty string")
+            return error_response("INVALID_PARAMS", "entry_id must be a non-empty string")
 
         direction_raw = arguments.get("direction", "both")
         if not isinstance(direction_raw, str):
             return error_response(
-                "INVALID_FIELD",
+                "INVALID_PARAMS",
                 f"direction must be a string, got: {type(direction_raw).__name__}",
             )
         direction = direction_raw.strip().lower()
         if direction not in _VALID_DIRECTIONS:
             return error_response(
-                "INVALID_FIELD",
+                "INVALID_PARAMS",
                 f"direction must be one of {sorted(_VALID_DIRECTIONS)}, got: {direction!r}",
             )
 
@@ -130,7 +130,7 @@ async def _handle_relations(
         if get_relation_type_raw is not None:
             if not isinstance(get_relation_type_raw, str):
                 return error_response(
-                    "INVALID_FIELD",
+                    "INVALID_PARAMS",
                     f"relation_type must be a string, got: {type(get_relation_type_raw).__name__}",
                 )
             get_relation_type = get_relation_type_raw.strip() or None
@@ -141,7 +141,7 @@ async def _handle_relations(
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("distillery_relations get: unexpected error")
-            return error_response("RELATIONS_ERROR", f"Failed to get relations: {exc}")
+            return error_response("INTERNAL", f"Failed to get relations: {exc}")
 
         return success_response(
             {
@@ -158,16 +158,16 @@ async def _handle_relations(
     # ------------------------------------------------------------------
     relation_id_raw = arguments.get("relation_id")
     if relation_id_raw is None or not isinstance(relation_id_raw, str):
-        return error_response("MISSING_FIELD", "relation_id is required for action='remove'")
+        return error_response("INVALID_PARAMS", "relation_id is required for action='remove'")
     relation_id = relation_id_raw.strip()
     if not relation_id:
-        return error_response("MISSING_FIELD", "relation_id must be a non-empty string")
+        return error_response("INVALID_PARAMS", "relation_id must be a non-empty string")
 
     try:
         removed = await store.remove_relation(relation_id)
     except Exception as exc:  # noqa: BLE001
         logger.exception("distillery_relations remove: unexpected error")
-        return error_response("RELATIONS_ERROR", f"Failed to remove relation: {exc}")
+        return error_response("INTERNAL", f"Failed to remove relation: {exc}")
 
     return success_response(
         {

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -82,7 +82,7 @@ async def _handle_search(
         search_results = await store.search(query=query, filters=filters, limit=limit)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error in distillery_search")
-        return error_response("SEARCH_ERROR", f"Search failed: {exc}")
+        return error_response("INTERNAL", f"Search failed: {exc}")
 
     results = [{"score": round(sr.score, 6), "entry": sr.entry.to_dict()} for sr in search_results]
 
@@ -187,7 +187,7 @@ async def _handle_find_similar(
         search_results = await store.find_similar(content=content, threshold=threshold, limit=limit)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error in distillery_find_similar")
-        return error_response("FIND_SIMILAR_ERROR", f"find_similar failed: {exc}")
+        return error_response("INTERNAL", f"find_similar failed: {exc}")
 
     results = [{"score": round(sr.score, 6), "entry": sr.entry.to_dict()} for sr in search_results]
     payload: dict[str, Any] = {
@@ -210,7 +210,7 @@ async def _handle_find_similar(
             payload["dedup"] = dedup_result
         except Exception as exc:  # noqa: BLE001
             logger.exception("Error running dedup check in find_similar")
-            return error_response("DEDUP_ERROR", f"Deduplication check failed: {exc}")
+            return error_response("INTERNAL", f"Deduplication check failed: {exc}")
 
     # --- conflict_check mode -------------------------------------------------
     if conflict_check:
@@ -255,7 +255,7 @@ async def _handle_find_similar(
                 payload["conflict_evaluation"] = eval_result
             except Exception as exc:  # noqa: BLE001
                 logger.exception("Error running conflict evaluation in find_similar")
-                return error_response("CONFLICT_ERROR", f"Conflict evaluation failed: {exc}")
+                return error_response("INTERNAL", f"Conflict evaluation failed: {exc}")
         else:
             # --- first pass: discover conflict candidates ---
             try:
@@ -277,7 +277,7 @@ async def _handle_find_similar(
                 payload["conflict_message"] = discovery_result.get("message", "")
             except Exception as exc:  # noqa: BLE001
                 logger.exception("Error running conflict discovery in find_similar")
-                return error_response("CONFLICT_ERROR", f"Conflict check failed: {exc}")
+                return error_response("INTERNAL", f"Conflict check failed: {exc}")
 
     return success_response(payload)
 
@@ -340,7 +340,7 @@ async def _handle_aggregate(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error in distillery_aggregate")
-        return error_response("AGGREGATE_ERROR", f"aggregate_entries failed: {exc}")
+        return error_response("INTERNAL", f"aggregate_entries failed: {exc}")
 
     return success_response(
         {

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -133,7 +133,7 @@ async def test_correct_archived_entry(store: DuckDBStore, original_entry: str) -
     )
     data = parse_mcp_response(result)
     assert data["error"] is True
-    assert data["code"] == "INVALID_STATE"
+    assert data["code"] == "INVALID_PARAMS"
     assert "archived" in data["message"].lower()
 
 

--- a/tests/test_e2e_mcp.py
+++ b/tests/test_e2e_mcp.py
@@ -498,8 +498,7 @@ class TestCallToolDispatcher:
         tools = await server.list_tools()
         tool_names = {t.name for t in tools}
 
-        # 8 tools removed: aggregate, metrics, stale, tag_tree, type_schemas,
-        # interests, poll, rescore — moved to webhooks or MCP resources.
+        # 3 tools removed: type_schemas (MCP resource), poll, rescore (webhooks).
         expected = {
             "distillery_store",
             "distillery_get",
@@ -513,6 +512,11 @@ class TestCallToolDispatcher:
             "distillery_watch",
             "distillery_configure",
             "distillery_relations",
+            "distillery_aggregate",
+            "distillery_metrics",
+            "distillery_stale",
+            "distillery_tag_tree",
+            "distillery_interests",
         }
         assert expected == tool_names, (
             f"Tool mismatch — extra: {tool_names - expected}, missing: {expected - tool_names}"

--- a/tests/test_find_similar_extended.py
+++ b/tests/test_find_similar_extended.py
@@ -217,7 +217,7 @@ class TestFindSimilarDedupAction:
             )
         data = parse_mcp_response(response)
         assert "error" in data
-        assert data["code"] == "DEDUP_ERROR"
+        assert data["code"] == "INTERNAL"
 
 
 # ===========================================================================
@@ -332,7 +332,7 @@ class TestFindSimilarConflictCheckPass1:
             )
         data = parse_mcp_response(response)
         assert "error" in data
-        assert data["code"] == "CONFLICT_ERROR"
+        assert data["code"] == "INTERNAL"
 
 
 # ===========================================================================
@@ -521,7 +521,7 @@ class TestFindSimilarConflictCheckPass2:
             )
         data = parse_mcp_response(response)
         assert "error" in data
-        assert data["code"] == "CONFLICT_ERROR"
+        assert data["code"] == "INTERNAL"
 
 
 # ===========================================================================

--- a/tests/test_interests.py
+++ b/tests/test_interests.py
@@ -553,7 +553,7 @@ class TestHandleSuggestSources:
         )
         data = json.loads(result[0].text)
         assert data.get("error") is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_watched_sources_excluded_from_suggestions(self) -> None:
         from distillery.mcp.server import _handle_interests

--- a/tests/test_mcp_analytics.py
+++ b/tests/test_mcp_analytics.py
@@ -514,7 +514,7 @@ class TestInterests:
         response = await _handle_interests(store, config, {"recency_days": "bad"})
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_interests_negative_recency_days(
         self, store: DuckDBStore, config: DistilleryConfig
@@ -522,7 +522,7 @@ class TestInterests:
         response = await _handle_interests(store, config, {"recency_days": -1})
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_interests_invalid_top_n(
         self, store: DuckDBStore, config: DistilleryConfig
@@ -530,13 +530,13 @@ class TestInterests:
         response = await _handle_interests(store, config, {"top_n": "bad"})
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_interests_zero_top_n(self, store: DuckDBStore, config: DistilleryConfig) -> None:
         response = await _handle_interests(store, config, {"top_n": 0})
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_interests_extraction_error(
         self, store: DuckDBStore, config: DistilleryConfig
@@ -549,7 +549,7 @@ class TestInterests:
             data = parse_mcp_response(response)
 
         assert data["error"] is True
-        assert data["code"] == "EXTRACTION_ERROR"
+        assert data["code"] == "INTERNAL"
 
     @staticmethod
     def _make_mock_profile():

--- a/tests/test_mcp_coverage_gaps.py
+++ b/tests/test_mcp_coverage_gaps.py
@@ -129,7 +129,7 @@ class TestSearchBudgetAndErrors:
             response = await _handle_search(store, {"query": "test"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "SEARCH_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_search_logs_search_event(self, store: DuckDBStore) -> None:
         """Successful search with results calls store.log_search."""
@@ -191,7 +191,7 @@ class TestFindSimilarGaps:
             response = await _handle_find_similar(store, {"content": "test"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "FIND_SIMILAR_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 class TestAggregateGaps:
@@ -202,7 +202,7 @@ class TestAggregateGaps:
             response = await _handle_aggregate(store, {"group_by": "entry_type"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "AGGREGATE_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_aggregate_invalid_limit(self, store: DuckDBStore) -> None:
         response = await _handle_aggregate(store, {"group_by": "entry_type", "limit": "bad"})
@@ -234,7 +234,7 @@ class TestStatusGaps:
             response = await _handle_metrics(store, cfg, None, {"scope": "summary"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "METRICS_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_status_remote_db_path(self) -> None:
         """Remote db paths (md:, s3://) are not expanded."""
@@ -323,7 +323,7 @@ class TestStoreGaps:
         )
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "RESERVED_PREFIX"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_store_non_string_tag_in_reserved_check(self, store: DuckDBStore) -> None:
         """Non-string tag triggers INVALID_PARAMS during reserved prefix check."""
@@ -368,7 +368,7 @@ class TestStoreGaps:
             )
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "STORE_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_store_invalid_source_rejected(self, store: DuckDBStore) -> None:
         """Invalid source value is rejected with INVALID_PARAMS error."""
@@ -421,7 +421,7 @@ class TestGetGaps:
             response = await _handle_get(store, {"entry_id": "any"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "STORE_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_get_with_feedback_logging(
         self, store: DuckDBStore, config: DistilleryConfig
@@ -539,7 +539,7 @@ class TestUpdateGaps:
             response = await _handle_update(store, {"entry_id": entry_id, "content": "updated"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "STORE_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_update_value_error(self, store: DuckDBStore) -> None:
         entry = make_entry(content="Value error test")
@@ -638,7 +638,7 @@ class TestListGaps:
             response = await _handle_list(store, {})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "LIST_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 class TestBuildFilters:
@@ -692,7 +692,7 @@ class TestClassifyGaps:
             )
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "STORE_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_classify_invalid_confidence_type(
         self, store: DuckDBStore, config: DistilleryConfig
@@ -826,7 +826,7 @@ class TestClassifyGaps:
             )
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "STORE_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_classify_update_key_error(
         self, store: DuckDBStore, config: DistilleryConfig
@@ -875,7 +875,7 @@ class TestReviewQueueGaps:
             response = await _handle_list(store, {"output_mode": "review"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "LIST_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 class TestResolveReviewGaps:
@@ -886,7 +886,7 @@ class TestResolveReviewGaps:
             response = await _handle_resolve_review(store, {"entry_id": "any", "action": "approve"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "STORE_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_resolve_review_not_found(self, store: DuckDBStore) -> None:
         response = await _handle_resolve_review(
@@ -969,7 +969,7 @@ class TestResolveReviewGaps:
             )
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "STORE_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 # ===========================================================================
@@ -1003,7 +1003,7 @@ class TestMetricsGaps:
             response = await _handle_metrics(store, config, embedding_provider, {})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "METRICS_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 class TestQualityGaps:
@@ -1018,7 +1018,7 @@ class TestQualityGaps:
             response = await _handle_metrics(store, cfg, None, {"scope": "search_quality"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "METRICS_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 class TestStaleGaps:
@@ -1032,7 +1032,7 @@ class TestStaleGaps:
             response = await _handle_stale(store, config, {})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "STALE_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 class TestTagTreeGaps:
@@ -1046,7 +1046,7 @@ class TestTagTreeGaps:
             response = await _handle_tag_tree(store, {})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "TAG_TREE_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 # ===========================================================================
@@ -1061,7 +1061,7 @@ class TestWatchGaps:
         response = await _handle_watch(store, {"action": "add", "url": 123, "source_type": "rss"})
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_watch_add_source_type_not_string(self, store: DuckDBStore) -> None:
         response = await _handle_watch(
@@ -1069,7 +1069,7 @@ class TestWatchGaps:
         )
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_watch_add_invalid_poll_interval(self, store: DuckDBStore) -> None:
         response = await _handle_watch(
@@ -1083,7 +1083,7 @@ class TestWatchGaps:
         )
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_watch_add_negative_poll_interval(self, store: DuckDBStore) -> None:
         response = await _handle_watch(
@@ -1136,14 +1136,14 @@ class TestWatchGaps:
             )
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "WATCH_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_watch_list_store_error(self, store: DuckDBStore) -> None:
         with patch.object(store, "list_feed_sources", side_effect=RuntimeError("boom")):
             response = await _handle_watch(store, {"action": "list"})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "WATCH_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_watch_remove_store_error(self, store: DuckDBStore) -> None:
         with patch.object(store, "remove_feed_source", side_effect=RuntimeError("boom")):
@@ -1152,7 +1152,7 @@ class TestWatchGaps:
             )
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "WATCH_ERROR"
+            assert data["code"] == "INTERNAL"
 
     async def test_watch_add_duplicate(self, store: DuckDBStore) -> None:
         with patch.object(store, "add_feed_source", side_effect=ValueError("duplicate")):
@@ -1166,7 +1166,7 @@ class TestWatchGaps:
             )
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "DUPLICATE_SOURCE"
+            assert data["code"] == "CONFLICT"
 
 
 class TestPollGaps:
@@ -1188,7 +1188,7 @@ class TestPollGaps:
             response = await _handle_poll(store, config, {})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "POLL_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 class TestRescoreGaps:
@@ -1200,7 +1200,7 @@ class TestRescoreGaps:
         response = await _handle_rescore(store, config, {"limit": "bad"})
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_rescore_error(self, store: DuckDBStore, config: DistilleryConfig) -> None:
         with patch(
@@ -1210,7 +1210,7 @@ class TestRescoreGaps:
             response = await _handle_rescore(store, config, {})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "RESCORE_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 class TestSuggestSourcesGaps:
@@ -1224,7 +1224,7 @@ class TestSuggestSourcesGaps:
         )
         data = parse_mcp_response(response)
         assert data["error"] is True
-        assert data["code"] == "INVALID_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_suggest_zero_max_suggestions(
         self, store: DuckDBStore, config: DistilleryConfig
@@ -1273,7 +1273,7 @@ class TestSuggestSourcesGaps:
             response = await _handle_interests(store, config, {"suggest_sources": True})
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "EXTRACTION_ERROR"
+            assert data["code"] == "INTERNAL"
 
 
 class TestNormaliseWatchedSet:
@@ -1709,7 +1709,7 @@ class TestStoreDbSizeCheck:
             )
             data = parse_mcp_response(response)
             assert data["error"] is True
-            assert data["code"] == "DB_SIZE_EXCEEDED"
+            assert data["code"] == "BUDGET_EXCEEDED"
         finally:
             import os
 

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -39,14 +39,17 @@ class TestToolErrorCode:
         assert str(code) == "INVALID_PARAMS"
 
     def test_all_codes_listed(self) -> None:
-        """Verify there are exactly 4 codes (no accidental additions)."""
+        """Verify there are exactly 7 codes (no accidental additions)."""
         codes = list(ToolErrorCode)
-        assert len(codes) == 4
+        assert len(codes) == 7
         assert set(codes) == {
             ToolErrorCode.INVALID_PARAMS,
             ToolErrorCode.NOT_FOUND,
             ToolErrorCode.CONFLICT,
             ToolErrorCode.INTERNAL,
+            ToolErrorCode.FORBIDDEN,
+            ToolErrorCode.BUDGET_EXCEEDED,
+            ToolErrorCode.RATE_LIMITED,
         }
 
 

--- a/tests/test_mcp_feeds.py
+++ b/tests/test_mcp_feeds.py
@@ -154,7 +154,7 @@ class TestHandleWatchList:
         result = await _handle_watch(store=store, arguments={"action": "list"})
         data = parse(result)
         assert data["error"] is True
-        assert data["code"] == "WATCH_ERROR"
+        assert data["code"] == "INTERNAL"
 
 
 # ---------------------------------------------------------------------------
@@ -235,7 +235,7 @@ class TestHandleWatchAdd:
         )
         data = parse(result)
         assert data["error"] is True
-        assert data["code"] == "MISSING_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_add_missing_source_type_returns_missing_field(self) -> None:
         store = FakeSourceStore()
@@ -245,7 +245,7 @@ class TestHandleWatchAdd:
         )
         data = parse(result)
         assert data["error"] is True
-        assert data["code"] == "MISSING_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_add_invalid_source_type_returns_error(self) -> None:
         store = FakeSourceStore()
@@ -259,7 +259,7 @@ class TestHandleWatchAdd:
         )
         data = parse(result)
         assert data["error"] is True
-        assert data["code"] == "INVALID_SOURCE_TYPE"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_add_invalid_poll_interval_zero_returns_error(self) -> None:
         store = FakeSourceStore()
@@ -303,7 +303,7 @@ class TestHandleWatchAdd:
         )
         data = parse(result)
         assert data["error"] is True
-        assert data["code"] == "DUPLICATE_SOURCE"
+        assert data["code"] == "CONFLICT"
 
     async def test_add_response_includes_updated_sources_list(self) -> None:
         store = FakeSourceStore()
@@ -349,7 +349,7 @@ class TestHandleWatchRemove:
         result = await _handle_watch(store=store, arguments={"action": "remove"})
         data = parse(result)
         assert data["error"] is True
-        assert data["code"] == "MISSING_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_remove_only_removes_matching_source(self) -> None:
         store = FakeSourceStore()
@@ -386,7 +386,7 @@ class TestHandleWatchInvalidAction:
         result = await _handle_watch(store=store, arguments={"action": "purge"})
         data = parse(result)
         assert data["error"] is True
-        assert data["code"] == "INVALID_ACTION"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_missing_action_returns_error(self) -> None:
         store = FakeSourceStore()
@@ -505,7 +505,7 @@ class TestHandlePoll:
 
         data = parse(result)
         assert data["error"] is True
-        assert data["code"] == "POLL_ERROR"
+        assert data["code"] == "INTERNAL"
         assert "network failure" in data["message"]
 
     async def test_poll_result_has_iso_polled_at(self) -> None:
@@ -706,7 +706,7 @@ class TestHandleSuggestSources:
 
         data = parse(result)
         assert data["error"] is True
-        assert data["code"] == "EXTRACTION_ERROR"
+        assert data["code"] == "INTERNAL"
 
     async def test_suggest_sources_response_shape(self) -> None:
         """Response always contains suggestions, suggestion_context, watched_sources, entry_count."""

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -32,9 +32,8 @@ MCP_HEADERS = {
     "Accept": "application/json, text/event-stream",
 }
 
-# All 12 tools that the Distillery MCP server exposes.
-# 8 tools removed: aggregate, metrics, stale, tag_tree, type_schemas,
-# interests, poll, rescore — moved to webhooks or MCP resources.
+# All 17 tools that the Distillery MCP server exposes.
+# 3 tools removed: type_schemas (MCP resource), poll, rescore (webhooks).
 EXPECTED_TOOLS = {
     "distillery_store",
     "distillery_get",
@@ -48,6 +47,11 @@ EXPECTED_TOOLS = {
     "distillery_watch",
     "distillery_configure",
     "distillery_relations",
+    "distillery_aggregate",
+    "distillery_metrics",
+    "distillery_stale",
+    "distillery_tag_tree",
+    "distillery_interests",
 }
 
 
@@ -160,7 +164,7 @@ class TestAllToolsAccessibleOverHttp:
             assert "result" in data, f"Expected result in: {data}"
             tools = data["result"]["tools"]
             tool_names = {t["name"] for t in tools}
-            assert len(tool_names) == 12, f"Expected 12 tools, got {len(tool_names)}: {tool_names}"
+            assert len(tool_names) == 17, f"Expected 17 tools, got {len(tool_names)}: {tool_names}"
             assert tool_names == EXPECTED_TOOLS, (
                 f"Tool mismatch.\nExpected: {EXPECTED_TOOLS}\nGot: {tool_names}"
             )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,6 +1,6 @@
 """Tests for the Distillery MCP server (T04.4 / T02.3).
 
-Tests cover the 12 registered MCP tools via direct handler calls with a mock
+Tests cover the 17 registered MCP tools via direct handler calls with a mock
 store and deterministic embedding provider:
 
   store -> search -> get -> update -> find_similar -> list -> status
@@ -9,7 +9,7 @@ The test harness exercises the server handlers directly without requiring a
 running stdio transport.  All handlers are async functions that accept a
 store object and an arguments dict -- this is the natural unit-test seam.
 
-Also exercises the ``create_server`` factory to confirm all 12 tools are
+Also exercises the ``create_server`` factory to confirm all 17 tools are
 registered and the lifespan context initialises state correctly.
 
 Tools removed from MCP surface (now webhooks or internal handlers):
@@ -666,8 +666,8 @@ class TestCreateServer:
         tools = await server.list_tools()
         tool_names = {t.name for t in tools}
 
-        # 8 tools removed: aggregate, metrics, stale, tag_tree, type_schemas,
-        # interests, poll, rescore — moved to webhooks or MCP resources.
+        # 3 tools removed: type_schemas (MCP resource), poll, rescore (webhooks).
+        # 5 analytics tools re-registered: aggregate, metrics, stale, tag_tree, interests.
         expected = {
             "distillery_store",
             "distillery_get",
@@ -681,6 +681,11 @@ class TestCreateServer:
             "distillery_watch",
             "distillery_configure",
             "distillery_relations",
+            "distillery_aggregate",
+            "distillery_metrics",
+            "distillery_stale",
+            "distillery_tag_tree",
+            "distillery_interests",
         }
         assert expected == tool_names, (
             f"Tool mismatch — extra: {tool_names - expected}, missing: {expected - tool_names}"
@@ -717,30 +722,20 @@ class TestCreateServer:
 
 
 class TestRemovedTools:
-    """Verify that the 8 tools removed from the MCP surface are not registered.
+    """Verify that tools moved to webhooks/resources are not registered as MCP tools.
 
-    These tools were removed in T02.2: stale, aggregate, tag_tree, metrics,
-    interests, type_schemas were absorbed into list extensions, webhooks, or
-    the distillery://schemas/entry-types MCP resource; poll and rescore were
-    moved to /api/poll and /api/rescore webhook endpoints.
-
-    Calling a removed tool name through the registered tool set must not
-    succeed — the tool simply does not exist in the server's tool registry.
+    type_schemas was moved to the distillery://schemas/entry-types MCP resource;
+    poll and rescore were moved to /api/poll and /api/rescore webhook endpoints.
     """
 
     _REMOVED_TOOL_NAMES = [
-        "distillery_stale",
-        "distillery_aggregate",
-        "distillery_tag_tree",
-        "distillery_metrics",
-        "distillery_interests",
         "distillery_type_schemas",
         "distillery_poll",
         "distillery_rescore",
     ]
 
     async def test_removed_tools_not_registered(self) -> None:
-        """None of the 8 removed tools should appear in list_tools()."""
+        """None of the removed tools should appear in list_tools()."""
         config = DistilleryConfig(
             storage=StorageConfig(database_path=":memory:"),
             embedding=EmbeddingConfig(provider="", model="stub", dimensions=4),
@@ -755,14 +750,14 @@ class TestRemovedTools:
             )
 
     async def test_removed_tools_count_unchanged(self) -> None:
-        """Exactly 12 tools must be registered — no removed tool has crept back."""
+        """Exactly 17 tools must be registered — no removed tool has crept back."""
         config = DistilleryConfig(
             storage=StorageConfig(database_path=":memory:"),
             embedding=EmbeddingConfig(provider="", model="stub", dimensions=4),
         )
         server = create_server(config)
         tools = await server.list_tools()
-        assert len(tools) == 12, (
-            f"Expected 12 registered tools, got {len(tools)}: "
+        assert len(tools) == 17, (
+            f"Expected 17 registered tools, got {len(tools)}: "
             f"{sorted(t.name for t in tools)}"
         )

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -289,7 +289,7 @@ async def test_handle_relations_null_action() -> None:
     result = await _handle_relations(AsyncMock(), {"action": None})
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "INVALID_ACTION"
+    assert data["code"] == "INVALID_PARAMS"
 
 
 @pytest.mark.unit
@@ -298,7 +298,7 @@ async def test_handle_relations_unknown_action() -> None:
     result = await _handle_relations(AsyncMock(), {"action": "delete"})
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "INVALID_ACTION"
+    assert data["code"] == "INVALID_PARAMS"
     assert "delete" in data["message"]
 
 
@@ -334,7 +334,7 @@ async def test_handle_relations_add_missing_from_id() -> None:
     )
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "MISSING_FIELD"
+    assert data["code"] == "INVALID_PARAMS"
     assert "from_id" in data["message"]
 
 
@@ -347,7 +347,7 @@ async def test_handle_relations_add_missing_to_id() -> None:
     )
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "MISSING_FIELD"
+    assert data["code"] == "INVALID_PARAMS"
     assert "to_id" in data["message"]
 
 
@@ -360,7 +360,7 @@ async def test_handle_relations_add_missing_relation_type() -> None:
     )
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "MISSING_FIELD"
+    assert data["code"] == "INVALID_PARAMS"
     assert "relation_type" in data["message"]
 
 
@@ -390,7 +390,7 @@ async def test_handle_relations_add_unexpected_error() -> None:
     )
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "RELATIONS_ERROR"
+    assert data["code"] == "INTERNAL"
 
 
 # ---------------------------------------------------------------------------
@@ -423,7 +423,7 @@ async def test_handle_relations_get_missing_entry_id() -> None:
     result = await _handle_relations(AsyncMock(), {"action": "get"})
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "MISSING_FIELD"
+    assert data["code"] == "INVALID_PARAMS"
     assert "entry_id" in data["message"]
 
 
@@ -436,7 +436,7 @@ async def test_handle_relations_get_invalid_direction() -> None:
     )
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "INVALID_FIELD"
+    assert data["code"] == "INVALID_PARAMS"
     assert "direction" in data["message"]
 
 
@@ -501,7 +501,7 @@ async def test_handle_relations_get_unexpected_error() -> None:
     )
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "RELATIONS_ERROR"
+    assert data["code"] == "INTERNAL"
 
 
 # ---------------------------------------------------------------------------
@@ -544,7 +544,7 @@ async def test_handle_relations_remove_missing_relation_id() -> None:
     result = await _handle_relations(AsyncMock(), {"action": "remove"})
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "MISSING_FIELD"
+    assert data["code"] == "INVALID_PARAMS"
     assert "relation_id" in data["message"]
 
 
@@ -560,4 +560,4 @@ async def test_handle_relations_remove_unexpected_error() -> None:
     )
     data = _parse(result)
     assert data["error"] is True
-    assert data["code"] == "RELATIONS_ERROR"
+    assert data["code"] == "INTERNAL"

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -302,7 +302,7 @@ class TestHandleWatchAdd:
         )
         data = json.loads(result[0].text)
         assert data.get("error") is True
-        assert data["code"] == "MISSING_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_add_missing_source_type_returns_error(self) -> None:
         from distillery.mcp.server import _handle_watch
@@ -314,7 +314,7 @@ class TestHandleWatchAdd:
         )
         data = json.loads(result[0].text)
         assert data.get("error") is True
-        assert data["code"] == "MISSING_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_add_invalid_source_type_returns_error(self) -> None:
         from distillery.mcp.server import _handle_watch
@@ -330,7 +330,7 @@ class TestHandleWatchAdd:
         )
         data = json.loads(result[0].text)
         assert data.get("error") is True
-        assert data["code"] == "INVALID_SOURCE_TYPE"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_add_trust_weight_out_of_range_returns_error(self) -> None:
         from distillery.mcp.server import _handle_watch
@@ -378,7 +378,7 @@ class TestHandleWatchAdd:
         )
         data = json.loads(result[0].text)
         assert data.get("error") is True
-        assert data["code"] == "DUPLICATE_SOURCE"
+        assert data["code"] == "CONFLICT"
 
     async def test_add_response_has_no_yaml_note(self) -> None:
         from distillery.mcp.server import _handle_watch
@@ -449,7 +449,7 @@ class TestHandleWatchRemove:
         )
         data = json.loads(result[0].text)
         assert data.get("error") is True
-        assert data["code"] == "MISSING_FIELD"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_remove_response_includes_updated_sources(self) -> None:
         from distillery.mcp.server import _handle_watch
@@ -494,7 +494,7 @@ class TestHandleWatchInvalidAction:
         )
         data = json.loads(result[0].text)
         assert data.get("error") is True
-        assert data["code"] == "INVALID_ACTION"
+        assert data["code"] == "INVALID_PARAMS"
 
     async def test_missing_action_returns_error(self) -> None:
         from distillery.mcp.server import _handle_watch
@@ -630,7 +630,7 @@ class TestHandleWatchBackendErrors:
         result = await _handle_watch(store=store, arguments={"action": "list"})
         data = json.loads(result[0].text)
         assert data["error"] is True
-        assert data["code"] == "WATCH_ERROR"
+        assert data["code"] == "INTERNAL"
 
     async def test_add_backend_error(self) -> None:
         from distillery.mcp.server import _handle_watch
@@ -646,7 +646,7 @@ class TestHandleWatchBackendErrors:
         )
         data = json.loads(result[0].text)
         assert data["error"] is True
-        assert data["code"] == "WATCH_ERROR"
+        assert data["code"] == "INTERNAL"
 
     async def test_remove_backend_error(self) -> None:
         from distillery.mcp.server import _handle_watch
@@ -658,4 +658,4 @@ class TestHandleWatchBackendErrors:
         )
         data = json.loads(result[0].text)
         assert data["error"] is True
-        assert data["code"] == "WATCH_ERROR"
+        assert data["code"] == "INTERNAL"


### PR DESCRIPTION
## Summary

Full implementation of #245 across 5 phases:

- **Phase 1** — Rewrote all 12 tool docstrings with structured template (USE WHEN, PARAMS with types/defaults/valid values, RETURNS, RELATED). Listed all 12 entry types where only 7 were shown.
- **Phase 2** — Registered 5 missing tool handlers as `@server.tool`: `distillery_aggregate`, `distillery_metrics`, `distillery_stale`, `distillery_tag_tree`, `distillery_interests`. Tool count: 12 → 17.
- **Phase 3** — Standardized error codes across 7 handler files. Expanded `ToolErrorCode` enum to 7 canonical codes (added FORBIDDEN, BUDGET_EXCEEDED, RATE_LIMITED). Replaced 15+ ad-hoc strings.
- **Phase 4** — Fixed `validate_required()` bug (treated `0`/`False` as missing). Added `validate_enum()` and `validate_positive_int()` helpers.
- **Phase 5** — Added `_VALID_RELATION_TYPES` (8 types) with validation on `add` action.

API reference documentation (Phase 6 in the issue) deferred to a separate PR.

## Test plan
- [x] 1980 tests pass, 73 skipped, 2 xfailed
- [x] `mypy --strict` — 22 files, no issues
- [x] `ruff check` — clean
- [ ] CI pipeline

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new analytics and insights tools: `distillery_aggregate`, `distillery_metrics`, `distillery_stale`, `distillery_tag_tree`, and `distillery_interests` for enhanced data analysis capabilities.

* **Refactor**
  * Standardized error codes across the system for consistency and clarity in error handling.
  * Enhanced validation logic for improved argument processing.
  * Updated tool documentation for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Relates to #245