### PR TITLE
fix(mcp): flip status to active on resolve_review reclassify (#316)

### DIFF
--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -172,8 +172,9 @@ async def _handle_resolve_review(
 
     * **approve**: sets ``status=active`` and records ``reviewed_at`` /
       ``reviewed_by`` in metadata.
-    * **reclassify**: updates ``entry_type`` and sets ``reclassified_from`` in
-      metadata.  Requires ``new_entry_type``.
+    * **reclassify**: updates ``entry_type``, sets ``status=active`` (a
+      reclassification implies approval), and records ``reclassified_from``
+      in metadata.  Requires ``new_entry_type``.
     * **archive**: soft-deletes the entry by setting ``status=archived``.
 
     Args:
@@ -246,6 +247,8 @@ async def _handle_resolve_review(
         if reviewer:
             new_metadata["reviewed_by"] = reviewer
         updates["entry_type"] = EntryType(new_type_str)
+        # Reclassification implies approval: flip status out of pending_review.
+        updates["status"] = EntryStatus.ACTIVE
         updates["metadata"] = new_metadata
 
     elif action == "archive":

--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -172,9 +172,10 @@ async def _handle_resolve_review(
 
     * **approve**: sets ``status=active`` and records ``reviewed_at`` /
       ``reviewed_by`` in metadata.
-    * **reclassify**: updates ``entry_type``, sets ``status=active`` (a
-      reclassification implies approval), and records ``reclassified_from``
-      in metadata.  Requires ``new_entry_type``.
+    * **reclassify**: updates ``entry_type`` and records ``reclassified_from``
+      in metadata.  Requires ``new_entry_type``.  Only promotes status to
+      ``active`` when the entry is currently ``pending_review`` — archived and
+      already-active entries keep their existing status.
     * **archive**: soft-deletes the entry by setting ``status=archived``.
 
     Args:
@@ -248,7 +249,10 @@ async def _handle_resolve_review(
             new_metadata["reviewed_by"] = reviewer
         updates["entry_type"] = EntryType(new_type_str)
         # Reclassification implies approval: flip status out of pending_review.
-        updates["status"] = EntryStatus.ACTIVE
+        # Only promote to active if the entry is currently pending_review to
+        # avoid accidentally reactivating archived or already-active entries.
+        if entry.status == EntryStatus.PENDING_REVIEW:
+            updates["status"] = EntryStatus.ACTIVE
         updates["metadata"] = new_metadata
 
     elif action == "archive":

--- a/tests/test_mcp_classify.py
+++ b/tests/test_mcp_classify.py
@@ -524,6 +524,48 @@ class TestResolveReviewTool:
         assert data["status"] == "active"
         assert "reviewed_by" not in data["metadata"]
 
+    async def test_resolve_reclassify_does_not_reactivate_archived_entry(
+        self, store: DuckDBStore
+    ) -> None:
+        """Reclassify must not flip an archived entry back to active."""
+        entry = make_entry(entry_type=EntryType.INBOX, status=EntryStatus.ARCHIVED)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "meeting",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert "error" not in data
+        # entry_type should be updated
+        assert data["entry_type"] == "meeting"
+        # status must stay archived, not flipped to active
+        assert data["status"] == "archived"
+
+    async def test_resolve_reclassify_does_not_reactivate_already_active_entry(
+        self, store: DuckDBStore
+    ) -> None:
+        """Reclassify must not disturb the status of an already-active entry."""
+        entry = make_entry(entry_type=EntryType.INBOX, status=EntryStatus.ACTIVE)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "reference",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert "error" not in data
+        assert data["entry_type"] == "reference"
+        assert data["status"] == "active"
+
 
 # ---------------------------------------------------------------------------
 # End-to-end classification flow

--- a/tests/test_mcp_classify.py
+++ b/tests/test_mcp_classify.py
@@ -416,6 +416,49 @@ class TestResolveReviewTool:
         assert data["metadata"]["reviewed_at"]
         assert data["metadata"]["reviewed_by"] == "alice"
 
+    async def test_resolve_reclassify_sets_status_active(self, store: DuckDBStore) -> None:
+        """Regression test for #316 -- reclassify must flip status out of pending_review."""
+        entry = make_entry(entry_type=EntryType.INBOX, status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "meeting",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert "error" not in data
+        assert data["status"] == "active"
+        assert data["entry_type"] == "meeting"
+        assert data["metadata"]["reclassified_from"] == "inbox"
+
+    async def test_resolve_reclassify_removes_from_review_queue(self, store: DuckDBStore) -> None:
+        """Reclassified entries must not linger in the pending-review queue (#316)."""
+        entry = make_entry(entry_type=EntryType.INBOX, status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        # Sanity check: entry is initially visible in the review queue.
+        queue_before = parse_mcp_response(await _handle_list(store, {"output_mode": "review"}))
+        assert entry_id in [e["id"] for e in queue_before["entries"]]
+
+        resolve_response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "meeting",
+            },
+        )
+        resolve_data = parse_mcp_response(resolve_response)
+        assert "error" not in resolve_data
+        assert resolve_data["status"] == "active"
+
+        queue_after = parse_mcp_response(await _handle_list(store, {"output_mode": "review"}))
+        assert entry_id not in [e["id"] for e in queue_after["entries"]]
+
     async def test_resolve_reclassify_requires_new_entry_type(self, store: DuckDBStore) -> None:
         entry = make_entry(status=EntryStatus.PENDING_REVIEW)
         entry_id = await store.store(entry)


### PR DESCRIPTION
## Summary
- `distillery_resolve_review(action="reclassify")` now sets `status=active` in addition to updating `entry_type` and recording `reclassified_from`.
- Previously entries were stuck at `status=pending_review` after a reclassify and continued to surface in `distillery_list(output_mode="review")`.
- `approve` / `archive` behavior is unchanged.

Fixes #316.

## Test plan
- [x] `ruff check src/ tests/` + `ruff format --check`
- [x] `mypy --strict src/distillery/`
- [x] `pytest tests/test_mcp_classify.py` (30 passed, incl. 2 new regression tests)
- [x] New test: reclassify sets `status=active` and preserves `reclassified_from`
- [x] New test: reclassified entry no longer appears in `output_mode="review"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified reclassification: reclassifying sets status to active only for entries in pending review; archived or already-active entries keep their status while their type and metadata are updated.

* **Tests**
  * Added regression tests to verify reclassification behavior and ensure queue membership updates correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->