### PR TITLE
fix(mcp): exempt loopback clients from rate limiting by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ distillery.yaml.local
 
 # Worktrees
 .worktrees/
+.claude/worktrees/
 
 # promptfoo local output
 .promptfoo/

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -760,19 +760,37 @@ def _parse_http_rate_limit(rl_raw: dict[str, Any]) -> HttpRateLimitConfig:
             f"server.http_rate_limit.loopback_exempt must be a boolean, got: {loopback_exempt_raw!r}"
         )
 
+    requests_per_minute = _parse_strict_int(
+        rl_raw.get("requests_per_minute", 60),
+        "server.http_rate_limit.requests_per_minute",
+    )
+    if requests_per_minute <= 0:
+        raise ValueError(
+            f"server.http_rate_limit.requests_per_minute must be > 0, got: {requests_per_minute}"
+        )
+
+    requests_per_hour = _parse_strict_int(
+        rl_raw.get("requests_per_hour", 600),
+        "server.http_rate_limit.requests_per_hour",
+    )
+    if requests_per_hour <= 0:
+        raise ValueError(
+            f"server.http_rate_limit.requests_per_hour must be > 0, got: {requests_per_hour}"
+        )
+
+    max_body_bytes = _parse_strict_int(
+        rl_raw.get("max_body_bytes", 1_048_576),
+        "server.http_rate_limit.max_body_bytes",
+    )
+    if max_body_bytes <= 0:
+        raise ValueError(
+            f"server.http_rate_limit.max_body_bytes must be > 0, got: {max_body_bytes}"
+        )
+
     return HttpRateLimitConfig(
-        requests_per_minute=_parse_strict_int(
-            rl_raw.get("requests_per_minute", 60),
-            "server.http_rate_limit.requests_per_minute",
-        ),
-        requests_per_hour=_parse_strict_int(
-            rl_raw.get("requests_per_hour", 600),
-            "server.http_rate_limit.requests_per_hour",
-        ),
-        max_body_bytes=_parse_strict_int(
-            rl_raw.get("max_body_bytes", 1_048_576),
-            "server.http_rate_limit.max_body_bytes",
-        ),
+        requests_per_minute=requests_per_minute,
+        requests_per_hour=requests_per_hour,
+        max_body_bytes=max_body_bytes,
         trust_proxy=trust_proxy_raw,
         loopback_exempt=loopback_exempt_raw,
     )

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -746,6 +746,29 @@ def _parse_rate_limit(raw: dict[str, Any]) -> RateLimitConfig:
     )
 
 
+def _parse_http_rate_limit(rl_raw: dict[str, Any]) -> HttpRateLimitConfig:
+    """Parse ``server.http_rate_limit`` with strict boolean validation."""
+    trust_proxy_raw = rl_raw.get("trust_proxy", False)
+    if not isinstance(trust_proxy_raw, bool):
+        raise ValueError(
+            f"server.http_rate_limit.trust_proxy must be a boolean, got: {trust_proxy_raw!r}"
+        )
+
+    loopback_exempt_raw = rl_raw.get("loopback_exempt", True)
+    if not isinstance(loopback_exempt_raw, bool):
+        raise ValueError(
+            f"server.http_rate_limit.loopback_exempt must be a boolean, got: {loopback_exempt_raw!r}"
+        )
+
+    return HttpRateLimitConfig(
+        requests_per_minute=int(rl_raw.get("requests_per_minute", 60)),
+        requests_per_hour=int(rl_raw.get("requests_per_hour", 600)),
+        max_body_bytes=int(rl_raw.get("max_body_bytes", 1_048_576)),
+        trust_proxy=trust_proxy_raw,
+        loopback_exempt=loopback_exempt_raw,
+    )
+
+
 def _parse_server(raw: dict[str, Any]) -> ServerConfig:
     """Parse the ``server`` section from a raw YAML mapping.
 
@@ -802,13 +825,7 @@ def _parse_server(raw: dict[str, Any]) -> ServerConfig:
             allowed_orgs=allowed_orgs,
             membership_cache_ttl_seconds=membership_cache_ttl_seconds,
         ),
-        http_rate_limit=HttpRateLimitConfig(
-            requests_per_minute=int(rl_raw.get("requests_per_minute", 60)),
-            requests_per_hour=int(rl_raw.get("requests_per_hour", 600)),
-            max_body_bytes=int(rl_raw.get("max_body_bytes", 1_048_576)),
-            trust_proxy=bool(rl_raw.get("trust_proxy", False)),
-            loopback_exempt=bool(rl_raw.get("loopback_exempt", True)),
-        ),
+        http_rate_limit=_parse_http_rate_limit(rl_raw),
         webhooks=WebhookConfig(
             enabled=bool(webhooks_raw.get("enabled", True)),
             secret_env=str(webhooks_raw.get("secret_env", "DISTILLERY_WEBHOOK_SECRET")),

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -272,12 +272,17 @@ class HttpRateLimitConfig:
         trust_proxy: When ``True``, prefer ``X-Forwarded-For`` for client IP
             extraction.  Enable when running behind a reverse proxy (Fly.io,
             nginx, Cloudflare).
+        loopback_exempt: When ``True`` (default), skip rate limiting for
+            requests from loopback addresses (``127.0.0.1``, ``::1``,
+            ``localhost``).  This prevents local concurrent workflows from
+            being starved by the shared per-IP bucket.
     """
 
     requests_per_minute: int = 60
     requests_per_hour: int = 600
     max_body_bytes: int = 1_048_576  # 1 MB
     trust_proxy: bool = False
