### PR TITLE
feat(feeds): add --purge option to /watch remove

### DIFF
--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -36,7 +36,7 @@ See CONVENTIONS.md — skip if already confirmed this conversation.
 |--------------------|--------|------------|
 | `/watch` or `/watch list` | `list` | none |
 | `/watch add <url> [--type TYPE] [--label LABEL]` | `add` | url, optional source_type, label |
-| `/watch remove <url>` | `remove` | url |
+| `/watch remove <url> [--purge]` | `remove` | url, optional purge |
 
 Default to `list` if no subcommand is recognizable.
 
@@ -55,7 +55,7 @@ Call `distillery_watch` with the parsed arguments:
 
 - **list**: `distillery_watch(action="list")`
 - **add**: `distillery_watch(action="add", url=..., source_type=..., label=..., poll_interval_minutes=..., trust_weight=...)`
-- **remove**: `distillery_watch(action="remove", url="<url>")`
+- **remove**: `distillery_watch(action="remove", url="<url>")` or `distillery_watch(action="remove", url="<url>", purge=true)` to also archive all historic entries from the source
 
 - On MCP errors, see CONVENTIONS.md error handling — display and stop
 
@@ -95,7 +95,8 @@ Feed Sources (N configured)
 If no sources: show "No feed sources configured." with usage hint.
 
 - **After `add`**: show added source details, updated table, and auto-poll status
-- **After `remove`**: confirm removal, show updated table
+- **After `remove`**: confirm removal, show updated table. If `--purge` was used, also report the number of archived entries
+- **After `remove --purge`**: "Removed source and archived N historic entries."
 
 Changes are persisted to the database automatically — no manual YAML editing required.
 

--- a/src/distillery/classification/heuristic.py
+++ b/src/distillery/classification/heuristic.py
@@ -116,9 +116,7 @@ class HeuristicClassifier:
         centroids = await self.compute_centroids(store, embedding_provider)
 
         if not centroids:
