### PR TITLE
feat(sync): use real author from source payloads

### DIFF
--- a/src/distillery/feeds/github.py
+++ b/src/distillery/feeds/github.py
@@ -166,6 +166,7 @@ def _event_to_feed_item(event: dict[str, Any], source_url: str) -> FeedItem:
         title=title,
         url=item_url,
         content=content or None,
+        author=actor_login or None,
         published_at=published_at,
         raw=event,
         extra={"event_type": event_type, "actor": actor_login, "repo": repo_name},

--- a/src/distillery/feeds/github.py
+++ b/src/distillery/feeds/github.py
@@ -114,7 +114,10 @@ def _event_to_feed_item(event: dict[str, Any], source_url: str) -> FeedItem:
     repo_info: dict[str, Any] = event.get("repo") or {}
     repo_name: str = str(repo_info.get("name", ""))
     actor_info: dict[str, Any] = event.get("actor") or {}
-    actor_login: str = str(actor_info.get("login", ""))
+    # Preserve a real None when the login is missing or non-string, so we
+    # never persist the literal string "None" as an author (#302).
+    actor_login_raw = actor_info.get("login")
+    actor_login: str = actor_login_raw.strip() if isinstance(actor_login_raw, str) else ""
     payload: dict[str, Any] = event.get("payload") or {}
 
     # Build a human-readable title.

--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -366,8 +366,12 @@ class GitHubSyncAdapter:
         external_id = _make_external_id(self._owner, self._repo, ref_type, number)
         content = _build_content(title, body, comments)
 
-        # Extract real author from the issue/PR payload.
-        real_author: str = (issue.get("user") or {}).get("login") or self._author
+        # Extract real author from the issue/PR payload.  Treat null,
+        # empty, and whitespace-only logins as missing so we fall back
+        # to the configured sync-tool author instead of persisting junk.
+        user_login_raw = (issue.get("user") or {}).get("login")
+        user_login = user_login_raw.strip() if isinstance(user_login_raw, str) else ""
+        real_author: str = user_login or self._author
 
         # Build tags from labels using shared sanitiser.
         from distillery.feeds.tags import sanitise_label
@@ -509,11 +513,14 @@ class GitHubSyncAdapter:
             existing = await self._find_existing(external_id)
 
             if existing is not None:
