### PR TITLE
feat(cli): dynamic MCP transport resolution for SessionStart hook

### DIFF
--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -174,7 +174,8 @@ auto-detected configurations.
 
 ### Prerequisites
 
-- Distillery MCP server running (HTTP or stdio — auto-detected)
+- **HTTP mode**: a Distillery MCP server running at a reachable URL (auto-detected)
+- **stdio mode**: `distillery-mcp` installed so the hook can launch it as a subprocess (no pre-running server required)
 - Python 3.11+ available on the system PATH
 
 ### Transport Resolution Order

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -28,8 +28,9 @@ appropriate Distillery handler. Register this one script for `UserPromptSubmit`,
 
 ### Prerequisites
 
-- Distillery MCP server running (HTTP or stdio — auto-detected, see below)
-  (required only for the `SessionStart` briefing; the `UserPromptSubmit` nudge works offline)
+- **HTTP mode**: Distillery MCP server running at a reachable URL (must be pre-started; the hook connects to it)
+- **stdio mode**: `distillery-mcp` installed and on PATH (the hook launches it as a subprocess — no pre-running server required)
+  _(required only for the `SessionStart` briefing; the `UserPromptSubmit` nudge works offline)_
 - Python 3.11+ available on the system PATH (for `SessionStart` briefing)
 - Claude Code with hook support
 

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -28,14 +28,14 @@ appropriate Distillery handler. Register this one script for `UserPromptSubmit`,
 
 ### Prerequisites
 
-- Distillery MCP server running with **HTTP transport** (`distillery-mcp --transport http`)
+- Distillery MCP server running (HTTP or stdio — auto-detected, see below)
   (required only for the `SessionStart` briefing; the `UserPromptSubmit` nudge works offline)
-- `curl` available on the system PATH (for `SessionStart` briefing)
+- Python 3.11+ available on the system PATH (for `SessionStart` briefing)
 - Claude Code with hook support
 