+    loopback_exempt: bool = True
 
 
 @dataclass
@@ -802,6 +807,7 @@ def _parse_server(raw: dict[str, Any]) -> ServerConfig:
             requests_per_hour=int(rl_raw.get("requests_per_hour", 600)),
             max_body_bytes=int(rl_raw.get("max_body_bytes", 1_048_576)),
             trust_proxy=bool(rl_raw.get("trust_proxy", False)),
+            loopback_exempt=bool(rl_raw.get("loopback_exempt", True)),
         ),
         webhooks=WebhookConfig(
             enabled=bool(webhooks_raw.get("enabled", True)),

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -761,9 +761,18 @@ def _parse_http_rate_limit(rl_raw: dict[str, Any]) -> HttpRateLimitConfig:
         )
 
     return HttpRateLimitConfig(
-        requests_per_minute=int(rl_raw.get("requests_per_minute", 60)),
-        requests_per_hour=int(rl_raw.get("requests_per_hour", 600)),
-        max_body_bytes=int(rl_raw.get("max_body_bytes", 1_048_576)),
+        requests_per_minute=_parse_strict_int(
+            rl_raw.get("requests_per_minute", 60),
+            "server.http_rate_limit.requests_per_minute",
+        ),
+        requests_per_hour=_parse_strict_int(
+            rl_raw.get("requests_per_hour", 600),
+            "server.http_rate_limit.requests_per_hour",
+        ),
+        max_body_bytes=_parse_strict_int(
+            rl_raw.get("max_body_bytes", 1_048_576),
+            "server.http_rate_limit.max_body_bytes",
+        ),
         trust_proxy=trust_proxy_raw,
         loopback_exempt=loopback_exempt_raw,
     )

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -769,6 +769,18 @@ def _parse_http_rate_limit(rl_raw: dict[str, Any]) -> HttpRateLimitConfig:
     )
 
 
+def _parse_webhooks(webhooks_raw: dict[str, Any]) -> WebhookConfig:
+    """Parse ``server.webhooks`` with strict boolean validation."""
+    enabled_raw = webhooks_raw.get("enabled", True)
+    if not isinstance(enabled_raw, bool):
+        raise ValueError(f"server.webhooks.enabled must be a boolean, got: {enabled_raw!r}")
+
+    return WebhookConfig(
+        enabled=enabled_raw,
+        secret_env=str(webhooks_raw.get("secret_env", "DISTILLERY_WEBHOOK_SECRET")),
+    )
+
+
 def _parse_server(raw: dict[str, Any]) -> ServerConfig:
     """Parse the ``server`` section from a raw YAML mapping.
 
@@ -826,10 +838,7 @@ def _parse_server(raw: dict[str, Any]) -> ServerConfig:
             membership_cache_ttl_seconds=membership_cache_ttl_seconds,
         ),
         http_rate_limit=_parse_http_rate_limit(rl_raw),
-        webhooks=WebhookConfig(
-            enabled=bool(webhooks_raw.get("enabled", True)),
-            secret_env=str(webhooks_raw.get("secret_env", "DISTILLERY_WEBHOOK_SECRET")),
-        ),
+        webhooks=_parse_webhooks(webhooks_raw),
     )
 
 

--- a/src/distillery/mcp/__main__.py
+++ b/src/distillery/mcp/__main__.py
@@ -191,6 +191,7 @@ def main(argv: list[str] | None = None) -> int:
                 requests_per_hour=rl.requests_per_hour,
                 max_body_bytes=rl.max_body_bytes,
                 trust_proxy=rl.trust_proxy,
+                loopback_exempt=rl.loopback_exempt,
                 org_checker=org_checker,
                 audit_callback=_auth_audit_cb,
             )

--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -125,7 +125,13 @@ class RateLimitMiddleware:
         app: The wrapped ASGI application.
         requests_per_minute: Maximum requests per IP per 60-second window.
         requests_per_hour: Maximum requests per IP per 3600-second window.
+        trust_proxy: Prefer ``X-Forwarded-For`` for client IP extraction.
+        loopback_exempt: When ``True`` (default), skip rate limiting for
+            requests originating from loopback addresses (``127.0.0.1``,
+            ``::1``, ``localhost``).
     """
