### PR TITLE
fix(mcp): add feed_url filter to distillery_list (#309)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -552,6 +552,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         stale_days: int | None = None,
         group_by: str | None = None,
         output: str | None = None,
+        feed_url: str | None = None,
     ) -> list[types.TextContent]:
         """List knowledge entries with optional filters and pagination (newest first).
 
@@ -584,6 +585,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             Mutually exclusive with output="stats".
           - output (str, optional): Set to "stats" for aggregate statistics.
             Mutually exclusive with group_by.
+          - feed_url (str, optional): Filter to entries ingested from a registered feed
+            source URL (matches metadata.source_url written by the poller). Use this to
+            retrieve all items polled from e.g. "https://hnrss.org/frontpage".
 
         RETURNS (success): { entries: list, count: int, total_count: int, limit: int, offset: int }
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
@@ -612,6 +616,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 stale_days=stale_days,
                 group_by=group_by,
                 output=output,
+                feed_url=feed_url,
             ),
         )
         return await _handle_list(store=c["store"], arguments=args)

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -1080,7 +1080,13 @@ def _build_filters_from_arguments(arguments: dict[str, Any]) -> dict[str, Any] |
     """Extract known filter keys from *arguments* into a filters dict.
 
     Keys extracted: ``entry_type``, ``author``, ``project``, ``tags``,
