### PR TITLE
fix(store): defensive WAL CHECKPOINT after schema init (#230)

### DIFF
--- a/src/distillery/mcp/__main__.py
+++ b/src/distillery/mcp/__main__.py
@@ -101,9 +101,10 @@ def main(argv: list[str] | None = None) -> int:
         Exit code: ``0`` on successful exit or interruption, ``1`` on error.
     """
 
-    # Convert SIGTERM into KeyboardInterrupt so atexit handlers run.
-    # Fly.io sends SIGTERM on scale-to-zero; without this, the DuckDB
-    # atexit CHECKPOINT never fires and the WAL is left dirty on disk.
+    # Convert SIGTERM into KeyboardInterrupt so the FastMCP lifespan
+    # finally-block runs and DuckDBStore.close() can CHECKPOINT the WAL.
+    # Fly.io sends SIGTERM on scale-to-zero; without this conversion the
+    # process exits immediately and the WAL may be left dirty on disk.
     def _sigterm_handler(signum: int, frame: object) -> None:  # pragma: no cover
         raise KeyboardInterrupt
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -553,6 +553,14 @@ class DuckDBStore:
             )
             logger.info("Vector-only search active (%s)", reason)
 
+        # Force a WAL checkpoint so all schema changes are flushed to the
+        # main database file.  This protects against SIGKILL or abrupt parent
+        # death leaving the WAL in a partially-written state.
+        try:
+            conn.execute("CHECKPOINT")
+        except duckdb.Error as exc:  # pragma: no cover – in-memory DBs may skip
+            logger.debug("Post-init CHECKPOINT skipped: %s", exc)
+
         self._conn = conn
         self._initialized = True
         logger.info("DuckDBStore initialized at %s", self._db_path)
@@ -572,8 +580,12 @@ class DuckDBStore:
         await asyncio.to_thread(self._sync_initialize)
 
     async def close(self) -> None:
-        """Close the database connection and release resources."""
+        """Checkpoint the WAL and close the database connection."""
         if self._conn is not None:
+            try:
+                await asyncio.to_thread(self._conn.execute, "CHECKPOINT")
+            except duckdb.Error as exc:  # pragma: no cover
+                logger.debug("Shutdown CHECKPOINT skipped: %s", exc)
             await asyncio.to_thread(self._conn.close)
             self._conn = None
             self._initialized = False


### PR DESCRIPTION
## Summary
- Add `CHECKPOINT` call at the end of `_sync_initialize` to flush the WAL after schema bootstrap, protecting against SIGKILL or abrupt parent death leaving the WAL in a partially-written state.
- Add `CHECKPOINT` in `close()` before closing the DuckDB connection so the WAL is clean on graceful shutdown.
- Fix stale comments in `__main__.py` that referenced a non-existent `atexit` handler — the FastMCP lifespan `finally`-block handles shutdown now.

Closes #230

## Test plan
- [x] `ruff check` and `ruff format` pass
- [x] `mypy --strict src/distillery/` passes (0 issues)
- [x] All store tests pass (`pytest tests/test_store*.py` — 59 passed)
- [x] Full test suite passes (1506 passed; 2 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database write persistence by adding checkpoint operations during initialization and shutdown to ensure data durability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->