+
+    _LOOPBACK_ADDRS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
 
     def __init__(
         self,
@@ -133,11 +139,13 @@ class RateLimitMiddleware:
         requests_per_minute: int = 60,
         requests_per_hour: int = 600,
         trust_proxy: bool = False,
+        loopback_exempt: bool = True,
     ) -> None:
         self.app = app
         self.requests_per_minute = requests_per_minute
         self.requests_per_hour = requests_per_hour
         self.trust_proxy = trust_proxy
+        self.loopback_exempt = loopback_exempt
         # ip -> _IPWindow.  In-memory state; resets on process restart.
         self._windows: dict[str, _IPWindow] = {}
 
@@ -147,6 +155,11 @@ class RateLimitMiddleware:
             return
 
         ip = _client_ip(scope, trust_proxy=self.trust_proxy)
+
+        if self.loopback_exempt and ip in self._LOOPBACK_ADDRS:
+            await self.app(scope, receive, send)
+            return
+
         now = time.monotonic()
 
         was_existing = ip in self._windows
@@ -465,6 +478,7 @@ def apply_http_middleware(
     requests_per_hour: int = 600,
     max_body_bytes: int = 1_048_576,
     trust_proxy: bool = False,
+    loopback_exempt: bool = True,
     org_checker: OrgMembershipChecker | None = None,
     audit_callback: AuditCallback | None = None,
 ) -> ASGIApp:
