### PR TITLE
fix(feeds): handle Jina 8194-token embedding limit with truncation

### DIFF
--- a/src/distillery/classification/heuristic.py
+++ b/src/distillery/classification/heuristic.py
@@ -116,9 +116,7 @@ class HeuristicClassifier:
         centroids = await self.compute_centroids(store, embedding_provider)
 
         if not centroids:
-            logger.info(
-                "HeuristicClassifier: no centroids available, sending to review"
-            )
+            logger.info("HeuristicClassifier: no centroids available, sending to review")
             return ClassificationResult(
                 entry_type=EntryType.INBOX,
                 confidence=0.0,

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -573,9 +573,7 @@ def _parse_classification(raw: dict[str, Any]) -> ClassificationConfig:
     mode_raw = raw.get("mode", "llm")
     mode = str(mode_raw)
     if mode not in ("llm", "heuristic"):
-        raise ValueError(
-            f"classification.mode must be 'llm' or 'heuristic', got: {mode!r}"
-        )
+        raise ValueError(f"classification.mode must be 'llm' or 'heuristic', got: {mode!r}")
 
     return ClassificationConfig(
         confidence_threshold=threshold,

--- a/src/distillery/embedding/jina.py
+++ b/src/distillery/embedding/jina.py
@@ -137,6 +137,7 @@ class JinaEmbeddingProvider:
             "input": texts,
             "task": task_type,
             "dimensions": self._dimensions,
+            "truncate": True,
         }
 
         headers = {

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from distillery.feeds.scorer import RelevanceScorer
+from distillery.feeds.truncation import truncate_content
 
 if TYPE_CHECKING:
     from distillery.config import DistilleryConfig, FeedSourceConfig
@@ -91,14 +92,18 @@ class PollerSummary:
     finished_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
 
 
-def _item_text(item: FeedItem) -> str:
+def _item_text(item: FeedItem, *, apply_truncation: bool = True) -> str:
     """Build a single text string from a feed item for embedding.
 
     Concatenates title and content with a newline separator, falling back to
-    whichever field is available.
+    whichever field is available.  When *apply_truncation* is ``True``
+    (the default) the result is pre-truncated to stay within the Jina
+    embedding model's token limit.
 
     Args:
         item: The feed item to convert.
+        apply_truncation: Whether to truncate the result to
+            :data:`~distillery.feeds.truncation.MAX_CONTENT_CHARS`.
 
     Returns:
         A non-empty text string, or an empty string if both fields are absent.
@@ -108,7 +113,10 @@ def _item_text(item: FeedItem) -> str:
         parts.append(item.title)
     if item.content:
         parts.append(item.content)
-    return "\n".join(parts)
+    text = "\n".join(parts)
+    if apply_truncation:
+        text = truncate_content(text)
+    return text
 
 
 def _build_adapter(source: FeedSourceConfig) -> Any:

--- a/src/distillery/feeds/truncation.py
+++ b/src/distillery/feeds/truncation.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 # English text averages ~4 chars/token, so 30 000 chars ≈ 7 500 tokens.
 MAX_CONTENT_CHARS = 30_000
 
+_TRUNCATED_SUFFIX = " [truncated]"
+
 
 def truncate_content(text: str, max_chars: int = MAX_CONTENT_CHARS) -> str:
     """Truncate *text* to at most *max_chars* characters.
@@ -43,4 +45,8 @@ def truncate_content(text: str, max_chars: int = MAX_CONTENT_CHARS) -> str:
         len(text),
         max_chars,
     )
-    return text[:max_chars] + " [truncated]"
+    suffix = _TRUNCATED_SUFFIX
+    if max_chars <= len(suffix):
+        return suffix[:max_chars]
+    cutoff = max_chars - len(suffix)
+    return text[:cutoff] + suffix

--- a/src/distillery/feeds/truncation.py
+++ b/src/distillery/feeds/truncation.py
@@ -1,0 +1,46 @@
+"""Content truncation utilities for feed item embedding.
+
+Provides a safety-net pre-truncation layer to ensure feed item content stays
+within the Jina embedding model's 8194-token input limit.  The Jina API also
+accepts ``truncate: true`` in the request payload, but pre-truncating avoids
+wasting bandwidth on oversized payloads and provides a clear log trail.
+
+The conservative character limit of 30 000 characters is safely under 8194
+tokens for all common languages (English averages ~4 characters per token).
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Conservative character limit that stays safely under Jina's 8194-token cap.
+# English text averages ~4 chars/token, so 30 000 chars ≈ 7 500 tokens.
+MAX_CONTENT_CHARS = 30_000
+
+
+def truncate_content(text: str, max_chars: int = MAX_CONTENT_CHARS) -> str:
+    """Truncate *text* to at most *max_chars* characters.
+
+    When truncation occurs a ``[truncated]`` marker is appended and a
+    DEBUG-level log message is emitted.
+
+    Args:
+        text: The content string to truncate.
+        max_chars: Maximum number of characters to keep.  Defaults to
+            :data:`MAX_CONTENT_CHARS` (30 000).
+
+    Returns:
+        The original string if it fits, or a truncated version with a
+        ``[truncated]`` suffix.
+    """
+    if len(text) <= max_chars:
+        return text
+
+    logger.debug(
+        "truncate_content: truncating %d chars to %d chars",
+        len(text),
+        max_chars,
+    )
+    return text[:max_chars] + " [truncated]"

--- a/src/distillery/mcp/org_membership.py
+++ b/src/distillery/mcp/org_membership.py
@@ -243,7 +243,9 @@ class OrgMembershipChecker:
             headers["Authorization"] = f"Bearer {token}"
 
         try:
-            async with httpx.AsyncClient(timeout=10.0, follow_redirects=False, verify=True) as client:
+            async with httpx.AsyncClient(
+                timeout=10.0, follow_redirects=False, verify=True
+            ) as client:
                 resp = await client.get(
                     f"{GITHUB_API}/orgs/{org}/members/{username}",
                     headers=headers,

--- a/src/distillery/mcp/tools/_common.py
+++ b/src/distillery/mcp/tools/_common.py
@@ -116,8 +116,7 @@ def validate_required(arguments: dict[str, Any], *fields: str) -> str | None:
     missing = [
         f
         for f in fields
-        if arguments.get(f) is None
-        or (isinstance(arguments.get(f), str) and not arguments.get(f))
+        if arguments.get(f) is None or (isinstance(arguments.get(f), str) and not arguments.get(f))
     ]
     if missing:
         return f"Missing required fields: {', '.join(missing)}"

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -149,9 +149,7 @@ async def _handle_store(
     output_mode_raw = arguments.get("output_mode")
     output_mode = output_mode_raw if output_mode_raw is not None else "full"
     if output_mode not in ("full", "summary"):
-        return error_response(
-            "INVALID_PARAMS", "Field 'output_mode' must be 'full' or 'summary'."
-        )
+        return error_response("INVALID_PARAMS", "Field 'output_mode' must be 'full' or 'summary'.")
 
     entry_type_str = arguments["entry_type"]
     if entry_type_str not in _VALID_ENTRY_TYPES:
@@ -227,7 +225,9 @@ async def _handle_store(
     embed_count = 1 if output_mode == "summary" else 3
     if cfg is not None:
         try:
-            record_and_check(store.connection, cfg.rate_limit.embedding_budget_daily, count=embed_count)
+            record_and_check(
+                store.connection, cfg.rate_limit.embedding_budget_daily, count=embed_count
+            )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
 
@@ -420,7 +420,9 @@ async def _handle_store_batch(
                 "INVALID_PARAMS", f"entries[{idx}] must be a dict, got {type(item).__name__}."
             )
         if "content" not in item:
-            return error_response("INVALID_PARAMS", f"entries[{idx}] is missing required 'content'.")
+            return error_response(
+                "INVALID_PARAMS", f"entries[{idx}] is missing required 'content'."
+            )
         if "author" not in item:
             return error_response("INVALID_PARAMS", f"entries[{idx}] is missing required 'author'.")
 
@@ -468,7 +470,11 @@ async def _handle_store_batch(
 
         # --- reserved prefix enforcement (mirror _handle_store logic) ---
         _reserved_allowed_sources: set[str] = {EntrySource.IMPORT.value}
-        if cfg is not None and cfg.tags.reserved_prefixes and source_str not in _reserved_allowed_sources:
+        if (
+            cfg is not None
+            and cfg.tags.reserved_prefixes
+            and source_str not in _reserved_allowed_sources
+        ):
             for tag in final_tags:
                 top = tag.split("/")[0]
                 if top in cfg.tags.reserved_prefixes:

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -509,27 +509,33 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
     async with poll_lock:
         poll_response = await _run_poll(state)
     poll_body = _extract(poll_response)
-    poll_result: dict[str, Any] = poll_body.get("data", poll_body) if poll_body.get("ok") else {
-        "ok": False, "error": poll_body.get("error", "poll failed")
-    }
+    poll_result: dict[str, Any] = (
+        poll_body.get("data", poll_body)
+        if poll_body.get("ok")
+        else {"ok": False, "error": poll_body.get("error", "poll failed")}
+    )
 
     # 2. Rescore — re-score existing entries (acquire rescore lock to serialize).
     rescore_lock = _endpoint_locks.setdefault("rescore", asyncio.Lock())
     async with rescore_lock:
         rescore_response = await _run_rescore(state)
     rescore_body = _extract(rescore_response)
-    rescore_result: dict[str, Any] = rescore_body.get("data", rescore_body) if rescore_body.get("ok") else {
-        "ok": False, "error": rescore_body.get("error", "rescore failed")
-    }
+    rescore_result: dict[str, Any] = (
+        rescore_body.get("data", rescore_body)
+        if rescore_body.get("ok")
+        else {"ok": False, "error": rescore_body.get("error", "rescore failed")}
+    )
 
     # 3. Classify-batch — classify pending inbox entries (acquire classify-batch lock to serialize).
     classify_lock = _endpoint_locks.setdefault("classify-batch", asyncio.Lock())
     async with classify_lock:
         classify_response = await _run_classify_batch(state)
     classify_body = _extract(classify_response)
-    classify_result: dict[str, Any] = classify_body.get("data", classify_body) if classify_body.get("ok") else {
-        "ok": False, "error": classify_body.get("error", "classify-batch failed")
-    }
+    classify_result: dict[str, Any] = (
+        classify_body.get("data", classify_body)
+        if classify_body.get("ok")
+        else {"ok": False, "error": classify_body.get("error", "classify-batch failed")}
+    )
 
     # 4. Search log retention — prune old search_log rows.
     retention_result: dict[str, Any] = {"ok": True, "deleted": 0}
@@ -538,6 +544,7 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
         store = state["store"]
         retention_days = config.rate_limit.search_log_retention_days
         try:
+
             def _prune() -> int:
                 conn = store.connection
                 result = conn.execute(
@@ -550,7 +557,11 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
             deleted = await asyncio.to_thread(_prune)
             retention_result = {"ok": True, "deleted": deleted}
             if deleted:
-                logger.info("Maintenance: pruned %d search_log rows older than %d days", deleted, retention_days)
+                logger.info(
+                    "Maintenance: pruned %d search_log rows older than %d days",
+                    deleted,
+                    retention_days,
+                )
         except Exception as exc:  # noqa: BLE001
             retention_result = {"ok": False, "error": f"search_log retention failed: {exc}"}
             logger.warning("Maintenance: search_log retention failed: %s", exc)
@@ -660,9 +671,7 @@ async def _run_classify_batch(
                         )
                     else:
                         entry_embedding = embedding_provider.embed(entry.content)
-                        best_type, best_sim = classifier.classify_entry(
-                            entry_embedding, centroids
-                        )
+                        best_type, best_sim = classifier.classify_entry(entry_embedding, centroids)
                         if best_type is not None:
                             classification = ClassificationResult(
                                 entry_type=EntryType(best_type),
@@ -783,9 +792,7 @@ async def _run_classify_batch(
     )
 
 
-async def _handle_classify_batch(
-    request: Request, state: dict[str, Any]
-) -> JSONResponse:
+async def _handle_classify_batch(request: Request, state: dict[str, Any]) -> JSONResponse:
     """Handler for ``POST /hooks/classify-batch``.
 
     Delegates to :func:`_run_classify_batch`.  Accepts optional query

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1606,8 +1606,7 @@ class DuckDBStore:
             where_clauses, params = self._build_filter_clauses(filters)
             if stale_days is not None:
                 where_clauses.append(
-                    "COALESCE(accessed_at, updated_at)"
-                    " < NOW() - INTERVAL (CAST(? AS INT)) DAYS"
+                    "COALESCE(accessed_at, updated_at) < NOW() - INTERVAL (CAST(? AS INT)) DAYS"
                 )
                 params.append(stale_days)
             where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""

--- a/tests/test_classification/test_heuristic.py
+++ b/tests/test_classification/test_heuristic.py
@@ -221,9 +221,9 @@ class TestClassifyEntry:
         """When multiple centroids exceed threshold, the highest wins."""
         v = _normalise([1.0, 0.5, 0.0, 0.0])
         centroids = {
-            "session": _normalise([1.0, 0.4, 0.0, 0.0]),    # very close
-            "bookmark": _normalise([1.0, 0.0, 0.0, 0.0]),   # close but less
-            "idea": _normalise([0.0, 0.0, 1.0, 0.0]),       # far
+            "session": _normalise([1.0, 0.4, 0.0, 0.0]),  # very close
+            "bookmark": _normalise([1.0, 0.0, 0.0, 0.0]),  # close but less
+            "idea": _normalise([0.0, 0.0, 1.0, 0.0]),  # far
         }
 
         classifier = HeuristicClassifier()
@@ -274,9 +274,7 @@ class TestClassifyIntegration:
         )
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert result.entry_type == EntryType.SESSION
         assert result.status == EntryStatus.ACTIVE