-> **Note:** The SessionStart handler targets the HTTP MCP transport, not stdio.
-> Hooks run as shell commands outside of an MCP session, so they must
-> communicate with the server over HTTP.
+> **Note:** The SessionStart handler auto-detects how Distillery MCP is installed
+> and uses the appropriate transport (HTTP or stdio). See the
+> [Transport Resolution Order](#transport-resolution-order) section below.
 
 ### Manual Setup
 
@@ -99,16 +99,23 @@ Configure all hooks via environment variables. Set these in your shell profile
 
 | Variable | Default | Description |
 |---|---|---|
-| `DISTILLERY_MCP_URL` | `http://localhost:8000/mcp` | MCP HTTP endpoint URL |
+| `DISTILLERY_MCP_URL` | _(auto-detect)_ | MCP HTTP endpoint URL (skips auto-detection) |
+| `DISTILLERY_MCP_COMMAND` | _(auto-detect)_ | MCP stdio command (skips auto-detection) |
 | `DISTILLERY_NUDGE_INTERVAL` | `30` | Prompts between memory nudge outputs |
 | `DISTILLERY_BRIEFING_LIMIT` | `5` | Recent entries in SessionStart briefing |
 | `DISTILLERY_BEARER_TOKEN` | _(empty)_ | Bearer token if OAuth is enabled |
 
-Example — nudge every 20 prompts, custom port:
+Example — nudge every 20 prompts, custom hosted URL:
 
 ```bash
 export DISTILLERY_NUDGE_INTERVAL=20
-export DISTILLERY_MCP_URL="http://localhost:9000/mcp"
+export DISTILLERY_MCP_URL="https://distillery-mcp.fly.dev/mcp"
+```
+
+Example — force stdio transport:
+
+```bash
+export DISTILLERY_MCP_COMMAND="distillery-mcp --db /path/to/knowledge.db"
 ```
 
 > **Security note:** Do not commit `DISTILLERY_BEARER_TOKEN` or other secrets
@@ -158,17 +165,43 @@ reminder at the start of every Claude Code session. This gives Claude awareness
 of recent knowledge entries and stale items for the current project without
 requiring a manual `/briefing` invocation.
 
+The shell script is a thin wrapper that delegates to `session_start_briefing.py`,
+which handles dynamic MCP transport resolution across HTTP, stdio, and
+auto-detected configurations.
+
 > This script is called automatically by `distillery-hooks.sh` for `SessionStart`
 > events. You only need to register it separately if you do not use the dispatcher.
 
 ### Prerequisites
 
-- Distillery MCP server running with **HTTP transport** (`distillery-mcp --transport http`)
-- `curl` available on the system PATH
+- Distillery MCP server running (HTTP or stdio — auto-detected)
+- Python 3.11+ available on the system PATH
 
-> **Note:** The hook targets the HTTP MCP transport, not stdio. Hooks run as
-> shell commands outside of an MCP session, so they must communicate with the
-> server over HTTP.
+### Transport Resolution Order
+
+The briefing hook auto-detects how Distillery MCP is installed using this
+priority order (first reachable wins):
+
+| Priority | Source | Transport |
+|----------|--------|-----------|
+| 1 | `DISTILLERY_MCP_URL` env var | HTTP |
+| 2 | `DISTILLERY_MCP_COMMAND` env var | stdio |
+| 3 | `.mcp.json` at repo root (walks up from cwd) | per config |
+| 4 | `~/.claude.json` project-scoped `mcpServers` | per config |
+| 5 | `~/.claude.json` global `mcpServers` | per config |
+| 6 | `~/.claude/plugins/**/.claude-plugin/plugin.json` | per config |
+| 7 | `distillery-mcp` on PATH | stdio |
+| 8 | `http://localhost:8000/mcp` | HTTP |
+
+For steps 3-6, the resolver looks for any `mcpServers` key containing
+"distill" (case-insensitive). Each matching entry can be either a URL-based
+(HTTP) or command-based (stdio) server configuration.
+
+After resolving a transport, the hook probes it for reachability:
+- **HTTP**: GET `/health` with a 2-second timeout
+- **stdio**: subprocess `initialize` handshake with a 3-second timeout
+
+If the resolved server is unreachable, the hook exits silently with code 0.
 
 ### Configuration
 
@@ -177,20 +210,27 @@ Configure the hook via environment variables. Set these in your shell profile
 
 | Variable | Default | Description |
 |---|---|---|
-| `DISTILLERY_MCP_URL` | `http://localhost:8000/mcp` | MCP HTTP endpoint URL |
+| `DISTILLERY_MCP_URL` | _(auto-detect)_ | MCP HTTP endpoint URL (skips auto-detection) |
+| `DISTILLERY_MCP_COMMAND` | _(auto-detect)_ | MCP stdio command (skips auto-detection) |
 | `DISTILLERY_BRIEFING_LIMIT` | `5` | Number of recent entries to include |
 | `DISTILLERY_BEARER_TOKEN` | _(empty)_ | Bearer token if OAuth is enabled |
 
-Example — custom port and more entries:
+Example — force hosted URL:
 
 ```bash
-export DISTILLERY_MCP_URL="http://localhost:9000/mcp"
+export DISTILLERY_MCP_URL="https://distillery-mcp.fly.dev/mcp"
 export DISTILLERY_BRIEFING_LIMIT="10"
+```
+
+Example — force stdio transport:
+
+```bash
+export DISTILLERY_MCP_COMMAND="distillery-mcp --db /path/to/knowledge.db"
 ```
 
 > **Security note:** Do not commit `DISTILLERY_BEARER_TOKEN` or other secrets
 > to version control. Use your shell profile or a secrets manager to set
-> these values. The hook script itself contains no credentials.
+> these values. The hook scripts contain no credentials.
 
 ### Expected Behavior
 

--- a/scripts/hooks/session-start-briefing.sh
+++ b/scripts/hooks/session-start-briefing.sh
@@ -1,146 +1,37 @@
 #!/usr/bin/env bash
-# session-start-briefing.sh — Distillery SessionStart hook for Claude Code
+# session-start-briefing.sh — Thin wrapper for the Python briefing hook
 #
-# Injects condensed briefing context at session start by calling the Distillery
-# MCP HTTP endpoint and formatting recent/stale entry summaries.
+# Delegates to session_start_briefing.py which handles dynamic MCP transport
+# resolution (HTTP, stdio, or auto-detected from config files).
 #
 # Usage: register in ~/.claude/settings.json (see scripts/hooks/README.md)
 # Input: hook JSON on stdin (hook_event_name, session_id, cwd)
-# Output: condensed briefing text on stdout → injected as system reminder
+# Output: condensed briefing text on stdout -> injected as system reminder
 #
 # Configuration (environment variables):
-#   DISTILLERY_MCP_URL       MCP HTTP endpoint (default: http://localhost:8000/mcp)
+#   DISTILLERY_MCP_URL         MCP HTTP endpoint (skips auto-detection)
+#   DISTILLERY_MCP_COMMAND     MCP stdio command (skips auto-detection)
 #   DISTILLERY_BRIEFING_LIMIT  Number of recent entries to show (default: 5)
-#   DISTILLERY_BEARER_TOKEN  Optional bearer token if OAuth is enabled
+#   DISTILLERY_BEARER_TOKEN    Optional bearer token if OAuth is enabled
 
 set -euo pipefail
 
-# ── Configuration ────────────────────────────────────────────────────────────
-MCP_URL="${DISTILLERY_MCP_URL:-http://localhost:8000/mcp}"
-LIMIT="${DISTILLERY_BRIEFING_LIMIT:-5}"
-BEARER_TOKEN="${DISTILLERY_BEARER_TOKEN:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_SCRIPT="${SCRIPT_DIR}/session_start_briefing.py"
 
-# ── Read hook input ───────────────────────────────────────────────────────────
-HOOK_JSON="$(cat)"
-CWD="$(echo "$HOOK_JSON" | grep -oE '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/"cwd"[[:space:]]*:[[:space:]]*"//;s/"//')"
-
-# Fall back to current directory if cwd not found in hook JSON
-if [[ -z "$CWD" ]]; then
-  CWD="$(pwd)"
-fi
-
-# ── Derive project name ───────────────────────────────────────────────────────
-# Try git root basename first, fall back to cwd basename
-PROJECT=""
-if command -v git >/dev/null 2>&1; then
-  GIT_ROOT="$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)"
-  if [[ -n "$GIT_ROOT" ]]; then
-    PROJECT="$(basename "$GIT_ROOT")"
+# Require Python 3.11+
+PYTHON=""
+for candidate in python3 python; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    PYTHON="$candidate"
+    break
   fi
-fi
-if [[ -z "$PROJECT" ]]; then
-  PROJECT="$(basename "$CWD")"
-fi
+done
 
-# ── Health check (2-second timeout) ──────────────────────────────────────────
-# If MCP server is unreachable, exit silently — no output, no error
-AUTH_HEADER=""
-if [[ -n "$BEARER_TOKEN" ]]; then
-  AUTH_HEADER="Authorization: Bearer ${BEARER_TOKEN}"
-fi
-
-health_check() {
-  if [[ -n "$AUTH_HEADER" ]]; then
-    curl --silent --max-time 2 --fail \
-      -H "$AUTH_HEADER" \
-      "${MCP_URL%/mcp}/health" >/dev/null 2>&1
-  else
-    curl --silent --max-time 2 --fail \
-      "${MCP_URL%/mcp}/health" >/dev/null 2>&1
-  fi
-}
-
-if ! health_check; then
-  # Silent failure — server unreachable
+if [[ -z "$PYTHON" ]]; then
+  # No Python available — exit silently
   exit 0
 fi
 
-# ── JSON-RPC helper ───────────────────────────────────────────────────────────
-call_tool() {
-  local tool_name="$1"
-  local params="$2"
-
-  local payload
-  payload="$(printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"%s","arguments":%s}}' \
-    "$tool_name" "$params")"
-
-  if [[ -n "$AUTH_HEADER" ]]; then
-    curl --silent --max-time 10 --fail \
-      -H "Content-Type: application/json" \
-      -H "$AUTH_HEADER" \
-      -d "$payload" \
-      "$MCP_URL" 2>/dev/null
-  else
-    curl --silent --max-time 10 --fail \
-      -H "Content-Type: application/json" \
-      -d "$payload" \
-      "$MCP_URL" 2>/dev/null
-  fi
-}
-
-# ── Fetch recent entries ──────────────────────────────────────────────────────
-RECENT_RAW=""
-RECENT_PARAMS="$(jq -n --arg project "$PROJECT" --argjson limit "$LIMIT" '{project:$project,limit:$limit}')"
-RECENT_RAW="$(call_tool "distillery_list" "$RECENT_PARAMS" 2>/dev/null || true)"
-
-# ── Fetch stale entries ───────────────────────────────────────────────────────
-STALE_RAW=""
-STALE_PARAMS="$(jq -n --argjson days 30 --argjson limit 3 '{days:$days,limit:$limit}')"
-STALE_RAW="$(call_tool "distillery_stale" "$STALE_PARAMS" 2>/dev/null || true)"
-
-# ── Parse and format output ───────────────────────────────────────────────────
-# Extract content snippets using robust JSON parsing
-# The MCP response wraps content in: {"result":{"content":[{"type":"text","text":"..."}]}}
-extract_text() {
-  local raw="$1"
-  if command -v jq >/dev/null 2>&1; then
-    echo "$raw" | jq -r '.result.content[0].text // empty' 2>/dev/null || true
-  else
-    # Fallback to Python if jq is not available
-    echo "$raw" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("result",{}).get("content",[{}])[0].get("text",""))' 2>/dev/null || true
-  fi
-}
-
-RECENT_TEXT="$(extract_text "$RECENT_RAW")"
-STALE_TEXT="$(extract_text "$STALE_RAW")"
-
-# ── Build condensed briefing (max 20 lines) ───────────────────────────────────
-BRIEFING_LINES=()
-BRIEFING_LINES+=("[Distillery] Project: ${PROJECT}")
-
-# Summarize recent entries
-if [[ -n "$RECENT_TEXT" && "$RECENT_TEXT" != "null" ]]; then
-  # Count entries by looking for entry patterns in the text
-  ENTRY_COUNT="$(echo "$RECENT_TEXT" | grep -c '"id"' 2>/dev/null || echo "0")"
-  if [[ "$ENTRY_COUNT" -gt 0 ]]; then
-    BRIEFING_LINES+=("Recent (${ENTRY_COUNT}): $(echo "$RECENT_TEXT" | grep -o '"content":"[^"]*"' | head -3 | sed 's/"content":"//;s/"$//' | cut -c1-60 | tr '\n' ', ' | sed 's/, $//')")
-  fi
-fi
-
-# Summarize stale entries
-if [[ -n "$STALE_TEXT" && "$STALE_TEXT" != "null" ]]; then
-  STALE_COUNT="$(echo "$STALE_TEXT" | grep -c '"id"' 2>/dev/null || echo "0")"
-  if [[ "$STALE_COUNT" -gt 0 ]]; then
-    BRIEFING_LINES+=("Stale (${STALE_COUNT}): $(echo "$STALE_TEXT" | grep -o '"content":"[^"]*"' | head -2 | sed 's/"content":"//;s/"$//' | cut -c1-60 | tr '\n' ', ' | sed 's/, $//')")
-  fi
-fi
-
-# Output the briefing (cap at 20 lines)
-LINE_COUNT=0
-for line in "${BRIEFING_LINES[@]}"; do
-  if [[ "$LINE_COUNT" -ge 20 ]]; then
-    break
-  fi
-  echo "$line"
-  LINE_COUNT=$((LINE_COUNT + 1))
-done
+# Exec the Python script, passing stdin through
+exec "$PYTHON" "$PYTHON_SCRIPT"

--- a/scripts/hooks/session_start_briefing.py
+++ b/scripts/hooks/session_start_briefing.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+"""Dynamic MCP transport resolution for SessionStart briefing hook.
+
+Resolves the Distillery MCP server using this priority order:
+1. DISTILLERY_MCP_URL env var -> HTTP
+2. DISTILLERY_MCP_COMMAND env var -> stdio
+3. .mcp.json at repo root (walk upward from cwd) -> mcpServers.*distill*
+4. ~/.claude.json -> projects[<cwd>].mcpServers.*distill*
+5. ~/.claude.json -> top-level mcpServers.*distill*
+6. ~/.claude/plugins/**/.claude-plugin/plugin.json -> mcpServers.distillery
+7. Fallback: distillery-mcp command on PATH (stdio)
+8. Fallback: http://localhost:8000/mcp
+
+No runtime dependencies beyond the Python 3.11+ stdlib.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ResolvedTransport:
+    """Result of MCP transport resolution."""
+
+    kind: str  # "http" or "stdio"
+    url: str = ""
+    command: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    source: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Resolution helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_json(path: Path) -> Any:
+    """Read and parse a JSON file, returning None on failure."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def _find_distillery_server(servers: Any) -> dict[str, Any] | None:
+    """Find a *distill* key in an mcpServers dict."""
+    if not isinstance(servers, dict):
+        return None
+    for key, value in servers.items():
+        if "distill" in key.lower() and isinstance(value, dict):
+            return value
+    return None
+
+
+def _server_entry_to_transport(entry: dict[str, Any], source: str) -> ResolvedTransport | None:
+    """Convert an mcpServers entry to a ResolvedTransport."""
+    # HTTP (url-based or type: sse/streamable-http)
+    url = entry.get("url", "")
+    if url:
+        return ResolvedTransport(kind="http", url=url, source=source)
+
+    # stdio (command-based)
+    cmd = entry.get("command", "")
+    args: list[str] = entry.get("args", [])
+    env_vars: dict[str, str] = entry.get("env", {})
+    if cmd:
+        full_cmd = [cmd] + [str(a) for a in args]
+        return ResolvedTransport(kind="stdio", command=full_cmd, env=env_vars, source=source)
+
+    return None
+
+
+def _walk_up_for_file(start: Path, filename: str) -> Path | None:
+    """Walk up from start directory looking for filename."""
+    current = start.resolve()
+    while True:
+        candidate = current / filename
+        if candidate.is_file():
+            return candidate
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Resolution steps (1-8)
+# ---------------------------------------------------------------------------
+
+
+def resolve_env_url() -> ResolvedTransport | None:
+    """Step 1: DISTILLERY_MCP_URL env var."""
+    url = os.environ.get("DISTILLERY_MCP_URL", "").strip()
+    if url:
+        return ResolvedTransport(kind="http", url=url, source="DISTILLERY_MCP_URL")
+    return None
+
+
+def resolve_env_command() -> ResolvedTransport | None:
+    """Step 2: DISTILLERY_MCP_COMMAND env var."""
+    cmd = os.environ.get("DISTILLERY_MCP_COMMAND", "").strip()
+    if cmd:
+        parts = cmd.split()
+        return ResolvedTransport(kind="stdio", command=parts, source="DISTILLERY_MCP_COMMAND")
+    return None
+
+
+def resolve_mcp_json(cwd: Path) -> ResolvedTransport | None:
+    """Step 3: .mcp.json at or above cwd."""
+    mcp_json_path = _walk_up_for_file(cwd, ".mcp.json")
+    if mcp_json_path is None:
+        return None
+    data = _read_json(mcp_json_path)
+    if not isinstance(data, dict):
+        return None
+    servers = data.get("mcpServers", {})
+    entry = _find_distillery_server(servers)
+    if entry is not None:
+        return _server_entry_to_transport(entry, f".mcp.json ({mcp_json_path})")
+    return None
+
+
+def resolve_claude_json_project(cwd: Path) -> ResolvedTransport | None:
+    """Step 4: ~/.claude.json -> projects[<cwd>].mcpServers."""
+    claude_json = Path.home() / ".claude.json"
+    data = _read_json(claude_json)
+    if not isinstance(data, dict):
+        return None
+    projects = data.get("projects", {})
+    if not isinstance(projects, dict):
+        return None
+    cwd_str = str(cwd.resolve())
+    for project_path, project_data in projects.items():
+        if not isinstance(project_data, dict):
+            continue
+        if cwd_str == project_path or cwd_str.startswith(project_path + "/"):
+            servers = project_data.get("mcpServers", {})
+            entry = _find_distillery_server(servers)
+            if entry is not None:
+                return _server_entry_to_transport(entry, f"~/.claude.json projects[{project_path}]")
+    return None
+
+
+def resolve_claude_json_global() -> ResolvedTransport | None:
+    """Step 5: ~/.claude.json -> top-level mcpServers."""
+    claude_json = Path.home() / ".claude.json"
+    data = _read_json(claude_json)
+    if not isinstance(data, dict):
+        return None
+    servers = data.get("mcpServers", {})
+    entry = _find_distillery_server(servers)
+    if entry is not None:
+        return _server_entry_to_transport(entry, "~/.claude.json (global)")
+    return None
+
+
+def resolve_plugin_json() -> ResolvedTransport | None:
+    """Step 6: ~/.claude/plugins/**/.claude-plugin/plugin.json."""
+    plugins_dir = Path.home() / ".claude" / "plugins"
+    if not plugins_dir.is_dir():
+        return None
+    try:
+        for plugin_json in plugins_dir.rglob(".claude-plugin/plugin.json"):
+            data = _read_json(plugin_json)
+            if not isinstance(data, dict):
+                continue
+            servers = data.get("mcpServers", {})
+            if isinstance(servers, dict) and "distillery" in servers:
+                entry = servers["distillery"]
+                if isinstance(entry, dict):
+                    return _server_entry_to_transport(entry, f"plugin ({plugin_json})")
+    except OSError:
+        pass
+    return None
+
+
+def resolve_path_command() -> ResolvedTransport | None:
+    """Step 7: distillery-mcp on PATH."""
+    if shutil.which("distillery-mcp") is not None:
+        return ResolvedTransport(
+            kind="stdio",
+            command=["distillery-mcp"],
+            source="distillery-mcp (PATH)",
+        )
+    return None
+
+
+def resolve_localhost_fallback() -> ResolvedTransport:
+    """Step 8: Fallback to localhost."""
+    return ResolvedTransport(
+        kind="http",
+        url="http://localhost:8000/mcp",
+        source="localhost fallback",
+    )
+
+
+def resolve_transport(cwd: Path | None = None) -> ResolvedTransport:
+    """Run the full resolution chain, returning the first match."""
+    if cwd is None:
+        cwd = Path.cwd()
+
+    resolvers = [
+        lambda: resolve_env_url(),
+        lambda: resolve_env_command(),
+        lambda: resolve_mcp_json(cwd),
+        lambda: resolve_claude_json_project(cwd),
+        lambda: resolve_claude_json_global(),
+        lambda: resolve_plugin_json(),
+        lambda: resolve_path_command(),
+    ]
+
+    for resolver in resolvers:
+        result = resolver()
+        if result is not None:
+            return result
+
+    return resolve_localhost_fallback()
+
+
+# ---------------------------------------------------------------------------
+# Probes — verify transport is actually reachable
+# ---------------------------------------------------------------------------
+
+
+def _http_health_check(base_url: str, bearer_token: str = "", timeout: int = 2) -> bool:
+    """GET /health on the HTTP transport."""
+    health_url = base_url.rstrip("/")
+    if health_url.endswith("/mcp"):
+        health_url = health_url[: -len("/mcp")] + "/health"
+    elif not health_url.endswith("/health"):
+        health_url = health_url + "/health"
+
+    req = urllib.request.Request(health_url, method="GET")
+    if bearer_token:
+        req.add_header("Authorization", f"Bearer {bearer_token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout):
+            return True
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+def _http_call_tool(
+    url: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    bearer_token: str = "",
+    timeout: int = 10,
+) -> Any:
+    """JSON-RPC tools/call over HTTP."""
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }
+    ).encode()
+
+    req = urllib.request.Request(url, data=payload, method="POST")
+    req.add_header("Content-Type", "application/json")
+    if bearer_token:
+        req.add_header("Authorization", f"Bearer {bearer_token}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def _stdio_call_tool(
+    command: list[str],
+    tool_name: str,
+    arguments: dict[str, Any],
+    extra_env: dict[str, str] | None = None,
+    timeout: int = 10,
+) -> Any:
+    """JSON-RPC tools/call over stdio subprocess.
+
+    Sends initialize, then tools/call, reads responses line by line.
+    """
+    init_msg = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "distillery-hook", "version": "1.0.0"},
+            },
+        }
+    )
+
+    call_msg = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }
+    )
+
+    env = dict(os.environ)
+    if extra_env:
+        env.update(extra_env)
+
+    try:
+        proc = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        # Send initialize + call, each newline-delimited
+        proc.stdin.write((init_msg + "\n").encode())
+        proc.stdin.write((call_msg + "\n").encode())
+        proc.stdin.flush()
+        proc.stdin.close()
+
+        # Read all output within timeout
+        try:
+            stdout_bytes, _ = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            return None
+
+        # Parse line-delimited JSON responses, find id=1
+        for line in stdout_bytes.decode(errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+                if isinstance(msg, dict) and msg.get("id") == 1:
+                    return msg
+            except json.JSONDecodeError:
+                continue
+
+    except (OSError, ValueError):
+        pass
+
+    return None
+
+
+def _stdio_health_check(
+    command: list[str],
+    extra_env: dict[str, str] | None = None,
+    timeout: int = 3,
+) -> bool:
+    """Check if a stdio MCP server starts successfully via initialize handshake."""
+    init_msg = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "distillery-hook", "version": "1.0.0"},
+            },
+        }
+    )
+
+    env = dict(os.environ)
+    if extra_env:
+        env.update(extra_env)
+
+    try:
+        proc = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        proc.stdin.write((init_msg + "\n").encode())
+        proc.stdin.flush()
+        proc.stdin.close()
+
+        try:
+            stdout_bytes, _ = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            return False
+
+        for line in stdout_bytes.decode(errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+                if isinstance(msg, dict) and "result" in msg:
+                    return True
+            except json.JSONDecodeError:
+                continue
+
+    except (OSError, ValueError):
+        pass
+
+    return False
+
+
+def probe_transport(transport: ResolvedTransport, bearer_token: str = "") -> bool:
+    """Verify that the resolved transport is actually reachable."""
+    if transport.kind == "http":
+        return _http_health_check(transport.url, bearer_token)
+    elif transport.kind == "stdio":
+        return _stdio_health_check(transport.command, transport.env)
+    return False
+
+
+def call_tool(
+    transport: ResolvedTransport,
+    tool_name: str,
+    arguments: dict[str, Any],
+    bearer_token: str = "",
+) -> Any:
+    """Call an MCP tool via the resolved transport."""
+    if transport.kind == "http":
+        return _http_call_tool(transport.url, tool_name, arguments, bearer_token)
+    elif transport.kind == "stdio":
+        return _stdio_call_tool(transport.command, tool_name, arguments, transport.env)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Briefing output
+# ---------------------------------------------------------------------------
+
+
+def extract_text(response: Any) -> str:
+    """Extract text from an MCP JSON-RPC response."""
+    if not isinstance(response, dict):
+        return ""
+    result = response.get("result", {})
+    if not isinstance(result, dict):
+        return ""
+    content = result.get("content", [])
+    if isinstance(content, list) and content:
+        first = content[0]
+        if isinstance(first, dict):
+            return first.get("text", "")
+    return ""
+
+
+def build_briefing(project: str, recent_text: str, stale_text: str) -> list[str]:
+    """Build condensed briefing lines (max 20)."""
+    lines: list[str] = [f"[Distillery] Project: {project}"]
+
+    if recent_text and recent_text != "null":
+        entry_count = recent_text.count('"id"')
+        if entry_count > 0:
+            # Extract content snippets
+            snippets: list[str] = []
+            for part in recent_text.split('"content":"')[1:4]:
+                snippet = part.split('"')[0][:60]
+                if snippet:
+                    snippets.append(snippet)
+            if snippets:
+                lines.append(f"Recent ({entry_count}): {', '.join(snippets)}")
+
+    if stale_text and stale_text != "null":
+        stale_count = stale_text.count('"id"')
+        if stale_count > 0:
+            snippets = []
+            for part in stale_text.split('"content":"')[1:3]:
+                snippet = part.split('"')[0][:60]
+                if snippet:
+                    snippets.append(snippet)
+            if snippets:
+                lines.append(f"Stale ({stale_count}): {', '.join(snippets)}")
+
+    return lines[:20]
+
+
+def derive_project(cwd: str) -> str:
+    """Derive project name from git root or cwd."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return os.path.basename(result.stdout.strip())
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return os.path.basename(cwd)
+
+
+def main() -> None:
+    """Entry point for the SessionStart briefing hook."""
+    # Read hook JSON from stdin
+    try:
+        hook_json_str = sys.stdin.read()
+    except (OSError, KeyboardInterrupt):
+        sys.exit(0)
+
+    # Parse cwd from hook input
+    cwd = ""
+    try:
+        hook_data = json.loads(hook_json_str)
+        cwd = hook_data.get("cwd", "")
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    if not cwd:
+        cwd = os.getcwd()
+
+    cwd_path = Path(cwd)
+
+    # Configuration
+    bearer_token = os.environ.get("DISTILLERY_BEARER_TOKEN", "")
+    limit = int(os.environ.get("DISTILLERY_BRIEFING_LIMIT", "5"))
+
+    # Resolve transport
+    transport = resolve_transport(cwd_path)
+
+    # Probe reachability — exit silently if unreachable
+    if not probe_transport(transport, bearer_token):
+        sys.exit(0)
+
+    # Derive project
+    project = derive_project(cwd)
+
+    # Fetch recent entries
+    recent_resp = call_tool(
+        transport,
+        "distillery_list",
+        {"project": project, "limit": limit},
+        bearer_token,
+    )
+    recent_text = extract_text(recent_resp)
+
+    # Fetch stale entries
+    stale_resp = call_tool(
+        transport,
+        "distillery_stale",
+        {"days": 30, "limit": 3},
+        bearer_token,
+    )
+    stale_text = extract_text(stale_resp)
+
+    # Build and output briefing
+    lines = build_briefing(project, recent_text, stale_text)
+    for line in lines:
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/session_start_briefing.py
+++ b/scripts/hooks/session_start_briefing.py
@@ -39,7 +39,29 @@ class ResolvedTransport:
     url: str = ""
     command: list[str] = field(default_factory=list)
     env: dict[str, str] = field(default_factory=dict)
+    headers: dict[str, str] = field(default_factory=dict)
     source: str = ""
+
+
+def _normalize_mcp_url(url: str) -> tuple[str, str]:
+    """Normalize a base URL into canonical (mcp_url, health_url).
+
+    The MCP endpoint always ends with ``/mcp`` (no trailing slash) and the
+    health endpoint is its sibling ``/health``. If the input already ends with
+    ``/mcp`` or ``/health``, the base is derived accordingly; otherwise the
+    input is treated as a base and ``/mcp`` is appended.
+    """
+    stripped = url.rstrip("/")
+    if stripped.endswith("/mcp"):
+        mcp_url = stripped
+        base = stripped[: -len("/mcp")]
+    elif stripped.endswith("/health"):
+        base = stripped[: -len("/health")]
+        mcp_url = base + "/mcp"
+    else:
+        base = stripped
+        mcp_url = stripped + "/mcp"
+    return mcp_url, base + "/health"
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +92,13 @@ def _server_entry_to_transport(entry: dict[str, Any], source: str) -> ResolvedTr
     # HTTP (url-based or type: sse/streamable-http)
     url = entry.get("url", "")
     if url:
-        return ResolvedTransport(kind="http", url=url, source=source)
+        raw_headers = entry.get("headers") or {}
+        headers = (
+            {str(k): str(v) for k, v in raw_headers.items()}
+            if isinstance(raw_headers, dict)
+            else {}
+        )
+        return ResolvedTransport(kind="http", url=url, headers=headers, source=source)
 
     # stdio (command-based)
     cmd = entry.get("command", "")
@@ -135,7 +163,12 @@ def resolve_mcp_json(cwd: Path) -> ResolvedTransport | None:
 
 
 def resolve_claude_json_project(cwd: Path) -> ResolvedTransport | None:
-    """Step 4: ~/.claude.json -> projects[<cwd>].mcpServers."""
+    """Step 4: ~/.claude.json -> projects[<cwd>].mcpServers.
+
+    When cwd is nested under multiple configured project paths, the *deepest*
+    (longest) matching project wins so nested subprojects override their
+    parents.
+    """
     claude_json = Path.home() / ".claude.json"
     data = _read_json(claude_json)
     if not isinstance(data, dict):
@@ -143,15 +176,29 @@ def resolve_claude_json_project(cwd: Path) -> ResolvedTransport | None:
     projects = data.get("projects", {})
     if not isinstance(projects, dict):
         return None
-    cwd_str = str(cwd.resolve())
+    cwd_resolved = cwd.resolve()
+    best: tuple[int, str, dict[str, Any]] | None = None
     for project_path, project_data in projects.items():
-        if not isinstance(project_data, dict):
+        if not isinstance(project_data, dict) or not isinstance(project_path, str):
             continue
-        if cwd_str == project_path or cwd_str.startswith(project_path + "/"):
-            servers = project_data.get("mcpServers", {})
-            entry = _find_distillery_server(servers)
-            if entry is not None:
-                return _server_entry_to_transport(entry, f"~/.claude.json projects[{project_path}]")
+        try:
+            candidate = Path(project_path).resolve()
+        except (OSError, ValueError):
+            continue
+        try:
+            if not (cwd_resolved == candidate or cwd_resolved.is_relative_to(candidate)):
+                continue
+        except (OSError, ValueError):
+            continue
+        depth = len(candidate.parts)
+        if best is None or depth > best[0]:
+            best = (depth, project_path, project_data)
+    if best is not None:
+        _, project_path, project_data = best
+        servers = project_data.get("mcpServers", {})
+        entry = _find_distillery_server(servers)
+        if entry is not None:
+            return _server_entry_to_transport(entry, f"~/.claude.json projects[{project_path}]")
     return None
 
 
@@ -251,7 +298,12 @@ def resolve_transport(cwd: Path | None = None, bearer_token: str = "") -> Resolv
 # ---------------------------------------------------------------------------
 
 
-def _http_health_check(base_url: str, bearer_token: str = "", timeout: int = 2) -> bool:
+def _http_health_check(
+    base_url: str,
+    bearer_token: str = "",
+    timeout: int = 2,
+    transport_headers: dict[str, str] | None = None,
+) -> bool:
     """Probe an HTTP MCP transport for reachability.
 
     Performs ``GET /health`` first and then a minimal JSON-RPC POST to the
@@ -260,22 +312,21 @@ def _http_health_check(base_url: str, bearer_token: str = "", timeout: int = 2) 
     ``result`` or ``error``). Returns False on any failure, ensuring a healthy
     sidecar alone cannot mask a dead MCP endpoint.
     """
-    stripped = base_url.rstrip("/")
-    if stripped.endswith("/mcp"):
-        mcp_url = stripped
-        base = stripped[: -len("/mcp")]
-    elif stripped.endswith("/health"):
-        base = stripped[: -len("/health")]
-        mcp_url = base + "/mcp"
-    else:
-        base = stripped
-        mcp_url = stripped + "/mcp"
-    health_url = base + "/health"
+    mcp_url, health_url = _normalize_mcp_url(base_url)
+
+    def _merge(call_headers: dict[str, str]) -> dict[str, str]:
+        merged: dict[str, str] = {}
+        if transport_headers:
+            merged.update(transport_headers)
+        merged.update(call_headers)
+        if bearer_token and "Authorization" not in merged:
+            merged["Authorization"] = f"Bearer {bearer_token}"
+        return merged
 
     # Step 1: GET /health
     req = urllib.request.Request(health_url, method="GET")
-    if bearer_token:
-        req.add_header("Authorization", f"Bearer {bearer_token}")
+    for name, value in _merge({}).items():
+        req.add_header(name, value)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if getattr(resp, "status", 200) >= 400:
@@ -293,10 +344,13 @@ def _http_health_check(base_url: str, bearer_token: str = "", timeout: int = 2) 
         }
     ).encode()
     mcp_req = urllib.request.Request(mcp_url, data=payload, method="POST")
-    mcp_req.add_header("Content-Type", "application/json")
-    mcp_req.add_header("Accept", "application/json, text/event-stream")
-    if bearer_token:
-        mcp_req.add_header("Authorization", f"Bearer {bearer_token}")
+    for name, value in _merge(
+        {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+    ).items():
+        mcp_req.add_header(name, value)
     try:
         with urllib.request.urlopen(mcp_req, timeout=timeout) as resp:
             status = getattr(resp, "status", 200)
@@ -324,8 +378,17 @@ def _http_call_tool(
     arguments: dict[str, Any],
     bearer_token: str = "",
     timeout: int = 10,
+    transport_headers: dict[str, str] | None = None,
 ) -> Any:
-    """JSON-RPC tools/call over HTTP."""
+    """JSON-RPC tools/call over HTTP.
+
+    ``url`` is normalized to the canonical ``/mcp`` endpoint so tool calls
+    always hit the MCP handler, never the health sidecar or bare base URL.
+    Per-call headers (``Content-Type``, ``Accept``, and bearer) override
+    matching ``transport_headers`` defaults.
+    """
+    mcp_url, _ = _normalize_mcp_url(url)
+
     payload = json.dumps(
         {
             "jsonrpc": "2.0",
@@ -335,10 +398,16 @@ def _http_call_tool(
         }
     ).encode()
 
-    req = urllib.request.Request(url, data=payload, method="POST")
-    req.add_header("Content-Type", "application/json")
+    req = urllib.request.Request(mcp_url, data=payload, method="POST")
+    merged: dict[str, str] = {}
+    if transport_headers:
+        merged.update(transport_headers)
+    merged["Content-Type"] = "application/json"
+    merged.setdefault("Accept", "application/json, text/event-stream")
     if bearer_token:
-        req.add_header("Authorization", f"Bearer {bearer_token}")
+        merged["Authorization"] = f"Bearer {bearer_token}"
+    for name, value in merged.items():
+        req.add_header(name, value)
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -499,7 +568,7 @@ def _stdio_health_check(
 def probe_transport(transport: ResolvedTransport, bearer_token: str = "") -> bool:
     """Verify that the resolved transport is actually reachable."""
     if transport.kind == "http":
-        return _http_health_check(transport.url, bearer_token)
+        return _http_health_check(transport.url, bearer_token, transport_headers=transport.headers)
     elif transport.kind == "stdio":
         return _stdio_health_check(transport.command, transport.env)
     return False
@@ -513,7 +582,13 @@ def call_tool(
 ) -> Any:
     """Call an MCP tool via the resolved transport."""
     if transport.kind == "http":
-        return _http_call_tool(transport.url, tool_name, arguments, bearer_token)
+        return _http_call_tool(
+            transport.url,
+            tool_name,
+            arguments,
+            bearer_token,
+            transport_headers=transport.headers,
+        )
     elif transport.kind == "stdio":
         return _stdio_call_tool(transport.command, tool_name, arguments, transport.env)
     return None

--- a/scripts/hooks/session_start_briefing.py
+++ b/scripts/hooks/session_start_briefing.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
 import urllib.error
 import urllib.request
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -112,7 +114,7 @@ def resolve_env_command() -> ResolvedTransport | None:
     """Step 2: DISTILLERY_MCP_COMMAND env var."""
     cmd = os.environ.get("DISTILLERY_MCP_COMMAND", "").strip()
     if cmd:
-        parts = cmd.split()
+        parts = shlex.split(cmd)
         return ResolvedTransport(kind="stdio", command=parts, source="DISTILLERY_MCP_COMMAND")
     return None
 
@@ -537,32 +539,56 @@ def extract_text(response: Any) -> str:
     return ""
 
 
+def _extract_snippets(text: str, max_items: int) -> tuple[int, list[str]]:
+    """Parse JSON entries and extract content snippets, falling back to string scanning.
+
+    Returns a (count, snippets) tuple where count is the number of entries found
+    and snippets is a list of truncated content strings (up to max_items).
+    """
+    # Attempt JSON parsing first
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, list):
+            count = len(parsed)
+            snippets: list[str] = []
+            for item in parsed[:max_items]:
+                if isinstance(item, dict):
+                    content = item.get("content", "")
+                    if isinstance(content, str) and content:
+                        snippets.append(content[:60])
+            return count, snippets
+        if isinstance(parsed, dict):
+            # Single entry wrapped in a dict — treat as a list of one
+            count = 1
+            content = parsed.get("content", "")
+            snippet = [content[:60]] if isinstance(content, str) and content else []
+            return count, snippet
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Fallback: brittle string scanning (preserves behaviour for non-JSON text)
+    count = text.count('"id"')
+    snippets = []
+    for part in text.split('"content":"')[1 : max_items + 1]:
+        snippet = part.split('"')[0][:60]
+        if snippet:
+            snippets.append(snippet)
+    return count, snippets
+
+
 def build_briefing(project: str, recent_text: str, stale_text: str) -> list[str]:
     """Build condensed briefing lines (max 20)."""
     lines: list[str] = [f"[Distillery] Project: {project}"]
 
     if recent_text and recent_text != "null":
-        entry_count = recent_text.count('"id"')
-        if entry_count > 0:
-            # Extract content snippets
-            snippets: list[str] = []
-            for part in recent_text.split('"content":"')[1:4]:
-                snippet = part.split('"')[0][:60]
-                if snippet:
-                    snippets.append(snippet)
-            if snippets:
-                lines.append(f"Recent ({entry_count}): {', '.join(snippets)}")
+        entry_count, snippets = _extract_snippets(recent_text, 3)
+        if entry_count > 0 and snippets:
+            lines.append(f"Recent ({entry_count}): {', '.join(snippets)}")
 
     if stale_text and stale_text != "null":
-        stale_count = stale_text.count('"id"')
-        if stale_count > 0:
-            snippets = []
-            for part in stale_text.split('"content":"')[1:3]:
-                snippet = part.split('"')[0][:60]
-                if snippet:
-                    snippets.append(snippet)
-            if snippets:
-                lines.append(f"Stale ({stale_count}): {', '.join(snippets)}")
+        stale_count, snippets = _extract_snippets(stale_text, 2)
+        if stale_count > 0 and snippets:
+            lines.append(f"Stale ({stale_count}): {', '.join(snippets)}")
 
     return lines[:20]
 
@@ -606,7 +632,15 @@ def main() -> None:
 
     # Configuration
     bearer_token = os.environ.get("DISTILLERY_BEARER_TOKEN", "")
-    limit = int(os.environ.get("DISTILLERY_BRIEFING_LIMIT", "5"))
+    _limit_raw = os.environ.get("DISTILLERY_BRIEFING_LIMIT", "5")
+    try:
+        limit = int(_limit_raw)
+    except ValueError:
+        warnings.warn(
+            f"DISTILLERY_BRIEFING_LIMIT={_limit_raw!r} is not a valid integer; defaulting to 5",
+            stacklevel=1,
+        )
+        limit = 5
 
     # Resolve transport — probes each candidate, returning the first reachable
     # match (or the localhost fallback if none were reachable).

--- a/scripts/hooks/session_start_briefing.py
+++ b/scripts/hooks/session_start_briefing.py
@@ -16,6 +16,7 @@ No runtime dependencies beyond the Python 3.11+ stdlib.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -205,8 +206,15 @@ def resolve_localhost_fallback() -> ResolvedTransport:
     )
 
 
-def resolve_transport(cwd: Path | None = None) -> ResolvedTransport:
-    """Run the full resolution chain, returning the first match."""
+def resolve_transport(cwd: Path | None = None, bearer_token: str = "") -> ResolvedTransport:
+    """Run the full resolution chain, returning the first *reachable* match.
+
+    Each resolver's candidate is probed for reachability; if it fails, the
+    chain falls through to the next resolver. This matches the documented
+    "first reachable wins" contract. If no candidate is reachable, the
+    localhost fallback is returned (without probing, so the caller can decide
+    how to report the failure).
+    """
     if cwd is None:
         cwd = Path.cwd()
 
@@ -221,9 +229,17 @@ def resolve_transport(cwd: Path | None = None) -> ResolvedTransport:
     ]
 
     for resolver in resolvers:
-        result = resolver()
-        if result is not None:
-            return result
+        try:
+            result = resolver()
+        except Exception:
+            continue
+        if result is None:
+            continue
+        try:
+            if probe_transport(result, bearer_token):
+                return result
+        except Exception:
+            continue
 
     return resolve_localhost_fallback()
 
@@ -234,21 +250,70 @@ def resolve_transport(cwd: Path | None = None) -> ResolvedTransport:
 
 
 def _http_health_check(base_url: str, bearer_token: str = "", timeout: int = 2) -> bool:
-    """GET /health on the HTTP transport."""
-    health_url = base_url.rstrip("/")
-    if health_url.endswith("/mcp"):
-        health_url = health_url[: -len("/mcp")] + "/health"
-    elif not health_url.endswith("/health"):
-        health_url = health_url + "/health"
+    """Probe an HTTP MCP transport for reachability.
 
