### PR TITLE
fix(plugin): make MCP server URL configurable via userConfig template

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "distillery",
       "source": "./",
       "description": "Knowledge base skills — capture, search, and synthesize project knowledge",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings"],
       "category": "knowledge-management"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -26,18 +26,12 @@
       "description": "GitHub OAuth app client secret for team access. Found alongside the client ID in your OAuth App settings",
       "type": "string",
       "sensitive": true
-    },
-    "distillery_mcp_url": {
-      "title": "Distillery MCP URL",
-      "description": "URL of the Distillery MCP server. Defaults to the hosted demo for onboarding. Self-hosters should set this to their own instance URL (e.g. http://localhost:8787/mcp). The hosted demo is for evaluation only — do not store sensitive data.",
-      "type": "string",
-      "default": "https://distillery-mcp.fly.dev/mcp"
     }
   },
   "mcpServers": {
     "distillery": {
       "type": "http",
-      "url": "${user_config.distillery_mcp_url}"
+      "url": "https://distillery-mcp.fly.dev/mcp"
     }
   },
   "hooks": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -26,12 +26,18 @@
       "description": "GitHub OAuth app client secret for team access. Found alongside the client ID in your OAuth App settings",
       "type": "string",
       "sensitive": true
+    },
+    "distillery_mcp_url": {
+      "title": "Distillery MCP URL",
+      "description": "URL of the Distillery MCP server. Defaults to the hosted demo for onboarding. Self-hosters should set this to their own instance URL (e.g. http://localhost:8787/mcp). The hosted demo is for evaluation only — do not store sensitive data.",
+      "type": "string",
+      "default": "https://distillery-mcp.fly.dev/mcp"
     }
   },
   "mcpServers": {
     "distillery": {
       "type": "http",
-      "url": "https://distillery-mcp.fly.dev/mcp"
+      "url": "${user_config.distillery_mcp_url}"
     }
   },
   "hooks": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "distillery",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Knowledge base skills for Claude Code — capture, search, and synthesize project knowledge",
   "author": {
     "name": "norrietaylor",
@@ -26,12 +26,18 @@
       "description": "GitHub OAuth app client secret for team access. Found alongside the client ID in your OAuth App settings",
       "type": "string",
       "sensitive": true
+    },
+    "distillery_mcp_url": {
+      "title": "Distillery MCP URL",
+      "description": "URL of the Distillery MCP server. Defaults to the hosted demo for onboarding. Self-hosters should set this to their own instance URL (e.g. http://localhost:8787/mcp). The hosted demo is for evaluation only — do not store sensitive data.",
+      "type": "string",
+      "default": "https://distillery-mcp.fly.dev/mcp"
     }
   },
   "mcpServers": {
     "distillery": {
       "type": "http",
-      "url": "https://distillery-mcp.fly.dev/mcp"
+      "url": "${user_config.distillery_mcp_url}"
     }
   },
   "hooks": {
@@ -41,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '[Distillery v0.3.2] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+            "command": "echo '[Distillery v0.3.3] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
           }
         ]
       }

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -116,11 +116,7 @@ To configure manually, add to `~/.claude/settings.json`:
 
 Deploy your own Distillery server with GitHub OAuth. See [Operator Deployment](../team/deployment.md) for setup and the [distill_ops](https://github.com/norrietaylor/distill_ops) repo for platform-specific guides (Fly.io, Prefect Horizon).
 
-To override the plugin's default demo URL, register your own MCP server at user scope. This shadows the plugin registration:
-
-```bash
-claude mcp add distillery --scope user --transport http --url https://your-instance.example.com/mcp
-```
+To point the plugin at your own instance, set the `distillery_mcp_url` plugin config field at enable time. Claude Code prompts for userConfig values when you enable the plugin, and the value is substituted into the plugin's MCP server registration automatically. Leave it at the default to use the hosted demo.
 
 ## Remote Auto-Poll Setup
 

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -116,6 +116,12 @@ To configure manually, add to `~/.claude/settings.json`:
 
 Deploy your own Distillery server with GitHub OAuth. See [Operator Deployment](../team/deployment.md) for setup and the [distill_ops](https://github.com/norrietaylor/distill_ops) repo for platform-specific guides (Fly.io, Prefect Horizon).
 
+To override the plugin's default demo URL, register your own MCP server at user scope. This shadows the plugin registration:
+
+```bash
+claude mcp add distillery --scope user --transport http --url https://your-instance.example.com/mcp
+```
+
 ## Remote Auto-Poll Setup
 
 Enable remote auto-polling so feed sources are polled automatically even when Claude Code is not running. This uses Claude Code's scheduled remote agents (triggers).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distillery-mcp"
-version = "0.3.2"
+version = "0.3.3"
 description = "A configurable embedding system with DuckDB storage and MCP server integration"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/distillery/__init__.py
+++ b/src/distillery/__init__.py
@@ -2,5 +2,5 @@
 
 import os
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __build_sha__ = os.environ.get("DISTILLERY_BUILD_SHA", "dev")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -233,15 +233,15 @@ class TestPluginMCPServers:
         server = manifest["mcpServers"]["distillery"]
         assert "url" in server
 
-    def test_distillery_server_url_uses_user_config(self) -> None:
-        """The distillery server URL must reference the userConfig template variable."""
+    def test_distillery_server_url_is_hardcoded_fly_url(self) -> None:
+        """The distillery server URL must be the hardcoded Fly.io hosted URL.
+
+        Note: ${user_config.<key>} interpolation is NOT supported in mcpServers.url.
+        Self-hosters should override via: claude mcp add distillery --scope user
+        """
         manifest = load_plugin_manifest()
         server = manifest["mcpServers"]["distillery"]
-        assert server["url"] == "${user_config.distillery_mcp_url}"
-        assert (
-            manifest["userConfig"]["distillery_mcp_url"]["default"]
-            == "https://distillery-mcp.fly.dev/mcp"
-        )
+        assert server["url"] == "https://distillery-mcp.fly.dev/mcp"
 
     def test_distillery_server_no_unsupported_fields(self) -> None:
         """The distillery server must not contain fields unsupported by the plugin schema."""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -233,11 +233,11 @@ class TestPluginMCPServers:
         server = manifest["mcpServers"]["distillery"]
         assert "url" in server
 
-    def test_distillery_server_url_is_fly_endpoint(self) -> None:
-        """The distillery server URL must point to the Fly.io hosted endpoint."""
+    def test_distillery_server_url_uses_user_config(self) -> None:
+        """The distillery server URL must reference the userConfig template variable."""
         manifest = load_plugin_manifest()
         server = manifest["mcpServers"]["distillery"]
-        assert server["url"] == "https://distillery-mcp.fly.dev/mcp"
+        assert server["url"] == "${user_config.distillery_mcp_url}"
 
     def test_distillery_server_no_unsupported_fields(self) -> None:
         """The distillery server must not contain fields unsupported by the plugin schema."""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -238,6 +238,10 @@ class TestPluginMCPServers:
         manifest = load_plugin_manifest()
         server = manifest["mcpServers"]["distillery"]
         assert server["url"] == "${user_config.distillery_mcp_url}"
+        assert (
+            manifest["userConfig"]["distillery_mcp_url"]["default"]
+            == "https://distillery-mcp.fly.dev/mcp"
+        )
 
     def test_distillery_server_no_unsupported_fields(self) -> None:
         """The distillery server must not contain fields unsupported by the plugin schema."""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -233,15 +233,21 @@ class TestPluginMCPServers:
         server = manifest["mcpServers"]["distillery"]
         assert "url" in server
 
-    def test_distillery_server_url_is_hardcoded_fly_url(self) -> None:
-        """The distillery server URL must be the hardcoded Fly.io hosted URL.
+    def test_distillery_server_url_uses_user_config(self) -> None:
+        """The distillery server URL must reference the userConfig template variable.
 
-        Note: ${user_config.<key>} interpolation is NOT supported in mcpServers.url.
-        Self-hosters should override via: claude mcp add distillery --scope user
+        ${user_config.<key>} interpolation is supported in mcpServers.*.url for
+        HTTP-type servers per the Claude Code plugin reference. Self-hosters override
+        the URL by setting the distillery_mcp_url userConfig field at plugin enable
+        time. The default resolves to the hosted Fly.io demo.
         """
         manifest = load_plugin_manifest()
         server = manifest["mcpServers"]["distillery"]
-        assert server["url"] == "https://distillery-mcp.fly.dev/mcp"
+        assert server["url"] == "${user_config.distillery_mcp_url}"
+        assert (
+            manifest["userConfig"]["distillery_mcp_url"]["default"]
+            == "https://distillery-mcp.fly.dev/mcp"
+        )
 
     def test_distillery_server_no_unsupported_fields(self) -> None:
         """The distillery server must not contain fields unsupported by the plugin schema."""


### PR DESCRIPTION
## Summary
- Add `distillery_mcp_url` to plugin `userConfig` with the hosted demo as default value
- Replace hardcoded URL in `mcpServers` with `${user_config.distillery_mcp_url}` template variable
- Self-hosters can now override the MCP URL via plugin config instead of relying on fragile user-scope shadow registrations
- Bump plugin version to 0.3.3 (hook banner updated accordingly)

Closes #235

## Test plan
- [ ] Install plugin fresh — verify `distillery_mcp_url` prompt appears at enable time with correct default
- [ ] Confirm `claude mcp list` shows the default URL when no override is set
- [ ] Set `distillery_mcp_url` to a self-hosted URL — verify `claude mcp list` reflects the override
- [ ] Verify existing `jina_api_key`, `github_client_id`, `github_client_secret` config fields still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation added to show how to register a custom MCP server at user scope to override the plugin's default demo endpoint; a default hosted URL remains available.

* **Chores**
  * Bumped package and plugin version to 0.3.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->