### PR TITLE
fix(feeds): auto-populate project/tags/author/metadata on gh-sync (#312)

### DIFF
--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -8,6 +8,8 @@ Provides the ``distillery`` entry point with the following subcommands:
   or code 1 on failure.
 - ``export``: Export all entries and feed sources to a JSON file.
 - ``import``: Import entries and feed sources from a JSON export file.
+- ``gh-backfill``: Populate ``project``/``tags``/``author``/``metadata``
+  on existing GitHub entries synced before #312 landed.
 - ``eval``: Run skill evaluation scenarios against Claude (requires
   ``ANTHROPIC_API_KEY`` and ``pip install 'distillery[eval]'``).
 - ``maintenance classify``: Classify pending entries using batch classification.
@@ -115,6 +117,18 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Retag all feed entries, not just those with empty tags",
+    )
+
+    gh_backfill_parser = subparsers.add_parser(
+        "gh-backfill",
+        help="Backfill project/tags/author/metadata on existing GitHub entries (#312)",
+        parents=[shared],
+    )
+    gh_backfill_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Report how many entries would be updated without writing changes",
     )
 
     export_parser = subparsers.add_parser(
@@ -691,6 +705,69 @@ def _cmd_retag(
         print(f"  total_scanned: {total_scanned}")
         print(f"  total_{action.replace(' ', '_')}: {total_updated}")
 
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# gh-backfill subcommand (#312)
+# ---------------------------------------------------------------------------
+
+
+def _cmd_gh_backfill(
+    config_path: str | None,
+    fmt: str,
+    dry_run: bool,
+) -> int:
+    """Implement the ``gh-backfill`` subcommand.
+
+    Walks all ``entry_type=github`` entries and populates the ``project``,
+    ``tags``, ``author``, and ``metadata.gh_number`` / ``metadata.gh_url``
+    fields that may be missing on entries synced before #312 landed.
+
+    Returns:
+        Exit code (0 on success, 1 on error).
+    """
+    try:
+        cfg = load_config(config_path)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error loading configuration: {exc}", file=sys.stderr)
+        return 1
+
+    async def _run() -> int:
+        from distillery.feeds.github_sync import backfill_github_metadata
+        from distillery.mcp.server import _create_embedding_provider, _normalize_db_path
+        from distillery.store.duckdb import DuckDBStore
+
+        embedding_provider = _create_embedding_provider(cfg)
+        db_path = _normalize_db_path(cfg.storage.database_path)
+
+        store = DuckDBStore(
+            db_path=db_path,
+            embedding_provider=embedding_provider,
+            s3_region=cfg.storage.s3_region,
+            s3_endpoint=cfg.storage.s3_endpoint,
+            hybrid_search=cfg.defaults.hybrid_search,
+            rrf_k=cfg.defaults.rrf_k,
+            recency_window_days=cfg.defaults.recency_window_days,
+            recency_min_weight=cfg.defaults.recency_min_weight,
+        )
+        await store.initialize()
+        try:
+            return await backfill_github_metadata(store, dry_run=dry_run)
+        finally:
+            await store.close()
+
+    try:
+        updated = asyncio.run(_run())
+    except Exception as exc:
+        print(f"Error during gh-backfill: {exc}", file=sys.stderr)
+        return 1
+
+    action = "would update" if dry_run else "updated"
+    if fmt == "json":
+        print(json.dumps({"dry_run": dry_run, "entries_updated": updated}))
+    else:
+        print(f"gh-backfill complete: {action} {updated} github entries")
     return 0
 
 
@@ -1697,6 +1774,12 @@ def main(argv: list[str] | None = None) -> None:
             fmt=fmt,
             dry_run=getattr(args, "dry_run", False),
             force=getattr(args, "force", False),
+        )
+    elif command == "gh-backfill":
+        exit_code = _cmd_gh_backfill(
+            config_path=config_path,
+            fmt=fmt,
+            dry_run=getattr(args, "dry_run", False),
         )
     elif command == "eval":
         exit_code = _cmd_eval(

--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -68,6 +68,90 @@ _XREF_PATTERN = re.compile(
 # Slug pattern for owner/repo.
 _SLUG_RE = re.compile(r"^[\w.\-]+/[\w.\-]+$")
 
+# Default author attribution when the GitHub payload omits ``user.login``.
+_DEFAULT_GH_AUTHOR = "gh-sync"
+
+# Allowed values for the ``state/*`` tag — keeps vocabulary bounded.
+_STATE_TAG_VALUES = frozenset({"open", "closed", "merged"})
+
+# Pattern each slash-separated tag segment must satisfy (see models.validate_tag).
+_TAG_CHAR_RE = re.compile(r"[^a-z0-9\-]")
+
+
+def _sanitize_tag_segment(raw: str) -> str:
+    """Return a tag segment that satisfies ``[a-z0-9][a-z0-9\\-]*``.
+
+    Lowercases, replaces ``_`` and ``.`` (and any other disallowed characters)
+    with ``-``, collapses runs of ``-``, and trims leading/trailing hyphens
+    and digits-only leading characters as needed.  Returns an empty string
+    when the input cannot be coerced to a valid segment.
+    """
+    if not raw:
+        return ""
+    lowered = raw.strip().lower()
+    # Replace any disallowed character with a hyphen.
+    replaced = _TAG_CHAR_RE.sub("-", lowered)
+    # Collapse runs of hyphens and strip leading/trailing hyphens.
+    collapsed = re.sub(r"-+", "-", replaced).strip("-")
+    return collapsed
+
+
+def _derive_state_tag_value(issue: dict[str, Any]) -> str | None:
+    """Return ``"merged"``/``"closed"``/``"open"`` for the issue, or ``None``.
+
+    For pull requests with ``pull_request.merged_at`` set, returns ``"merged"``.
+    Otherwise falls back to the issue's ``state`` field when it is one of
+    ``open`` or ``closed``.  Unknown states return ``None``.
+    """
+    pr_info = issue.get("pull_request")
+    if isinstance(pr_info, dict) and pr_info.get("merged_at"):
+        return "merged"
+    state = issue.get("state")
+    if isinstance(state, str) and state.lower() in _STATE_TAG_VALUES:
+        return state.lower()
+    return None
+
+
+def _build_github_tags(
+    *,
+    repo: str,
+    ref_type: str,
+    issue: dict[str, Any],
+    labels: list[str],
+) -> list[str]:
+    """Assemble the canonical tag list for a GitHub-sourced entry.
+
+    Always includes:
+      - ``source/github``
+      - ``repo/<sanitised repo>`` (only when the sanitised name is non-empty)
+      - ``ref-type/<issue|pr>``
+      - ``state/<open|closed|merged>`` (only when resolvable)
+
+    Also appends sanitised GitHub labels (``bug``, ``high-priority``) that
+    pass tag-validation; anything that cannot be coerced is silently dropped.
+    """
+    tags: list[str] = ["source/github"]
+    repo_seg = _sanitize_tag_segment(repo)
+    if repo_seg:
+        tags.append(f"repo/{repo_seg}")
+    if ref_type in {"issue", "pr"}:
+        tags.append(f"ref-type/{ref_type}")
+    state_value = _derive_state_tag_value(issue)
+    if state_value is not None:
+        tags.append(f"state/{state_value}")
+    for label in labels:
+        sanitised = _sanitize_tag_segment(label)
+        if sanitised:
+            tags.append(sanitised)
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for tag in tags:
+        if tag not in seen:
+            seen.add(tag)
+            unique.append(tag)
+    return unique
+
 
 def _parse_github_url(url: str) -> tuple[str, str]:
     """Extract ``(owner, repo)`` from a GitHub repository URL or slug.
@@ -164,9 +248,14 @@ class GitHubSyncAdapter:
     token:
         Optional GitHub PAT.  Falls back to ``GITHUB_TOKEN`` env var.
     author:
-        Author field for created entries.  Defaults to ``"gh-sync"``.
+        Optional override for the entry author.  When ``None`` (the default)
+        each entry's author is derived from the GitHub payload's
+        ``user.login`` field, falling back to ``"gh-sync"``.
     project:
-        Optional project name for scoping entries.
+        Optional project name for scoping entries.  When ``None`` the adapter
+        uses the bare repository name (e.g. ``"distillery"``) so synced
+        entries are filterable by the same project value that ``/distill``
+        and friends assign via ``basename $(git rev-parse --show-toplevel)``.
     """
 
     def __init__(
@@ -174,14 +263,16 @@ class GitHubSyncAdapter:
         store: DistilleryStore,
         url: str,
         token: str | None = None,
-        author: str = "gh-sync",
+        author: str | None = None,
         project: str | None = None,
     ) -> None:
         self._store = store
         self._owner, self._repo = _parse_github_url(url)
         self._token = token or os.environ.get("GITHUB_TOKEN", "")
-        self._author = author
-        self._project = project
+        self._author_override = author
+        # Default project to the bare repo name so git-derived filters line up
+        # with entries created via /distill, /bookmark, etc.
+        self._project = project if project is not None else self._repo
         self._metadata_key = f"gh_sync_last_{self._owner}/{self._repo}"
 
     @property
@@ -366,17 +457,28 @@ class GitHubSyncAdapter:
         external_id = _make_external_id(self._owner, self._repo, ref_type, number)
         content = _build_content(title, body, comments)
 
-        # Extract real author from the issue/PR payload.  Treat null,
-        # empty, and whitespace-only logins as missing so we fall back
-        # to the configured sync-tool author instead of persisting junk.
-        user_login_raw = (issue.get("user") or {}).get("login")
-        user_login = user_login_raw.strip() if isinstance(user_login_raw, str) else ""
-        real_author: str = user_login or self._author
+        # Canonical tag set (source/github, repo/<repo>, ref-type/<type>,
+        # state/<state>) plus any sanitised GitHub labels.
+        tags = _build_github_tags(
+            repo=self._repo,
+            ref_type=ref_type,
+            issue=issue,
+            labels=labels,
+        )
 
-        # Build tags from labels using shared sanitiser.
-        from distillery.feeds.tags import sanitise_label
-
-        tags: list[str] = [t for lbl in labels if (t := sanitise_label(lbl)) is not None]
+        # Derive author from the GitHub payload when the caller hasn't pinned
+        # an override — otherwise gh-sync entries show up with no attribution.
+        # Treat null, empty, and whitespace-only logins as missing so we fall
+        # back to the configured sync-tool author instead of persisting junk.
+        author = self._author_override
+        if not author:
+            user = issue.get("user")
+            if isinstance(user, dict):
+                gh_login = user.get("login")
+                if isinstance(gh_login, str) and gh_login.strip():
+                    author = gh_login.strip()
+        if not author:
+            author = _DEFAULT_GH_AUTHOR
 
         metadata: dict[str, Any] = {
             "repo": f"{self._owner}/{self._repo}",
@@ -389,13 +491,18 @@ class GitHubSyncAdapter:
             "assignees": assignees,
             "external_id": external_id,
             "imported_by": "gh-sync",
+            # Convenience duplicates requested by #312 — some downstream
+            # consumers (UI, digests) look for these specific keys rather
+            # than ref_number / url.
+            "gh_number": number,
+            "gh_url": html_url,
         }
 
         return Entry(
             content=content,
             entry_type=EntryType.GITHUB,
             source=EntrySource.IMPORT,
-            author=real_author,
+            author=author,
             project=self._project,
             tags=tags,
             status=EntryStatus.ACTIVE,
@@ -513,9 +620,10 @@ class GitHubSyncAdapter:
             existing = await self._find_existing(external_id)
 
             if existing is not None:
-                # Update existing entry.  Include ``author`` so re-syncs
-                # correct stale tool-authored entries with the real payload
-                # author (see issue #302).
+                # Update existing entry.  Also backfill project/author so
+                # previously-synced items pick up the real payload author
+                # (#302) and the canonical project/tags (#312) on the next
+                # sync cycle even without a one-off backfill run.
                 await self._store.update(
                     existing.id,
                     {
@@ -523,6 +631,7 @@ class GitHubSyncAdapter:
                         "author": entry.author,
                         "metadata": entry.metadata,
                         "tags": entry.tags,
+                        "project": entry.project,
                     },
                 )
                 entry_id = existing.id
@@ -806,3 +915,177 @@ class SyncResult:
             "pages_processed": self.pages_processed,
             "errors": self.errors,
         }
+
+
+# ---------------------------------------------------------------------------
+# Backfill helper (#312)
+# ---------------------------------------------------------------------------
+
+
+# How many entries to scan per page when walking the store.
+_BACKFILL_PAGE_SIZE = 200
+
+
+def _infer_repo_slug(metadata: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Return ``(owner, repo)`` inferred from entry metadata, or ``(None, None)``.
+
+    Tries ``metadata["repo"]`` first (stored as ``owner/repo``), then falls
+    back to ``metadata["external_id"]`` which has the form
+    ``owner/repo#issue-42``.
+    """
+    repo_raw = metadata.get("repo")
+    if isinstance(repo_raw, str) and "/" in repo_raw:
+        owner, _, repo = repo_raw.partition("/")
+        if owner and repo:
+            return owner, repo.split("#", 1)[0]
+
+    external_id = metadata.get("external_id")
+    if isinstance(external_id, str) and "/" in external_id:
+        slug, _, _ = external_id.partition("#")
+        owner, _, repo = slug.partition("/")
+        if owner and repo:
+            return owner, repo
+
+    return None, None
+
+
+async def backfill_github_metadata(
+    store: DistilleryStore,
+    *,
+    page_size: int = _BACKFILL_PAGE_SIZE,
+    dry_run: bool = False,
+) -> int:
+    """Backfill project/tags/author/metadata on existing ``github`` entries.
+
+    Scans all entries with ``entry_type=github`` and fills in the canonical
+    metadata added in #312 without re-fetching from GitHub:
+
+    - ``project`` defaults to the bare repo name (``distillery``) when unset
+      or empty.
+    - ``tags`` are replaced with the canonical set
+      (``source/github``, ``repo/<name>``, ``ref-type/<type>``,
+      ``state/<state>``) plus any existing sanitised labels, when the entry's
+      current tag list is empty or missing any canonical tag.
+    - ``author`` is populated from the entry's own metadata when the stored
+      author is empty or the legacy ``"gh-sync"`` placeholder and we can
+      recover a real GitHub login.
+    - ``metadata.gh_number`` and ``metadata.gh_url`` are populated from the
+      existing ``ref_number`` / ``url`` fields when absent.
+
+    The helper does *not* call GitHub; all source-of-truth data must already
+    be present on the entry.  Entries without recoverable repo/ref_type
+    metadata are skipped.
+
+    Args:
+        store: The Distillery store to scan and update.
+        page_size: Number of entries to fetch per ``list_entries`` call.
+        dry_run: When ``True`` no writes are performed; the function still
+            returns the number of entries that *would* have been updated.
+
+    Returns:
+        The number of entries that were updated (or would be, for dry runs).
+    """
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+
+    updated = 0
+    offset = 0
+    while True:
+        batch = await store.list_entries(
+            filters={"entry_type": EntryType.GITHUB.value},
+            limit=page_size,
+            offset=offset,
+        )
+        if not batch:
+            break
+
+        for entry in batch:
+            updates = _compute_backfill_updates(entry)
+            if not updates:
+                continue
+            updated += 1
+            if not dry_run:
+                await store.update(entry.id, updates)
+
+        if len(batch) < page_size:
+            break
+        offset += len(batch)
+
+    return updated
+
+
+def _compute_backfill_updates(entry: Entry) -> dict[str, Any]:
+    """Return the update dict needed to bring *entry* up to the #312 schema.
+
+    Returns an empty dict when no changes are needed.  Splitting this logic
+    out keeps :func:`backfill_github_metadata` easy to reason about and
+    lets tests exercise the per-entry decisions without a store.
+    """
+    metadata = dict(entry.metadata or {})
+    owner, repo = _infer_repo_slug(metadata)
+
+    # Without repo info we cannot build canonical tags reliably.  Leave the
+    # entry alone rather than guessing.
+    if owner is None or repo is None:
+        return {}
+
+    ref_type_raw = metadata.get("ref_type")
+    ref_type = ref_type_raw if isinstance(ref_type_raw, str) else ""
+
+    updates: dict[str, Any] = {}
+
+    # ``project`` — prefer the repo name when the stored value is empty.
+    if not entry.project:
+        updates["project"] = repo
+
+    # ``author`` — only replace when the existing value is empty or the
+    # legacy placeholder, and only when metadata gives us a real login.
+    legacy_authors = {"", _DEFAULT_GH_AUTHOR}
+    if entry.author in legacy_authors:
+        stored_login = metadata.get("user_login")
+        if isinstance(stored_login, str) and stored_login.strip():
+            updates["author"] = stored_login.strip()
+
+    # ``metadata.gh_number`` / ``metadata.gh_url`` — copy from the legacy
+    # ``ref_number`` / ``url`` keys when missing.
+    metadata_changed = False
+    if "gh_number" not in metadata and isinstance(metadata.get("ref_number"), int):
+        metadata["gh_number"] = metadata["ref_number"]
+        metadata_changed = True
+    if "gh_url" not in metadata and isinstance(metadata.get("url"), str):
+        metadata["gh_url"] = metadata["url"]
+        metadata_changed = True
+
+    # ``tags`` — rebuild the canonical set.  We preserve any existing
+    # non-canonical tags (hand-authored labels, etc.) by merging them in.
+    issue_like: dict[str, Any] = {
+        "state": metadata.get("state"),
+    }
+    # Re-create the ``pull_request.merged_at`` signal for PR entries that
+    # were already closed at sync time.
+    if ref_type == "pr" and isinstance(metadata.get("merged_at"), str):
+        issue_like["pull_request"] = {"merged_at": metadata["merged_at"]}
+    stored_labels_raw = metadata.get("labels") or []
+    stored_labels = [lbl for lbl in stored_labels_raw if isinstance(lbl, str)]
+
+    canonical_tags = _build_github_tags(
+        repo=repo,
+        ref_type=ref_type,
+        issue=issue_like,
+        labels=stored_labels,
+    )
+    # Merge with any existing tags we don't already know about.
+    existing_tags = list(entry.tags or [])
+    seen: set[str] = set(canonical_tags)
+    merged_tags = list(canonical_tags)
+    for tag in existing_tags:
+        if tag not in seen:
+            seen.add(tag)
+            merged_tags.append(tag)
+    if merged_tags != existing_tags:
+        updates["tags"] = merged_tags
+
+    if metadata_changed:
+        updates["metadata"] = metadata
+
+    return updates

--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -480,6 +480,18 @@ class GitHubSyncAdapter:
         if not author:
             author = _DEFAULT_GH_AUTHOR
 
+        # Merged-at timestamp (PRs only) — preserved so _compute_backfill_updates
+        # can detect merged PRs during backfill and keep the state/merged tag.
+        merged_at: str | None = None
+        if isinstance(pr_info := issue.get("pull_request"), dict):
+            pr_merged = pr_info.get("merged_at")
+            if isinstance(pr_merged, str) and pr_merged:
+                merged_at = pr_merged
+        if merged_at is None:
+            top_merged = issue.get("merged_at")
+            if isinstance(top_merged, str) and top_merged:
+                merged_at = top_merged
+
         metadata: dict[str, Any] = {
             "repo": f"{self._owner}/{self._repo}",
             "ref_type": ref_type,
@@ -496,6 +508,7 @@ class GitHubSyncAdapter:
             # than ref_number / url.
             "gh_number": number,
             "gh_url": html_url,
+            "merged_at": merged_at,
         }
 
         return Entry(
@@ -754,8 +767,9 @@ class GitHubSyncAdapter:
             existing = await self._find_existing(external_id)
 
             if existing is not None:
-                # Include ``author`` on update so re-syncs correct stale
-                # tool-authored entries with the real payload author (#302).
+                # Include ``author`` and ``project`` on update so re-syncs
+                # correct stale tool-authored entries (#302) and pick up the
+                # canonical project/tag backfill (#312) without a one-off run.
                 await self._store.update(
                     existing.id,
                     {
@@ -763,6 +777,7 @@ class GitHubSyncAdapter:
                         "author": entry.author,
                         "metadata": entry.metadata,
                         "tags": entry.tags,
+                        "project": entry.project,
                     },
                 )
                 entry_id = existing.id

--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -82,9 +82,10 @@ def _sanitize_tag_segment(raw: str) -> str:
     """Return a tag segment that satisfies ``[a-z0-9][a-z0-9\\-]*``.
 
     Lowercases, replaces ``_`` and ``.`` (and any other disallowed characters)
-    with ``-``, collapses runs of ``-``, and trims leading/trailing hyphens
-    and digits-only leading characters as needed.  Returns an empty string
-    when the input cannot be coerced to a valid segment.
+    with ``-``, collapses runs of ``-``, and trims leading/trailing hyphens.
+    Digits are permitted in any position (including as the leading character)
+    because the tag schema accepts ``[a-z0-9]`` at the start.  Returns an
+    empty string when the input cannot be coerced to a valid segment.
     """
     if not raw:
         return ""
@@ -509,6 +510,9 @@ class GitHubSyncAdapter:
             "gh_number": number,
             "gh_url": html_url,
             "merged_at": merged_at,
+            # Persisted so ``_compute_backfill_updates`` can heal older entries
+            # that lost author attribution (see legacy_authors branch below).
+            "user_login": author,
         }
 
         return Entry(

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -14,11 +14,16 @@ from distillery.feeds.github_sync import (
     GitHubSyncAdapter,
     SyncResult,
     _build_content,
+    _build_github_tags,
+    _compute_backfill_updates,
+    _derive_state_tag_value,
     _extract_cross_refs,
     _make_external_id,
     _parse_github_url,
+    _sanitize_tag_segment,
+    backfill_github_metadata,
 )
-from distillery.models import EntryType
+from distillery.models import Entry, EntrySource, EntryStatus, EntryType
 
 # ---------------------------------------------------------------------------
 # Unit tests — helper functions
@@ -407,3 +412,385 @@ class TestGitHubSyncAdapterSync:
         adapter = GitHubSyncAdapter(store=store, url="test/repo")
         result = await adapter.sync()
         assert result.created == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests for #312 — project/tags/author/metadata auto-population
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeTagSegment:
+    """Test tag-segment sanitisation."""
+
+    @pytest.mark.unit
+    def test_lowercases(self) -> None:
+        assert _sanitize_tag_segment("Distillery") == "distillery"
+
+    @pytest.mark.unit
+    def test_replaces_disallowed_chars(self) -> None:
+        assert _sanitize_tag_segment("my_repo.name") == "my-repo-name"
+
+    @pytest.mark.unit
+    def test_collapses_hyphens(self) -> None:
+        assert _sanitize_tag_segment("a__b..c") == "a-b-c"
+
+    @pytest.mark.unit
+    def test_strips_leading_trailing(self) -> None:
+        assert _sanitize_tag_segment(".foo.") == "foo"
+
+    @pytest.mark.unit
+    def test_empty(self) -> None:
+        assert _sanitize_tag_segment("") == ""
+        assert _sanitize_tag_segment("...") == ""
+
+
+class TestDeriveStateTagValue:
+    """Test state-tag derivation."""
+
+    @pytest.mark.unit
+    def test_open_issue(self) -> None:
+        assert _derive_state_tag_value({"state": "open"}) == "open"
+
+    @pytest.mark.unit
+    def test_closed_issue(self) -> None:
+        assert _derive_state_tag_value({"state": "closed"}) == "closed"
+
+    @pytest.mark.unit
+    def test_merged_pr(self) -> None:
+        issue = {
+            "state": "closed",
+            "pull_request": {"merged_at": "2026-04-01T00:00:00Z"},
+        }
+        assert _derive_state_tag_value(issue) == "merged"
+
+    @pytest.mark.unit
+    def test_unmerged_pr_closed(self) -> None:
+        issue = {"state": "closed", "pull_request": {"merged_at": None}}
+        assert _derive_state_tag_value(issue) == "closed"
+
+    @pytest.mark.unit
+    def test_unknown_state(self) -> None:
+        assert _derive_state_tag_value({"state": "mystery"}) is None
+
+
+class TestBuildGithubTags:
+    """Canonical tag assembly."""
+
+    @pytest.mark.unit
+    def test_core_tags_present(self) -> None:
+        tags = _build_github_tags(
+            repo="distillery",
+            ref_type="issue",
+            issue={"state": "open"},
+            labels=[],
+        )
+        assert "source/github" in tags
+        assert "repo/distillery" in tags
+        assert "ref-type/issue" in tags
+        assert "state/open" in tags
+
+    @pytest.mark.unit
+    def test_pr_merged_tag(self) -> None:
+        tags = _build_github_tags(
+            repo="distillery",
+            ref_type="pr",
+            issue={"state": "closed", "pull_request": {"merged_at": "2026-04-01"}},
+            labels=[],
+        )
+        assert "ref-type/pr" in tags
+        assert "state/merged" in tags
+
+    @pytest.mark.unit
+    def test_labels_sanitised(self) -> None:
+        tags = _build_github_tags(
+            repo="my.repo",
+            ref_type="issue",
+            issue={"state": "open"},
+            labels=["Bug", "high priority", "area: docs"],
+        )
+        assert "repo/my-repo" in tags
+        assert "bug" in tags
+        assert "high-priority" in tags
+        assert "area-docs" in tags
+
+    @pytest.mark.unit
+    def test_tags_deduplicated(self) -> None:
+        tags = _build_github_tags(
+            repo="distillery",
+            ref_type="issue",
+            issue={"state": "open"},
+            labels=["source/github"],  # intentional duplicate
+        )
+        assert tags.count("source/github") == 1
+
+
+class TestSyncAutoPopulatesFields:
+    """End-to-end check for the #312 fix on the sync path."""
+
+    @pytest.mark.integration
+    async def test_new_entry_has_project_tags_author_metadata(
+        self,
+        store,
+        httpx_mock,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """A freshly synced issue must have project/tags/author/metadata populated."""
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/acme/widgets/issues\?.*"),
+            json=[
+                _mock_issue(
+                    number=42,
+                    title="Something broke",
+                    body="Need to fix this",
+                    state="open",
+                    labels=[{"name": "bug"}],
+                )
+            ],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/acme/widgets/issues/42/comments.*"),
+            json=[],
+        )
+
+        adapter = GitHubSyncAdapter(store=store, url="acme/widgets")
+        result = await adapter.sync()
+        assert result.created == 1
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        assert len(entries) == 1
+        entry = entries[0]
+
+        # project defaults to the bare repo name (matches git basename convention).
+        assert entry.project == "widgets"
+
+        # author pulled from GitHub payload user.login ("author").
+        assert entry.author == "author"
+
+        # Canonical tag set is present alongside label-derived tags.
+        assert "source/github" in entry.tags
+        assert "repo/widgets" in entry.tags
+        assert "ref-type/issue" in entry.tags
+        assert "state/open" in entry.tags
+        assert "bug" in entry.tags
+
+        # Convenience metadata fields requested by the issue.
+        assert entry.metadata["gh_number"] == 42
+        assert entry.metadata["gh_url"].endswith("/issues/42")
+
+    @pytest.mark.integration
+    async def test_pr_gets_merged_state_tag(
+        self,
+        store,
+        httpx_mock,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """Merged PRs should pick up ``state/merged`` rather than closed."""
+        pr = _mock_issue(number=7, title="Feature", is_pr=True, state="closed")
+        pr["pull_request"] = {
+            "url": "https://api.github.com/repos/test/repo/pulls/7",
+            "merged_at": "2026-04-01T12:00:00Z",
+        }
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[pr],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues/7/comments.*"),
+            json=[],
+        )
+
+        adapter = GitHubSyncAdapter(store=store, url="test/repo")
+        await adapter.sync()
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        assert "state/merged" in entries[0].tags
+        assert "state/closed" not in entries[0].tags
+        assert "ref-type/pr" in entries[0].tags
+
+    @pytest.mark.integration
+    async def test_explicit_project_and_author_override(
+        self,
+        store,
+        httpx_mock,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """Explicit project/author kwargs must win over auto-derivation."""
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[_mock_issue(number=1)],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues/1/comments.*"),
+            json=[],
+        )
+
+        adapter = GitHubSyncAdapter(
+            store=store,
+            url="test/repo",
+            project="custom-project",
+            author="alice",
+        )
+        await adapter.sync()
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        assert entries[0].project == "custom-project"
+        assert entries[0].author == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Backfill helper tests (#312)
+# ---------------------------------------------------------------------------
+
+
+def _make_legacy_github_entry(
+    *,
+    owner: str = "acme",
+    repo: str = "widgets",
+    ref_type: str = "issue",
+    number: int = 1,
+    state: str = "open",
+    labels: list[str] | None = None,
+    author: str = "",
+    project: str | None = None,
+    tags: list[str] | None = None,
+    user_login: str | None = None,
+) -> Entry:
+    """Construct an Entry shaped like pre-#312 gh-sync output."""
+    metadata: dict = {
+        "repo": f"{owner}/{repo}",
+        "ref_type": ref_type,
+        "ref_number": number,
+        "title": "Legacy title",
+        "url": f"https://github.com/{owner}/{repo}/issues/{number}",
+        "state": state,
+        "labels": labels or [],
+        "assignees": [],
+        "external_id": f"{owner}/{repo}#{ref_type}-{number}",
+    }
+    if user_login is not None:
+        metadata["user_login"] = user_login
+    return Entry(
+        content="# Legacy title",
+        entry_type=EntryType.GITHUB,
+        source=EntrySource.IMPORT,
+        author=author,
+        project=project,
+        tags=tags or [],
+        status=EntryStatus.ACTIVE,
+        metadata=metadata,
+    )
+
+
+class TestComputeBackfillUpdates:
+    """Per-entry backfill decision logic."""
+
+    @pytest.mark.unit
+    def test_fills_project_from_repo(self) -> None:
+        entry = _make_legacy_github_entry(project=None)
+        updates = _compute_backfill_updates(entry)
+        assert updates["project"] == "widgets"
+
+    @pytest.mark.unit
+    def test_preserves_non_null_project(self) -> None:
+        entry = _make_legacy_github_entry(project="already-set")
+        updates = _compute_backfill_updates(entry)
+        assert "project" not in updates
+
+    @pytest.mark.unit
+    def test_rebuilds_canonical_tags(self) -> None:
+        entry = _make_legacy_github_entry(tags=[])
+        updates = _compute_backfill_updates(entry)
+        new_tags = updates["tags"]
+        assert "source/github" in new_tags
+        assert "repo/widgets" in new_tags
+        assert "ref-type/issue" in new_tags
+        assert "state/open" in new_tags
+
+    @pytest.mark.unit
+    def test_copies_metadata_aliases(self) -> None:
+        entry = _make_legacy_github_entry()
+        updates = _compute_backfill_updates(entry)
+        assert updates["metadata"]["gh_number"] == 1
+        assert updates["metadata"]["gh_url"].endswith("/issues/1")
+
+    @pytest.mark.unit
+    def test_sets_author_from_user_login_when_placeholder(self) -> None:
+        entry = _make_legacy_github_entry(author="gh-sync", user_login="octocat")
+        updates = _compute_backfill_updates(entry)
+        assert updates["author"] == "octocat"
+
+    @pytest.mark.unit
+    def test_leaves_author_when_set(self) -> None:
+        entry = _make_legacy_github_entry(author="alice", user_login="octocat")
+        updates = _compute_backfill_updates(entry)
+        assert "author" not in updates
+
+    @pytest.mark.unit
+    def test_skips_entry_without_repo_info(self) -> None:
+        entry = Entry(
+            content="orphan",
+            entry_type=EntryType.GITHUB,
+            source=EntrySource.IMPORT,
+            author="",
+            metadata={},
+        )
+        assert _compute_backfill_updates(entry) == {}
+
+
+class TestBackfillGithubMetadataIntegration:
+    """Full backfill loop against the in-memory store."""
+
+    @pytest.mark.integration
+    async def test_backfill_updates_legacy_entries(self, store) -> None:  # type: ignore[no-untyped-def]
+        # Seed two legacy entries + one non-github entry that must be untouched.
+        legacy_a = _make_legacy_github_entry(number=1, project=None, tags=[])
+        legacy_b = _make_legacy_github_entry(number=2, project=None, tags=[])
+        unrelated = Entry(
+            content="a session",
+            entry_type=EntryType.SESSION,
+            source=EntrySource.CLAUDE_CODE,
+            author="alice",
+            project=None,
+            tags=[],
+        )
+        a_id = await store.store(legacy_a)
+        b_id = await store.store(legacy_b)
+        unrelated_id = await store.store(unrelated)
+
+        updated = await backfill_github_metadata(store)
+        assert updated == 2
+
+        updated_a = await store.get(a_id)
+        updated_b = await store.get(b_id)
+        untouched = await store.get(unrelated_id)
+
+        assert updated_a is not None and updated_b is not None and untouched is not None
+        assert updated_a.project == "widgets"
+        assert "source/github" in updated_a.tags
+        assert "repo/widgets" in updated_a.tags
+        assert "ref-type/issue" in updated_a.tags
+        assert updated_b.project == "widgets"
+        # Non-github entries are left alone.
+        assert untouched.project is None
+        assert untouched.tags == []
+
+    @pytest.mark.integration
+    async def test_backfill_dry_run_does_not_write(self, store) -> None:  # type: ignore[no-untyped-def]
+        entry = _make_legacy_github_entry(project=None, tags=[])
+        entry_id = await store.store(entry)
+
+        would_update = await backfill_github_metadata(store, dry_run=True)
+        assert would_update == 1
+
+        # Entry should still be in its pre-backfill shape.
+        reloaded = await store.get(entry_id)
+        assert reloaded is not None
+        assert reloaded.project is None
+        assert reloaded.tags == []
+
+    @pytest.mark.integration
+    async def test_backfill_is_idempotent(self, store) -> None:  # type: ignore[no-untyped-def]
+        entry = _make_legacy_github_entry(project=None, tags=[])
+        await store.store(entry)
+
+        first = await backfill_github_metadata(store)
+        second = await backfill_github_metadata(store)
+        assert first == 1
+        assert second == 0


### PR DESCRIPTION
## Summary

Closes #312. All GitHub-synced entries on staging were landing with `project: null` and `tags: []`, breaking project/tag filters for 4,251 entries.

- `GitHubSyncAdapter` now auto-populates `project` (bare repo name), `author` (from `issue.user.login`), canonical `tags` (`source/github`, `repo/<name>`, `ref-type/<issue|pr>`, `state/<open|closed|merged>` + sanitised GitHub labels), and `metadata.gh_number` / `metadata.gh_url`.
- The update path propagates the same fields so re-syncing a repo heals previously-written entries.
- `project` can still be overridden via `GitHubSyncAdapter(project=...)`; `author` via `GitHubSyncAdapter(author=...)`. When `author=None` (the new default) the GH login wins.
- `ref-type` uses a hyphen instead of an underscore because tag segments must match `[a-z0-9][a-z0-9-]*`.

## Backfill

Added `backfill_github_metadata(store, *, page_size=200, dry_run=False) -> int` in `src/distillery/feeds/github_sync.py` and wired up a CLI subcommand:

```
distillery gh-backfill --dry-run       # report how many entries need updating
distillery gh-backfill                 # apply the fix
```

The helper reuses stored metadata only (`repo`, `ref_type`, `state`, `labels`) — no GitHub round-trip. Entries without recoverable repo info are skipped. Per the task brief, the backfill was **not** executed against any live store; the PR only ships the function + CLI wiring. Run `distillery gh-backfill --dry-run` in staging first to verify the count (expected ~4,251).

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/`
- [x] `PYTHONPATH=$PWD/src python -m mypy --strict src/distillery/` (Success: no issues found in 56 source files)
- [x] `PYTHONPATH=$PWD/src python -m pytest tests/test_github_sync.py -q` (57 passed)
- [x] `PYTHONPATH=$PWD/src python -m pytest tests/ -q -m unit` (1350 passed; 1 pre-existing unrelated timezone failure in `test_cli_export_import::test_roundtrip_fidelity`)
- [ ] Staging dry-run: `distillery gh-backfill --dry-run`
- [ ] Staging apply: `distillery gh-backfill`
- [ ] Verify `distillery_list(entry_type="github", filters={"project": "<repo>"})` returns populated entries after backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `gh-backfill` CLI command with `--dry-run` to populate missing GitHub metadata (project, tags, author, GH number/URL) without writing.
  * Enhanced GitHub sync to generate canonical tags, auto-fill project/author, and include GH metadata on new/updated entries.

* **Tests**
  * Added unit and integration tests covering tag sanitization, state tagging, metadata enrichment, and backfill behavior (including dry-run and idempotency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->