+    Performs ``GET /health`` first and then a minimal JSON-RPC POST to the
+    ``/mcp`` endpoint. Both must succeed with a 2xx status; the JSON-RPC
+    response must parse as a JSON-RPC reply (``jsonrpc``, ``id``, and either
+    ``result`` or ``error``). Returns False on any failure, ensuring a healthy
+    sidecar alone cannot mask a dead MCP endpoint.
+    """
+    stripped = base_url.rstrip("/")
+    if stripped.endswith("/mcp"):
+        mcp_url = stripped
+        base = stripped[: -len("/mcp")]
+    elif stripped.endswith("/health"):
+        base = stripped[: -len("/health")]
+        mcp_url = base + "/mcp"
+    else:
+        base = stripped
+        mcp_url = stripped + "/mcp"
+    health_url = base + "/health"
+
+    # Step 1: GET /health
     req = urllib.request.Request(health_url, method="GET")
     if bearer_token:
         req.add_header("Authorization", f"Bearer {bearer_token}")
     try:
-        with urllib.request.urlopen(req, timeout=timeout):
-            return True
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if getattr(resp, "status", 200) >= 400:
+                return False
     except (urllib.error.URLError, OSError, ValueError):
         return False
+
+    # Step 2: JSON-RPC POST /mcp
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {},
+        }
+    ).encode()
+    mcp_req = urllib.request.Request(mcp_url, data=payload, method="POST")
+    mcp_req.add_header("Content-Type", "application/json")
+    mcp_req.add_header("Accept", "application/json, text/event-stream")
+    if bearer_token:
+        mcp_req.add_header("Authorization", f"Bearer {bearer_token}")
+    try:
+        with urllib.request.urlopen(mcp_req, timeout=timeout) as resp:
+            status = getattr(resp, "status", 200)
+            if status >= 400:
+                return False
+            body = resp.read()
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return False
+
+    if not isinstance(parsed, dict):
+        return False
+    if parsed.get("jsonrpc") != "2.0":
+        return False
+    return "result" in parsed or "error" in parsed
 
 
 def _http_call_tool(
@@ -280,18 +345,8 @@ def _http_call_tool(
         return None
 
 
-def _stdio_call_tool(
-    command: list[str],
-    tool_name: str,
-    arguments: dict[str, Any],
-    extra_env: dict[str, str] | None = None,
-    timeout: int = 10,
-) -> Any:
-    """JSON-RPC tools/call over stdio subprocess.
-
-    Sends initialize, then tools/call, reads responses line by line.
-    """
-    init_msg = json.dumps(
+def _build_init_msg() -> str:
+    return json.dumps(
         {
             "jsonrpc": "2.0",
             "id": 0,
@@ -304,6 +359,33 @@ def _stdio_call_tool(
         }
     )
 
+
+def _build_initialized_notification() -> str:
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {},
+        }
+    )
+
+
+def _stdio_call_tool(
+    command: list[str],
+    tool_name: str,
+    arguments: dict[str, Any],
+    extra_env: dict[str, str] | None = None,
+    timeout: int = 10,
+) -> Any:
+    """JSON-RPC ``tools/call`` over a stdio subprocess.
+
+    Protocol sequence: ``initialize`` request, ``notifications/initialized``
+    notification (required by MCP), then the ``tools/call`` request. All
+    messages are written as a single ``communicate`` input blob (stdin is
+    closed *by* ``communicate``, never manually before it), so we avoid the
+    "flush of closed file" ``ValueError`` that results from closing stdin and
+    then calling ``communicate``.
+    """
     call_msg = json.dumps(
         {
             "jsonrpc": "2.0",
@@ -317,6 +399,10 @@ def _stdio_call_tool(
     if extra_env:
         env.update(extra_env)
 
+    payload = (
+        _build_init_msg() + "\n" + _build_initialized_notification() + "\n" + call_msg + "\n"
+    ).encode()
+
     try:
         proc = subprocess.Popen(
             command,
@@ -325,37 +411,31 @@ def _stdio_call_tool(
             stderr=subprocess.DEVNULL,
             env=env,
         )
-        assert proc.stdin is not None
-        assert proc.stdout is not None
+    except OSError:
+        return None
 
-        # Send initialize + call, each newline-delimited
-        proc.stdin.write((init_msg + "\n").encode())
-        proc.stdin.write((call_msg + "\n").encode())
-        proc.stdin.flush()
-        proc.stdin.close()
-
-        # Read all output within timeout
+    try:
         try:
-            stdout_bytes, _ = proc.communicate(timeout=timeout)
+            stdout_bytes, _ = proc.communicate(input=payload, timeout=timeout)
         except subprocess.TimeoutExpired:
             proc.kill()
-            proc.wait()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=1)
             return None
+    except OSError:
+        return None
 
-        # Parse line-delimited JSON responses, find id=1
-        for line in stdout_bytes.decode(errors="replace").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                msg = json.loads(line)
-                if isinstance(msg, dict) and msg.get("id") == 1:
-                    return msg
-            except json.JSONDecodeError:
-                continue
-
-    except (OSError, ValueError):
-        pass
+    # Parse line-delimited JSON responses, find id=1
+    for line in stdout_bytes.decode(errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(msg, dict) and msg.get("id") == 1:
+            return msg
 
     return None
 
@@ -365,23 +445,18 @@ def _stdio_health_check(
     extra_env: dict[str, str] | None = None,
     timeout: int = 3,
 ) -> bool:
-    """Check if a stdio MCP server starts successfully via initialize handshake."""
-    init_msg = json.dumps(
-        {
-            "jsonrpc": "2.0",
-            "id": 0,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "distillery-hook", "version": "1.0.0"},
-            },
-        }
-    )
+    """Verify that a stdio MCP server completes the initialize handshake.
 
