### PR TITLE
feat(store): support group_by='tags' in distillery_list

### DIFF
--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -149,9 +149,7 @@ async def _handle_store(
     output_mode_raw = arguments.get("output_mode")
     output_mode = output_mode_raw if output_mode_raw is not None else "full"
     if output_mode not in ("full", "summary"):
-        return error_response(
-            "INVALID_PARAMS", "Field 'output_mode' must be 'full' or 'summary'."
-        )
+        return error_response("INVALID_PARAMS", "Field 'output_mode' must be 'full' or 'summary'.")
 
     entry_type_str = arguments["entry_type"]
     if entry_type_str not in _VALID_ENTRY_TYPES:
@@ -227,7 +225,9 @@ async def _handle_store(
     embed_count = 1 if output_mode == "summary" else 3
     if cfg is not None:
         try:
-            record_and_check(store.connection, cfg.rate_limit.embedding_budget_daily, count=embed_count)
+            record_and_check(
+                store.connection, cfg.rate_limit.embedding_budget_daily, count=embed_count
+            )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
 
@@ -420,7 +420,9 @@ async def _handle_store_batch(
                 "INVALID_PARAMS", f"entries[{idx}] must be a dict, got {type(item).__name__}."
             )
         if "content" not in item:
-            return error_response("INVALID_PARAMS", f"entries[{idx}] is missing required 'content'.")
+            return error_response(
+                "INVALID_PARAMS", f"entries[{idx}] is missing required 'content'."
+            )
         if "author" not in item:
             return error_response("INVALID_PARAMS", f"entries[{idx}] is missing required 'author'.")
 
@@ -468,7 +470,11 @@ async def _handle_store_batch(
 
         # --- reserved prefix enforcement (mirror _handle_store logic) ---
         _reserved_allowed_sources: set[str] = {EntrySource.IMPORT.value}
-        if cfg is not None and cfg.tags.reserved_prefixes and source_str not in _reserved_allowed_sources:
+        if (
+            cfg is not None
+            and cfg.tags.reserved_prefixes
+            and source_str not in _reserved_allowed_sources
+        ):
             for tag in final_tags:
                 top = tag.split("/")[0]
                 if top in cfg.tags.reserved_prefixes:
@@ -754,7 +760,7 @@ async def _handle_update(
 # ---------------------------------------------------------------------------
 
 _VALID_OUTPUT_MODES = frozenset({"full", "summary", "ids", "review"})
-_VALID_GROUP_BY_VALUES = frozenset({"entry_type", "status", "author", "project", "source"})
+_VALID_GROUP_BY_VALUES = frozenset({"entry_type", "status", "author", "project", "source", "tags"})
 
 
 def _entry_to_summary_dict(entry: Any) -> dict[str, Any]:

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -293,6 +293,7 @@ _AGGREGATE_GROUP_BY_MAP: dict[str, str] = {
     "author": "author",
     "project": "project",
     "source": "source",
+    "tags": "UNNEST(tags)",
     "metadata.source_url": "json_extract_string(metadata, '$.source_url')",
     "metadata.source_type": "json_extract_string(metadata, '$.source_type')",
 }

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1576,8 +1576,10 @@ class DuckDBStore:
         Parameters:
             group_by: Logical field name.  Supported values:
                 ``"entry_type"``, ``"status"``, ``"author"``, ``"project"``,
-                ``"source"``, ``"metadata.source_url"``, ``"metadata.source_type"``.
-                The SQL expression is resolved here so that callers only ever pass
+                ``"source"``, ``"tags"``, ``"metadata.source_url"``,
+                ``"metadata.source_type"``.  For ``"tags"`` a two-step CTE
+                is used to UNNEST the array before aggregating.  The SQL
+                expression is resolved here so that callers only ever pass
                 the logical name (validated by the MCP layer against an allowlist).
             filters: Optional metadata constraints (see ``_build_filter_clauses``).
             limit: Maximum number of groups to return.
@@ -1598,28 +1600,49 @@ class DuckDBStore:
             where_clauses, params = self._build_filter_clauses(filters)
             if stale_days is not None:
                 where_clauses.append(
-                    "COALESCE(accessed_at, updated_at)"
-                    " < NOW() - INTERVAL (CAST(? AS INT)) DAYS"
+                    "COALESCE(accessed_at, updated_at) < NOW() - INTERVAL (CAST(? AS INT)) DAYS"
                 )
                 params.append(stale_days)
             where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
 
-            # Single CTE query: window functions compute true totals over the
-            # full grouped result set, while LIMIT returns only the top-N rows.
-            sql = (
-                f"WITH grouped AS ("
-                f"SELECT {group_expr} AS value, COUNT(*) AS group_count "
-                f"FROM entries "
-                f"{where_sql} "
-                f"GROUP BY 1"
-                f") "
-                f"SELECT value, group_count, "
-                f"COUNT(*) OVER () AS total_groups, "
-                f"COALESCE(SUM(group_count) OVER (), 0) AS total_entries "
-                f"FROM grouped "
-                f"ORDER BY group_count DESC, value ASC NULLS LAST "
-                f"LIMIT ?"
-            )
+            # DuckDB does not support UNNEST() directly inside a CTE
+            # SELECT, so for array fields (tags) we use a two-step CTE:
+            # first explode rows, then aggregate.  Scalar fields use the
+            # original single-CTE path.
+            if group_by == "tags":
+                sql = (
+                    f"WITH exploded AS ("
+                    f"SELECT UNNEST(tags) AS value "
+                    f"FROM entries "
+                    f"{where_sql}"
+                    f"), "
+                    f"grouped AS ("
+                    f"SELECT value, COUNT(*) AS group_count "
+                    f"FROM exploded "
+                    f"GROUP BY 1"
+                    f") "
+                    f"SELECT value, group_count, "
+                    f"COUNT(*) OVER () AS total_groups, "
+                    f"COALESCE(SUM(group_count) OVER (), 0) AS total_entries "
+                    f"FROM grouped "
+                    f"ORDER BY group_count DESC, value ASC NULLS LAST "
+                    f"LIMIT ?"
+                )
+            else:
+                sql = (
+                    f"WITH grouped AS ("
+                    f"SELECT {group_expr} AS value, COUNT(*) AS group_count "
+                    f"FROM entries "
+                    f"{where_sql} "
+                    f"GROUP BY 1"
+                    f") "
+                    f"SELECT value, group_count, "
+                    f"COUNT(*) OVER () AS total_groups, "
+                    f"COALESCE(SUM(group_count) OVER (), 0) AS total_entries "
+                    f"FROM grouped "
+                    f"ORDER BY group_count DESC, value ASC NULLS LAST "
+                    f"LIMIT ?"
+                )
             rows = conn.execute(sql, list(params) + [limit]).fetchall()
             total_groups = int(rows[0][2]) if rows else 0
             total_entries = int(rows[0][3]) if rows else 0

--- a/tests/test_mcp_tools/test_list_extensions.py
+++ b/tests/test_mcp_tools/test_list_extensions.py
@@ -80,8 +80,12 @@ async def store_with_stale(store: Any) -> Any:  # type: ignore[return]
     await _store_entry_with_timestamps(store, stale1, accessed_at=thirty_days_ago)
     await _store_entry_with_timestamps(store, stale2, accessed_at=thirty_days_ago)
     await _store_entry_with_timestamps(store, recent1, accessed_at=one_day_ago)
-    await _store_entry_with_timestamps(store, old_no_access, accessed_at=None, updated_at=thirty_days_ago)
-    await _store_entry_with_timestamps(store, new_no_access, accessed_at=None, updated_at=one_day_ago)
+    await _store_entry_with_timestamps(
+        store, old_no_access, accessed_at=None, updated_at=thirty_days_ago
+    )
+    await _store_entry_with_timestamps(
+        store, new_no_access, accessed_at=None, updated_at=one_day_ago
+    )
 
     store._stale_ids = {stale1.id, stale2.id, old_no_access.id}
     store._recent_ids = {recent1.id, new_no_access.id}
@@ -430,14 +434,6 @@ class TestGroupBy:
         assert by_source.get("manual") == 4
         assert by_source.get("claude-code") == 1
 
-    @pytest.mark.xfail(
-        reason=(
-            "DuckDB 1.5.1 does not support UNNEST() in a CTE SELECT; "
-            "group_by=tags requires store-layer fix to use a two-step CTE. "
-            "See aggregate_entries in duckdb.py."
-        ),
-        strict=True,
-    )
     async def test_group_by_tags(self, populated_store: Any) -> None:
         """group_by=tags unnests tags array — each tag gets its own count."""
         result = await _handle_list(
@@ -453,8 +449,8 @@ class TestGroupBy:
 
     @pytest.mark.xfail(
         reason=(
-            "DuckDB 1.5.1 does not support UNNEST() in a CTE SELECT; "
-            "group_by=tags with tag_prefix requires store-layer fix. "
+            "tag_prefix currently filters entries (not individual tags); "
+            "group_by=tags with tag_prefix needs post-explode filtering. "
             "See aggregate_entries in duckdb.py."
         ),
         strict=True,


### PR DESCRIPTION
## Summary
- Add `tags` to valid `group_by` values in `distillery_list` and `distillery_aggregate` MCP tools
- Implement two-step CTE in DuckDB `aggregate_entries` to work around DuckDB 1.5.1's lack of UNNEST() support in CTE SELECT clauses
- Remove `xfail` marker from `test_group_by_tags` (now passing); update `test_group_by_tags_with_tag_prefix` xfail reason

Closes #283

## Test plan
- [x] `ruff check src/ tests/` passes
- [x] `ruff format` applied to changed files
- [x] `mypy --strict src/distillery/` passes (0 issues)
- [x] `pytest` passes (2055 passed, 1 xfailed, 1 pre-existing failure unrelated to this PR)
- [x] `test_group_by_tags` now passes without xfail
- [x] `test_group_by_tags_with_tag_prefix` remains xfail (tag_prefix filters entries not individual tags — separate enhancement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for grouping results by individual tags across list and aggregate operations, enabling more granular data organization and analysis.

* **Refactor**
  * Code formatting improvements and query structure enhancements to support the new tag-grouping functionality.

* **Tests**
  * Updated test expectations and corrected test markers to properly validate tag-grouping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->