### PR TITLE
fix(mcp): honor reviewer param in resolve_review with actor tracking (#315)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -812,9 +812,13 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         args: dict[str, Any] = dict(
             entry_id=entry_id, action=action, **_omit_none(new_entry_type=new_entry_type)
         )
-        eff_reviewer = user or reviewer
-        if eff_reviewer is not None:
-            args["reviewer"] = eff_reviewer
+        # Pass actor (server identity) and reviewer (client-supplied) as
+        # distinct fields so the handler can record both ``reviewed_by`` and
+        # ``on_behalf_of`` when they differ (issue #315).
+        if user:
+            args["actor"] = user
+        if reviewer is not None:
+            args["reviewer"] = reviewer
         result = await _handle_resolve_review(store=c["store"], arguments=args)
         await _audit(c, user, "distillery_resolve_review", entry_id, action, result)
         return result

--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -257,6 +257,11 @@ async def _handle_resolve_review(
             new_metadata["reviewed_by"] = performed_by
         if on_behalf_of:
             new_metadata["on_behalf_of"] = on_behalf_of
+        else:
+            # Clear any stale delegation keys from a previous delegated action.
+            new_metadata.pop("on_behalf_of", None)
+            new_metadata.pop("reclassified_on_behalf_of", None)
+            new_metadata.pop("archived_on_behalf_of", None)
         updates["metadata"] = new_metadata
 
     elif action == "reclassify":
@@ -283,6 +288,11 @@ async def _handle_resolve_review(
         if on_behalf_of:
             new_metadata["on_behalf_of"] = on_behalf_of
             new_metadata["reclassified_on_behalf_of"] = on_behalf_of
+        else:
+            # Clear any stale delegation keys from a previous delegated action.
+            new_metadata.pop("on_behalf_of", None)
+            new_metadata.pop("reclassified_on_behalf_of", None)
+            new_metadata.pop("archived_on_behalf_of", None)
         updates["entry_type"] = EntryType(new_type_str)
         # Reclassification implies approval: flip status out of pending_review.
         # Only promote to active if the entry is currently pending_review to
@@ -298,6 +308,11 @@ async def _handle_resolve_review(
             new_metadata["archived_by"] = performed_by
         if on_behalf_of:
             new_metadata["archived_on_behalf_of"] = on_behalf_of
+        else:
+            # Clear any stale delegation keys from a previous delegated action.
+            new_metadata.pop("on_behalf_of", None)
+            new_metadata.pop("reclassified_on_behalf_of", None)
+            new_metadata.pop("archived_on_behalf_of", None)
         updates["metadata"] = new_metadata
 
     # --- persist ------------------------------------------------------------

--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -250,18 +250,23 @@ async def _handle_resolve_review(
 
     updates: dict[str, Any] = {}
 
+    def _clear_stale_delegation_keys(metadata: dict[str, Any]) -> None:
+        """Remove any *_on_behalf_of keys left over from a previous delegated action."""
+        stale = [k for k in metadata if k.endswith("_on_behalf_of") or k == "on_behalf_of"]
+        for k in stale:
+            metadata.pop(k)
+
     if action == "approve":
         updates["status"] = EntryStatus.ACTIVE
         new_metadata["reviewed_at"] = now
         if performed_by:
             new_metadata["reviewed_by"] = performed_by
+        else:
+            new_metadata.pop("reviewed_by", None)
         if on_behalf_of:
             new_metadata["on_behalf_of"] = on_behalf_of
         else:
-            # Clear any stale delegation keys from a previous delegated action.
-            new_metadata.pop("on_behalf_of", None)
-            new_metadata.pop("reclassified_on_behalf_of", None)
-            new_metadata.pop("archived_on_behalf_of", None)
+            _clear_stale_delegation_keys(new_metadata)
         updates["metadata"] = new_metadata
 
     elif action == "reclassify":
@@ -285,14 +290,14 @@ async def _handle_resolve_review(
             # terminology consistent with ``archived_by``.
             new_metadata["reviewed_by"] = performed_by
             new_metadata["reclassified_by"] = performed_by
+        else:
+            new_metadata.pop("reviewed_by", None)
+            new_metadata.pop("reclassified_by", None)
         if on_behalf_of:
             new_metadata["on_behalf_of"] = on_behalf_of
             new_metadata["reclassified_on_behalf_of"] = on_behalf_of
         else:
-            # Clear any stale delegation keys from a previous delegated action.
-            new_metadata.pop("on_behalf_of", None)
-            new_metadata.pop("reclassified_on_behalf_of", None)
-            new_metadata.pop("archived_on_behalf_of", None)
+            _clear_stale_delegation_keys(new_metadata)
         updates["entry_type"] = EntryType(new_type_str)
         # Reclassification implies approval: flip status out of pending_review.
         # Only promote to active if the entry is currently pending_review to
@@ -306,13 +311,12 @@ async def _handle_resolve_review(
         new_metadata["archived_at"] = now
         if performed_by:
             new_metadata["archived_by"] = performed_by
+        else:
+            new_metadata.pop("archived_by", None)
         if on_behalf_of:
             new_metadata["archived_on_behalf_of"] = on_behalf_of
         else:
-            # Clear any stale delegation keys from a previous delegated action.
-            new_metadata.pop("on_behalf_of", None)
-            new_metadata.pop("reclassified_on_behalf_of", None)
-            new_metadata.pop("archived_on_behalf_of", None)
+            _clear_stale_delegation_keys(new_metadata)
         updates["metadata"] = new_metadata
 
     # --- persist ------------------------------------------------------------

--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -178,9 +178,19 @@ async def _handle_resolve_review(
       already-active entries keep their existing status.
     * **archive**: soft-deletes the entry by setting ``status=archived``.
 
+    Actor tracking (see issue #315):
+      * ``actor`` (server-supplied OAuth / git identity) is recorded as the
+        canonical *_by field (``reviewed_by`` / ``reclassified_by`` /
+        ``archived_by``).
+      * ``reviewer`` (client-supplied override) is recorded as the
+        corresponding ``*_on_behalf_of`` field *when it differs* from the
+        actor.  If only ``reviewer`` is supplied (no actor), it becomes the
+        *_by field for backward compatibility.
+
     Args:
         store: Initialised ``DuckDBStore``.
-        arguments: Raw MCP tool arguments dict.
+        arguments: Raw MCP tool arguments dict.  Recognised keys include
+            ``actor`` (server identity) and ``reviewer`` (on-behalf-of).
 
     Returns:
         MCP content list with the serialised updated entry or an error.
@@ -216,9 +226,26 @@ async def _handle_resolve_review(
             details={"entry_id": entry_id},
         )
 
+    # --- resolve actor vs reviewer -----------------------------------------
+    # ``actor`` is the authenticated server identity (OAuth/git); ``reviewer``
+    # is the client-supplied override.  Normalise "" / falsy to None so that
+    # empty OAuth identities don't stomp on a provided reviewer.
+    raw_actor = arguments.get("actor")
+    actor: str | None = raw_actor if isinstance(raw_actor, str) and raw_actor else None
+    raw_reviewer = arguments.get("reviewer")
+    reviewer: str | None = raw_reviewer if isinstance(raw_reviewer, str) and raw_reviewer else None
+
+    # Canonical "who did this" — actor wins; fall back to reviewer if no actor
+    # is present (stdio transport, no OAuth).
+    performed_by: str | None = actor or reviewer
+    # On-behalf-of is only meaningful when there's an actor *and* a distinct
+    # reviewer.  Without an actor, the reviewer is the actor (no delegation).
+    on_behalf_of: str | None = (
+        reviewer if (actor is not None and reviewer is not None and reviewer != actor) else None
+    )
+
     # --- build updates per action -------------------------------------------
     now = datetime.now(tz=UTC).isoformat()
-    reviewer: str | None = arguments.get("reviewer")
     new_metadata: dict[str, Any] = dict(entry.metadata)
 
     updates: dict[str, Any] = {}
@@ -226,8 +253,10 @@ async def _handle_resolve_review(
     if action == "approve":
         updates["status"] = EntryStatus.ACTIVE
         new_metadata["reviewed_at"] = now
-        if reviewer:
-            new_metadata["reviewed_by"] = reviewer
+        if performed_by:
+            new_metadata["reviewed_by"] = performed_by
+        if on_behalf_of:
+            new_metadata["on_behalf_of"] = on_behalf_of
         updates["metadata"] = new_metadata
 
     elif action == "reclassify":
@@ -245,8 +274,15 @@ async def _handle_resolve_review(
             )
         new_metadata["reclassified_from"] = entry.entry_type.value
         new_metadata["reviewed_at"] = now
-        if reviewer:
-            new_metadata["reviewed_by"] = reviewer
+        if performed_by:
+            # Keep ``reviewed_by`` for backward compatibility with existing
+            # consumers; also record the explicit ``reclassified_by`` to keep
+            # terminology consistent with ``archived_by``.
+            new_metadata["reviewed_by"] = performed_by
+            new_metadata["reclassified_by"] = performed_by
+        if on_behalf_of:
+            new_metadata["on_behalf_of"] = on_behalf_of
+            new_metadata["reclassified_on_behalf_of"] = on_behalf_of
         updates["entry_type"] = EntryType(new_type_str)
         # Reclassification implies approval: flip status out of pending_review.
         # Only promote to active if the entry is currently pending_review to
@@ -258,8 +294,10 @@ async def _handle_resolve_review(
     elif action == "archive":
         updates["status"] = EntryStatus.ARCHIVED
         new_metadata["archived_at"] = now
-        if reviewer:
-            new_metadata["archived_by"] = reviewer
+        if performed_by:
+            new_metadata["archived_by"] = performed_by
+        if on_behalf_of:
+            new_metadata["archived_on_behalf_of"] = on_behalf_of
         updates["metadata"] = new_metadata
 
     # --- persist ------------------------------------------------------------

--- a/tests/test_mcp_classify.py
+++ b/tests/test_mcp_classify.py
@@ -523,6 +523,182 @@ class TestResolveReviewTool:
         assert "error" not in data
         assert data["status"] == "active"
         assert "reviewed_by" not in data["metadata"]
+        assert "on_behalf_of" not in data["metadata"]
+
+    # ------------------------------------------------------------------
+    # Issue #315: actor + on-behalf-of tracking
+    # ------------------------------------------------------------------
+
+    async def test_resolve_approve_records_reviewer_on_behalf_of_actor(
+        self, store: DuckDBStore
+    ) -> None:
+        """When actor and reviewer differ, record both (issue #315)."""
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "approve",
+                "actor": "server-identity",
+                "reviewer": "uxtest-a4",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert "error" not in data
+        assert data["metadata"]["reviewed_by"] == "server-identity"
+        assert data["metadata"]["on_behalf_of"] == "uxtest-a4"
+
+    async def test_resolve_approve_actor_only_no_on_behalf_of(self, store: DuckDBStore) -> None:
+        """Actor alone populates reviewed_by; on_behalf_of is not written."""
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "approve",
+                "actor": "server-identity",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["metadata"]["reviewed_by"] == "server-identity"
+        assert "on_behalf_of" not in data["metadata"]
+
+    async def test_resolve_approve_actor_equals_reviewer_no_on_behalf_of(
+        self, store: DuckDBStore
+    ) -> None:
+        """When reviewer == actor, skip on_behalf_of (no self-delegation)."""
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "approve",
+                "actor": "alice",
+                "reviewer": "alice",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["metadata"]["reviewed_by"] == "alice"
+        assert "on_behalf_of" not in data["metadata"]
+
+    async def test_resolve_approve_reviewer_only_falls_back_to_reviewed_by(
+        self, store: DuckDBStore
+    ) -> None:
+        """No actor (stdio transport): reviewer populates reviewed_by directly."""
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {"entry_id": entry_id, "action": "approve", "reviewer": "uxtest-a4"},
+        )
+        data = parse_mcp_response(response)
+        assert data["metadata"]["reviewed_by"] == "uxtest-a4"
+        assert "on_behalf_of" not in data["metadata"]
+
+    async def test_resolve_archive_records_actor_and_on_behalf_of(self, store: DuckDBStore) -> None:
+        """Archive action honours both actor and reviewer (issue #315)."""
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "archive",
+                "actor": "server-identity",
+                "reviewer": "uxtest-a4",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["status"] == "archived"
+        assert data["metadata"]["archived_by"] == "server-identity"
+        assert data["metadata"]["archived_on_behalf_of"] == "uxtest-a4"
+
+    async def test_resolve_archive_without_reviewer(self, store: DuckDBStore) -> None:
+        """Archive with actor only: no archived_on_behalf_of written."""
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "archive",
+                "actor": "server-identity",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["metadata"]["archived_by"] == "server-identity"
+        assert "archived_on_behalf_of" not in data["metadata"]
+
+    async def test_resolve_reclassify_records_actor_and_on_behalf_of(
+        self, store: DuckDBStore
+    ) -> None:
+        """Reclassify honours actor + reviewer with reclassified_* fields."""
+        entry = make_entry(entry_type=EntryType.INBOX, status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "meeting",
+                "actor": "server-identity",
+                "reviewer": "uxtest-a4",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["entry_type"] == "meeting"
+        assert data["metadata"]["reviewed_by"] == "server-identity"
+        assert data["metadata"]["reclassified_by"] == "server-identity"
+        assert data["metadata"]["on_behalf_of"] == "uxtest-a4"
+        assert data["metadata"]["reclassified_on_behalf_of"] == "uxtest-a4"
+
+    async def test_resolve_reclassify_without_reviewer(self, store: DuckDBStore) -> None:
+        """Reclassify with actor only: no on_behalf_of fields."""
+        entry = make_entry(entry_type=EntryType.INBOX, status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "meeting",
+                "actor": "server-identity",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["metadata"]["reviewed_by"] == "server-identity"
+        assert data["metadata"]["reclassified_by"] == "server-identity"
+        assert "on_behalf_of" not in data["metadata"]
+        assert "reclassified_on_behalf_of" not in data["metadata"]
+
+    async def test_resolve_approve_ignores_empty_reviewer(self, store: DuckDBStore) -> None:
+        """Empty-string reviewer is treated as absent (no on_behalf_of)."""
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "approve",
+                "actor": "server-identity",
+                "reviewer": "",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["metadata"]["reviewed_by"] == "server-identity"
+        assert "on_behalf_of" not in data["metadata"]
 
     async def test_resolve_reclassify_does_not_reactivate_archived_entry(
         self, store: DuckDBStore

--- a/tests/test_mcp_classify.py
+++ b/tests/test_mcp_classify.py
@@ -742,6 +742,58 @@ class TestResolveReviewTool:
         assert data["entry_type"] == "reference"
         assert data["status"] == "active"
 
+    async def test_resolve_clears_stale_on_behalf_of_when_later_action_has_no_reviewer(
+        self, store: DuckDBStore
+    ) -> None:
+        """Stale *_on_behalf_of keys are removed when a subsequent action has no reviewer.
+
+        Regression test for CodeRabbit review: a delegated reclassify followed by a
+        non-delegated approve must not leave behind on_behalf_of /
+        reclassified_on_behalf_of from the first action.
+        """
+        # Step 1: Create a pending-review entry.
+        entry = make_entry(entry_type=EntryType.INBOX, status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        # Step 2: Delegated reclassify — actor + distinct reviewer, so
+        #         on_behalf_of and reclassified_on_behalf_of are written.
+        reclassify_response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "meeting",
+                "actor": "server-bot",
+                "reviewer": "reviewer-alice",
+            },
+        )
+        reclassify_data = parse_mcp_response(reclassify_response)
+        assert "error" not in reclassify_data
+        assert reclassify_data["entry_type"] == "meeting"
+        assert reclassify_data["metadata"]["on_behalf_of"] == "reviewer-alice"
+        assert reclassify_data["metadata"]["reclassified_on_behalf_of"] == "reviewer-alice"
+
+        # Manually reset entry back to pending_review so we can resolve it again.
+        await store.update(entry_id, {"status": EntryStatus.PENDING_REVIEW})
+
+        # Step 3: Non-delegated approve — actor only, no reviewer.
+        approve_response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "approve",
+                "actor": "server-bot",
+            },
+        )
+        approve_data = parse_mcp_response(approve_response)
+        assert "error" not in approve_data
+        assert approve_data["status"] == "active"
+
+        # Step 4: Assert that no *_on_behalf_of keys survive from the first action.
+        metadata = approve_data["metadata"]
+        stale_keys = [k for k in metadata if k.endswith("_on_behalf_of") or k == "on_behalf_of"]
+        assert stale_keys == [], f"Stale delegation keys found: {stale_keys}"
+
 
 # ---------------------------------------------------------------------------
 # End-to-end classification flow


### PR DESCRIPTION
## Summary

Fixes #315. `distillery_resolve_review` accepted a `reviewer` parameter in its schema but silently discarded it whenever an OAuth/server identity was present, because the server wrapper coalesced `user or reviewer` and passed only the server identity to the handler.

The server wrapper now forwards both the server identity (as `actor`) and the client-supplied `reviewer` as distinct fields to `_handle_resolve_review`. The handler records:

- **approve**: `reviewed_by` (actor) + `on_behalf_of` (reviewer, when different from actor)
- **reclassify**: `reviewed_by` / `reclassified_by` + matching `on_behalf_of` / `reclassified_on_behalf_of`
- **archive**: `archived_by` + `archived_on_behalf_of`

Fallback semantics preserve backward compatibility for stdio transport (no OAuth):
- If only `reviewer` is supplied, it populates the canonical `*_by` field directly (no `on_behalf_of`).
- If `reviewer == actor`, `on_behalf_of` is not written (no self-delegation).
- Empty strings are normalised to `None`.

Scope: kept strictly to actor/reviewer tracking. `reclassify`'s action dispatch and status behaviour are untouched to avoid conflicting with the separate #316 work.

## Test plan

- [x] `ruff check src/ tests/` + `ruff format src/ tests/`
- [x] `mypy --strict src/distillery/` — no issues
- [x] New unit tests in `tests/test_mcp_classify.py` covering actor-only, reviewer-only, actor+reviewer, actor==reviewer, empty-string reviewer, and archive/reclassify parity
- [x] Full `pytest -m unit` suite (1329 passed; one pre-existing unrelated timezone failure in `test_cli_export_import::test_roundtrip_fidelity` exists on the base branch too)
- [x] Broader related suites (`test_mcp_coverage_gaps`, `test_mcp_server`, `test_e2e_mcp`, `test_mcp_http_transport`) — 227 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better distinction between server identity and client-supplied reviewer when recording who performed review actions; delegation metadata (performed-by / on-behalf-of) now recorded consistently and stale delegation fields are cleared when not applicable.
  * Ensured full transaction recovery when full-text setup fails so the store remains consistent.

* **Tests**
  * Expanded tests covering approval/archive/reclassify metadata and delegation/no-delegation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->