@@ -291,9 +289,7 @@ class TestClassifyIntegration:
         # Session cluster in one direction.
         for i in range(MIN_ENTRIES_PER_TYPE):
             content = f"session content {i}"
-            deterministic_embedding_provider.register(
-                content, _normalise([1.0, 0.0, 0.0, 0.0])
-            )
+            deterministic_embedding_provider.register(content, _normalise([1.0, 0.0, 0.0, 0.0]))
             entry = make_entry(
                 content=content,
                 entry_type=EntryType.SESSION,
@@ -303,18 +299,14 @@ class TestClassifyIntegration:
 
         # Inbox entry in an orthogonal direction.
         inbox_content = "completely unrelated content"
-        deterministic_embedding_provider.register(
-            inbox_content, _normalise([0.0, 0.0, 0.0, 1.0])
-        )
+        deterministic_embedding_provider.register(inbox_content, _normalise([0.0, 0.0, 0.0, 1.0]))
         inbox_entry = make_entry(
             content=inbox_content,
             entry_type=EntryType.INBOX,
         )
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert result.entry_type == EntryType.INBOX
         assert result.status == EntryStatus.PENDING_REVIEW
@@ -332,9 +324,7 @@ class TestClassifyIntegration:
         )
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert result.entry_type == EntryType.INBOX
         assert result.status == EntryStatus.PENDING_REVIEW
