### PR TITLE
fix(feeds): parallelise poll sources and skip redundant semantic dedup

### DIFF
--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -36,6 +36,12 @@ _DEDUP_THRESHOLD = 0.95
 # Default minimum relevance threshold to store an item.
 _DEFAULT_RELEVANCE_THRESHOLD = 0.0
 
+# Source types whose ``item_id`` is authoritative (globally unique and stable).
+# When an item from one of these source types passes the fast ``_has_external_id``
+# check (not found), the expensive semantic dedup pass via ``_is_duplicate`` is
+# skipped entirely — the external_id guarantee is sufficient.
+_AUTHORITATIVE_EXTERNAL_ID_TYPES: frozenset[str] = frozenset({"github", "rss"})
+
 
 @dataclass
 class PollResult:
@@ -502,16 +508,37 @@ class FeedPoller:
         except Exception:  # noqa: BLE001
             logger.debug("FeedPoller: keyword map build failed — topic tagging disabled")
 
-        for source in sources:
-            result = await self._poll_source(source, scorer, keyword_map=keyword_map)
-            summary.results.append(result)
-            summary.total_fetched += result.items_fetched
-            summary.total_stored += result.items_stored
-            summary.total_skipped_dedup += result.items_skipped_dedup
-            summary.total_below_threshold += result.items_below_threshold
-            summary.sources_polled += 1
-            if result.errors:
+        # Poll all sources concurrently — each _poll_source is independent.
+        results = await asyncio.gather(
+            *(self._poll_source(source, scorer, keyword_map=keyword_map) for source in sources),
+            return_exceptions=True,
+        )
+
+        for idx, result in enumerate(results):
+            if isinstance(result, BaseException):
+                # Unexpected exception from _poll_source — record as errored.
+                err_result = PollResult(
+                    source_url=sources[idx].url,
+                    source_type=sources[idx].source_type,
+                    errors=[f"Unexpected error: {result}"],
+                )
+                summary.results.append(err_result)
+                summary.sources_polled += 1
                 summary.sources_errored += 1
+                logger.warning(
+                    "FeedPoller: unexpected error polling %s: %s",
+                    sources[idx].url,
+                    result,
+                )
+            else:
+                summary.results.append(result)
+                summary.total_fetched += result.items_fetched
+                summary.total_stored += result.items_stored
+                summary.total_skipped_dedup += result.items_skipped_dedup
+                summary.total_below_threshold += result.items_below_threshold
+                summary.sources_polled += 1
+                if result.errors:
+                    summary.sources_errored += 1
 
         summary.finished_at = datetime.now(tz=UTC)
         return summary
@@ -574,8 +601,14 @@ class FeedPoller:
                 result.items_skipped_dedup += 1
                 continue
 
-            # Semantic dedup: skip if a near-duplicate already exists
-            if await self._is_duplicate(item, text, batch_entry_ids):
+            # Semantic dedup: skip if a near-duplicate already exists.
+            # For source types with authoritative external IDs (e.g. github,
+            # rss), the _has_external_id check above is sufficient — skip the
+            # expensive embedding-based similarity search entirely.
+            if (
+                source.source_type not in _AUTHORITATIVE_EXTERNAL_ID_TYPES
+                and await self._is_duplicate(item, text, batch_entry_ids)
+            ):
                 result.items_skipped_dedup += 1
                 continue
 

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -267,24 +267,40 @@ class TestFeedPollerRSS:
         assert summary.total_stored == 0
         assert summary.total_below_threshold == 1
 
-    async def test_duplicate_items_are_skipped(self) -> None:
+    async def test_duplicate_items_are_skipped_via_external_id(self) -> None:
+        """RSS sources use authoritative external_id dedup — _has_external_id match."""
         items = [_make_feed_item(item_id="id1", title="Dup title", content="Dup content")]
         src = self._rss_source()
         store = _make_store(feed_sources=[_source_to_dict(src)])
         cfg = _make_config(sources=[src], digest_threshold=0.0)