@@ -485,6 +499,7 @@ def apply_http_middleware(
         requests_per_hour: Per-IP hour limit (default 600).
         max_body_bytes: Maximum body size in bytes (default 1 MB).
         trust_proxy: Prefer ``X-Forwarded-For`` for client IP extraction.
+        loopback_exempt: Skip rate limiting for loopback IPs (default ``True``).
         org_checker: Optional org membership checker.  When provided and
             :attr:`~distillery.mcp.org_membership.OrgMembershipChecker.enabled`
             is ``True``, :class:`OrgMembershipMiddleware` is added.
@@ -503,6 +518,7 @@ def apply_http_middleware(
         requests_per_minute=requests_per_minute,
         requests_per_hour=requests_per_hour,
         trust_proxy=trust_proxy,
+        loopback_exempt=loopback_exempt,
     )
     app = RequestIDMiddleware(app)
     return app

--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -95,7 +95,7 @@ def _client_ip(scope: Scope, *, trust_proxy: bool = False) -> str:
         headers = Headers(scope=scope)
         forwarded = headers.get("x-forwarded-for")
         if forwarded:
-            return forwarded.split(",")[0].strip()
+            return str(forwarded).split(",")[0].strip()
 
     client = scope.get("client")
     if client and isinstance(client, (list, tuple)) and len(client) >= 1:
@@ -105,7 +105,7 @@ def _client_ip(scope: Scope, *, trust_proxy: bool = False) -> str:
         headers = Headers(scope=scope)
         forwarded = headers.get("x-forwarded-for")
         if forwarded:
-            return forwarded.split(",")[0].strip()
+            return str(forwarded).split(",")[0].strip()
 
     return "unknown"
 
@@ -261,7 +261,7 @@ class BodySizeLimitMiddleware:
 
         async def _limited_receive() -> _State:
             nonlocal total
-            message = await receive()
+            message: _State = await receive()
             if message["type"] == "http.request":
                 chunk = message.get("body", b"")
                 total += len(chunk)

--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -154,11 +154,18 @@ class RateLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        ip = _client_ip(scope, trust_proxy=self.trust_proxy)
+        # Loopback exemption: use the raw ASGI peer address (scope["client"])
+        # directly — never trust _client_ip() here, because it may fall back
+        # to X-Forwarded-For which can be spoofed.
+        if self.loopback_exempt:
+            client = scope.get("client")
+            if client and isinstance(client, (list, tuple)) and len(client) >= 1:
+                peer_ip = str(client[0])
+                if peer_ip in self._LOOPBACK_ADDRS:
+                    await self.app(scope, receive, send)
+                    return
 
-        if self.loopback_exempt and ip in self._LOOPBACK_ADDRS:
-            await self.app(scope, receive, send)
-            return
+        ip = _client_ip(scope, trust_proxy=self.trust_proxy)
 
         now = time.monotonic()
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -753,7 +753,7 @@ class TestApplyHttpMiddleware:
             assert cap.status == 200
 
     async def test_loopback_exempt_disabled_in_composition(self) -> None:
-        """When loopback_exempt=False, localhost is rate-limited in composed stack."""
+        """When loopback_exempt=False, 127.0.0.1 is rate-limited in composed stack."""
         app = apply_http_middleware(
             _dummy_app,
             requests_per_minute=1,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -163,7 +163,9 @@ class TestRateLimitMiddleware:
             assert cap.status == 200
 
     async def test_rejects_exceeding_per_minute_limit(self) -> None:
-        mw = RateLimitMiddleware(_dummy_app, requests_per_minute=3, requests_per_hour=100)
+        mw = RateLimitMiddleware(
+            _dummy_app, requests_per_minute=3, requests_per_hour=100, loopback_exempt=False
+        )
         # Use up quota
         for _ in range(3):
             cap = _ResponseCapture()
@@ -182,7 +184,9 @@ class TestRateLimitMiddleware:
         assert body["retry_after"] > 0
 
     async def test_rejects_exceeding_per_hour_limit(self) -> None:
-        mw = RateLimitMiddleware(_dummy_app, requests_per_minute=100, requests_per_hour=3)
+        mw = RateLimitMiddleware(
+            _dummy_app, requests_per_minute=100, requests_per_hour=3, loopback_exempt=False
+        )
         for _ in range(3):
             cap = _ResponseCapture()
             await mw(_make_scope(), _noop_receive, cap)
@@ -247,6 +251,57 @@ class TestRateLimitMiddleware:
         await mw(scope, _noop_receive, cap)
         # websocket type passes directly to app, which responds 200
         assert cap.status == 200
+
+    async def test_loopback_127_exempt_by_default(self) -> None:
+        """Requests from 127.0.0.1 bypass rate limiting when loopback_exempt=True."""
+        mw = RateLimitMiddleware(_dummy_app, requests_per_minute=1, requests_per_hour=1)
+        assert mw.loopback_exempt is True
+        # Should allow unlimited requests from 127.0.0.1
+        for _ in range(10):
+            cap = _ResponseCapture()
+            await mw(_make_scope(client=("127.0.0.1", 12345)), _noop_receive, cap)
+            assert cap.status == 200
+
+    async def test_loopback_ipv6_exempt_by_default(self) -> None:
+        """Requests from ::1 bypass rate limiting when loopback_exempt=True."""
+        mw = RateLimitMiddleware(_dummy_app, requests_per_minute=1, requests_per_hour=1)
+        for _ in range(10):
+            cap = _ResponseCapture()
+            await mw(_make_scope(client=("::1", 12345)), _noop_receive, cap)
+            assert cap.status == 200
+
+    async def test_loopback_localhost_exempt_by_default(self) -> None:
+        """Requests from 'localhost' bypass rate limiting when loopback_exempt=True."""
+        mw = RateLimitMiddleware(_dummy_app, requests_per_minute=1, requests_per_hour=1)
+        for _ in range(10):
+            cap = _ResponseCapture()
+            await mw(_make_scope(client=("localhost", 12345)), _noop_receive, cap)
+            assert cap.status == 200
+
+    async def test_loopback_exempt_disabled(self) -> None:
+        """When loopback_exempt=False, 127.0.0.1 is rate-limited normally."""
+        mw = RateLimitMiddleware(
+            _dummy_app, requests_per_minute=2, requests_per_hour=100, loopback_exempt=False
+        )
+        for _ in range(2):
+            cap = _ResponseCapture()
+            await mw(_make_scope(client=("127.0.0.1", 12345)), _noop_receive, cap)
+            assert cap.status == 200
+        # Third request should be rate-limited
+        cap = _ResponseCapture()
+        await mw(_make_scope(client=("127.0.0.1", 12345)), _noop_receive, cap)
+        assert cap.status == 429
+
+    async def test_loopback_exempt_does_not_affect_external_ips(self) -> None:
+        """External IPs are still rate-limited even when loopback_exempt=True."""
+        mw = RateLimitMiddleware(_dummy_app, requests_per_minute=2, requests_per_hour=100)
+        for _ in range(2):
+            cap = _ResponseCapture()
+            await mw(_make_scope(client=("10.0.0.1", 12345)), _noop_receive, cap)
+            assert cap.status == 200
+        cap = _ResponseCapture()
+        await mw(_make_scope(client=("10.0.0.1", 12345)), _noop_receive, cap)
+        assert cap.status == 429
 
     async def test_evicts_idle_ip_windows(self) -> None:
         """Windows for idle IPs are cleaned up to prevent unbounded memory."""
@@ -660,6 +715,7 @@ class TestApplyHttpMiddleware:
             _dummy_app,
             requests_per_minute=2,
             requests_per_hour=100,
+            loopback_exempt=False,
         )
         for _ in range(2):
             cap = _ResponseCapture()
@@ -681,6 +737,35 @@ class TestApplyHttpMiddleware:
         scope = _make_scope(headers=[(b"content-length", b"200")])
         await app(scope, _noop_receive, cap)
         assert cap.status == 413
+
+    async def test_loopback_exempt_in_composition(self) -> None:
+        """Loopback exemption works through the composed middleware stack."""
+        app = apply_http_middleware(
+            _dummy_app,
+            requests_per_minute=1,
+            requests_per_hour=1,
+            loopback_exempt=True,
+        )
+        # 127.0.0.1 should bypass rate limiting
+        for _ in range(5):
+            cap = _ResponseCapture()
+            await app(_make_scope(client=("127.0.0.1", 12345)), _noop_receive, cap)
+            assert cap.status == 200
+
+    async def test_loopback_exempt_disabled_in_composition(self) -> None:
+        """When loopback_exempt=False, localhost is rate-limited in composed stack."""
+        app = apply_http_middleware(
+            _dummy_app,
+            requests_per_minute=1,
+            requests_per_hour=100,
+            loopback_exempt=False,
+        )
+        cap = _ResponseCapture()
+        await app(_make_scope(client=("127.0.0.1", 12345)), _noop_receive, cap)
+        assert cap.status == 200
+        cap = _ResponseCapture()
+        await app(_make_scope(client=("127.0.0.1", 12345)), _noop_receive, cap)
+        assert cap.status == 429
 
     async def test_request_id_present_in_composition(self) -> None:
         """X-Request-ID header is echoed on responses from the composed stack."""
@@ -741,6 +826,7 @@ class TestRequestIDMiddleware:
             _dummy_app,
             requests_per_minute=1,
             requests_per_hour=100,
+            loopback_exempt=False,
         )
         # First request succeeds and consumes the quota.
         cap = _ResponseCapture()


