### PR TITLE
fix(cli): flush stdout before sys.exit in retag and other subcommands

### DIFF
--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import json
 import sys
 from pathlib import Path
@@ -1570,6 +1571,8 @@ def main(argv: list[str] | None = None) -> None:
 
     # Flush output streams before exiting to ensure all output is visible
     # when invoked via entry_points (e.g. `distillery retag --dry-run`).
-    sys.stdout.flush()
-    sys.stderr.flush()
+    # Guard against BrokenPipeError when piped to a closed consumer (e.g. `| head`).
+    for _stream in (sys.stdout, sys.stderr):
+        with contextlib.suppress(BrokenPipeError):
+            _stream.flush()
     sys.exit(exit_code)

--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -1520,59 +1520,56 @@ def main(argv: list[str] | None = None) -> None:
     fmt: str = args.format if args.format is not None else "text"
     command: str | None = args.command
 
+    exit_code: int = 0
+
     if command is None:
         parser.print_help()
-        sys.exit(0)
     elif command == "status":
-        sys.exit(_cmd_status(config_path, fmt))
+        exit_code = _cmd_status(config_path, fmt)
     elif command == "health":
-        sys.exit(_cmd_health(config_path, fmt))
+        exit_code = _cmd_health(config_path, fmt)
     elif command == "poll":
-        sys.exit(
-            _cmd_poll(
-                config_path=config_path,
-                fmt=fmt,
-                source_url=getattr(args, "source", None),
-            )
+        exit_code = _cmd_poll(
+            config_path=config_path,
+            fmt=fmt,
+            source_url=getattr(args, "source", None),
         )
     elif command == "export":
-        sys.exit(
-            _cmd_export(
-                config_path=config_path,
-                fmt=fmt,
-                output_path=args.output,
-            )
+        exit_code = _cmd_export(
+            config_path=config_path,
+            fmt=fmt,
+            output_path=args.output,
         )
     elif command == "import":
-        sys.exit(
-            _cmd_import(
-                config_path=config_path,
-                fmt=fmt,
-                input_path=args.input,
-                mode=args.mode,
-                yes=args.yes,
-            )
+        exit_code = _cmd_import(
+            config_path=config_path,
+            fmt=fmt,
+            input_path=args.input,
+            mode=args.mode,
+            yes=args.yes,
         )
     elif command == "retag":
-        sys.exit(
-            _cmd_retag(
-                config_path=config_path,
-                fmt=fmt,
-                dry_run=getattr(args, "dry_run", False),
-                force=getattr(args, "force", False),
-            )
+        exit_code = _cmd_retag(
+            config_path=config_path,
+            fmt=fmt,
+            dry_run=getattr(args, "dry_run", False),
+            force=getattr(args, "force", False),
         )
     elif command == "eval":
-        sys.exit(
-            _cmd_eval(
-                scenarios_dir=getattr(args, "scenarios_dir", None),
-                skill_filter=getattr(args, "skill", None),
-                save_baseline=getattr(args, "save_baseline", None),
-                baseline=getattr(args, "baseline", None),
-                model=getattr(args, "model", "claude-haiku-4-5-20251001"),
-                fmt=fmt,
-                compare_cost=getattr(args, "compare_cost", False),
-            )
+        exit_code = _cmd_eval(
+            scenarios_dir=getattr(args, "scenarios_dir", None),
+            skill_filter=getattr(args, "skill", None),
+            save_baseline=getattr(args, "save_baseline", None),
+            baseline=getattr(args, "baseline", None),
+            model=getattr(args, "model", "claude-haiku-4-5-20251001"),
+            fmt=fmt,
+            compare_cost=getattr(args, "compare_cost", False),
         )
     else:  # pragma: no cover – argparse rejects unknown subcommands
         parser.error(f"Unknown command: {command}")
+
+    # Flush output streams before exiting to ensure all output is visible
+    # when invoked via entry_points (e.g. `distillery retag --dry-run`).
+    sys.stdout.flush()
+    sys.stderr.flush()
+    sys.exit(exit_code)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -976,3 +976,34 @@ class TestRetagCommand:
         with pytest.raises(SystemExit) as exc:
             main(["retag", "--config", str(cfg_path), "--dry-run"])
         assert exc.value.code == 0
+
+    def test_retag_via_main_produces_text_output(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``distillery retag --dry-run`` produces visible output via main()."""
+        db_path = str(tmp_path / "test.db")
+        cfg_path = write_config(tmp_path, db_path)
+        with pytest.raises(SystemExit) as exc:
+            main(["retag", "--config", str(cfg_path), "--dry-run"])
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert "Retag complete" in captured.out
+        assert "total_scanned" in captured.out
+
+    def test_retag_via_main_produces_json_output(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``distillery retag --dry-run --format json`` produces JSON via main()."""
+        db_path = str(tmp_path / "test.db")
+        cfg_path = write_config(tmp_path, db_path)
+        with pytest.raises(SystemExit) as exc:
+            main(["retag", "--config", str(cfg_path), "--dry-run", "--format", "json"])
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["dry_run"] is True
+        assert "total_scanned" in data


### PR DESCRIPTION
## Summary
- Restructure the CLI dispatch block in `main()` to capture subcommand exit codes into a local variable instead of passing them directly to `sys.exit()`
- Add explicit `sys.stdout.flush()` / `sys.stderr.flush()` before `sys.exit()` so output is always visible when invoked via the `distillery` entry point
- Add two new tests verifying that `distillery retag` produces visible text and JSON output when dispatched through `main()`

Closes #169

## Test plan
- [x] Existing `test_retag_via_main_dispatches` still passes (exit code 0)
- [x] New `test_retag_via_main_produces_text_output` verifies "Retag complete" appears in captured stdout
- [x] New `test_retag_via_main_produces_json_output` verifies valid JSON with expected keys in stdout
- [x] All 59 CLI tests pass
- [x] `ruff check` and `ruff format` clean
- [x] `mypy --strict` passes on `src/distillery/cli.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI reliability by ensuring standard output and error are consistently flushed before the process exits, preventing truncated or missing output.

* **Tests**
  * Added automated tests covering the retag subcommand, validating both human-readable and JSON outputs and confirming successful (zero) exit status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->