-    ``status``, ``verification``, ``source``, ``date_from``, ``date_to``.
+    ``status``, ``verification``, ``source``, ``date_from``, ``date_to``,
+    ``tag_prefix``, ``session_id``, ``feed_url``.
+
+    The ``feed_url`` key is translated to a ``metadata.source_url`` filter so
+    callers can retrieve entries ingested from a registered feed source
+    (poller writes ``metadata.source_url`` to match the registry URL, while
+    the entry's ``source`` column is set to ``import``).
 
     Args:
         arguments: The tool argument dict.
@@ -1105,6 +1111,12 @@ def _build_filters_from_arguments(arguments: dict[str, Any]) -> dict[str, Any] |
     for key in filter_keys:
         if key in arguments and arguments[key] is not None:
             filters[key] = arguments[key]
+
+    # Translate feed_url → metadata.source_url (the field poller records).
+    feed_url = arguments.get("feed_url")
+    if feed_url is not None:
+        filters["metadata.source_url"] = feed_url
+
     return filters if filters else None
 
 

--- a/tests/test_list_output_modes.py
+++ b/tests/test_list_output_modes.py
@@ -315,3 +315,93 @@ class TestAggregate:
         by_author = {g["value"]: g["count"] for g in data["groups"]}
         assert by_author.get("alice") == 3
         assert by_author.get("bob") == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: feed_url filter (issue #309)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestListFeedUrlFilter:
+    """Verify distillery_list(feed_url=...) matches metadata.source_url.
+
+    Regression test for issue #309: the feed poller persists each ingested
+    item with ``metadata.source_url == <registry url>`` but leaves
+    ``Entry.source == "import"``.  Callers filtering by ``source=<url>``
+    therefore got zero results even when hundreds of items had been polled
+    from that feed.  The new ``feed_url`` parameter translates to a
+    ``metadata.source_url`` filter so callers can retrieve every ingested
+    item for a registered feed.
+    """
+
+    async def test_feed_url_filters_to_matching_entries(self, populated_store) -> None:
+        result = await _handle_list(
+            store=populated_store,
+            arguments={
+                "limit": 10,
+                "feed_url": "https://github.com/org/repo",
+            },
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error"), data
+        assert data["count"] == 2
+        assert data["total_count"] == 2
+        for entry in data["entries"]:
+            assert entry["metadata"]["source_url"] == "https://github.com/org/repo"
+
+    async def test_feed_url_different_url_returns_only_that_feed(self, populated_store) -> None:
+        result = await _handle_list(
+            store=populated_store,
+            arguments={
+                "limit": 10,
+                "feed_url": "https://example.com/rss",
+            },
+        )
+        data = parse_mcp_response(result)
+        assert data["count"] == 1
+        assert data["total_count"] == 1
+        assert data["entries"][0]["metadata"]["source_url"] == "https://example.com/rss"
+
+    async def test_feed_url_no_match_returns_empty(self, populated_store) -> None:
+        result = await _handle_list(
+            store=populated_store,
+            arguments={
+                "limit": 10,
+                "feed_url": "https://nowhere.example.com/feed",
+            },
+        )
+        data = parse_mcp_response(result)
+        assert data["count"] == 0
+        assert data["total_count"] == 0
+        assert data["entries"] == []
+
+    async def test_feed_url_combines_with_entry_type(self, populated_store) -> None:
+        # feed_url must be AND-combined with other filters, not replace them.
+        result = await _handle_list(
+            store=populated_store,
+            arguments={
+                "limit": 10,
+                "feed_url": "https://github.com/org/repo",
+                "entry_type": "feed",
+            },
+        )
+        data = parse_mcp_response(result)
+        assert data["count"] == 2
+        for entry in data["entries"]:
+            assert entry["entry_type"] == "feed"
+            assert entry["metadata"]["source_url"] == "https://github.com/org/repo"
+
+    async def test_source_filter_unchanged_semantics(self, populated_store) -> None:
+        # Regression guard: source=<url> must NOT magically match feed items.
+        # It still filters by EntrySource column (claude-code, manual, import, …).
+        result = await _handle_list(
+            store=populated_store,
+            arguments={
+                "limit": 10,
+                "source": "https://github.com/org/repo",
+            },
+        )
+        data = parse_mcp_response(result)
+        # No entry's `source` column equals this URL, so the count is 0.
+        assert data["count"] == 0


### PR DESCRIPTION
## Summary
- Fixes #309 — `distillery_list(source=<feed url>)` returned 0 entries because the poller persists ingested items with `Entry.source == "import"` and writes the feed URL to `metadata.source_url`, not to the `source` column.
- Adds a new `feed_url: str | None` parameter to the `distillery_list` MCP tool that translates to the already-supported `metadata.source_url` filter on `DuckDBStore.list_entries`.
- No change to `source` semantics — callers filtering by `source="import"` still get all imported entries, and the new filter can be AND-combined with `entry_type="feed"`, `date_from`, etc.

## Why this shape
- The ingest path already writes `metadata["source_url"] = item.source_url` where `item.source_url == <registry url>` (see `src/distillery/feeds/poller.py::_item_to_entry_kwargs`). No migration/backfill is required for existing entries.
- Silently redefining the `source` filter to match `metadata.source_url` would be a breaking change for any caller that filters by `EntrySource` values like `claude-code` / `manual` / `import`.
- `DuckDBStore._build_filter_clauses` already supports `metadata.*` path filters (with an allowlisted character set) and is used by the poller's own `_has_external_id` fast dedup. We are reusing that machinery.

## Test plan
- [x] `ruff check src/ tests/`
- [x] `ruff format src/ tests/`
- [x] `mypy --strict src/distillery/`
- [x] `pytest tests/test_list_output_modes.py -q -x -m unit` (18 passed)
- [x] `pytest tests/test_poller.py tests/test_watch.py tests/test_mcp_server.py -q -x -m unit` (74 passed)
- [ ] Manual staging validation: `distillery_list(feed_url="https://hnrss.org/frontpage", limit=5)` should now return ingested items.

## Backfill note
No backfill is required — every entry ingested by the poller since day one has `metadata.source_url` recorded. Confirming on staging with `distillery_aggregate(group_by="metadata.source_url", entry_type="feed", limit=50)` is the quickest way to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering capability by feed source URL, allowing users to retrieve entries based on which registered feed they were ingested from.

* **Tests**
  * Added test coverage for the new feed URL filtering feature to ensure accurate filtering across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->