-            logger.info(
-                "HeuristicClassifier: no centroids available, sending to review"
-            )
+            logger.info("HeuristicClassifier: no centroids available, sending to review")
             return ClassificationResult(
                 entry_type=EntryType.INBOX,
                 confidence=0.0,

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -573,9 +573,7 @@ def _parse_classification(raw: dict[str, Any]) -> ClassificationConfig:
     mode_raw = raw.get("mode", "llm")
     mode = str(mode_raw)
     if mode not in ("llm", "heuristic"):
-        raise ValueError(
-            f"classification.mode must be 'llm' or 'heuristic', got: {mode!r}"
-        )
+        raise ValueError(f"classification.mode must be 'llm' or 'heuristic', got: {mode!r}")
 
     return ClassificationConfig(
         confidence_threshold=threshold,

--- a/src/distillery/mcp/org_membership.py
+++ b/src/distillery/mcp/org_membership.py
@@ -243,7 +243,9 @@ class OrgMembershipChecker:
             headers["Authorization"] = f"Bearer {token}"
 
         try:
-            async with httpx.AsyncClient(timeout=10.0, follow_redirects=False, verify=True) as client:
+            async with httpx.AsyncClient(
+                timeout=10.0, follow_redirects=False, verify=True
+            ) as client:
                 resp = await client.get(
                     f"{GITHUB_API}/orgs/{org}/members/{username}",
                     headers=headers,

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -810,6 +810,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         poll_interval_minutes: int | None = None,
         trust_weight: float | None = None,
         sync_history: bool = False,
+        purge: bool = False,
     ) -> list[types.TextContent]:
         """Manage monitored feed sources for ambient intelligence.
 
@@ -826,10 +827,13 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - sync_history (bool, optional, default=false): When true and source_type is
             "github", immediately syncs existing issues/PRs into the knowledge base
             after adding the source.
+          - purge (bool, optional, default=false): When true and action is "remove",
+            archives all entries from the removed source (soft-delete). Returns the
+            count of archived entries in purged_entries.
 
         RETURNS (success): { sources: list, count: int } (list) or
           { added: dict, sources: list, sync?: { created: int, updated: int, relations: int } } (add) or
-          { removed_url: str, removed: bool, sources: list } (remove)
+          { removed_url: str, removed: bool, sources: list, purged_entries?: int } (remove)
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "CONFLICT" | "INTERNAL", message: "..." }
 
         RELATED: distillery_interests (to discover sources to watch),
@@ -842,6 +846,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             arguments=dict(
                 action=action,
                 sync_history=sync_history,
+                purge=purge,
                 **_omit_none(
                     url=url,
                     source_type=source_type,

--- a/src/distillery/mcp/tools/_common.py
+++ b/src/distillery/mcp/tools/_common.py
@@ -116,8 +116,7 @@ def validate_required(arguments: dict[str, Any], *fields: str) -> str | None:
     missing = [
         f
         for f in fields
-        if arguments.get(f) is None
-        or (isinstance(arguments.get(f), str) and not arguments.get(f))
+        if arguments.get(f) is None or (isinstance(arguments.get(f), str) and not arguments.get(f))
     ]
     if missing:
         return f"Missing required fields: {', '.join(missing)}"

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -149,9 +149,7 @@ async def _handle_store(
     output_mode_raw = arguments.get("output_mode")
     output_mode = output_mode_raw if output_mode_raw is not None else "full"
     if output_mode not in ("full", "summary"):
-        return error_response(
-            "INVALID_PARAMS", "Field 'output_mode' must be 'full' or 'summary'."
-        )
+        return error_response("INVALID_PARAMS", "Field 'output_mode' must be 'full' or 'summary'.")
 
     entry_type_str = arguments["entry_type"]
     if entry_type_str not in _VALID_ENTRY_TYPES:
@@ -227,7 +225,9 @@ async def _handle_store(
     embed_count = 1 if output_mode == "summary" else 3
     if cfg is not None:
         try:
-            record_and_check(store.connection, cfg.rate_limit.embedding_budget_daily, count=embed_count)
+            record_and_check(
+                store.connection, cfg.rate_limit.embedding_budget_daily, count=embed_count
+            )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
 
@@ -420,7 +420,9 @@ async def _handle_store_batch(
                 "INVALID_PARAMS", f"entries[{idx}] must be a dict, got {type(item).__name__}."
             )
         if "content" not in item:
-            return error_response("INVALID_PARAMS", f"entries[{idx}] is missing required 'content'.")
+            return error_response(
+                "INVALID_PARAMS", f"entries[{idx}] is missing required 'content'."
+            )
         if "author" not in item:
             return error_response("INVALID_PARAMS", f"entries[{idx}] is missing required 'author'.")
 
@@ -468,7 +470,11 @@ async def _handle_store_batch(
 
         # --- reserved prefix enforcement (mirror _handle_store logic) ---
         _reserved_allowed_sources: set[str] = {EntrySource.IMPORT.value}
-        if cfg is not None and cfg.tags.reserved_prefixes and source_str not in _reserved_allowed_sources:
+        if (
+            cfg is not None
+            and cfg.tags.reserved_prefixes
+            and source_str not in _reserved_allowed_sources
+        ):
             for tag in final_tags:
                 top = tag.split("/")[0]
                 if top in cfg.tags.reserved_prefixes:

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -191,19 +191,66 @@ async def _handle_watch(
     if not url:
         return error_response("INVALID_PARAMS", "url is required for action='remove'")
 
+    purge = bool(arguments.get("purge", False))
+
     try:
         removed = await store.remove_feed_source(url)
         db_sources = await store.list_feed_sources()
     except Exception as exc:  # noqa: BLE001
         logger.exception("distillery_watch: failed to remove feed source")
         return error_response("INTERNAL", f"Failed to remove feed source: {exc}")
-    return success_response(
-        {
-            "removed_url": url,
-            "removed": removed,
-            "sources": db_sources,
-        }
-    )
+
+    response_data: dict[str, Any] = {
+        "removed_url": url,
+        "removed": removed,
+        "sources": db_sources,
+    }
+
+    # When purge is requested, archive all entries from this source.
+    if purge and removed:
+        try:
+            archived_count = await _purge_source_entries(store, url)
+            response_data["purged_entries"] = archived_count
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("distillery_watch: failed to purge entries for %s", url)
+            response_data["purge_error"] = str(exc)
+
+    return success_response(response_data)
+
+
+# ---------------------------------------------------------------------------
+# Purge helper — archive entries from a removed feed source
+# ---------------------------------------------------------------------------
+
+
+async def _purge_source_entries(store: Any, source_url: str) -> int:
+    """Archive all active entries whose ``metadata.source_url`` matches *source_url*.
+
+    Iterates through matching entries in batches and sets ``status="archived"``
+    on each one via ``store.update()``.  Returns the total count of archived
+    entries.
+
+    Args:
+        store: An initialised storage backend with ``list_entries`` and ``update``.
+        source_url: The feed source URL whose entries should be archived.
+
+    Returns:
+        Number of entries that were archived.
+    """
+    archived = 0
+    batch_size = 100
+    while True:
+        entries = await store.list_entries(
+            filters={"metadata.source_url": source_url, "status": "active"},
+            limit=batch_size,
+            offset=0,
+        )
+        if not entries:
+            break
+        for entry in entries:
+            await store.update(entry.id, {"status": "archived"})
+            archived += 1
+    return archived
 
 
 # ---------------------------------------------------------------------------

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -200,7 +200,7 @@ async def _handle_watch(
         logger.exception("distillery_watch: failed to remove feed source")
         return error_response("INTERNAL", f"Failed to remove feed source: {exc}")
 
-    response_data: dict[str, Any] = {
+    remove_data: dict[str, Any] = {
         "removed_url": url,
         "removed": removed,
         "sources": db_sources,
@@ -210,12 +210,12 @@ async def _handle_watch(
     if purge and removed:
         try:
             archived_count = await _purge_source_entries(store, url)
-            response_data["purged_entries"] = archived_count
+            remove_data["purged_entries"] = archived_count
         except Exception as exc:  # noqa: BLE001
             logger.exception("distillery_watch: failed to purge entries for %s", url)
-            response_data["purge_error"] = str(exc)
+            remove_data["purge_error"] = str(exc)
 
-    return success_response(response_data)
+    return success_response(remove_data)
 
 
 # ---------------------------------------------------------------------------

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -211,9 +211,9 @@ async def _handle_watch(
         try:
             archived_count = await _purge_source_entries(store, url)
             remove_data["purged_entries"] = archived_count
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             logger.exception("distillery_watch: failed to purge entries for %s", url)
-            remove_data["purge_error"] = str(exc)
+            remove_data["purge_error"] = "Failed to archive historic entries."
 
     return success_response(remove_data)
 
@@ -224,7 +224,7 @@ async def _handle_watch(
 
 
 async def _purge_source_entries(store: Any, source_url: str) -> int:
-    """Archive all active entries whose ``metadata.source_url`` matches *source_url*.
+    """Archive all non-archived entries whose ``metadata.source_url`` matches *source_url*.
 
     Iterates through matching entries in batches and sets ``status="archived"``
     on each one via ``store.update()``.  Returns the total count of archived
@@ -239,17 +239,20 @@ async def _purge_source_entries(store: Any, source_url: str) -> int:
     """
     archived = 0
     batch_size = 100
+    offset = 0
     while True:
         entries = await store.list_entries(
-            filters={"metadata.source_url": source_url, "status": "active"},
+            filters={"metadata.source_url": source_url},
             limit=batch_size,
-            offset=0,
+            offset=offset,
         )
         if not entries:
             break
         for entry in entries:
-            await store.update(entry.id, {"status": "archived"})
-            archived += 1
+            if getattr(entry, "status", None) != "archived":
+                await store.update(entry.id, {"status": "archived"})
+                archived += 1
+        offset += batch_size
     return archived
 
 

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -509,27 +509,33 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
     async with poll_lock:
         poll_response = await _run_poll(state)
     poll_body = _extract(poll_response)
-    poll_result: dict[str, Any] = poll_body.get("data", poll_body) if poll_body.get("ok") else {
-        "ok": False, "error": poll_body.get("error", "poll failed")
-    }
+    poll_result: dict[str, Any] = (
+        poll_body.get("data", poll_body)
+        if poll_body.get("ok")
+        else {"ok": False, "error": poll_body.get("error", "poll failed")}
+    )
 
     # 2. Rescore — re-score existing entries (acquire rescore lock to serialize).
     rescore_lock = _endpoint_locks.setdefault("rescore", asyncio.Lock())
     async with rescore_lock:
         rescore_response = await _run_rescore(state)
     rescore_body = _extract(rescore_response)
-    rescore_result: dict[str, Any] = rescore_body.get("data", rescore_body) if rescore_body.get("ok") else {
-        "ok": False, "error": rescore_body.get("error", "rescore failed")
-    }
+    rescore_result: dict[str, Any] = (
+        rescore_body.get("data", rescore_body)
+        if rescore_body.get("ok")
+        else {"ok": False, "error": rescore_body.get("error", "rescore failed")}
+    )
 
     # 3. Classify-batch — classify pending inbox entries (acquire classify-batch lock to serialize).
     classify_lock = _endpoint_locks.setdefault("classify-batch", asyncio.Lock())
     async with classify_lock:
         classify_response = await _run_classify_batch(state)
     classify_body = _extract(classify_response)
-    classify_result: dict[str, Any] = classify_body.get("data", classify_body) if classify_body.get("ok") else {
-        "ok": False, "error": classify_body.get("error", "classify-batch failed")
-    }
+    classify_result: dict[str, Any] = (
+        classify_body.get("data", classify_body)
+        if classify_body.get("ok")
+        else {"ok": False, "error": classify_body.get("error", "classify-batch failed")}
+    )
 
     # 4. Search log retention — prune old search_log rows.
     retention_result: dict[str, Any] = {"ok": True, "deleted": 0}
@@ -538,6 +544,7 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
         store = state["store"]
         retention_days = config.rate_limit.search_log_retention_days
         try:
+
             def _prune() -> int:
                 conn = store.connection
                 result = conn.execute(
@@ -550,7 +557,11 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
             deleted = await asyncio.to_thread(_prune)
             retention_result = {"ok": True, "deleted": deleted}
             if deleted:
-                logger.info("Maintenance: pruned %d search_log rows older than %d days", deleted, retention_days)
+                logger.info(
+                    "Maintenance: pruned %d search_log rows older than %d days",
+                    deleted,
+                    retention_days,
+                )
         except Exception as exc:  # noqa: BLE001
             retention_result = {"ok": False, "error": f"search_log retention failed: {exc}"}
             logger.warning("Maintenance: search_log retention failed: %s", exc)
@@ -660,9 +671,7 @@ async def _run_classify_batch(
                         )
                     else:
                         entry_embedding = embedding_provider.embed(entry.content)
-                        best_type, best_sim = classifier.classify_entry(
-                            entry_embedding, centroids
-                        )
+                        best_type, best_sim = classifier.classify_entry(entry_embedding, centroids)
                         if best_type is not None:
                             classification = ClassificationResult(
                                 entry_type=EntryType(best_type),
@@ -783,9 +792,7 @@ async def _run_classify_batch(
     )
 
 
-async def _handle_classify_batch(
-    request: Request, state: dict[str, Any]
-) -> JSONResponse:
+async def _handle_classify_batch(request: Request, state: dict[str, Any]) -> JSONResponse:
     """Handler for ``POST /hooks/classify-batch``.
 
     Delegates to :func:`_run_classify_batch`.  Accepts optional query

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1598,8 +1598,7 @@ class DuckDBStore:
             where_clauses, params = self._build_filter_clauses(filters)
             if stale_days is not None:
                 where_clauses.append(
-                    "COALESCE(accessed_at, updated_at)"
-                    " < NOW() - INTERVAL (CAST(? AS INT)) DAYS"
+                    "COALESCE(accessed_at, updated_at) < NOW() - INTERVAL (CAST(? AS INT)) DAYS"
                 )
                 params.append(stale_days)
             where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""

--- a/tests/test_classification/test_heuristic.py
+++ b/tests/test_classification/test_heuristic.py
@@ -221,9 +221,9 @@ class TestClassifyEntry:
         """When multiple centroids exceed threshold, the highest wins."""
         v = _normalise([1.0, 0.5, 0.0, 0.0])
         centroids = {
-            "session": _normalise([1.0, 0.4, 0.0, 0.0]),    # very close
-            "bookmark": _normalise([1.0, 0.0, 0.0, 0.0]),   # close but less
-            "idea": _normalise([0.0, 0.0, 1.0, 0.0]),       # far
+            "session": _normalise([1.0, 0.4, 0.0, 0.0]),  # very close
+            "bookmark": _normalise([1.0, 0.0, 0.0, 0.0]),  # close but less
+            "idea": _normalise([0.0, 0.0, 1.0, 0.0]),  # far
         }
 
         classifier = HeuristicClassifier()
@@ -274,9 +274,7 @@ class TestClassifyIntegration:
         )
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert result.entry_type == EntryType.SESSION
         assert result.status == EntryStatus.ACTIVE
@@ -291,9 +289,7 @@ class TestClassifyIntegration:
         # Session cluster in one direction.
         for i in range(MIN_ENTRIES_PER_TYPE):
             content = f"session content {i}"
-            deterministic_embedding_provider.register(
-                content, _normalise([1.0, 0.0, 0.0, 0.0])
-            )
+            deterministic_embedding_provider.register(content, _normalise([1.0, 0.0, 0.0, 0.0]))
             entry = make_entry(
                 content=content,
                 entry_type=EntryType.SESSION,
@@ -303,18 +299,14 @@ class TestClassifyIntegration:
 
         # Inbox entry in an orthogonal direction.
         inbox_content = "completely unrelated content"
-        deterministic_embedding_provider.register(
-            inbox_content, _normalise([0.0, 0.0, 0.0, 1.0])
-        )
+        deterministic_embedding_provider.register(inbox_content, _normalise([0.0, 0.0, 0.0, 1.0]))
         inbox_entry = make_entry(
             content=inbox_content,
             entry_type=EntryType.INBOX,
         )
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert result.entry_type == EntryType.INBOX
         assert result.status == EntryStatus.PENDING_REVIEW
@@ -332,9 +324,7 @@ class TestClassifyIntegration:
         )
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert result.entry_type == EntryType.INBOX
         assert result.status == EntryStatus.PENDING_REVIEW
@@ -349,9 +339,7 @@ class TestClassifyIntegration:
         # Only 2 session entries -- insufficient.
         for i in range(MIN_ENTRIES_PER_TYPE - 1):
             content = f"session item {i}"
-            deterministic_embedding_provider.register(
-                content, _normalise([1.0, 0.0, 0.0, 0.0])
-            )
+            deterministic_embedding_provider.register(content, _normalise([1.0, 0.0, 0.0, 0.0]))
             entry = make_entry(
                 content=content,
                 entry_type=EntryType.SESSION,
@@ -360,18 +348,14 @@ class TestClassifyIntegration:
             await store.store(entry)
 
         inbox_content = "similar to session"
-        deterministic_embedding_provider.register(
-            inbox_content, _normalise([1.0, 0.0, 0.0, 0.0])
-        )
+        deterministic_embedding_provider.register(inbox_content, _normalise([1.0, 0.0, 0.0, 0.0]))
         inbox_entry = make_entry(
             content=inbox_content,
             entry_type=EntryType.INBOX,
         )
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert result.status == EntryStatus.PENDING_REVIEW
 
@@ -386,8 +370,6 @@ class TestClassifyIntegration:
         inbox_entry = make_entry(content="anything", entry_type=EntryType.INBOX)
 
         classifier = HeuristicClassifier()
-        result = await classifier.classify(
-            inbox_entry, store, deterministic_embedding_provider
-        )
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert isinstance(result, ClassificationResult)

--- a/tests/test_mcp_coverage_gaps.py
+++ b/tests/test_mcp_coverage_gaps.py
@@ -1890,7 +1890,6 @@ class TestWebhookRecordAudit:
         assert raw is not None
 
 
-
 # ===========================================================================
 # Auth CIMDFetcher patch behavior (auth.py lines 118-152, 167-185)
 # ===========================================================================

--- a/tests/test_mcp_feeds.py
+++ b/tests/test_mcp_feeds.py
@@ -421,7 +421,7 @@ class FakePurgeStore(FakeSourceStore):
                 match = False
             if match:
                 results.append(e)
-        return results[:limit]
+        return results[offset : offset + limit]
 
     async def update(self, entry_id: str, updates: dict[str, Any]) -> FakeEntry:
         for e in self._entries:
@@ -564,7 +564,7 @@ class TestHandleWatchRemovePurge:
         data = parse(result)
         assert data["removed"] is True
         assert "purge_error" in data
-        assert "DB error during purge" in data["purge_error"]
+        assert data["purge_error"] == "Failed to archive historic entries."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_feeds.py
+++ b/tests/test_mcp_feeds.py
@@ -376,6 +376,198 @@ class TestHandleWatchRemove:
 
 
 # ---------------------------------------------------------------------------
+# _handle_watch — remove with purge
+# ---------------------------------------------------------------------------
+
+
+class FakeEntry:
+    """Minimal entry stub for purge tests."""
+
+    def __init__(self, entry_id: str, source_url: str, status: str = "active") -> None:
+        self.id = entry_id
+        self.source_url = source_url
+        self.status = status
+        self.metadata: dict[str, Any] = {"source_url": source_url}
+
+
+class FakePurgeStore(FakeSourceStore):
+    """Extends FakeSourceStore with list_entries and update for purge tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._entries: list[FakeEntry] = []
+
+    def seed_entry(self, entry_id: str, source_url: str, status: str = "active") -> None:
+        self._entries.append(FakeEntry(entry_id, source_url, status))
+
+    async def list_entries(
+        self,
+        filters: dict[str, Any] | None,
+        limit: int,
+        offset: int,
+        **kwargs: Any,
+    ) -> list[FakeEntry]:
+        if not filters:
+            return []
+        results = []
+        for e in self._entries:
+            match = True
+            if (
+                "metadata.source_url" in filters
+                and e.metadata["source_url"] != filters["metadata.source_url"]
+            ):
+                match = False
+            if "status" in filters and e.status != filters["status"]:
+                match = False
+            if match:
+                results.append(e)
+        return results[:limit]
+
+    async def update(self, entry_id: str, updates: dict[str, Any]) -> FakeEntry:
+        for e in self._entries:
+            if e.id == entry_id:
+                for k, v in updates.items():
+                    setattr(e, k, v)
+                return e
+        raise KeyError(f"No entry with id {entry_id}")
+
+
+class TestHandleWatchRemovePurge:
+    async def test_remove_with_purge_false_does_not_archive(self) -> None:
+        """Default purge=false should not include purged_entries in response."""
+        store = FakePurgeStore()
+        await store.add_feed_source(url="https://example.com/rss", source_type="rss")
+        store.seed_entry("e1", "https://example.com/rss")
+        result = await _handle_watch(
+            store=store,
+            arguments={"action": "remove", "url": "https://example.com/rss"},
+        )
+        data = parse(result)
+        assert data["removed"] is True
+        assert "purged_entries" not in data
+        # Entry should still be active
+        assert store._entries[0].status == "active"
+
+    async def test_remove_with_purge_true_archives_entries(self) -> None:
+        """purge=true should archive matching entries and report count."""
+        store = FakePurgeStore()
+        await store.add_feed_source(url="https://example.com/rss", source_type="rss")
+        store.seed_entry("e1", "https://example.com/rss")
+        store.seed_entry("e2", "https://example.com/rss")
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "remove",
+                "url": "https://example.com/rss",
+                "purge": True,
+            },
+        )
+        data = parse(result)
+        assert data["removed"] is True
+        assert data["purged_entries"] == 2
+        # All matching entries should now be archived
+        for e in store._entries:
+            if e.source_url == "https://example.com/rss":
+                assert e.status == "archived"
+
+    async def test_remove_purge_only_archives_matching_source(self) -> None:
+        """purge should only archive entries from the removed source URL."""
+        store = FakePurgeStore()
+        await store.add_feed_source(url="https://example.com/rss", source_type="rss")
+        await store.add_feed_source(url="https://other.com/rss", source_type="rss")
+        store.seed_entry("e1", "https://example.com/rss")
+        store.seed_entry("e2", "https://other.com/rss")
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "remove",
+                "url": "https://example.com/rss",
+                "purge": True,
+            },
+        )
+        data = parse(result)
+        assert data["purged_entries"] == 1
+        # Only the matching entry should be archived
+        assert store._entries[0].status == "archived"
+        assert store._entries[1].status == "active"
+
+    async def test_remove_purge_skips_already_archived(self) -> None:
+        """purge should not re-archive entries that are already archived."""
+        store = FakePurgeStore()
+        await store.add_feed_source(url="https://example.com/rss", source_type="rss")
+        store.seed_entry("e1", "https://example.com/rss", status="archived")
+        store.seed_entry("e2", "https://example.com/rss", status="active")
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "remove",
+                "url": "https://example.com/rss",
+                "purge": True,
+            },
+        )
+        data = parse(result)
+        assert data["purged_entries"] == 1
+
+    async def test_remove_purge_nonexistent_source_does_not_purge(self) -> None:
+        """When the source does not exist (removed=false), purge should not run."""
+        store = FakePurgeStore()
+        store.seed_entry("e1", "https://example.com/rss")
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "remove",
+                "url": "https://example.com/rss",
+                "purge": True,
+            },
+        )
+        data = parse(result)
+        assert data["removed"] is False
+        assert "purged_entries" not in data
+        # Entry should remain active
+        assert store._entries[0].status == "active"
+
+    async def test_remove_purge_zero_entries(self) -> None:
+        """purge with no matching entries should report purged_entries=0."""
+        store = FakePurgeStore()
+        await store.add_feed_source(url="https://example.com/rss", source_type="rss")
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "remove",
+                "url": "https://example.com/rss",
+                "purge": True,
+            },
+        )
+        data = parse(result)
+        assert data["removed"] is True
+        assert data["purged_entries"] == 0
+
+    async def test_remove_purge_error_returns_purge_error(self) -> None:
+        """If purge fails, response should include purge_error but still succeed overall."""
+        store = FakePurgeStore()
+        await store.add_feed_source(url="https://example.com/rss", source_type="rss")
+
+        # Make list_entries raise to simulate a purge failure
+        async def failing_list(*args: Any, **kwargs: Any) -> list:  # type: ignore[type-arg]
+            raise RuntimeError("DB error during purge")
+
+        store.list_entries = failing_list  # type: ignore[assignment]
+
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "remove",
+                "url": "https://example.com/rss",
+                "purge": True,
+            },
+        )
+        data = parse(result)
+        assert data["removed"] is True
+        assert "purge_error" in data
+        assert "DB error during purge" in data["purge_error"]
+
+
+# ---------------------------------------------------------------------------
 # _handle_watch — invalid action
 # ---------------------------------------------------------------------------
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -753,6 +753,5 @@ class TestRemovedTools:
         server = create_server(config)
         tools = await server.list_tools()
         assert len(tools) == 13, (
-            f"Expected 13 registered tools, got {len(tools)}: "
-            f"{sorted(t.name for t in tools)}"
+            f"Expected 13 registered tools, got {len(tools)}: {sorted(t.name for t in tools)}"
         )