+    Writes ``initialize`` + ``notifications/initialized`` as a single input
+    blob to ``communicate``, which handles stdin close safely. A successful
+    handshake is signalled by a JSON-RPC reply with ``id == 0`` and a
+    ``result`` field (the server's initialize response).
+    """
     env = dict(os.environ)
     if extra_env:
         env.update(extra_env)
+
+    payload = (_build_init_msg() + "\n" + _build_initialized_notification() + "\n").encode()
 
     try:
         proc = subprocess.Popen(
@@ -391,33 +466,30 @@ def _stdio_health_check(
             stderr=subprocess.DEVNULL,
             env=env,
         )
-        assert proc.stdin is not None
-        assert proc.stdout is not None
+    except OSError:
+        return False
 
-        proc.stdin.write((init_msg + "\n").encode())
-        proc.stdin.flush()
-        proc.stdin.close()
-
+    try:
         try:
-            stdout_bytes, _ = proc.communicate(timeout=timeout)
+            stdout_bytes, _ = proc.communicate(input=payload, timeout=timeout)
         except subprocess.TimeoutExpired:
             proc.kill()
-            proc.wait()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=1)
             return False
+    except OSError:
+        return False
 
-        for line in stdout_bytes.decode(errors="replace").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                msg = json.loads(line)
-                if isinstance(msg, dict) and "result" in msg:
-                    return True
-            except json.JSONDecodeError:
-                continue
-
-    except (OSError, ValueError):
-        pass
+    for line in stdout_bytes.decode(errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(msg, dict) and msg.get("id") == 0 and "result" in msg:
+            return True
 
     return False
 
@@ -536,10 +608,12 @@ def main() -> None:
     bearer_token = os.environ.get("DISTILLERY_BEARER_TOKEN", "")
     limit = int(os.environ.get("DISTILLERY_BRIEFING_LIMIT", "5"))
 
-    # Resolve transport
-    transport = resolve_transport(cwd_path)
+    # Resolve transport — probes each candidate, returning the first reachable
+    # match (or the localhost fallback if none were reachable).
+    transport = resolve_transport(cwd_path, bearer_token)
 
-    # Probe reachability — exit silently if unreachable
+    # Probe reachability — exit silently if unreachable (covers the fallback
+    # path where no prior candidate probed as reachable).
     if not probe_transport(transport, bearer_token):
         sys.exit(0)
 

--- a/tests/test_session_start_briefing.py
+++ b/tests/test_session_start_briefing.py
@@ -282,7 +282,8 @@ class TestResolveLocalhostFallback:
 class TestResolveTransport:
     def test_env_url_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_cwd: Path) -> None:
         monkeypatch.setenv("DISTILLERY_MCP_URL", "https://custom.example.com/mcp")
-        result = briefing.resolve_transport(tmp_cwd)
+        with patch("session_start_briefing.probe_transport", return_value=True):
+            result = briefing.resolve_transport(tmp_cwd)
         assert result.kind == "http"
         assert result.url == "https://custom.example.com/mcp"
         assert result.source == "DISTILLERY_MCP_URL"
@@ -291,7 +292,8 @@ class TestResolveTransport:
         self, monkeypatch: pytest.MonkeyPatch, clean_env: None, tmp_cwd: Path
     ) -> None:
         monkeypatch.setenv("DISTILLERY_MCP_COMMAND", "my-distillery")
-        result = briefing.resolve_transport(tmp_cwd)
+        with patch("session_start_briefing.probe_transport", return_value=True):
+            result = briefing.resolve_transport(tmp_cwd)
         assert result.kind == "stdio"
         assert result.source == "DISTILLERY_MCP_COMMAND"
 
@@ -303,6 +305,40 @@ class TestResolveTransport:
             result = briefing.resolve_transport(tmp_cwd)
         assert result.kind == "http"
         assert result.url == "http://localhost:8000/mcp"
+        assert result.source == "localhost fallback"
+
+    def test_first_reachable_wins(
+        self, monkeypatch: pytest.MonkeyPatch, clean_env: None, tmp_cwd: Path
+    ) -> None:
+        """If the first candidate exists but fails probing, the resolver must
+        continue to later candidates rather than returning early."""
+        # First candidate: DISTILLERY_MCP_URL (dead — probe will return False)
+        monkeypatch.setenv("DISTILLERY_MCP_URL", "https://dead.example.com/mcp")
+        # Second candidate: DISTILLERY_MCP_COMMAND (reachable — probe True)
+        monkeypatch.setenv("DISTILLERY_MCP_COMMAND", "my-reachable-cmd")
+
+        def fake_probe(transport: briefing.ResolvedTransport, _token: str = "") -> bool:
+            # Only the stdio candidate is "reachable"
+            return transport.source == "DISTILLERY_MCP_COMMAND"
+
+        with patch("session_start_briefing.probe_transport", side_effect=fake_probe):
+            result = briefing.resolve_transport(tmp_cwd)
+
+        assert result.kind == "stdio"
+        assert result.source == "DISTILLERY_MCP_COMMAND"
+        assert result.command == ["my-reachable-cmd"]
+
+    def test_all_candidates_unreachable_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch, clean_env: None, tmp_cwd: Path
+    ) -> None:
+        """If every candidate fails probing, the localhost fallback is returned."""
+        monkeypatch.setenv("DISTILLERY_MCP_URL", "https://dead.example.com/mcp")
+        with (
+            patch("session_start_briefing.probe_transport", return_value=False),
+            patch("shutil.which", return_value=None),
+            patch.object(Path, "home", return_value=tmp_cwd / "fakehome"),
+        ):
+            result = briefing.resolve_transport(tmp_cwd)
         assert result.source == "localhost fallback"
 
 
@@ -428,3 +464,67 @@ class TestProbeTransport:
     def test_unknown_kind(self) -> None:
         transport = briefing.ResolvedTransport(kind="unknown")
         assert briefing.probe_transport(transport) is False
+
+
+# ---------------------------------------------------------------------------
+# Real stdio subprocess (exercises Popen/communicate wiring)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStdioSubprocess:
+    """Exercise the real _stdio_health_check / _stdio_call_tool subprocess flow.
+
+    These tests guard against regressions in the Popen/communicate sequence —
+    specifically the `flush of closed file` ValueError that surfaces when
+    stdin is closed before `communicate()` is called on CPython.
+    """
+
+    def test_health_check_with_real_subprocess(self) -> None:
+        """A trivial Python script that emits a valid initialize reply should
+        cause _stdio_health_check to return True."""
+        script = (
+            "import sys, json\n"
+            "sys.stdin.readline()  # initialize request\n"
+            'reply = {"jsonrpc": "2.0", "id": 0, "result": {"capabilities": {}}}\n'
+            'sys.stdout.write(json.dumps(reply) + "\\n")\n'
+            "sys.stdout.flush()\n"
+        )
+        command = [sys.executable, "-c", script]
+        assert briefing._stdio_health_check(command, timeout=5) is True
+
+    def test_health_check_fails_on_nonzero_exit_with_no_reply(self) -> None:
+        """A subprocess that exits without emitting an initialize result
+        should cause _stdio_health_check to return False, not raise."""
+        command = [sys.executable, "-c", "import sys; sys.exit(1)"]
+        assert briefing._stdio_health_check(command, timeout=5) is False
+
+    def test_call_tool_with_real_subprocess(self) -> None:
+        """Drive the full two-round-trip flow against a fake MCP server."""
+        script = (
+            "import sys, json\n"
+            "# initialize\n"
+            "sys.stdin.readline()\n"
+            'sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": 0, '
+            '"result": {"capabilities": {}}}) + "\\n")\n'
+            "# notifications/initialized (no reply)\n"
+            "sys.stdin.readline()\n"
+            "# tools/call\n"
+            "sys.stdin.readline()\n"
+            'sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": 1, '
+            '"result": {"content": [{"type": "text", "text": "pong"}]}}) + "\\n")\n'
+            "sys.stdout.flush()\n"
+        )
+        command = [sys.executable, "-c", script]
+        resp = briefing._stdio_call_tool(command, "ping", {}, timeout=5)
+        assert isinstance(resp, dict)
+        assert resp.get("id") == 1
+        assert resp.get("result", {}).get("content", [{}])[0].get("text") == "pong"
+
+    def test_call_tool_handles_timeout(self) -> None:
+        """A subprocess that never replies should time out cleanly and
+        return None instead of hanging or raising."""
+        # Read forever; never respond.
+        script = "import sys\nwhile True:\n    if not sys.stdin.readline(): break\n"
+        command = [sys.executable, "-c", script]
+        assert briefing._stdio_call_tool(command, "noop", {}, timeout=1) is None

--- a/tests/test_session_start_briefing.py
+++ b/tests/test_session_start_briefing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -528,3 +529,131 @@ class TestStdioSubprocess:
         script = "import sys\nwhile True:\n    if not sys.stdin.readline(): break\n"
         command = [sys.executable, "-c", script]
         assert briefing._stdio_call_tool(command, "noop", {}, timeout=1) is None
+
+
+# ---------------------------------------------------------------------------
+# CodeRabbit follow-ups: URL normalization, header passthrough, deepest project
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNormalizeMcpUrl:
+    def test_bare_base_appends_mcp(self) -> None:
+        mcp_url, health_url = briefing._normalize_mcp_url("https://host.example/")
+        assert mcp_url == "https://host.example/mcp"
+        assert health_url == "https://host.example/health"
+
+    def test_already_mcp(self) -> None:
+        mcp_url, health_url = briefing._normalize_mcp_url("https://host.example/mcp")
+        assert mcp_url == "https://host.example/mcp"
+        assert health_url == "https://host.example/health"
+
+    def test_trailing_slash_on_mcp(self) -> None:
+        mcp_url, _ = briefing._normalize_mcp_url("https://host.example/mcp/")
+        assert mcp_url == "https://host.example/mcp"
+
+    def test_health_url_input(self) -> None:
+        mcp_url, health_url = briefing._normalize_mcp_url("https://host.example/health")
+        assert mcp_url == "https://host.example/mcp"
+        assert health_url == "https://host.example/health"
+
+
+@pytest.mark.unit
+class TestTransportHeaders:
+    def test_server_entry_preserves_headers(self) -> None:
+        entry = {
+            "url": "https://team.example/mcp",
+            "headers": {"X-Team-Token": "secret"},
+        }
+        transport = briefing._server_entry_to_transport(entry, "test")
+        assert transport is not None
+        assert transport.headers == {"X-Team-Token": "secret"}
+
+    def test_server_entry_missing_headers_is_empty(self) -> None:
+        transport = briefing._server_entry_to_transport({"url": "https://team.example/mcp"}, "test")
+        assert transport is not None
+        assert transport.headers == {}
+
+    def test_http_call_tool_merges_transport_headers(self) -> None:
+        captured: dict[str, Any] = {}
+
+        class _FakeResp:
+            status = 200
+
+            def read(self) -> bytes:
+                return b'{"jsonrpc":"2.0","id":1,"result":{}}'
+
+            def __enter__(self) -> _FakeResp:
+                return self
+
+            def __exit__(self, *_: Any) -> None:
+                return None
+
+        def fake_urlopen(req: Any, timeout: int = 10) -> _FakeResp:
+            captured["url"] = req.full_url
+            captured["headers"] = dict(req.header_items())
+            return _FakeResp()
+
+        with patch.object(briefing.urllib.request, "urlopen", fake_urlopen):
+            briefing._http_call_tool(
+                "https://team.example",
+                "ping",
+                {},
+                bearer_token="tok",
+                transport_headers={"X-Team-Token": "secret"},
+            )
+        assert captured["url"] == "https://team.example/mcp"
+        # header_items lowercases keys in urllib
+        headers = {k.lower(): v for k, v in captured["headers"].items()}
+        assert headers["x-team-token"] == "secret"
+        assert headers["authorization"] == "Bearer tok"
+        assert headers["content-type"] == "application/json"
+
+
+@pytest.mark.unit
+class TestDeepestProjectMatch:
+    def test_nested_subproject_wins(self, tmp_path: Path) -> None:
+        parent = tmp_path / "workspace"
+        child = parent / "packages" / "app"
+        child.mkdir(parents=True)
+
+        claude_json = tmp_path / "home" / ".claude.json"
+        claude_json.parent.mkdir(parents=True, exist_ok=True)
+        claude_json.write_text(
+            json.dumps(
+                {
+                    "projects": {
+                        str(parent): {
+                            "mcpServers": {"distillery": {"url": "http://parent-server/mcp"}}
+                        },
+                        str(child): {
+                            "mcpServers": {"distillery": {"url": "http://child-server/mcp"}}
+                        },
+                    }
+                }
+            )
+        )
+        with patch.object(Path, "home", return_value=tmp_path / "home"):
+            result = briefing.resolve_claude_json_project(child)
+        assert result is not None
+        assert result.url == "http://child-server/mcp"
+
+    def test_no_match_returns_none(self, tmp_path: Path) -> None:
+        other = tmp_path / "other"
+        other.mkdir()
+        claude_json = tmp_path / "home" / ".claude.json"
+        claude_json.parent.mkdir(parents=True, exist_ok=True)
+        claude_json.write_text(
+            json.dumps(
+                {
+                    "projects": {
+                        str(tmp_path / "elsewhere"): {
+                            "mcpServers": {"distillery": {"url": "http://x/mcp"}}
+                        }
+                    }
+                }
+            )
+        )
+        with patch.object(Path, "home", return_value=tmp_path / "home"):
+            result = briefing.resolve_claude_json_project(other)
+        assert result is None

--- a/tests/test_session_start_briefing.py
+++ b/tests/test_session_start_briefing.py
@@ -1,0 +1,430 @@
+"""Unit tests for scripts/hooks/session_start_briefing.py resolver."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add scripts/hooks to the import path so we can import the module
+HOOKS_DIR = Path(__file__).resolve().parent.parent / "scripts" / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+import session_start_briefing as briefing  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_cwd(tmp_path: Path) -> Path:
+    """Return a temporary directory to use as cwd."""
+    return tmp_path
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove Distillery env vars to start from a clean state."""
+    for var in [
+        "DISTILLERY_MCP_URL",
+        "DISTILLERY_MCP_COMMAND",
+        "DISTILLERY_BEARER_TOKEN",
+        "DISTILLERY_BRIEFING_LIMIT",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Step 1: DISTILLERY_MCP_URL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveEnvUrl:
+    def test_returns_http_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTILLERY_MCP_URL", "https://my-server.fly.dev/mcp")
+        result = briefing.resolve_env_url()
+        assert result is not None
+        assert result.kind == "http"
+        assert result.url == "https://my-server.fly.dev/mcp"
+        assert result.source == "DISTILLERY_MCP_URL"
+
+    def test_returns_none_when_unset(self, clean_env: None) -> None:
+        result = briefing.resolve_env_url()
+        assert result is None
+
+    def test_returns_none_when_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTILLERY_MCP_URL", "  ")
+        result = briefing.resolve_env_url()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Step 2: DISTILLERY_MCP_COMMAND
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveEnvCommand:
+    def test_returns_stdio_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTILLERY_MCP_COMMAND", "distillery-mcp --db /tmp/test.db")
+        result = briefing.resolve_env_command()
+        assert result is not None
+        assert result.kind == "stdio"
+        assert result.command == ["distillery-mcp", "--db", "/tmp/test.db"]
+        assert result.source == "DISTILLERY_MCP_COMMAND"
+
+    def test_returns_none_when_unset(self, clean_env: None) -> None:
+        result = briefing.resolve_env_command()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Step 3: .mcp.json
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveMcpJson:
+    def test_finds_http_server(self, tmp_cwd: Path) -> None:
+        mcp_json = tmp_cwd / ".mcp.json"
+        mcp_json.write_text(
+            json.dumps({"mcpServers": {"distillery-local": {"url": "http://localhost:9000/mcp"}}})
+        )
+        result = briefing.resolve_mcp_json(tmp_cwd)
+        assert result is not None
+        assert result.kind == "http"
+        assert result.url == "http://localhost:9000/mcp"
+
+    def test_finds_stdio_server(self, tmp_cwd: Path) -> None:
+        mcp_json = tmp_cwd / ".mcp.json"
+        mcp_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "distillery": {
+                            "command": "distillery-mcp",
+                            "args": ["--db", "/tmp/test.db"],
+                        }
+                    }
+                }
+            )
+        )
+        result = briefing.resolve_mcp_json(tmp_cwd)
+        assert result is not None
+        assert result.kind == "stdio"
+        assert result.command == ["distillery-mcp", "--db", "/tmp/test.db"]
+
+    def test_walks_up_directories(self, tmp_cwd: Path) -> None:
+        mcp_json = tmp_cwd / ".mcp.json"
+        mcp_json.write_text(
+            json.dumps({"mcpServers": {"distillery": {"url": "http://localhost:8000/mcp"}}})
+        )
+        subdir = tmp_cwd / "src" / "deep"
+        subdir.mkdir(parents=True)
+        result = briefing.resolve_mcp_json(subdir)
+        assert result is not None
+        assert result.kind == "http"
+
+    def test_returns_none_when_no_file(self, tmp_cwd: Path) -> None:
+        result = briefing.resolve_mcp_json(tmp_cwd)
+        assert result is None
+
+    def test_returns_none_when_no_distillery(self, tmp_cwd: Path) -> None:
+        mcp_json = tmp_cwd / ".mcp.json"
+        mcp_json.write_text(
+            json.dumps({"mcpServers": {"other-server": {"url": "http://other:8000"}}})
+        )
+        result = briefing.resolve_mcp_json(tmp_cwd)
+        assert result is None
+
+    def test_handles_malformed_json(self, tmp_cwd: Path) -> None:
+        mcp_json = tmp_cwd / ".mcp.json"
+        mcp_json.write_text("not json")
+        result = briefing.resolve_mcp_json(tmp_cwd)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Step 4: ~/.claude.json project-scoped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveClaudeJsonProject:
+    def test_finds_project_server(self, tmp_cwd: Path, tmp_path: Path) -> None:
+        claude_json = tmp_path / "home" / ".claude.json"
+        claude_json.parent.mkdir(parents=True, exist_ok=True)
+        claude_json.write_text(
+            json.dumps(
+                {
+                    "projects": {
+                        str(tmp_cwd): {
+                            "mcpServers": {"distillery": {"url": "http://localhost:8000/mcp"}}
+                        }
+                    }
+                }
+            )
+        )
+        with patch.object(Path, "home", return_value=tmp_path / "home"):
+            result = briefing.resolve_claude_json_project(tmp_cwd)
+        assert result is not None
+        assert result.kind == "http"
+
+    def test_returns_none_when_no_file(self, tmp_cwd: Path, tmp_path: Path) -> None:
+        with patch.object(Path, "home", return_value=tmp_path / "nonexistent"):
+            result = briefing.resolve_claude_json_project(tmp_cwd)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Step 5: ~/.claude.json global
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveClaudeJsonGlobal:
+    def test_finds_global_server(self, tmp_path: Path) -> None:
+        claude_json = tmp_path / "home" / ".claude.json"
+        claude_json.parent.mkdir(parents=True, exist_ok=True)
+        claude_json.write_text(
+            json.dumps({"mcpServers": {"distillery": {"command": "distillery-mcp", "args": []}}})
+        )
+        with patch.object(Path, "home", return_value=tmp_path / "home"):
+            result = briefing.resolve_claude_json_global()
+        assert result is not None
+        assert result.kind == "stdio"
+        assert result.command == ["distillery-mcp"]
+
+    def test_returns_none_when_no_file(self, tmp_path: Path) -> None:
+        with patch.object(Path, "home", return_value=tmp_path / "nonexistent"):
+            result = briefing.resolve_claude_json_global()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Step 6: plugin.json
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolvePluginJson:
+    def test_finds_plugin_server(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "home" / ".claude" / "plugins" / "distillery" / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "distillery": {
+                            "command": "distillery-mcp",
+                            "args": ["--transport", "stdio"],
+                        }
+                    }
+                }
+            )
+        )
+        with patch.object(Path, "home", return_value=tmp_path / "home"):
+            result = briefing.resolve_plugin_json()
+        assert result is not None
+        assert result.kind == "stdio"
+
+    def test_returns_none_when_no_plugins(self, tmp_path: Path) -> None:
+        with patch.object(Path, "home", return_value=tmp_path / "nonexistent"):
+            result = briefing.resolve_plugin_json()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Step 7: distillery-mcp on PATH
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolvePathCommand:
+    def test_finds_command_on_path(self) -> None:
+        with patch("shutil.which", return_value="/usr/local/bin/distillery-mcp"):
+            result = briefing.resolve_path_command()
+        assert result is not None
+        assert result.kind == "stdio"
+        assert result.command == ["distillery-mcp"]
+
+    def test_returns_none_when_not_on_path(self) -> None:
+        with patch("shutil.which", return_value=None):
+            result = briefing.resolve_path_command()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Step 8: localhost fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveLocalhostFallback:
+    def test_returns_http_localhost(self) -> None:
+        result = briefing.resolve_localhost_fallback()
+        assert result.kind == "http"
+        assert result.url == "http://localhost:8000/mcp"
+        assert result.source == "localhost fallback"
+
+
+# ---------------------------------------------------------------------------
+# Full resolution chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveTransport:
+    def test_env_url_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_cwd: Path) -> None:
+        monkeypatch.setenv("DISTILLERY_MCP_URL", "https://custom.example.com/mcp")
+        result = briefing.resolve_transport(tmp_cwd)
+        assert result.kind == "http"
+        assert result.url == "https://custom.example.com/mcp"
+        assert result.source == "DISTILLERY_MCP_URL"
+
+    def test_env_command_second(
+        self, monkeypatch: pytest.MonkeyPatch, clean_env: None, tmp_cwd: Path
+    ) -> None:
+        monkeypatch.setenv("DISTILLERY_MCP_COMMAND", "my-distillery")
+        result = briefing.resolve_transport(tmp_cwd)
+        assert result.kind == "stdio"
+        assert result.source == "DISTILLERY_MCP_COMMAND"
+
+    def test_falls_through_to_localhost(self, clean_env: None, tmp_cwd: Path) -> None:
+        with (
+            patch("shutil.which", return_value=None),
+            patch.object(Path, "home", return_value=tmp_cwd / "fakehome"),
+        ):
+            result = briefing.resolve_transport(tmp_cwd)
+        assert result.kind == "http"
+        assert result.url == "http://localhost:8000/mcp"
+        assert result.source == "localhost fallback"
+
+
+# ---------------------------------------------------------------------------
+# extract_text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractText:
+    def test_extracts_text_from_response(self) -> None:
+        resp = {"result": {"content": [{"type": "text", "text": "hello world"}]}}
+        assert briefing.extract_text(resp) == "hello world"
+
+    def test_returns_empty_for_none(self) -> None:
+        assert briefing.extract_text(None) == ""
+
+    def test_returns_empty_for_empty_content(self) -> None:
+        assert briefing.extract_text({"result": {"content": []}}) == ""
+
+
+# ---------------------------------------------------------------------------
+# build_briefing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildBriefing:
+    def test_basic_briefing(self) -> None:
+        lines = briefing.build_briefing("myproject", "", "")
+        assert lines == ["[Distillery] Project: myproject"]
+
+    def test_with_recent_entries(self) -> None:
+        recent = '{"id":"1","content":"first entry"},{"id":"2","content":"second"}'
+        lines = briefing.build_briefing("proj", recent, "")
+        assert len(lines) == 2
+        assert lines[0] == "[Distillery] Project: proj"
+        assert "Recent (2)" in lines[1]
+
+    def test_max_20_lines(self) -> None:
+        lines = briefing.build_briefing("p", "", "")
+        assert len(lines) <= 20
+
+
+# ---------------------------------------------------------------------------
+# _server_entry_to_transport
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestServerEntryToTransport:
+    def test_url_entry(self) -> None:
+        entry = {"url": "http://example.com/mcp"}
+        result = briefing._server_entry_to_transport(entry, "test")
+        assert result is not None
+        assert result.kind == "http"
+
+    def test_command_entry(self) -> None:
+        entry = {"command": "my-cmd", "args": ["--flag"], "env": {"FOO": "bar"}}
+        result = briefing._server_entry_to_transport(entry, "test")
+        assert result is not None
+        assert result.kind == "stdio"
+        assert result.command == ["my-cmd", "--flag"]
+        assert result.env == {"FOO": "bar"}
+
+    def test_empty_entry(self) -> None:
+        result = briefing._server_entry_to_transport({}, "test")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _find_distillery_server
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFindDistilleryServer:
+    def test_finds_exact_match(self) -> None:
+        servers = {"distillery": {"url": "http://x"}}
+        assert briefing._find_distillery_server(servers) == {"url": "http://x"}
+
+    def test_finds_partial_match(self) -> None:
+        servers = {"my-distillery-server": {"url": "http://y"}}
+        result = briefing._find_distillery_server(servers)
+        assert result == {"url": "http://y"}
+
+    def test_case_insensitive(self) -> None:
+        servers = {"Distillery": {"url": "http://z"}}
+        result = briefing._find_distillery_server(servers)
+        assert result == {"url": "http://z"}
+
+    def test_returns_none_for_no_match(self) -> None:
+        servers = {"other-server": {"url": "http://a"}}
+        assert briefing._find_distillery_server(servers) is None
+
+    def test_returns_none_for_non_dict(self) -> None:
+        assert briefing._find_distillery_server("not a dict") is None
+        assert briefing._find_distillery_server(None) is None
+
+
+# ---------------------------------------------------------------------------
+# probe_transport (mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProbeTransport:
+    def test_http_probe_success(self) -> None:
+        transport = briefing.ResolvedTransport(kind="http", url="http://localhost:8000/mcp")
+        with patch("session_start_briefing._http_health_check", return_value=True):
+            assert briefing.probe_transport(transport) is True
+
+    def test_http_probe_failure(self) -> None:
+        transport = briefing.ResolvedTransport(kind="http", url="http://localhost:8000/mcp")
+        with patch("session_start_briefing._http_health_check", return_value=False):
+            assert briefing.probe_transport(transport) is False
+
+    def test_stdio_probe_success(self) -> None:
+        transport = briefing.ResolvedTransport(kind="stdio", command=["distillery-mcp"])
+        with patch("session_start_briefing._stdio_health_check", return_value=True):
+            assert briefing.probe_transport(transport) is True
+
+    def test_unknown_kind(self) -> None:
+        transport = briefing.ResolvedTransport(kind="unknown")
+        assert briefing.probe_transport(transport) is False

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.2.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1536,23 +1536,23 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/5a/7523ff55668a233beef7e909e8e2074a1cc3b620e0bbf0a4ec5f38549b3b/langchain_core-1.2.31.tar.gz", hash = "sha256:aad3ecc9e4dce2dd2bb79526c81b92e5322fd81db7834a031cb80359f2e3ebaa", size = 850756, upload-time = "2026-04-16T13:26:29.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/52/02/668ddf4f1cf963ad691bdbea672a85244e6271eb0a4acfaf662bbd94a3b1/langchain_core-1.2.31-py3-none-any.whl", hash = "sha256:c407193edb99311cc36ec3e4d3667a065bbc4d7d72fbb6e368538b9b134d4033", size = 513264, upload-time = "2026-04-16T13:26:27.566Z" },
 ]
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.12"
+version = "1.1.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/fd/7dee16e882c4c1577d48db174d85aa3a0ee09ba61eb6a5d41650285ca80c/langchain_openai-1.1.12.tar.gz", hash = "sha256:ccf5ef02c896f6807b4d0e51aaf678a72ce81ae41201cae8d65e11eeff9ecb79", size = 1114119, upload-time = "2026-03-23T18:59:19.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/f5/b1a56f703fb90952b07ff9fb5507123a39df1267d62a7f2bb821c5dbb628/langchain_openai-1.1.14.tar.gz", hash = "sha256:71b4262932fabe506ce79c175dbc956cc48f24d81e20b27662df493147750643", size = 1115195, upload-time = "2026-04-16T14:55:24.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/a6/68fb22e3604015e6f546fa1d3677d24378b482855ae74710cbf4aec44132/langchain_openai-1.1.12-py3-none-any.whl", hash = "sha256:da71ca3f2d18c16f7a2443cc306aa195ad2a07054335ac9b0626dcae02b6a0c5", size = 88487, upload-time = "2026-03-23T18:59:17.978Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fa/8c33befbc0cf81b21371cc1dab4e7bf94a80b8116194f263a5021ec02529/langchain_openai-1.1.14-py3-none-any.whl", hash = "sha256:cb525d2011f9813fc15a7dcfd4bca5b87badcbcb2c113a7fbe45d1b8a1bbb69c", size = 88705, upload-time = "2026-04-16T14:55:23.159Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1557,14 +1557,14 @@ wheels = [
 
 [[package]]
 name = "langchain-text-splitters"
-version = "1.1.1"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/38/14121ead61e0e75f79c3a35e5148ac7c2fe754a55f76eab3eed573269524/langchain_text_splitters-1.1.1.tar.gz", hash = "sha256:34861abe7c07d9e49d4dc852d0129e26b32738b60a74486853ec9b6d6a8e01d2", size = 279352, upload-time = "2026-02-18T23:02:42.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/66/d9e0c3b83b0ad75ee746c51ba347cacecb8d656b96e1d513f3e334d1ccab/langchain_text_splitters-1.1.1-py3-none-any.whl", hash = "sha256:5ed0d7bf314ba925041e7d7d17cd8b10f688300d5415fb26c29442f061e329dc", size = 35734, upload-time = "2026-02-18T23:02:41.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/26/1ef06f56198d631296d646a6223de35bcc6cf9795ceb2442816bc963b84c/langchain_text_splitters-1.1.2-py3-none-any.whl", hash = "sha256:a2de0d799ff31886429fd6e2e0032df275b60ec817c19059a7b46181cc1c2f10", size = 35903, upload-time = "2026-04-16T14:20:38.243Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -200,14 +200,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.6.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace hardcoded `http://localhost:8000/mcp` in the SessionStart briefing hook with a Python-based dynamic transport resolver
- Auto-detects MCP installation across 8 resolution sources: env vars, `.mcp.json`, `~/.claude.json` (project + global), plugin manifests, PATH lookup, and localhost fallback
- Supports both HTTP and stdio transports with reachability probes before making tool calls
- Shell script becomes a thin wrapper that execs the Python script

## Changes

- **New** `scripts/hooks/session_start_briefing.py` — stdlib-only Python 3.11+ resolver with 8-step resolution chain, HTTP/stdio probes, and briefing output
- **Rewrite** `scripts/hooks/session-start-briefing.sh` — thin wrapper that finds Python and execs the resolver
- **Update** `scripts/hooks/README.md` — documents `DISTILLERY_MCP_COMMAND` env var and transport resolution order table
- **New** `tests/test_session_start_briefing.py` — 41 unit tests covering all 8 resolver branches, helpers, and probe logic

Closes #303

## Test plan

- [x] 41 unit tests pass (`pytest tests/test_session_start_briefing.py -v`)
- [x] `ruff check` and `ruff format` clean
- [x] `mypy --strict src/distillery/` passes
- [x] Existing test suite unaffected (pre-existing failures in test_watch/test_webhooks/test_mcp_server are unrelated)
- [ ] Manual: verify SessionStart hook with HTTP transport
- [ ] Manual: verify SessionStart hook with stdio transport
- [ ] Manual: verify silent exit when no MCP server is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flexible MCP transport selection supporting HTTP or subprocess (stdio), with reachability probes and silent exit when no transport is reachable
  * New Python-based session-start hook wrapper that invokes the briefing generator (requires Python 3.11+)

* **Documentation**
  * Updated hook docs with transport resolution order, env vars, examples for forcing stdio and hosted HTTP, and clarified security notes

* **Tests**
  * Added tests covering transport resolution, probing, briefing formatting, URL normalization, header handling, and stdio integration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->