+
+        # _has_external_id calls list_entries with metadata filter — return a match.
+        from distillery.models import Entry, EntrySource, EntryType
+
+        existing = Entry(
+            content="existing",
+            entry_type=EntryType.FEED,
+            source=EntrySource.IMPORT,
+            author="poller",
+            metadata={"external_id": "id1"},
+        )
+
+        async def _list_entries(
+            filters: dict[str, object] | None = None,
+            limit: int = 10,
+            offset: int = 0,
+        ) -> list[object]:
+            if filters and filters.get("metadata.external_id") == "id1":
+                return [existing]
+            return []
+
+        store.list_entries.side_effect = _list_entries
 
         with patch("distillery.feeds.poller._build_adapter") as mock_build:
             mock_adapter = MagicMock()
             mock_adapter.fetch.return_value = items
             mock_build.return_value = mock_adapter
 
-            async def _find_similar(content: str, threshold: float, limit: int) -> list:
-                if threshold == 0.95:
-                    # Return a match with the same external_id → dedup
-                    return [_make_search_result(score=0.97, external_id="id1")]
-                return []
-
-            store.find_similar.side_effect = _find_similar
             poller = FeedPoller(store=store, config=cfg)
             summary = await poller.poll()
 
@@ -418,6 +434,154 @@ class TestFeedPollerMultipleSources:
         assert summary.total_fetched == 3
         assert summary.total_stored == 3
         assert len(summary.results) == 2
