### PR TITLE
fix(skills/watch): update webhook URL to use /api prefix

### DIFF
--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -70,14 +70,16 @@ After a successful `add`, ensure automatic polling is configured. Never create d
 
 **4b. Local schedule (CronCreate):**
 
-Check `CronList` for any job whose prompt contains `distillery_poll`. If found, skip to Step 5.
+Check `CronList` for any job whose prompt contains `/api/hooks/poll` or `distillery_poll`. If found, skip to Step 5.
+
+When creating the webhook URL for polling, use `<webhook-base-url>/api/hooks/poll` format.
 
 ```text
-CronCreate(cron="23 * * * *", prompt="Use distillery_poll to poll all configured feed sources. Report a one-line summary of items fetched and stored.", recurring=true, durable=true)
+CronCreate(cron="23 * * * *", prompt="Use distillery_poll to poll all configured feed sources via /api/hooks/poll. Report a one-line summary of items fetched and stored.", recurring=true, durable=true)
 ```
 Pick an off-peak minute (not :00 or :30). Durable jobs survive restarts but auto-expire after 7 days.
 
-**4c. Cleanup on `remove`:** After a successful `remove`, if no sources remain, delete/pause the auto-poll schedule via `CronDelete` (local only). Display: "Auto-poll paused: no feed sources remaining."
+**4c. Cleanup on `remove`:** After a successful `remove`, if no sources remain, delete/pause the auto-poll schedule via `CronDelete` (local only). Check for jobs containing `/api/hooks/poll` in the prompt and remove them. Display: "Auto-poll paused: no feed sources remaining."
 
 ### Step 5: Confirm
 


### PR DESCRIPTION
## Summary

Fixes the webhook URL construction in the watch skill documentation to use the correct /api/hooks/poll endpoint instead of /hooks/poll.

## Changes

- Update CronList check to look for /api/hooks/poll in job prompts
- Update CronCreate example to reference /api/hooks/poll endpoint  
- Update cleanup logic to check for /api/hooks/poll when removing jobs
- Fixes issue #258

## Context

The SKILL.md documentation was instructing Claude to build poll webhook URLs by appending /hooks/poll, but the actual mounted route is /api/hooks/poll. This ensures scheduled cron jobs target the correct endpoint.

Fixes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic polling schedule detection to recognize additional polling methods
  * Enhanced cleanup process for auto-poll schedules to ensure proper identification and management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->