--- a/tests/test_mcp_tools/test_list_extensions.py
+++ b/tests/test_mcp_tools/test_list_extensions.py
@@ -80,8 +80,12 @@ async def store_with_stale(store: Any) -> Any:  # type: ignore[return]
     await _store_entry_with_timestamps(store, stale1, accessed_at=thirty_days_ago)
     await _store_entry_with_timestamps(store, stale2, accessed_at=thirty_days_ago)
     await _store_entry_with_timestamps(store, recent1, accessed_at=one_day_ago)
-    await _store_entry_with_timestamps(store, old_no_access, accessed_at=None, updated_at=thirty_days_ago)
-    await _store_entry_with_timestamps(store, new_no_access, accessed_at=None, updated_at=one_day_ago)
+    await _store_entry_with_timestamps(
+        store, old_no_access, accessed_at=None, updated_at=thirty_days_ago
+    )
+    await _store_entry_with_timestamps(
+        store, new_no_access, accessed_at=None, updated_at=one_day_ago
+    )
 
     store._stale_ids = {stale1.id, stale2.id, old_no_access.id}
     store._recent_ids = {recent1.id, new_no_access.id}

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -522,9 +522,7 @@ async def test_hooks_poll_source_url_query_param(
     shared = _make_shared_state(store)
 
     target_url = "https://example.com/feed"
-    result = PollResult(
-        source_url=target_url, source_type="rss", items_fetched=3, items_stored=2
-    )
+    result = PollResult(source_url=target_url, source_type="rss", items_fetched=3, items_stored=2)
     summary = PollerSummary(results=[result], total_fetched=3, total_stored=2, sources_polled=1)
 
     mock_poller = MagicMock()

--- a/tests/test_webhooks/test_classify_batch.py
+++ b/tests/test_webhooks/test_classify_batch.py
@@ -181,13 +181,9 @@ async def test_classify_batch_heuristic_mode_classifies(
     # Mock classifier: compute_centroids returns a centroid dict,
     # classify_entry returns deterministic results per entry.
     mock_classifier = MagicMock()
-    mock_classifier.compute_centroids = AsyncMock(
-        return_value={"session": [0.1, 0.2, 0.3, 0.4]}
-    )
+    mock_classifier.compute_centroids = AsyncMock(return_value={"session": [0.1, 0.2, 0.3, 0.4]})
     # First call: match → session; second call: no match
-    mock_classifier.classify_entry = MagicMock(
-        side_effect=[("session", 0.82), (None, 0.3)]
-    )
+    mock_classifier.classify_entry = MagicMock(side_effect=[("session", 0.82), (None, 0.3)])
 
     # list_entries returns our two entries; update succeeds.
     mock_store = MagicMock()
@@ -273,10 +269,12 @@ async def test_classify_batch_llm_mode_queues_as_pending_review(
     # Mock LLM client that returns classification results with different confidences
     mock_llm_client = MagicMock()
     # Entry A: high confidence -> should be classified as ACTIVE
-    mock_llm_client.classify = AsyncMock(side_effect=[
-        '{"entry_type": "session", "confidence": 0.85, "reasoning": "High confidence session", "suggested_tags": [], "suggested_project": null}',
-        '{"entry_type": "minutes", "confidence": 0.55, "reasoning": "Low confidence meeting", "suggested_tags": [], "suggested_project": null}'
-    ])
+    mock_llm_client.classify = AsyncMock(
+        side_effect=[
+            '{"entry_type": "session", "confidence": 0.85, "reasoning": "High confidence session", "suggested_tags": [], "suggested_project": null}',
+            '{"entry_type": "minutes", "confidence": 0.55, "reasoning": "Low confidence meeting", "suggested_tags": [], "suggested_project": null}',
+        ]
+    )
 
     shared = _make_shared_state(store)
     shared["llm_client"] = mock_llm_client
@@ -321,9 +319,7 @@ async def test_classify_batch_heuristic_error_counting(
     entry_b = _make_entry("Content B")
 
     mock_classifier = MagicMock()
-    mock_classifier.compute_centroids = AsyncMock(
-        return_value={"reference": [0.1, 0.2, 0.3, 0.4]}
-    )
+    mock_classifier.compute_centroids = AsyncMock(return_value={"reference": [0.1, 0.2, 0.3, 0.4]})
     # classify_entry returns a match for both entries.
     mock_classifier.classify_entry = MagicMock(return_value=("reference", 0.75))
 

--- a/tests/test_webhooks/test_maintenance.py
+++ b/tests/test_webhooks/test_maintenance.py
@@ -142,8 +142,9 @@ async def test_maintenance_combined_response_format(
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     shared = _make_shared_state(store)
 
-    mock_poller = _make_poller_mock(sources_polled=2, total_fetched=10, total_stored=7,
-                                    rescored=15, upgraded=3, downgraded=2)
+    mock_poller = _make_poller_mock(
+        sources_polled=2, total_fetched=10, total_stored=7, rescored=15, upgraded=3, downgraded=2
+    )
 
     with patch("distillery.feeds.poller.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())


### PR DESCRIPTION
## Summary

- Adds optional `purge` parameter (default `false`) to `distillery_watch` when `action="remove"`
- When `purge=true`, archives all entries matching the removed source's `metadata.source_url` by setting `status="archived"` (soft-delete)
- Returns `purged_entries` count in the response; gracefully handles failures via `purge_error` field
- Updates `/watch` SKILL.md to document `--purge` flag

Closes #275

## Test plan

- [x] 7 new unit tests in `TestHandleWatchRemovePurge` covering: purge=false (no-op), purge=true (archives entries), source-scoped archiving, skip already-archived, nonexistent source, zero entries, error handling
- [x] All 2061 existing tests continue to pass
- [x] `ruff check` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --purge option to /watch remove to optionally archive historic entries for the removed source and report the number archived.

* **Tests**
  * Added tests covering remove+purge behavior, counting/archiving logic, scope limits, and purge error paths.

* **Documentation**
  * Updated command docs and usage synopsis to document the new purge option and its reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->