+
+
+# ---------------------------------------------------------------------------
+# Parallel source polling
+# ---------------------------------------------------------------------------
+
+
+class TestFeedPollerParallel:
+    async def test_sources_polled_concurrently(self) -> None:
+        """Verify that _poll_source is called for all sources via asyncio.gather."""
+        sources = [
+            FeedSourceConfig(url="https://a.com/rss", source_type="rss"),
+            FeedSourceConfig(url="https://b.com/rss", source_type="rss"),
+        ]
+        items_a = [_make_feed_item(item_id="a1", source_url="https://a.com/rss")]
+        items_b = [_make_feed_item(item_id="b1", source_url="https://b.com/rss")]
+
+        store = _make_store(feed_sources=[_source_to_dict(s) for s in sources])
+
+        source_items_map = {
+            "https://a.com/rss": items_a,
+            "https://b.com/rss": items_b,
+        }
+        cfg = _make_config(sources=sources, digest_threshold=0.0)
+
+        def _build_adapter_side_effect(source: FeedSourceConfig) -> MagicMock:
+            mock = MagicMock()
+            mock.fetch.return_value = source_items_map[source.url]
+            return mock
+
+        async def _find_similar(content: str, threshold: float, limit: int) -> list:
+            return [_make_search_result(score=0.8)]
+
+        store.find_similar.side_effect = _find_similar
+
+        with patch(
+            "distillery.feeds.poller._build_adapter", side_effect=_build_adapter_side_effect
+        ):
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.sources_polled == 2
+        assert summary.total_fetched == 2
+        assert summary.total_stored == 2
+
+    async def test_one_source_error_does_not_block_others(self) -> None:
+        """If one source's adapter fails, other sources still complete."""
+        sources = [
+            FeedSourceConfig(url="https://good.com/rss", source_type="rss"),
+            FeedSourceConfig(url="https://bad.com/rss", source_type="rss"),
+        ]
+        store = _make_store(feed_sources=[_source_to_dict(s) for s in sources])
+
+        cfg = _make_config(sources=sources, digest_threshold=0.0)
+
+        def _build_adapter_side_effect(source: FeedSourceConfig) -> MagicMock:
+            mock = MagicMock()
+            if source.url == "https://bad.com/rss":
+                mock.fetch.side_effect = RuntimeError("network error")
+            else:
+                mock.fetch.return_value = [
+                    _make_feed_item(item_id="g1", source_url="https://good.com/rss")
+                ]
+            return mock
+
+        async def _find_similar(content: str, threshold: float, limit: int) -> list:
+            return [_make_search_result(score=0.8)]
+
+        store.find_similar.side_effect = _find_similar
+
+        with patch(
+            "distillery.feeds.poller._build_adapter", side_effect=_build_adapter_side_effect
+        ):
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.sources_polled == 2
+        assert summary.sources_errored == 1
+        assert summary.total_stored == 1
+
+
+# ---------------------------------------------------------------------------
+# Authoritative external_id dedup skip
+# ---------------------------------------------------------------------------
+
+
+class TestAuthoritativeExternalIdSkip:
+    async def test_rss_skips_semantic_dedup(self) -> None:
+        """RSS sources skip _is_duplicate (find_similar with 0.95 threshold)."""
+        items = [_make_feed_item(item_id="new1", title="New item", content="Content")]
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.0)
+
+        find_similar_thresholds: list[float] = []
+
+        async def _find_similar(content: str, threshold: float, limit: int) -> list:
+            find_similar_thresholds.append(threshold)
+            return [_make_search_result(score=0.8)]
+
+        store.find_similar.side_effect = _find_similar
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        # find_similar should only be called for scoring (threshold 0.0),
+        # never for dedup (threshold 0.95) since RSS is authoritative.
+        assert all(t != 0.95 for t in find_similar_thresholds), (
+            f"Unexpected dedup find_similar call; thresholds seen: {find_similar_thresholds}"
+        )
+        assert summary.total_stored == 1
+
+    async def test_non_authoritative_source_still_runs_semantic_dedup(self) -> None:
+        """A source type not in _AUTHORITATIVE_EXTERNAL_ID_TYPES still runs semantic dedup."""
+        items = [_make_feed_item(item_id="new1", title="New item", content="Content")]
+        src = FeedSourceConfig(url="https://example.com/feed", source_type="hackernews")
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.0)
+
+        find_similar_thresholds: list[float] = []
+
+        async def _find_similar(content: str, threshold: float, limit: int) -> list:
+            find_similar_thresholds.append(threshold)
+            if threshold == 0.95:
+                return []  # no dedup match
+            return [_make_search_result(score=0.8)]
+
+        store.find_similar.side_effect = _find_similar
+
+        # Need to patch _build_adapter to handle 'hackernews' type
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        # Should have called find_similar with 0.95 for dedup
+        assert 0.95 in find_similar_thresholds, (
+            f"Expected dedup find_similar call; thresholds seen: {find_similar_thresholds}"
+        )
+        assert summary.total_stored == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Parallelise source polling**: `FeedPoller.poll()` now runs `_poll_source` for all sources concurrently via `asyncio.gather` instead of serially. Each source is independent, so this scales with source count rather than being additive.
- **Skip redundant semantic dedup**: For source types with authoritative external IDs (`github`, `rss`), the expensive embedding-based `_is_duplicate` call (which runs `find_similar` at 0.95 threshold) is skipped entirely when the fast `_has_external_id` check already passed. A new `_AUTHORITATIVE_EXTERNAL_ID_TYPES` frozenset controls which source types opt in.
- **Graceful error handling**: If any source raises an unexpected exception during concurrent polling, it's caught via `return_exceptions=True` and recorded as an errored source without blocking others.

Closes #221

## Test plan
- [x] Existing poller tests updated and passing (35/35)
- [x] New `TestFeedPollerParallel` tests verify concurrent execution and error isolation
- [x] New `TestAuthoritativeExternalIdSkip` tests verify RSS skips semantic dedup while non-authoritative sources still run it
- [x] `mypy --strict` passes
- [x] `ruff check` and `ruff format` clean
- [x] Full test suite: 1957 passed (1 pre-existing unrelated failure in test_cli_export_import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feed polling now executes concurrently across all sources instead of sequentially, improving performance.
  * Individual source failures no longer block polling of other sources; errors are logged and tracked separately.
  * Optimized deduplication for authoritative source types to reduce processing overhead.

* **Tests**
  * Added test coverage for concurrent polling and per-source error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->