-                # Update existing entry.
+                # Update existing entry.  Include ``author`` so re-syncs
+                # correct stale tool-authored entries with the real payload
+                # author (see issue #302).
                 await self._store.update(
                     existing.id,
                     {
                         "content": entry.content,
+                        "author": entry.author,
                         "metadata": entry.metadata,
                         "tags": entry.tags,
                     },
@@ -638,10 +645,13 @@ class GitHubSyncAdapter:
             existing = await self._find_existing(external_id)
 
             if existing is not None:
+                # Include ``author`` on update so re-syncs correct stale
+                # tool-authored entries with the real payload author (#302).
                 await self._store.update(
                     existing.id,
                     {
                         "content": entry.content,
+                        "author": entry.author,
                         "metadata": entry.metadata,
                         "tags": entry.tags,
                     },

--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -366,6 +366,9 @@ class GitHubSyncAdapter:
         external_id = _make_external_id(self._owner, self._repo, ref_type, number)
         content = _build_content(title, body, comments)
 
+        # Extract real author from the issue/PR payload.
+        real_author: str = (issue.get("user") or {}).get("login") or self._author
+
         # Build tags from labels using shared sanitiser.
         from distillery.feeds.tags import sanitise_label
 
@@ -381,13 +384,14 @@ class GitHubSyncAdapter:
             "labels": labels,
             "assignees": assignees,
             "external_id": external_id,
+            "imported_by": "gh-sync",
         }
 
         return Entry(
             content=content,
             entry_type=EntryType.GITHUB,
             source=EntrySource.IMPORT,
-            author=self._author,
+            author=real_author,
             project=self._project,
             tags=tags,
             status=EntryStatus.ACTIVE,

--- a/src/distillery/feeds/models.py
+++ b/src/distillery/feeds/models.py
@@ -29,6 +29,9 @@ class FeedItem:
         url: URL pointing directly to the item (article, event page, etc.).
         content: Full or summarised body text of the item.  May be ``None``
             when the source only provides a title/link.
+        author: The original content creator (e.g. GitHub username, RSS
+            author element).  ``None`` when the source does not provide
+            author information.
         published_at: Publication or event creation timestamp.  ``None`` if
             not provided by the source.
         raw: The original parsed object (dict for JSON sources, element for
@@ -44,6 +47,7 @@ class FeedItem:
     title: str | None = None
     url: str | None = None
     content: str | None = None
+    author: str | None = None
     published_at: datetime | None = None
     raw: Any = field(default=None, compare=False, repr=False)
     extra: dict[str, Any] = field(default_factory=dict)

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -401,7 +401,13 @@ def _item_to_entry_kwargs(
         tags = _derive_source_tags(item, item.source_type)
 
     # Use real author from source payload when available; fall back to tool name.
-    author = item.author or "distillery-poller"
+    # Treat None, empty, and whitespace-only authors as missing (#302).
+    raw_author = item.author
+    author = (
+        raw_author.strip()
+        if isinstance(raw_author, str) and raw_author.strip()
+        else "distillery-poller"
+    )
 
     return {
         "content": text or item.source_url,

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -386,6 +386,7 @@ def _item_to_entry_kwargs(
         "source_type": item.source_type,
         "external_id": item.item_id,
         "relevance_score": relevance_score,
+        "imported_by": "distillery-poller",
     }
     if item.title:
         metadata["title"] = item.title
@@ -399,11 +400,14 @@ def _item_to_entry_kwargs(
     else:
         tags = _derive_source_tags(item, item.source_type)
 
+    # Use real author from source payload when available; fall back to tool name.
+    author = item.author or "distillery-poller"
+
     return {
         "content": text or item.source_url,
         "entry_type": EntryType.FEED,
         "source": EntrySource.IMPORT,
-        "author": "distillery-poller",
+        "author": author,
         "tags": tags,
         "metadata": metadata,
     }

--- a/src/distillery/feeds/rss.py
+++ b/src/distillery/feeds/rss.py
@@ -29,6 +29,9 @@ logger = logging.getLogger(__name__)
 # Atom namespace URI.
 _ATOM_NS = "http://www.w3.org/2005/Atom"
 
+# Dublin Core namespace (used for <dc:creator> in RSS feeds).
+_DC_NS = "http://purl.org/dc/elements/1.1/"
+
 # Request timeout in seconds.
 _REQUEST_TIMEOUT = 30.0
 
@@ -189,6 +192,9 @@ def _parse_rss_item(item: Element, source_url: str) -> FeedItem:
     guid = _text(item, "guid")
     pub_date_raw = _text(item, "pubDate")
 
+    # Author: try <author>, then <dc:creator>.
+    author = _text(item, "author") or _text(item, "creator", _DC_NS)
+
     item_id = guid or _stable_id(source_url, f"{link or ''}{title or ''}")
     published_at = _parse_rfc822_date(pub_date_raw) if pub_date_raw else None
 
@@ -211,6 +217,7 @@ def _parse_rss_item(item: Element, source_url: str) -> FeedItem:
         title=title,
         url=link,
         content=description,
+        author=author,
         published_at=published_at,
         raw=item,
         extra=extra,
@@ -237,6 +244,12 @@ def _parse_atom_entry(entry: Element, source_url: str) -> FeedItem:
     atom_id = _text(entry, "id", ns)
     updated_raw = _text(entry, "updated", ns)
     published_raw = _text(entry, "published", ns)
+
+    # Atom <author><name>
+    author: str | None = None
+    author_el = entry.find(f"{{{ns}}}author")
+    if author_el is not None:
+        author = _text(author_el, "name", ns)
 
     # Atom <link rel="alternate"> or first <link>
     link: str | None = None
@@ -271,6 +284,7 @@ def _parse_atom_entry(entry: Element, source_url: str) -> FeedItem:
         title=title,
         url=link,
         content=content,
+        author=author,
         published_at=published_at,
         raw=entry,
     )

--- a/tests/test_real_author.py
+++ b/tests/test_real_author.py
@@ -127,6 +127,43 @@ class TestGitHubSyncRealAuthor:
         assert entries[0].author == "carol"
 
     @pytest.mark.integration
+    async def test_existing_entry_author_is_updated_from_payload(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        """Re-syncing an existing entry should correct a stale tool author."""
+        # First sync: payload has no user → entry gets the fallback author.
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[_mock_issue(number=1, user_login=None)],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues/1/comments.*"),
+            json=[],
+        )
+
+        adapter = GitHubSyncAdapter(store=store, url="test/repo")
+        await adapter.sync()
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        assert len(entries) == 1
+        assert entries[0].author == "gh-sync"
+
+        # Second sync: payload now includes a real user → existing entry
+        # should be updated with the real author.
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[_mock_issue(number=1, user_login="alice")],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues/1/comments.*"),
+            json=[],
+        )
+
+        await adapter.sync()
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        assert len(entries) == 1  # still one entry, not a duplicate
+        assert entries[0].author == "alice"
+
+    @pytest.mark.integration
     async def test_mixed_authors_in_batch(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]
         """Multiple issues with different authors should each get the correct author."""
         httpx_mock.add_response(

--- a/tests/test_real_author.py
+++ b/tests/test_real_author.py
@@ -1,0 +1,312 @@
+"""Tests for real author extraction from source payloads (issue #302).
+
+Covers:
+- GitHubSyncAdapter: extracts user.login from issue/PR payload
+- RSS poller: extracts author from RSS <author> / <dc:creator> and Atom <author><name>
+- Fallback behaviour when author is missing from payload
+- metadata.imported_by records the sync tool name
+"""
+
+from __future__ import annotations
+
+import re
+import textwrap
+
+import pytest
+
+from distillery.feeds.github_sync import GitHubSyncAdapter
+from distillery.feeds.models import FeedItem
+from distillery.feeds.poller import _item_to_entry_kwargs
+from distillery.feeds.rss import parse_feed_xml
+
+# ---------------------------------------------------------------------------
+# GitHub sync — author extraction
+# ---------------------------------------------------------------------------
+
+
+def _mock_issue(
+    number: int = 1,
+    title: str = "Test issue",
+    body: str | None = "Issue body",
+    user_login: str | None = "octocat",
+    is_pr: bool = False,
+) -> dict:
+    """Build a mock GitHub issue API response with configurable user."""
+    issue: dict = {
+        "number": number,
+        "title": title,
+        "body": body,
+        "state": "open",
+        "html_url": f"https://github.com/test/repo/issues/{number}",
+        "labels": [],
+        "assignees": [],
+    }
+    if user_login is not None:
+        issue["user"] = {"login": user_login}
+    else:
+        issue["user"] = None
+    if is_pr:
+        issue["pull_request"] = {"url": f"https://api.github.com/repos/test/repo/pulls/{number}"}
+    return issue
+
+
+class TestGitHubSyncRealAuthor:
+    """GitHubSyncAdapter should use user.login from the issue payload."""
+
+    @pytest.mark.integration
+    async def test_entry_author_is_github_user(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        """Entry author should be the GitHub user who created the issue."""
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[_mock_issue(number=1, user_login="alice")],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues/1/comments.*"),
+            json=[],
+        )
+
+        adapter = GitHubSyncAdapter(store=store, url="test/repo")
+        await adapter.sync()
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        assert len(entries) == 1
+        assert entries[0].author == "alice"
+
+    @pytest.mark.integration
+    async def test_imported_by_metadata(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        """metadata.imported_by should record 'gh-sync'."""
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[_mock_issue(number=1, user_login="bob")],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues/1/comments.*"),
+            json=[],
+        )
+
+        adapter = GitHubSyncAdapter(store=store, url="test/repo")
+        await adapter.sync()
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        assert entries[0].metadata["imported_by"] == "gh-sync"
+
+    @pytest.mark.integration
+    async def test_fallback_when_user_missing(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        """When user is null in payload, author should fall back to adapter default."""
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[_mock_issue(number=1, user_login=None)],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues/1/comments.*"),
+            json=[],
+        )
+
+        adapter = GitHubSyncAdapter(store=store, url="test/repo")
+        await adapter.sync()
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        assert entries[0].author == "gh-sync"
+
+    @pytest.mark.integration
+    async def test_pr_author_extracted(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        """PR entries should also use user.login as author."""
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[_mock_issue(number=5, user_login="carol", is_pr=True)],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues/5/comments.*"),
+            json=[],
+        )
+
+        adapter = GitHubSyncAdapter(store=store, url="test/repo")
+        await adapter.sync()
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        assert entries[0].author == "carol"
+
+    @pytest.mark.integration
+    async def test_mixed_authors_in_batch(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]
+        """Multiple issues with different authors should each get the correct author."""
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[
+                _mock_issue(number=1, user_login="alice"),
+                _mock_issue(number=2, user_login="bob"),
+                _mock_issue(number=3, user_login=None),
+            ],
+        )
+        for n in (1, 2, 3):
+            httpx_mock.add_response(
+                url=re.compile(rf".*/repos/test/repo/issues/{n}/comments.*"),
+                json=[],
+            )
+
+        adapter = GitHubSyncAdapter(store=store, url="test/repo")
+        await adapter.sync()
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        authors = {e.metadata["ref_number"]: e.author for e in entries}
+        assert authors[1] == "alice"
+        assert authors[2] == "bob"
+        assert authors[3] == "gh-sync"  # fallback
+
+
+# ---------------------------------------------------------------------------
+# RSS / Atom — author extraction
+# ---------------------------------------------------------------------------
+
+
+_RSS_WITH_AUTHOR_XML = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0">
+      <channel>
+        <item>
+          <title>Post with author</title>
+          <link>https://example.com/1</link>
+          <author>jane@example.com (Jane Doe)</author>
+          <guid>guid-1</guid>
+        </item>
+        <item>
+          <title>Post without author</title>
+          <link>https://example.com/2</link>
+          <guid>guid-2</guid>
+        </item>
+      </channel>
+    </rss>
+""").encode()
+
+
+_RSS_WITH_DC_CREATOR_XML = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+      <channel>
+        <item>
+          <title>Post with dc:creator</title>
+          <link>https://example.com/1</link>
+          <dc:creator>John Smith</dc:creator>
+          <guid>guid-dc-1</guid>
+        </item>
+      </channel>
+    </rss>
+""").encode()
+
+
+_ATOM_WITH_AUTHOR_XML = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <title>Atom Feed</title>
+      <id>https://example.com/atom</id>
+      <entry>
+        <id>entry-1</id>
+        <title>Entry with author</title>
+        <link rel="alternate" href="https://example.com/entry/1"/>
+        <author><name>Alice Author</name></author>
+        <summary>Summary</summary>
+      </entry>
+      <entry>
+        <id>entry-2</id>
+        <title>Entry without author</title>
+        <link rel="alternate" href="https://example.com/entry/2"/>
+        <summary>Another summary</summary>
+      </entry>
+    </feed>
+""").encode()
+
+
+class TestRSSAuthorExtraction:
+    """RSS parser should extract author from <author> and <dc:creator>."""
+
+    _SOURCE_URL = "https://example.com/feed"
+
+    @pytest.mark.unit
+    def test_rss_author_present(self) -> None:
+        items = parse_feed_xml(_RSS_WITH_AUTHOR_XML, self._SOURCE_URL)
+        assert items[0].author == "jane@example.com (Jane Doe)"
+
+    @pytest.mark.unit
+    def test_rss_author_missing(self) -> None:
+        items = parse_feed_xml(_RSS_WITH_AUTHOR_XML, self._SOURCE_URL)
+        assert items[1].author is None
+
+    @pytest.mark.unit
+    def test_rss_dc_creator(self) -> None:
+        items = parse_feed_xml(_RSS_WITH_DC_CREATOR_XML, self._SOURCE_URL)
+        assert items[0].author == "John Smith"
+
+
+class TestAtomAuthorExtraction:
+    """Atom parser should extract author from <author><name>."""
+
+    _SOURCE_URL = "https://example.com/atom"
+
+    @pytest.mark.unit
+    def test_atom_author_present(self) -> None:
+        items = parse_feed_xml(_ATOM_WITH_AUTHOR_XML, self._SOURCE_URL)
+        assert items[0].author == "Alice Author"
+
+    @pytest.mark.unit
+    def test_atom_author_missing(self) -> None:
+        items = parse_feed_xml(_ATOM_WITH_AUTHOR_XML, self._SOURCE_URL)
+        assert items[1].author is None
+
+
+# ---------------------------------------------------------------------------
+# Poller — _item_to_entry_kwargs author handling
+# ---------------------------------------------------------------------------
+
+
+class TestPollerAuthorHandling:
+    """_item_to_entry_kwargs should use item.author when available."""
+
+    @pytest.mark.unit
+    def test_author_from_feed_item(self) -> None:
+        item = FeedItem(
+            source_url="https://example.com/feed",
+            source_type="rss",
+            item_id="test-1",
+            title="Test",
+            content="Content",
+            author="feed-author",
+        )
+        kwargs = _item_to_entry_kwargs(item, 0.8)
+        assert kwargs["author"] == "feed-author"
+
+    @pytest.mark.unit
+    def test_fallback_to_distillery_poller(self) -> None:
+        item = FeedItem(
+            source_url="https://example.com/feed",
+            source_type="rss",
+            item_id="test-2",
+            title="Test",
+            content="Content",
+        )
+        kwargs = _item_to_entry_kwargs(item, 0.8)
+        assert kwargs["author"] == "distillery-poller"
+
+    @pytest.mark.unit
+    def test_imported_by_in_metadata(self) -> None:
+        item = FeedItem(
+            source_url="https://example.com/feed",
+            source_type="rss",
+            item_id="test-3",
+            title="Test",
+            content="Content",
+            author="someone",
+        )
+        kwargs = _item_to_entry_kwargs(item, 0.8)
+        assert kwargs["metadata"]["imported_by"] == "distillery-poller"
+
+    @pytest.mark.unit
+    def test_empty_string_author_falls_back(self) -> None:
+        item = FeedItem(
+            source_url="https://example.com/feed",
+            source_type="rss",
+            item_id="test-4",
+            title="Test",
+            content="Content",
+            author="",
+        )
+        kwargs = _item_to_entry_kwargs(item, 0.8)
+        assert kwargs["author"] == "distillery-poller"


### PR DESCRIPTION
## Summary

- **GitHubSyncAdapter** now reads `user.login` from the issue/PR payload and sets it as the entry `author` instead of `"gh-sync"`
- **RSS/Atom parsers** extract author from `<author>`, `<dc:creator>` (RSS), and `<author><name>` (Atom) elements, populating the new `FeedItem.author` field
- **Feed poller** uses `item.author` when available; falls back to `"distillery-poller"` when absent
- **`metadata.imported_by`** records the sync tool name (`"gh-sync"` or `"distillery-poller"`) for provenance tracking
- **GitHub events adapter** also populates `FeedItem.author` from the event actor login

Closes #302

## Test plan

- [x] 14 new tests in `tests/test_real_author.py` covering:
  - Author present in GitHub payload (issue and PR)
  - Author missing from payload (fallback to tool name)
  - Mixed authors in a batch sync
  - `metadata.imported_by` set correctly
  - RSS `<author>` extraction
  - RSS `<dc:creator>` extraction
  - Atom `<author><name>` extraction
  - Author missing from RSS/Atom (returns None)
  - Poller uses `item.author` when present
  - Poller falls back for empty/missing author
  - `imported_by` in poller metadata
- [x] All 220 feed-related tests pass with no regressions
- [x] `mypy --strict` passes on all 60 source files
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented author attribution by extracting creator information from GitHub issues/pull requests and RSS/Atom feeds.
  * Added import source tracking in metadata to identify data ingestion paths.

* **Bug Fixes**
  * Improved handling of missing or invalid author data to prevent invalid string values.

* **Tests**
  * Added comprehensive test suite validating author extraction across all ingestion paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->