### PR TITLE
fix(config): remove stale distillery_tag_tree permission

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,6 @@
       "mcp__plugin_distillery_distillery__distillery_status",
       "mcp__plugin_distillery_distillery__distillery_store",
       "mcp__plugin_distillery_distillery__distillery_suggest_sources",
-      "mcp__plugin_distillery_distillery__distillery_tag_tree",
       "mcp__plugin_distillery_distillery__distillery_type_schemas",
       "mcp__plugin_distillery_distillery__distillery_update",
       "mcp__plugin_distillery_distillery__distillery_watch",


### PR DESCRIPTION
## Summary
- Removed stale `mcp__plugin_distillery_distillery__distillery_tag_tree` permission from `.claude/settings.local.json`
- The `distillery_tag_tree` tool was previously removed from the MCP server but the permission entry was left behind

Closes #286

## Test plan
- [x] `ruff check src/ tests/` passes
- [x] `mypy --strict src/distillery/` passes
- [x] `pytest` passes (2 pre-existing failures unrelated to this change)
- [x] Verified JSON remains valid after edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings.

**Note:** This change has no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->