### PR TITLE
fix(mcp): add read-only mode to distillery_configure and fix /tune skill

### DIFF
--- a/skills/tune/SKILL.md
+++ b/skills/tune/SKILL.md
@@ -46,7 +46,12 @@ No flags = read-only mode (display current thresholds).
 
 ### Step 3: Retrieve Current Configuration
 
-Call `distillery_configure(action="get", section="feeds.thresholds")` and extract `alert` (default: 0.85) and `digest` (default: 0.60). If the call returns an error or the section is absent, show defaults and note live values could not be confirmed.
+Read current thresholds by omitting the `value` parameter:
+
+- `distillery_configure(section="feeds.thresholds", key="alert")`
+- `distillery_configure(section="feeds.thresholds", key="digest")`
+
+Extract the `value` field from each response (defaults: alert=0.85, digest=0.60). If either call returns an error, show defaults and note live values could not be confirmed.
 
 ### Step 4: Apply Changes (if flags provided)
 
@@ -115,7 +120,7 @@ Tuning Guide:
 
 ## Rules
 
-- Always call `distillery_configure(action="get", section="feeds.thresholds")` first to verify MCP availability and retrieve current thresholds
+- Always call `distillery_configure(section="feeds.thresholds", key="alert")` and `distillery_configure(section="feeds.thresholds", key="digest")` first to verify MCP availability and retrieve current thresholds
 - In read-only mode, display thresholds without confirmation
 - Validate `--alert` >= `--digest` before applying; reject invalid combinations
 - Always ask for confirmation before applying changes

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -908,12 +908,12 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         ctx: Context,
         section: str,
         key: str,
-        value: str | int | float,
+        value: str | int | float | None = None,
     ) -> list[types.TextContent]:
-        """Update a runtime configuration value and persist it to distillery.yaml.
+        """Read or update a runtime configuration value.
 
-        USE WHEN: adjusting thresholds, classification settings, or feed
-        parameters at runtime without editing the config file directly.
+        USE WHEN: reading current thresholds/settings, or adjusting them
+        at runtime without editing the config file directly.
 
         PARAMS:
           - section (str, required): Config section path (dotted notation).
@@ -922,10 +922,12 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             Valid keys by section: feeds.thresholds: [alert, digest];
             defaults: [dedup_threshold, dedup_limit, stale_days];
             classification: [confidence_threshold, mode].
-          - value (str | int | float, required): New value. Must satisfy type and
-            range constraints for the given key.
+          - value (str | int | float | None, optional): New value. Omit to read
+            the current value. When provided, must satisfy type and range
+            constraints for the given key.
 