@@ -349,9 +339,7 @@ class TestClassifyIntegration:
         # Only 2 session entries -- insufficient.
         for i in range(MIN_ENTRIES_PER_TYPE - 1):
             content = f"session item {i}"
-            deterministic_embedding_provider.register(
-                content, _normalise([1.0, 0.0, 0.0, 0.0])
-            )
+            deterministic_embedding_provider.register(content, _normalise([1.0, 0.0, 0.0, 0.0]))
             entry = make_entry(
                 content=content,
                 entry_type=EntryType.SESSION,
@@ -360,18 +348,14 @@ class TestClassifyIntegration:
             await store.store(entry)
 
         inbox_content = "similar to session"
-        deterministic_embedding_provider.register(
-            inbox_content, _normalise([1.0, 0.0, 0.0, 0.0])
-        )
+        deterministic_embedding_provider.register(inbox_content, _normalise([1.0, 0.0, 0.0, 0.0]))
         inbox_entry = make_entry(
             content=inbox_content,
             entry_type=EntryType.INBOX,
         )
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert result.status == EntryStatus.PENDING_REVIEW
 
@@ -386,8 +370,6 @@ class TestClassifyIntegration:
         inbox_entry = make_entry(content="anything", entry_type=EntryType.INBOX)
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert isinstance(result, ClassificationResult)

--- a/tests/test_mcp_coverage_gaps.py
+++ b/tests/test_mcp_coverage_gaps.py
@@ -1890,7 +1890,6 @@ class TestWebhookRecordAudit:
         assert raw is not None
 
 
-
 # ===========================================================================
 # Auth CIMDFetcher patch behavior (auth.py lines 118-152, 167-185)
 # ===========================================================================

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -753,6 +753,5 @@ class TestRemovedTools:
         server = create_server(config)
         tools = await server.list_tools()
         assert len(tools) == 13, (
-            f"Expected 13 registered tools, got {len(tools)}: "
-            f"{sorted(t.name for t in tools)}"
+            f"Expected 13 registered tools, got {len(tools)}: {sorted(t.name for t in tools)}"
         )

--- a/tests/test_mcp_tools/test_list_extensions.py
+++ b/tests/test_mcp_tools/test_list_extensions.py
@@ -80,8 +80,12 @@ async def store_with_stale(store: Any) -> Any:  # type: ignore[return]
     await _store_entry_with_timestamps(store, stale1, accessed_at=thirty_days_ago)
     await _store_entry_with_timestamps(store, stale2, accessed_at=thirty_days_ago)
     await _store_entry_with_timestamps(store, recent1, accessed_at=one_day_ago)
-    await _store_entry_with_timestamps(store, old_no_access, accessed_at=None, updated_at=thirty_days_ago)
-    await _store_entry_with_timestamps(store, new_no_access, accessed_at=None, updated_at=one_day_ago)
+    await _store_entry_with_timestamps(
+        store, old_no_access, accessed_at=None, updated_at=thirty_days_ago
+    )
+    await _store_entry_with_timestamps(
+        store, new_no_access, accessed_at=None, updated_at=one_day_ago
+    )
 
     store._stale_ids = {stale1.id, stale2.id, old_no_access.id}
     store._recent_ids = {recent1.id, new_no_access.id}

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,0 +1,133 @@
+"""Tests for the feed content truncation utilities.
+
+Covers:
+  - truncate_content: no-op for short text, truncation for long text
+  - truncate_content: custom max_chars parameter
+  - _item_text integration with truncation
+  - Jina payload includes truncate: true
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from distillery.feeds.models import FeedItem
+from distillery.feeds.poller import _item_text
+from distillery.feeds.truncation import MAX_CONTENT_CHARS, truncate_content
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# truncate_content
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateContent:
+    def test_short_text_unchanged(self) -> None:
+        text = "Hello, world!"
+        assert truncate_content(text) == text
+
+    def test_exact_limit_unchanged(self) -> None:
+        text = "a" * MAX_CONTENT_CHARS
+        assert truncate_content(text) == text
+
+    def test_over_limit_truncated(self) -> None:
+        text = "a" * (MAX_CONTENT_CHARS + 500)
+        result = truncate_content(text)
+        assert len(result) == MAX_CONTENT_CHARS + len(" [truncated]")
+        assert result.endswith(" [truncated]")
+        assert result[:MAX_CONTENT_CHARS] == "a" * MAX_CONTENT_CHARS
+
+    def test_empty_text_unchanged(self) -> None:
+        assert truncate_content("") == ""
+
+    def test_custom_max_chars(self) -> None:
+        text = "abcdefghij"  # 10 chars
+        result = truncate_content(text, max_chars=5)
+        assert result == "abcde [truncated]"
+
+    def test_custom_max_chars_no_truncation(self) -> None:
+        text = "abc"
+        result = truncate_content(text, max_chars=5)
+        assert result == "abc"
+
+
+# ---------------------------------------------------------------------------
+# _item_text with truncation
+# ---------------------------------------------------------------------------
+
+
+class TestItemTextTruncation:
+    def test_short_content_unchanged(self) -> None:
+        item = FeedItem(
+            source_url="https://example.com",
+            source_type="rss",
+            item_id="1",
+            title="Short title",
+            content="Short content",
+        )
+        result = _item_text(item)
+        assert result == "Short title\nShort content"
+
+    def test_long_content_truncated(self) -> None:
+        long_content = "x" * (MAX_CONTENT_CHARS + 1000)
+        item = FeedItem(
+            source_url="https://example.com",
+            source_type="rss",
+            item_id="1",
+            title="Title",
+            content=long_content,
+        )
+        result = _item_text(item)
+        assert result.endswith(" [truncated]")
+        # Title + newline + truncated content
+        assert len(result) <= MAX_CONTENT_CHARS + len(" [truncated]") + len("Title\n")
+
+    def test_truncation_can_be_disabled(self) -> None:
+        long_content = "x" * (MAX_CONTENT_CHARS + 1000)
+        item = FeedItem(
+            source_url="https://example.com",
+            source_type="rss",
+            item_id="1",
+            content=long_content,
+        )
+        result = _item_text(item, apply_truncation=False)
+        assert len(result) == MAX_CONTENT_CHARS + 1000
+        assert "[truncated]" not in result
+
+
+# ---------------------------------------------------------------------------
+# Jina payload includes truncate: true
+# ---------------------------------------------------------------------------
+
+
+class TestJinaTruncateFlag:
+    def test_jina_payload_includes_truncate_true(self) -> None:
+        """Verify that JinaEmbeddingProvider sends truncate: true in the API payload."""
+        from distillery.embedding.jina import JinaEmbeddingProvider
+
+        provider = JinaEmbeddingProvider(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": [{"embedding": [0.1] * 1024, "index": 0}],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+
+        with patch("distillery.embedding.jina.httpx.Client", return_value=mock_client):
+            provider.embed("test text")
+
+        # Extract the payload from the post call
+        call_args = mock_client.post.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert payload is not None
+        assert payload["truncate"] is True

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -15,7 +15,11 @@ import pytest
 
 from distillery.feeds.models import FeedItem
 from distillery.feeds.poller import _item_text
-from distillery.feeds.truncation import MAX_CONTENT_CHARS, truncate_content
+from distillery.feeds.truncation import (
+    _TRUNCATED_SUFFIX,
+    MAX_CONTENT_CHARS,
+    truncate_content,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -37,17 +41,26 @@ class TestTruncateContent:
     def test_over_limit_truncated(self) -> None:
         text = "a" * (MAX_CONTENT_CHARS + 500)
         result = truncate_content(text)
-        assert len(result) == MAX_CONTENT_CHARS + len(" [truncated]")
-        assert result.endswith(" [truncated]")
-        assert result[:MAX_CONTENT_CHARS] == "a" * MAX_CONTENT_CHARS
+        assert len(result) == MAX_CONTENT_CHARS
+        assert result.endswith(_TRUNCATED_SUFFIX)
+        cutoff = MAX_CONTENT_CHARS - len(_TRUNCATED_SUFFIX)
+        assert result[:cutoff] == "a" * cutoff
 
     def test_empty_text_unchanged(self) -> None:
         assert truncate_content("") == ""
 
     def test_custom_max_chars(self) -> None:
-        text = "abcdefghij"  # 10 chars
+        text = "a" * 30  # 30 chars, will be truncated to 20
+        result = truncate_content(text, max_chars=20)
+        assert len(result) == 20
+        assert result.endswith(_TRUNCATED_SUFFIX)
+
+    def test_custom_max_chars_very_small(self) -> None:
+        """When max_chars is smaller than the suffix, return truncated suffix."""
+        text = "abcdefghij"
         result = truncate_content(text, max_chars=5)
-        assert result == "abcde [truncated]"
+        assert len(result) == 5
+        assert result == _TRUNCATED_SUFFIX[:5]
 
     def test_custom_max_chars_no_truncation(self) -> None:
         text = "abc"
@@ -82,9 +95,9 @@ class TestItemTextTruncation:
             content=long_content,
         )
         result = _item_text(item)
-        assert result.endswith(" [truncated]")
-        # Title + newline + truncated content
-        assert len(result) <= MAX_CONTENT_CHARS + len(" [truncated]") + len("Title\n")
+        assert result.endswith(_TRUNCATED_SUFFIX)
+        # Title + newline + truncated content (which itself is <= MAX_CONTENT_CHARS)
+        assert len(result) <= MAX_CONTENT_CHARS + len("Title\n")
 
     def test_truncation_can_be_disabled(self) -> None:
         long_content = "x" * (MAX_CONTENT_CHARS + 1000)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -522,9 +522,7 @@ async def test_hooks_poll_source_url_query_param(
     shared = _make_shared_state(store)
 
     target_url = "https://example.com/feed"
-    result = PollResult(
-        source_url=target_url, source_type="rss", items_fetched=3, items_stored=2
-    )
+    result = PollResult(source_url=target_url, source_type="rss", items_fetched=3, items_stored=2)
     summary = PollerSummary(results=[result], total_fetched=3, total_stored=2, sources_polled=1)
 
     mock_poller = MagicMock()

--- a/tests/test_webhooks/test_classify_batch.py
+++ b/tests/test_webhooks/test_classify_batch.py
@@ -181,13 +181,9 @@ async def test_classify_batch_heuristic_mode_classifies(
     # Mock classifier: compute_centroids returns a centroid dict,
     # classify_entry returns deterministic results per entry.
     mock_classifier = MagicMock()
-    mock_classifier.compute_centroids = AsyncMock(
-        return_value={"session": [0.1, 0.2, 0.3, 0.4]}
-    )
+    mock_classifier.compute_centroids = AsyncMock(return_value={"session": [0.1, 0.2, 0.3, 0.4]})
     # First call: match → session; second call: no match
-    mock_classifier.classify_entry = MagicMock(
-        side_effect=[("session", 0.82), (None, 0.3)]
-    )
+    mock_classifier.classify_entry = MagicMock(side_effect=[("session", 0.82), (None, 0.3)])
 
     # list_entries returns our two entries; update succeeds.
     mock_store = MagicMock()
@@ -273,10 +269,12 @@ async def test_classify_batch_llm_mode_queues_as_pending_review(
     # Mock LLM client that returns classification results with different confidences
     mock_llm_client = MagicMock()
     # Entry A: high confidence -> should be classified as ACTIVE
-    mock_llm_client.classify = AsyncMock(side_effect=[
-        '{"entry_type": "session", "confidence": 0.85, "reasoning": "High confidence session", "suggested_tags": [], "suggested_project": null}',
-        '{"entry_type": "minutes", "confidence": 0.55, "reasoning": "Low confidence meeting", "suggested_tags": [], "suggested_project": null}'
-    ])
+    mock_llm_client.classify = AsyncMock(
+        side_effect=[
+            '{"entry_type": "session", "confidence": 0.85, "reasoning": "High confidence session", "suggested_tags": [], "suggested_project": null}',
+            '{"entry_type": "minutes", "confidence": 0.55, "reasoning": "Low confidence meeting", "suggested_tags": [], "suggested_project": null}',
+        ]
+    )
 
     shared = _make_shared_state(store)
     shared["llm_client"] = mock_llm_client
@@ -321,9 +319,7 @@ async def test_classify_batch_heuristic_error_counting(
     entry_b = _make_entry("Content B")
 
     mock_classifier = MagicMock()
-    mock_classifier.compute_centroids = AsyncMock(
-        return_value={"reference": [0.1, 0.2, 0.3, 0.4]}
-    )
+    mock_classifier.compute_centroids = AsyncMock(return_value={"reference": [0.1, 0.2, 0.3, 0.4]})
     # classify_entry returns a match for both entries.
     mock_classifier.classify_entry = MagicMock(return_value=("reference", 0.75))
 

--- a/tests/test_webhooks/test_maintenance.py
+++ b/tests/test_webhooks/test_maintenance.py
@@ -142,8 +142,9 @@ async def test_maintenance_combined_response_format(
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     shared = _make_shared_state(store)
 
-    mock_poller = _make_poller_mock(sources_polled=2, total_fetched=10, total_stored=7,
-                                    rescored=15, upgraded=3, downgraded=2)
+    mock_poller = _make_poller_mock(
+        sources_polled=2, total_fetched=10, total_stored=7, rescored=15, upgraded=3, downgraded=2
+    )
 
     with patch("distillery.feeds.poller.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())


### PR DESCRIPTION
## Summary
- Adds `truncate: true` to the Jina embedding API request payload so oversized content is automatically truncated server-side
- Adds a `truncate_content()` utility that pre-truncates feed item content to 30,000 chars (~7,500 tokens) as a client-side safety net before embedding
- Applies truncation in `_item_text()` when preparing feed items for embedding during poll/sync
- Existing error handling already skips items that fail after truncation and logs warnings
- Adds 10 unit tests covering truncation logic, `_item_text` integration, and Jina payload verification

Closes #274

## Test plan
- [x] `truncate_content` returns short text unchanged
- [x] `truncate_content` truncates text exceeding the limit and appends `[truncated]` marker
- [x] `truncate_content` supports custom `max_chars` parameter
- [x] `_item_text` applies truncation by default for long content
- [x] `_item_text` truncation can be disabled via `apply_truncation=False`
- [x] Jina API payload includes `truncate: true` flag
- [x] All existing tests pass (184 tests in feeds/embedding/poller/truncation)
- [x] mypy --strict passes on all modified source files
- [x] ruff check and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic content truncation for feed items (30,000 character limit by default)
  * Jina embedding requests now include truncation parameter for improved processing efficiency
  * Truncation can be optionally disabled when needed

* **Bug Fixes / Improvements**
  * Enhanced embedding accuracy with truncation flag in API requests
  * Streamlined content handling to prevent oversized data processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->