### PR TITLE
fix(mcp): exclude archived entries from list/search by default (#317)

### DIFF
--- a/src/distillery/eval/mcp_bridge.py
+++ b/src/distillery/eval/mcp_bridge.py
@@ -125,14 +125,30 @@ DISTILLERY_TOOL_SCHEMAS: list[dict[str, Any]] = [
     },
     {
         "name": "distillery_list",
-        "description": "List entries without semantic ranking (newest first).",
+        "description": (
+            "List entries without semantic ranking (newest first). "
+            "Archived entries are hidden by default; pass include_archived=true "
+            "or status='any' to include them, or status='archived' to list only them."
+        ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "entry_type": {"type": "string"},
                 "author": {"type": "string"},
                 "project": {"type": "string"},
-                "status": {"type": "string"},
+                "status": {
+                    "type": "string",
+                    "description": (
+                        "Filter by status. Defaults to active + pending_review. "
+                        "Pass 'archived' for archived only, or 'any' for all statuses."
+                    ),
+                },
+                "include_archived": {
+                    "type": "boolean",
+                    "description": (
+                        "When true, include archived entries alongside the default set."
+                    ),
+                },
                 "limit": {"type": "integer", "description": "Max results (default 10)."},
                 "offset": {"type": "integer"},
                 "output_mode": {

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -553,11 +553,17 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         group_by: str | None = None,
         output: str | None = None,
         feed_url: str | None = None,
+        include_archived: bool = False,
     ) -> list[types.TextContent]:
         """List knowledge entries with optional filters and pagination (newest first).
 
         USE WHEN: browsing or filtering entries without a semantic query.
         Use distillery_search instead when you have a natural-language question.
+
+        By default, only entries with status in (active, pending_review) are
+        returned — archived entries are hidden. Pass ``status="archived"`` to
+        list only archived entries, ``status="any"`` to include every status,
+        or ``include_archived=true`` to add archived entries to the default view.
 
         PARAMS:
           - entry_type (str, optional): Filter by type. Valid: [session, bookmark, minutes,
@@ -565,7 +571,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - author (str, optional): Filter by author.
           - project (str, optional): Filter by project scope.
           - tags (list[str], optional): Filter by tags (AND match).
-          - status (str, optional): Filter by status. Valid: [active, pending_review, archived].
+          - status (str, optional): Filter by status. Valid: [active, pending_review,
+            archived, any]. Default hides archived; use "any" to include all.
           - verification (str, optional): Filter by verification. Valid: [unverified, testing, verified].
           - source (str, optional): Filter by origin. Valid: [claude-code, manual, import,
             inference, documentation, external].
@@ -591,6 +598,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - feed_url (str, optional): Filter to entries ingested from a registered feed
             source URL (matches metadata.source_url written by the poller). Use this to
             retrieve all items polled from e.g. "https://hnrss.org/frontpage".
+          - include_archived (bool, optional, default=False): Include archived entries
+            in the default view (same effect as status="any" when status is unset).
 
         RETURNS (success): { entries: list, count: int, total_count: int, limit: int, offset: int }
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
@@ -603,6 +612,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             limit=limit,
             offset=offset,
             output_mode=output_mode,
+            include_archived=include_archived,
             **_omit_none(
                 entry_type=entry_type,
                 author=author,
@@ -639,11 +649,18 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         date_to: str | None = None,
         limit: int = 10,
         tag_prefix: str | None = None,
+        include_archived: bool = False,
     ) -> list[types.TextContent]:
         """Search knowledge entries using semantic similarity (cosine distance, ranked descending).
 
         USE WHEN: finding entries that match a natural-language question or topic.
         Each result includes a similarity score (0-1, higher is more relevant).
+
+        By default, only entries with status in (active, pending_review) are
+        considered — archived entries are hidden. Pass ``status="archived"``
+        to search only archived entries, ``status="any"`` to include every
+        status, or ``include_archived=true`` to add archived entries to the
+        default candidate set.
 
         PARAMS:
           - query (str, required): Natural-language search query.
@@ -658,6 +675,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - date_to (str, optional): ISO 8601 upper bound.
           - limit (int, optional, default=10): Max results (1-200).
           - tag_prefix (str, optional): Filter tags by namespace prefix.
+          - include_archived (bool, optional, default=False): Include archived entries
+            in the candidate set.
 
         RETURNS (success): { results: [{ score: float, entry: {...} }], count: int }
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
@@ -669,6 +688,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         args: dict[str, Any] = dict(
             query=query,
             limit=limit,
+            include_archived=include_archived,
             **_omit_none(
                 entry_type=entry_type,
                 author=author,

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -873,6 +873,12 @@ _SUMMARY_CONTENT_PREVIEW_CHARS = 200
 # Maximum character length for derived titles in summary mode.
 _SUMMARY_TITLE_CHARS = 120
 
+# Default statuses returned when the caller does not specify one.  Archived
+# entries are excluded from default views so that deleted/superseded content
+# does not leak into user-facing lists or searches.  Callers can opt back in
+# via ``include_archived=True`` or the sentinel ``status="any"``.
+_DEFAULT_VISIBLE_STATUSES: tuple[str, ...] = ("active", "pending_review")
+
 
 def _derive_title(entry: Any) -> str:
     """Return a short title for *entry* — the ``title`` metadata key if present,
@@ -1030,11 +1036,18 @@ async def _handle_list(
             "Provide source, entry_type, author, tag_prefix, project, or verification.",
         )
 
-    # review mode implicitly filters to pending_review status.
+    # review mode implicitly filters to pending_review status (takes precedence
+    # over any default/visible-status logic).
     if output_mode == "review":
         if filters is None:
             filters = {}
         filters["status"] = "pending_review"
+    else:
+        filter_result = _apply_default_status_filter(filters, arguments)
+        if isinstance(filter_result, list):
+            # Error response from validation.
+            return filter_result
+        filters = filter_result
 
     # --- group_by mode -------------------------------------------------------
     if group_by is not None:
@@ -1130,6 +1143,52 @@ async def _handle_list(
 # ---------------------------------------------------------------------------
 # Shared filter builder (used by _handle_list and search handlers)
 # ---------------------------------------------------------------------------
+
+
+def _apply_default_status_filter(
+    filters: dict[str, Any] | None,
+    arguments: dict[str, Any],
+) -> dict[str, Any] | None | list[types.TextContent]:
+    """Apply the default ``status`` filter that hides archived entries.
+
+    Semantics:
+
+    * If the caller passed ``include_archived=True``: no status filter is
+      added (all statuses returned).
+    * If the caller passed ``status="any"``: the sentinel is stripped and no
+      status filter is added (all statuses returned).
+    * If the caller passed any other explicit ``status`` value (including a
+      list): it is left untouched.
+    * Otherwise: the filter is populated with
+      ``status IN ('active', 'pending_review')`` so archived entries are
+      excluded from default views.
+
+    Returns the (possibly mutated) filters dict, or an MCP error response
+    list when ``include_archived`` has the wrong type.
+    """
+    include_archived_raw = arguments.get("include_archived")
+    if include_archived_raw is not None and not isinstance(include_archived_raw, bool):
+        return error_response("INVALID_PARAMS", "Field 'include_archived' must be a boolean")
+    include_archived = bool(include_archived_raw) if include_archived_raw is not None else False
+
+    # Detect the sentinel ``status="any"`` early; it overrides the default
+    # archived-exclusion and means "return every status".
+    if filters is not None and filters.get("status") == "any":
+        remaining = {k: v for k, v in filters.items() if k != "status"}
+        return remaining if remaining else None
+
+    # If the caller has a specific status filter, leave it alone.
+    if filters is not None and "status" in filters:
+        return filters
+
+    # If the caller opted out of the default filter, do nothing.
+    if include_archived:
+        return filters
+
+    if filters is None:
+        filters = {}
+    filters["status"] = list(_DEFAULT_VISIBLE_STATUSES)
+    return filters
 
 
 def _build_filters_from_arguments(arguments: dict[str, Any]) -> dict[str, Any] | None:
@@ -1339,6 +1398,8 @@ __all__ = [
     "_handle_correct",
     "_handle_list",
     "_build_filters_from_arguments",
+    "_apply_default_status_filter",
+    "_DEFAULT_VISIBLE_STATUSES",
     "_VALID_ENTRY_TYPES",
     "_VALID_STATUSES",
     "_VALID_VERIFICATIONS",

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -22,7 +22,10 @@ from distillery.mcp.tools._common import (
     validate_type,
 )
 from distillery.mcp.tools._errors import validate_limit
-from distillery.mcp.tools.crud import _build_filters_from_arguments
+from distillery.mcp.tools.crud import (
+    _apply_default_status_filter,
+    _build_filters_from_arguments,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +80,11 @@ async def _handle_search(
             return error_response("BUDGET_EXCEEDED", str(exc))
 
     filters = _build_filters_from_arguments(arguments)
+    filter_result = _apply_default_status_filter(filters, arguments)
+    if isinstance(filter_result, list):
+        # Error response from status-filter validation.
+        return filter_result
+    filters = filter_result
 
     try:
         search_results = await store.search(query=query, filters=filters, limit=limit)

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1016,8 +1016,15 @@ class DuckDBStore:
                 params.append(tag_list)
 
         if "status" in filters:
-            clauses.append("status = ?")
-            params.append(str(filters["status"]))
+            val = filters["status"]
+            if isinstance(val, list):
+                if val:
+                    placeholders = ", ".join("?" for _ in val)
+                    clauses.append(f"status IN ({placeholders})")
+                    params.extend(str(v) for v in val)
+            else:
+                clauses.append("status = ?")
+                params.append(str(val))
 
         if "verification" in filters:
             clauses.append("verification = ?")

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -223,7 +223,9 @@ class DistilleryStore(Protocol):
         Parameters:
             filters: Optional metadata constraints. Supported keys:
                 ``entry_type``, ``author``, ``project``, ``tags`` (matches any
-                tag), ``status``, ``verification``, ``date_from``, ``date_to``.
+                tag), ``status`` (str or list[str] — a list matches any of the
+                listed statuses via SQL ``IN``), ``verification`` (one of
+                "unverified", "testing", "verified"), ``date_from``, ``date_to``.
             limit: Maximum number of entries (or groups) to return.
             offset: Number of entries to skip for pagination (ignored in
                 group_by / stats modes).
@@ -242,6 +244,13 @@ class DistilleryStore(Protocol):
         Returns:
             ``list[Entry]`` in default mode; ``dict[str, Any]`` when
             *group_by* or *output="stats"* is supplied.
+
+        Notes:
+            This method performs no implicit status filtering. Callers that want
+            to exclude archived entries by default must pass
+            ``status=["active", "pending_review"]`` (or similar) explicitly. The
+            MCP ``distillery_list`` tool applies this default on behalf of the
+            caller.
         """
         ...
 

--- a/tests/test_list_archived_default.py
+++ b/tests/test_list_archived_default.py
@@ -1,0 +1,198 @@
+"""Tests for distillery_list / distillery_search default archived-exclusion.
+
+Issue #317: by default ``distillery_list`` (and ``distillery_search``) must
+hide archived entries. Explicit opt-in is required to see them, via either
+``status="archived"`` (archived only), ``status="any"`` (all statuses), or
+``include_archived=True`` (default set + archived).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.mcp.tools.crud import (
+    _DEFAULT_VISIBLE_STATUSES,
+    _apply_default_status_filter,
+    _handle_list,
+)
+from distillery.mcp.tools.search import _handle_search
+from distillery.models import EntryStatus
+from tests.conftest import make_entry, parse_mcp_response
+
+
+@pytest.fixture
+async def status_mixed_store(store):  # type: ignore[return]
+    """Store with an active, pending_review, and archived entry each."""
+    active = make_entry(content="active entry content")
+    pending = make_entry(content="pending entry content", status=EntryStatus.PENDING_REVIEW)
+    archived = make_entry(content="archived entry content")
+
+    await store.store(active)
+    await store.store(pending)
+    archived_id = await store.store(archived)
+    # Soft-delete the third entry to mark it archived.
+    await store.delete(archived_id)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# distillery_list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestListDefaultExcludesArchived:
+    async def test_default_excludes_archived(self, status_mixed_store) -> None:
+        result = await _handle_list(store=status_mixed_store, arguments={"limit": 50, "output_mode": "full"})
+        data = parse_mcp_response(result)
+        statuses = {e["status"] for e in data["entries"]}
+        assert "archived" not in statuses
+        assert statuses.issubset({"active", "pending_review"})
+        assert data["count"] == 2
+        assert data["total_count"] == 2
+
+    async def test_explicit_status_archived_returns_only_archived(self, status_mixed_store) -> None:
+        result = await _handle_list(
+            store=status_mixed_store,
+            arguments={"limit": 50, "status": "archived", "output_mode": "full"},
+        )
+        data = parse_mcp_response(result)
+        assert data["count"] == 1
+        assert data["entries"][0]["status"] == "archived"
+
+    async def test_status_any_returns_all(self, status_mixed_store) -> None:
+        result = await _handle_list(
+            store=status_mixed_store,
+            arguments={"limit": 50, "status": "any", "output_mode": "full"},
+        )
+        data = parse_mcp_response(result)
+        statuses = {e["status"] for e in data["entries"]}
+        assert statuses == {"active", "pending_review", "archived"}
+        assert data["count"] == 3
+
+    async def test_include_archived_returns_all(self, status_mixed_store) -> None:
+        result = await _handle_list(
+            store=status_mixed_store,
+            arguments={"limit": 50, "include_archived": True, "output_mode": "full"},
+        )
+        data = parse_mcp_response(result)
+        statuses = {e["status"] for e in data["entries"]}
+        assert statuses == {"active", "pending_review", "archived"}
+        assert data["count"] == 3
+
+    async def test_explicit_status_active_excludes_others(self, status_mixed_store) -> None:
+        result = await _handle_list(
+            store=status_mixed_store,
+            arguments={"limit": 50, "status": "active", "output_mode": "full"},
+        )
+        data = parse_mcp_response(result)
+        assert data["count"] == 1
+        assert data["entries"][0]["status"] == "active"
+
+    async def test_review_mode_overrides_default(self, status_mixed_store) -> None:
+        # review mode filters to pending_review and must not be overridden by
+        # the default archived-exclusion logic.
+        result = await _handle_list(
+            store=status_mixed_store,
+            arguments={"limit": 50, "output_mode": "review"},
+        )
+        data = parse_mcp_response(result)
+        assert data["count"] == 1
+        assert data["entries"][0]["entry_type"]  # review payload shape
+
+    async def test_include_archived_invalid_type(self, status_mixed_store) -> None:
+        result = await _handle_list(
+            store=status_mixed_store,
+            arguments={"limit": 10, "include_archived": "yes"},
+        )
+        data = parse_mcp_response(result)
+        assert data.get("error") is True
+        assert data.get("code") == "INVALID_PARAMS"
+
+
+# ---------------------------------------------------------------------------
+# _apply_default_status_filter helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestApplyDefaultStatusFilter:
+    def test_empty_filters_gets_default(self) -> None:
+        out = _apply_default_status_filter(None, {})
+        assert isinstance(out, dict)
+        assert out["status"] == list(_DEFAULT_VISIBLE_STATUSES)
+
+    def test_explicit_status_preserved(self) -> None:
+        out = _apply_default_status_filter({"status": "archived"}, {})
+        assert out == {"status": "archived"}
+
+    def test_status_any_strips_key(self) -> None:
+        out = _apply_default_status_filter({"status": "any"}, {})
+        # Expect filters to end up without a status key (caller includes all).
+        assert out is None or "status" not in out
+
+    def test_status_any_with_other_filter_strips_only_status(self) -> None:
+        out = _apply_default_status_filter({"status": "any", "author": "x"}, {})
+        assert isinstance(out, dict)
+        assert out == {"author": "x"}
+
+    def test_include_archived_skips_default(self) -> None:
+        out = _apply_default_status_filter(None, {"include_archived": True})
+        assert out is None or "status" not in out
+
+    def test_include_archived_invalid_returns_error_response(self) -> None:
+        out = _apply_default_status_filter(None, {"include_archived": "yes"})
+        # Error responses are lists of TextContent.
+        assert isinstance(out, list)
+
+
+# ---------------------------------------------------------------------------
+# distillery_search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSearchDefaultExcludesArchived:
+    async def test_default_search_excludes_archived(self, status_mixed_store) -> None:
+        result = await _handle_search(
+            store=status_mixed_store,
+            arguments={"query": "entry content", "limit": 50},
+        )
+        data = parse_mcp_response(result)
+        statuses = {r["entry"]["status"] for r in data["results"]}
+        assert "archived" not in statuses
+
+    async def test_search_status_any_includes_archived(self, status_mixed_store) -> None:
+        result = await _handle_search(
+            store=status_mixed_store,
+            arguments={"query": "entry content", "limit": 50, "status": "any"},
+        )
+        data = parse_mcp_response(result)
+        statuses = {r["entry"]["status"] for r in data["results"]}
+        assert "archived" in statuses
+
+    async def test_search_include_archived_flag(self, status_mixed_store) -> None:
+        result = await _handle_search(
+            store=status_mixed_store,
+            arguments={
+                "query": "entry content",
+                "limit": 50,
+                "include_archived": True,
+            },
+        )
+        data = parse_mcp_response(result)
+        statuses = {r["entry"]["status"] for r in data["results"]}
+        assert "archived" in statuses
+
+    async def test_search_status_archived_returns_only_archived(self, status_mixed_store) -> None:
+        result = await _handle_search(
+            store=status_mixed_store,
+            arguments={
+                "query": "entry content",
+                "limit": 50,
+                "status": "archived",
+            },
+        )
+        data = parse_mcp_response(result)
+        statuses = {r["entry"]["status"] for r in data["results"]}
+        assert statuses == {"archived"}


### PR DESCRIPTION
## Summary
- `distillery_list` and `distillery_search` now hide archived entries from default views, returning only `active` and `pending_review` status.
- Added `include_archived` tool parameter and `status="any"` sentinel for opt-in visibility; explicit `status="archived"` still returns archived-only results.
- Taught `DuckDBStore._build_filter_clauses` to emit SQL `IN (...)` when `status` is a list so the default multi-status predicate works at the store layer.
- Internal callers (feeds poller, github_sync, interests extractor, cli retag) use `store.list_entries` directly with their own explicit filters — their behaviour is unchanged.

Resolves issue #317. Scope was intentionally limited to the archived-default filter so it does not conflict with the parallel `output_mode` default work tracked in issue #311.

## Test plan
- [x] `ruff check src/ tests/`
- [x] `ruff format src/ tests/`
- [x] `PYTHONPATH=$PWD/src python -m mypy --strict src/distillery/`
- [x] `pytest tests/test_list_archived_default.py -m unit` (17 new tests: default-exclusion, explicit archived, status="any", include_archived flag, review output mode precedence, helper behaviour, invalid include_archived type)
- [x] `pytest tests/test_list_output_modes.py tests/test_mcp_server.py tests/test_mcp_coverage_gaps.py tests/test_store_protocol.py tests/test_store_integration.py tests/test_tags.py tests/test_session_id.py -m unit` (all green)
- [x] Full unit suite: 1346 passed (one pre-existing unrelated failure in `tests/test_cli_export_import.py::test_roundtrip_fidelity`, a timezone bug present on the base branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)