### PR TITLE
fix(skills): enforce allowed-tools sandbox in forked skill contexts

### DIFF
--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -300,7 +300,7 @@ Skills with `context: fork` run in an isolated agent context with a restricted `
 2. The forked context must not attempt to work around MCP errors by shelling out, running scripts, or using any tool not declared in `allowed-tools`.
 3. On any MCP tool failure, the skill must display the error per the Error Handling section below and halt immediately.
 
-**Skills currently using `context: fork`:** `/pour`, `/radar`, `/digest`, `/investigate`, `/briefing`.
+**Skills currently using `context: fork`:** `/pour`, `/radar`, `/digest`, `/investigate`, `/briefing`, `/gh-sync`.
 
 ## Error Handling
 

--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -290,6 +290,18 @@ The following table lists all valid `source` values, describing their origin and
 
 Use the `source` filter in `/recall` to retrieve entries by provenance (e.g., search only documentation sources for verified facts).
 
+## Forked Context Constraints
+
+Skills with `context: fork` run in an isolated agent context with a restricted `allowed-tools` list. Due to platform limitations, the forked context may attempt to use tools outside its allowlist (such as Bash or Python) when an MCP tool call fails. To defend against this:
+
+1. Every `context: fork` skill MUST include these two rules at the top of its `## Rules` section:
+   - `NEVER use Bash, Python, or any tool not listed in allowed-tools`
+   - `If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.`
+2. The forked context must not attempt to work around MCP errors by shelling out, running scripts, or using any tool not declared in `allowed-tools`.
+3. On any MCP tool failure, the skill must display the error per the Error Handling section below and halt immediately.
+
+**Skills currently using `context: fork`:** `/pour`, `/radar`, `/digest`, `/investigate`, `/briefing`.
+
 ## Error Handling
 
 If any MCP tool returns an error, display it and stop (no retry loops):

--- a/skills/briefing/SKILL.md
+++ b/skills/briefing/SKILL.md
@@ -327,6 +327,8 @@ Generated: 2026-04-08 09:15 UTC
 
 ## Rules
 
+- NEVER use Bash, Python, or any tool not listed in allowed-tools
+- If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.
 - Always call `distillery_list(limit=1)` first as the MCP health check; stop if it fails
 - Auto-detect project from `basename $(git rev-parse --show-toplevel)` when `--project` is not provided
 - Display-only — no `--store` flag, no storing of output

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -239,6 +239,8 @@ Tags: digest, team-activity, internal
 
 ## Rules
 
+- NEVER use Bash, Python, or any tool not listed in allowed-tools
+- If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.
 - Default lookback is 7 days — respect `--days` override
 - Only include `session`, `bookmark`, `minutes`, `idea`, `reference` entry types — never `feed`, `github`, or `digest`
 - Display digest by default; store only with `--store` flag

--- a/skills/gh-sync/SKILL.md
+++ b/skills/gh-sync/SKILL.md
@@ -219,6 +219,8 @@ Synced 8 issues, 4 PRs from norrietaylor/distillery. 5 new, 7 updated. 6 cross-r
 
 ## Rules
 
+- NEVER use Bash, Python, or any tool not listed in allowed-tools
+- If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.
 - `owner/repo` argument is required — ask if not provided
 - `--issues` and `--prs` can be combined (equivalent to syncing both)
 - Never store duplicate entries — always check `metadata.external_id` before storing

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -276,6 +276,8 @@ Investigated "<topic>": <N> entries across <phases> phases, <K> relationship edg
 
 ## Rules
 
+- NEVER use Bash, Python, or any tool not listed in allowed-tools
+- If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.
 - Always use `[Entry <short-id>]` citation format (short-id = first 8 chars of UUID)
 - Deduplicate the result set by entry ID across all phases — each entry counted once
 - Record which phase first discovered each entry

--- a/skills/pour/SKILL.md
+++ b/skills/pour/SKILL.md
@@ -128,6 +128,8 @@ Heading `# Pour: <Topic>`, then sections Summary, Timeline, Key Decisions, Contr
 
 ## Rules
 
+- NEVER use Bash, Python, or any tool not listed in allowed-tools
+- If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.
 - Always use `[Entry <short-id>]` citation format (short-id = first 8 chars of UUID)
 - Every factual claim must trace to an entry -- never synthesize without citing
 - Omit sections with no content

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -185,6 +185,8 @@ Tags: digest, radar, ambient
 
 ## Rules
 
+- NEVER use Bash, Python, or any tool not listed in allowed-tools
+- If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.
 - Default lookback is 7 days; default limit is 20 — respect overrides
 - Group entries by source tag when available; fall back to topic grouping
 - Display digest by default; store only with `--store` flag


### PR DESCRIPTION
## Summary
- Add explicit tool-restriction rules to all 5 `context: fork` skills (`/pour`, `/radar`, `/digest`, `/investigate`, `/briefing`) preventing use of Bash, Python, or any tool outside their `allowed-tools` list
- Add "Forked Context Constraints" section to `skills/CONVENTIONS.md` documenting the defensive pattern for all current and future forked skills
- On MCP tool failure, forked skills must report the error and stop rather than attempting workarounds

Closes #285

## Test plan
- [ ] Verify each updated SKILL.md contains the two new rules at the top of its Rules section
- [ ] Verify CONVENTIONS.md contains the new Forked Context Constraints section
- [ ] Confirm no Python source changes (markdown-only fix)
- [ ] Test a forked skill (e.g., `/pour`) with a failing MCP tool to verify it stops cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated operational rules for `/pour`, `/radar`, `/digest`, `/investigate`, `/briefing`, and `/gh-sync` skills with stricter constraints.
  * Skills now explicitly forbid use of undeclared tools and require immediate error reporting when tool calls fail, preventing workaround attempts.
  * Added standardized constraint guidelines for consistent behavior across affected skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->