-        RETURNS (success): { changed: bool, section: str, key: str, previous_value: any,
+        RETURNS (read): { section: str, key: str, value: any, message: str }
+        RETURNS (write): { changed: bool, section: str, key: str, previous_value: any,
           new_value: any, disk_written: bool, message: str }
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
 

--- a/src/distillery/mcp/tools/configure.py
+++ b/src/distillery/mcp/tools/configure.py
@@ -3,6 +3,9 @@
 Implements the ``distillery_configure`` tool that allows runtime
 configuration changes via MCP, writing updates atomically to the
 YAML config file on disk while also patching the in-memory config.
+
+When ``value`` is omitted (None), the tool operates in read-only mode
+and returns the current value for the given section+key.
 """
 
 from __future__ import annotations
@@ -169,10 +172,31 @@ async def _handle_configure(
             "INVALID_PARAMS",
             "Parameter 'key' is required and must be a non-empty string.",
         )
+
+    # --- Read-only mode: value omitted ---
     if value is None:
-        return error_response(
-            "INVALID_PARAMS",
-            "Parameter 'value' is required.",
+        spec = _ALLOWED_KEYS.get((section, key))
+        if spec is None:
+            return error_response(
+                "INVALID_PARAMS",
+                f"Configuration key '{section}.{key}' is not a recognised configurable key. "
+                f"Allowed keys: "
+                f"{', '.join(f'{s}.{k}' for s, k in sorted(_ALLOWED_KEYS))}.",
+            )
+        try:
+            current = _get_nested(config, section, key)
+        except AttributeError:
+            return error_response(
+                "INTERNAL",
+                f"Unable to read current value for '{section}.{key}'.",
+            )
+        return success_response(
+            {
+                "section": section,
+                "key": key,
+                "value": current,
+                "message": f"Current value of {section}.{key} is {current}",
+            }
         )
 
     # --- Check allowlist ---

--- a/tests/test_mcp_configure.py
+++ b/tests/test_mcp_configure.py
@@ -80,13 +80,22 @@ class TestRequiredParams:
         assert "key" in data["message"]
 
     @pytest.mark.asyncio
-    async def test_missing_value(self) -> None:
+    async def test_missing_section_for_read(self) -> None:
         cfg = make_config()
-        result = await _handle_configure(cfg, {"section": "feeds.thresholds", "key": "alert"})
+        result = await _handle_configure(cfg, {"key": "alert"})
         data = parse(result)
         assert data["error"] is True
         assert data["code"] == "INVALID_PARAMS"
-        assert "value" in data["message"]
+        assert "section" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_missing_key_for_read(self) -> None:
+        cfg = make_config()
+        result = await _handle_configure(cfg, {"section": "feeds.thresholds"})
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert "key" in data["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -411,3 +420,79 @@ class TestValueCoercion:
         assert data["changed"] is True
         assert data["new_value"] == 5
         assert cfg.defaults.dedup_limit == 5
+
+
+# ---------------------------------------------------------------------------
+# Read-only mode (value omitted)
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyMode:
+    """When value is omitted (None), return the current config value."""
+
+    @pytest.mark.asyncio
+    async def test_read_alert_threshold(self) -> None:
+        cfg = make_config(alert=0.9, digest=0.5)
+        result = await _handle_configure(cfg, {"section": "feeds.thresholds", "key": "alert"})
+        data = parse(result)
+        assert data.get("error") is None or data.get("error") is False
+        assert data["section"] == "feeds.thresholds"
+        assert data["key"] == "alert"
+        assert data["value"] == 0.9
+        assert "0.9" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_read_digest_threshold(self) -> None:
+        cfg = make_config(alert=0.85, digest=0.65)
+        result = await _handle_configure(cfg, {"section": "feeds.thresholds", "key": "digest"})
+        data = parse(result)
+        assert data["value"] == 0.65
+
+    @pytest.mark.asyncio
+    async def test_read_dedup_threshold(self) -> None:
+        cfg = make_config(dedup_threshold=0.88)
+        result = await _handle_configure(cfg, {"section": "defaults", "key": "dedup_threshold"})
+        data = parse(result)
+        assert data["value"] == 0.88
+
+    @pytest.mark.asyncio
+    async def test_read_confidence_threshold(self) -> None:
+        cfg = make_config(confidence_threshold=0.7)
+        result = await _handle_configure(
+            cfg, {"section": "classification", "key": "confidence_threshold"}
+        )
+        data = parse(result)
+        assert data["value"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_read_unknown_key_rejected(self) -> None:
+        cfg = make_config()
+        result = await _handle_configure(cfg, {"section": "feeds.thresholds", "key": "nonexistent"})
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert "not a recognised" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_read_unknown_section_rejected(self) -> None:
+        cfg = make_config()
+        result = await _handle_configure(cfg, {"section": "bogus", "key": "whatever"})
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
+    @pytest.mark.asyncio
+    async def test_read_does_not_mutate_config(self) -> None:
+        cfg = make_config(alert=0.85)
+        await _handle_configure(cfg, {"section": "feeds.thresholds", "key": "alert"})
+        assert cfg.feeds.thresholds.alert == 0.85
+
+    @pytest.mark.asyncio
+    async def test_read_with_explicit_none_value(self) -> None:
+        cfg = make_config(alert=0.85)
+        result = await _handle_configure(
+            cfg, {"section": "feeds.thresholds", "key": "alert", "value": None}
+        )
+        data = parse(result)
+        assert data.get("error") is None or data.get("error") is False
+        assert data["value"] == 0.85


### PR DESCRIPTION
## Summary
- Add read-only mode to `distillery_configure`: when `value` is omitted (None), the tool returns the current value for the given section+key instead of erroring
- Update `/tune` SKILL.md to use the correct API (remove `action="get"`, just omit `value` to read)
- Add 8 unit tests covering read-only mode (valid reads, unknown keys, immutability, explicit None)

Closes #284

## Test plan
- [x] `ruff check` passes
- [x] `mypy --strict src/distillery/` passes (0 issues in 58 files)
- [x] All 31 configure tests pass (23 existing + 8 new)
- [x] Existing write-mode tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration tool now supports reading current values, enabling retrieval of thresholds and other settings without modification.

* **Documentation**
  * Updated instructions for fetching configuration using dedicated key-specific retrieval calls.

* **Tests**
  * Comprehensive test coverage added for configuration read operations and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->