### PR DESCRIPTION
## Summary
- Add `loopback_exempt` parameter (default `True`) to `RateLimitMiddleware` that skips rate limiting for requests from `127.0.0.1`, `::1`, and `localhost`
- Wire the config knob through `HttpRateLimitConfig.loopback_exempt` so it can be toggled in `distillery.yaml` under `server.http_rate_limit.loopback_exempt`
- Add 7 new unit tests covering loopback exemption (enabled/disabled, all three addresses, external IP unaffected, composition tests)

Closes #236

## Test plan
- [x] `pytest tests/test_middleware.py` — all 51 tests pass (7 new + 44 existing updated)
- [x] `mypy --strict src/distillery/` — no type errors
- [x] `ruff check src/ tests/` — all checks passed
- [x] Full `pytest` suite — 1960 passed (1 pre-existing unrelated failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable loopback exemption for HTTP rate limiting: loopback addresses (127.0.0.1, ::1, localhost) are exempt by default, with an option to disable; setting is honored across the HTTP middleware stack.

* **Bug Fixes / Improvements**
  * Configuration parsing tightened to require real boolean/integer values for rate-limit and webhook settings, preventing silent coercion.

* **Tests**
  * Added and updated tests for loopback exemption behavior, propagation, and deterministic rate-limiting.

* **Chores**
  * Updated ignore rules to include an additional worktree path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->