### PR TITLE
fix(feeds): surface poll liveness on distillery_watch list (#310)

### DIFF
--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -466,7 +466,13 @@ class FeedPoller:
         db_sources = await self._store.list_feed_sources()
         if source_url is not None:
             db_sources = [s for s in db_sources if s["url"] == source_url]
-        sources = [FeedSourceConfig(**s) for s in db_sources]
+        # list_feed_sources returns liveness fields (last_polled_at, etc.)
+        # that are not part of FeedSourceConfig — filter to the constructor
+        # kwargs before instantiation.
+        _cfg_fields = {"url", "source_type", "label", "poll_interval_minutes", "trust_weight"}
+        sources = [
+            FeedSourceConfig(**{k: v for k, v in s.items() if k in _cfg_fields}) for s in db_sources
+        ]
         if not sources:
             logger.debug("FeedPoller: no sources configured — skipping poll")
             summary.finished_at = datetime.now(tz=UTC)
@@ -530,6 +536,7 @@ class FeedPoller:
                     sources[idx].url,
                     result,
                 )
+                await self._persist_poll_status(err_result)
             else:
                 summary.results.append(result)
                 summary.total_fetched += result.items_fetched
@@ -539,9 +546,41 @@ class FeedPoller:
                 summary.sources_polled += 1
                 if result.errors:
                     summary.sources_errored += 1
+                await self._persist_poll_status(result)
 
         summary.finished_at = datetime.now(tz=UTC)
         return summary
+
+    async def _persist_poll_status(self, result: PollResult) -> None:
+        """Persist liveness metadata for a single poll outcome.
+
+        The store is the source of truth for feed health — update the
+        ``last_polled_at``, ``last_item_count``, and ``last_error``
+        columns after each source poll so ``distillery_watch(action=
+        'list')`` can surface them without a separate status tool.
+
+        Any exception raised by ``record_poll_status`` is swallowed with a
+        debug log so that persistence failures do not mask poll results.
+        Backends that predate the protocol addition may not expose the
+        method — in that case we simply skip the update.
+        """
+        recorder = getattr(self._store, "record_poll_status", None)
+        if recorder is None:
+            return
+        error_msg = result.errors[0] if result.errors else None
+        try:
+            await recorder(
+                result.source_url,
+                polled_at=result.polled_at,
+                item_count=result.items_stored,
+                error=error_msg,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "FeedPoller: failed to persist poll status for %s",
+                result.source_url,
+                exc_info=True,
+            )
 
     async def _poll_source(
         self,

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1841,12 +1841,15 @@ class DuckDBStore:
         *url* exists.
         """
         assert self._conn is not None
+        item_count_int = int(item_count)
+        if item_count_int < 0:
+            raise ValueError(f"item_count must be non-negative, got: {item_count_int}")
         truncated = _sanitise_last_error(error, self._LAST_ERROR_MAX_LEN)
         result = self._conn.execute(
             "UPDATE feed_sources "
             "SET last_polled_at = ?, last_item_count = ?, last_error = ? "
             "WHERE url = ? RETURNING url",
-            [polled_at, int(item_count), truncated, url],
+            [polled_at, item_count_int, truncated, url],
         )
         return len(result.fetchall()) > 0
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -48,6 +48,29 @@ def _sql_escape(value: str) -> str:
     return value.replace("'", "''")
 
 
+def _sanitise_last_error(error: str | None, max_len: int) -> str | None:
+    """Collapse whitespace and truncate a feed-poll error string.
+
+    Returns ``None`` when *error* is ``None`` or empty after stripping so
+    successful polls clear any previous error.  Control characters
+    (including newlines and carriage returns) are collapsed to single
+    spaces so the payload is operator-friendly and less likely to leak
+    stack-trace fragments verbatim.  The resulting string is truncated
+    to *max_len* characters with an ellipsis suffix when truncation
+    occurs.
+    """
+    if error is None:
+        return None
+    # Collapse runs of whitespace / control chars to single spaces.
+    collapsed = re.sub(r"\s+", " ", error).strip()
+    if not collapsed:
+        return None
+    if len(collapsed) <= max_len:
+        return collapsed
+    # Preserve total length of exactly *max_len* including ellipsis.
+    return collapsed[: max_len - 1] + "\u2026"
+
+
 _AGGREGATE_EXPR_MAP: dict[str, str] = {
     "entry_type": "entry_type",
     "status": "status",
@@ -1710,23 +1733,50 @@ class DuckDBStore:
     # ------------------------------------------------------------------
 
     def _sync_list_feed_sources(self) -> list[dict[str, Any]]:
-        """Return all persisted feed sources as dicts."""
+        """Return all persisted feed sources as dicts.
+
+        Includes liveness fields (``last_polled_at``, ``last_item_count``,
+        ``last_error``, ``next_poll_at``) so operators can determine feed
+        health from a single query.  Timestamps are serialised to ISO 8601
+        strings.  ``next_poll_at`` is derived from ``last_polled_at +
+        poll_interval_minutes`` and is ``None`` when the source has never
+        been polled.
+        """
+        from datetime import timedelta
+
         assert self._conn is not None
         result = self._conn.execute(
-            "SELECT url, source_type, label, poll_interval_minutes, trust_weight "
+            "SELECT url, source_type, label, poll_interval_minutes, trust_weight, "
+            "last_polled_at, last_item_count, last_error "
             "FROM feed_sources ORDER BY created_at"
         )
         rows = result.fetchall()
-        return [
-            {
-                "url": row[0],
-                "source_type": row[1],
-                "label": row[2],
-                "poll_interval_minutes": row[3],
-                "trust_weight": row[4],
-            }
-            for row in rows
-        ]
+        sources: list[dict[str, Any]] = []
+        for row in rows:
+            last_polled_at: datetime | None = row[5]
+            poll_interval_minutes: int = row[3]
+            last_polled_iso: str | None = (
+                last_polled_at.isoformat() if last_polled_at is not None else None
+            )
+            next_poll_at: str | None = (
+                (last_polled_at + timedelta(minutes=poll_interval_minutes)).isoformat()
+                if last_polled_at is not None
+                else None
+            )
+            sources.append(
+                {
+                    "url": row[0],
+                    "source_type": row[1],
+                    "label": row[2],
+                    "poll_interval_minutes": poll_interval_minutes,
+                    "trust_weight": row[4],
+                    "last_polled_at": last_polled_iso,
+                    "last_item_count": row[6] if row[6] is not None else 0,
+                    "last_error": row[7],
+                    "next_poll_at": next_poll_at,
+                }
+            )
+        return sources
 
     def _sync_add_feed_source(
         self,
@@ -1761,6 +1811,36 @@ class DuckDBStore:
         result = self._conn.execute("DELETE FROM feed_sources WHERE url = ? RETURNING url", [url])
         return len(result.fetchall()) > 0
 
+    # Maximum length of a persisted ``last_error`` string.  Longer errors are
+    # truncated to keep the liveness payload small and to avoid storing
+    # sensitive traceback fragments verbatim.
+    _LAST_ERROR_MAX_LEN = 200
+
+    def _sync_record_poll_status(
+        self,
+        url: str,
+        *,
+        polled_at: datetime,
+        item_count: int,
+        error: str | None,
+    ) -> bool:
+        """Persist the outcome of a poll against a feed source.
+
+        Stores *polled_at*, *item_count*, and a truncated+sanitised *error*
+        (or ``NULL``) on the matching ``feed_sources`` row.  Returns
+        ``True`` when a row was updated, ``False`` when no source with
+        *url* exists.
+        """
+        assert self._conn is not None
+        truncated = _sanitise_last_error(error, self._LAST_ERROR_MAX_LEN)
+        result = self._conn.execute(
+            "UPDATE feed_sources "
+            "SET last_polled_at = ?, last_item_count = ?, last_error = ? "
+            "WHERE url = ? RETURNING url",
+            [polled_at, int(item_count), truncated, url],
+        )
+        return len(result.fetchall()) > 0
+
     async def list_feed_sources(self) -> list[dict[str, Any]]:
         """Return all persisted feed sources as dicts."""
         return await asyncio.to_thread(self._sync_list_feed_sources)
@@ -1781,6 +1861,35 @@ class DuckDBStore:
     async def remove_feed_source(self, url: str) -> bool:
         """Remove a feed source by URL. Returns True if it existed."""
         return await asyncio.to_thread(self._sync_remove_feed_source, url)
+
+    async def record_poll_status(
+        self,
+        url: str,
+        *,
+        polled_at: datetime,
+        item_count: int,
+        error: str | None,
+    ) -> bool:
+        """Record the outcome of a poll against a feed source.
+
+        Args:
+            url: The feed source URL (primary key).
+            polled_at: UTC timestamp of the poll attempt.
+            item_count: Items successfully ingested during the poll.
+            error: Error message when the poll failed, or ``None`` on success.
+                The value is truncated and sanitised before persistence.
+
+        Returns:
+            ``True`` if a matching row was updated, ``False`` if no source
+            with *url* exists.
+        """
+        return await asyncio.to_thread(
+            self._sync_record_poll_status,
+            url,
+            polled_at=polled_at,
+            item_count=item_count,
+            error=error,
+        )
 
     # ------------------------------------------------------------------
     # Metadata helpers

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1753,8 +1753,17 @@ class DuckDBStore:
         rows = result.fetchall()
         sources: list[dict[str, Any]] = []
         for row in rows:
-            last_polled_at: datetime | None = row[5]
+            last_polled_raw: datetime | None = row[5]
             poll_interval_minutes: int = row[3]
+            # DuckDB TIMESTAMP is naive — assume UTC and attach tzinfo so the
+            # serialised value preserves the "+00:00" offset downstream.
+            last_polled_at: datetime | None = None
+            if last_polled_raw is not None:
+                last_polled_at = (
+                    last_polled_raw.replace(tzinfo=UTC)
+                    if last_polled_raw.tzinfo is None
+                    else last_polled_raw.astimezone(UTC)
+                )
             last_polled_iso: str | None = (
                 last_polled_at.isoformat() if last_polled_at is not None else None
             )

--- a/src/distillery/store/migrations.py
+++ b/src/distillery/store/migrations.py
@@ -330,6 +330,29 @@ def add_session_id(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
     logger.info("Migration 11: session_id column added")
 
 
+_ADD_FEED_SOURCE_LIVENESS_COLUMNS = [
+    "ALTER TABLE feed_sources ADD COLUMN IF NOT EXISTS last_polled_at TIMESTAMP;",
+    "ALTER TABLE feed_sources ADD COLUMN IF NOT EXISTS last_item_count INTEGER DEFAULT 0;",
+    "ALTER TABLE feed_sources ADD COLUMN IF NOT EXISTS last_error VARCHAR;",
+]
+
+
+def add_feed_source_liveness(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
+    """Migration 12: Add liveness columns to ``feed_sources``.
+
+    Adds three nullable columns used by operators to answer "is this feed
+    working?" without consulting a separate sync-status tool:
+
+    - ``last_polled_at`` (TIMESTAMP) — UTC instant of the most recent poll.
+    - ``last_item_count`` (INTEGER) — items ingested on the last poll.
+    - ``last_error`` (VARCHAR) — truncated error message from the last poll,
+      or ``NULL`` when the poll succeeded.
+    """
+    for stmt in _ADD_FEED_SOURCE_LIVENESS_COLUMNS:
+        conn.execute(stmt)
+    logger.info("Migration 12: feed_sources liveness columns added")
+
+
 # ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
@@ -346,6 +369,7 @@ MIGRATIONS: dict[int, MigrationFunc] = {
     9: add_expires_at,
     10: add_verification,
     11: add_session_id,
+    12: add_feed_source_liveness,
 }
 """Ordered mapping of schema version to migration function.
 

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -263,7 +263,10 @@ class DistilleryStore(Protocol):
         """Return all persisted feed sources as dicts.
 
         Each dict contains keys: ``url``, ``source_type``, ``label``,
-        ``poll_interval_minutes``, ``trust_weight``.
+        ``poll_interval_minutes``, ``trust_weight``, ``last_polled_at``
+        (ISO 8601 string or ``None``), ``last_item_count`` (int),
+        ``last_error`` (str or ``None``), and ``next_poll_at``
+        (ISO 8601 string or ``None``).
 
         Returns:
             List of feed source dicts ordered by creation time.
@@ -304,6 +307,30 @@ class DistilleryStore(Protocol):
         Returns:
             ``True`` if the source existed and was removed, ``False``
             otherwise.
+        """
+        ...
+
+    async def record_poll_status(
+        self,
+        url: str,
+        *,
+        polled_at: datetime,
+        item_count: int,
+        error: str | None,
+    ) -> bool:
+        """Persist the outcome of a poll against a feed source.
+
+        Args:
+            url: The feed source URL (primary key).
+            polled_at: UTC timestamp of the poll attempt.
+            item_count: Items successfully ingested during the poll.
+            error: Error message when the poll failed, or ``None`` on
+                success.  Implementations must truncate and sanitise the
+                value before persistence.
+
+        Returns:
+            ``True`` if the row was updated, ``False`` if no source with
+            *url* exists.
         """
         ...
 

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -663,6 +663,75 @@ class TestClose:
         await store.close()  # should be a no-op
 
 
+class TestFeedSourceLiveness:
+    """DuckDBStore surfaces liveness metadata alongside feed sources."""
+
+    async def test_list_includes_liveness_fields_defaults(self, store: DuckDBStore) -> None:
+        await store.add_feed_source(
+            url="https://example.com/rss",
+            source_type="rss",
+            poll_interval_minutes=30,
+        )
+        sources = await store.list_feed_sources()
+        assert len(sources) == 1
+        src = sources[0]
+        assert src["last_polled_at"] is None
+        assert src["last_item_count"] == 0
+        assert src["last_error"] is None
+        assert src["next_poll_at"] is None
+
+    async def test_record_poll_status_updates_fields(self, store: DuckDBStore) -> None:
+        await store.add_feed_source(
+            url="https://example.com/rss",
+            source_type="rss",
+            poll_interval_minutes=60,
+        )
+        polled_at = datetime(2026, 4, 16, 12, 0, tzinfo=UTC)
+        updated = await store.record_poll_status(
+            "https://example.com/rss",
+            polled_at=polled_at,
+            item_count=5,
+            error=None,
+        )
+        assert updated is True
+
+        sources = await store.list_feed_sources()
+        src = sources[0]
+        assert src["last_polled_at"] is not None
+        assert src["last_item_count"] == 5
+        assert src["last_error"] is None
+        assert src["next_poll_at"] is not None
+
+    async def test_record_poll_status_surfaces_error(self, store: DuckDBStore) -> None:
+        await store.add_feed_source(
+            url="https://example.com/rss",
+            source_type="rss",
+        )
+        polled_at = datetime(2026, 4, 16, 12, 0, tzinfo=UTC)
+        long_error = "A" * 500
+        await store.record_poll_status(
+            "https://example.com/rss",
+            polled_at=polled_at,
+            item_count=0,
+            error=long_error,
+        )
+        src = (await store.list_feed_sources())[0]
+        assert src["last_error"] is not None
+        # Truncated to 200 chars with ellipsis suffix.
+        assert len(src["last_error"]) == 200
+        assert src["last_error"].endswith("\u2026")
+        assert src["last_item_count"] == 0
+
+    async def test_record_poll_status_unknown_url_returns_false(self, store: DuckDBStore) -> None:
+        result = await store.record_poll_status(
+            "https://not-there.example/rss",
+            polled_at=datetime.now(tz=UTC),
+            item_count=0,
+            error=None,
+        )
+        assert result is False
+
+
 # ---------------------------------------------------------------------------
 # Hybrid search (BM25 + vector RRF fusion with recency decay)
 # ---------------------------------------------------------------------------

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -997,3 +997,47 @@ class TestHybridGracefulFallback:
     ) -> None:
         """_fts_available should be False when hybrid_search is disabled."""
         assert vector_only_store._fts_available is False  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# _sanitise_last_error helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSanitiseLastError:
+    """Unit tests for ``DuckDBStore._sanitise_last_error``.
+
+    Moved here from ``tests/test_mcp_feeds.py`` to keep private-helper tests
+    alongside their module.
+    """
+
+    def test_none_returns_none(self) -> None:
+        from distillery.store.duckdb import _sanitise_last_error
+
+        assert _sanitise_last_error(None, 200) is None
+
+    def test_empty_returns_none(self) -> None:
+        from distillery.store.duckdb import _sanitise_last_error
+
+        assert _sanitise_last_error("   \n\t", 200) is None
+
+    def test_short_error_is_preserved(self) -> None:
+        from distillery.store.duckdb import _sanitise_last_error
+
+        assert _sanitise_last_error("upstream 502", 200) == "upstream 502"
+
+    def test_collapses_whitespace_and_newlines(self) -> None:
+        from distillery.store.duckdb import _sanitise_last_error
+
+        raw = "Traceback:\n  File 'x'\n  ValueError: boom"
+        assert _sanitise_last_error(raw, 200) == "Traceback: File 'x' ValueError: boom"
+
+    def test_truncates_when_longer_than_max_len(self) -> None:
+        from distillery.store.duckdb import _sanitise_last_error
+
+        raw = "x" * 500
+        result = _sanitise_last_error(raw, 50)
+        assert result is not None
+        assert len(result) == 50
+        assert result.endswith("\u2026")

--- a/tests/test_mcp_feeds.py
+++ b/tests/test_mcp_feeds.py
@@ -12,6 +12,7 @@ test_watch.py so they run without a live database.
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -31,7 +32,6 @@ from distillery.mcp.tools.feeds import (
     _handle_poll,
     _handle_watch,
 )
-from distillery.store.duckdb import _sanitise_last_error
 
 pytestmark = pytest.mark.unit
 
@@ -39,6 +39,21 @@ pytestmark = pytest.mark.unit
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
+
+def _fake_sanitise_last_error(error: str | None, max_len: int = 200) -> str | None:
+    """Mirror ``DuckDBStore._sanitise_last_error`` locally so tests don't import
+    the private helper.  Collapses whitespace, truncates to *max_len*, returns
+    ``None`` for empty/whitespace input.
+    """
+    if error is None:
+        return None
+    collapsed = re.sub(r"\s+", " ", error).strip()
+    if not collapsed:
+        return None
+    if len(collapsed) <= max_len:
+        return collapsed
+    return collapsed[: max_len - 1] + "\u2026"
 
 
 def parse(result: list) -> dict:  # type: ignore[type-arg]
@@ -111,14 +126,12 @@ class FakeSourceStore:
     ) -> bool:
         from datetime import timedelta
 
-        from distillery.store.duckdb import _sanitise_last_error
-
         for src in self._sources:
             if src["url"] != url:
                 continue
             src["last_polled_at"] = polled_at.isoformat()
             src["last_item_count"] = int(item_count)
-            src["last_error"] = _sanitise_last_error(error, 200)
+            src["last_error"] = _fake_sanitise_last_error(error, 200)
             src["next_poll_at"] = (
                 polled_at + timedelta(minutes=src["poll_interval_minutes"])
             ).isoformat()
@@ -829,31 +842,6 @@ class TestHandleSuggestSources:
         assert "entry_count" in data
 
 
-# ---------------------------------------------------------------------------
-# _sanitise_last_error — helper that truncates + sanitises poll error strings
-# ---------------------------------------------------------------------------
-
-
-class TestSanitiseLastError:
-    def test_none_returns_none(self) -> None:
-        assert _sanitise_last_error(None, 200) is None
-
-    def test_empty_returns_none(self) -> None:
-        # An all-whitespace input collapses to an empty string → None so
-        # a successful poll clears any previous error.
-        assert _sanitise_last_error("   \n\t", 200) is None
-
-    def test_short_error_is_preserved(self) -> None:
-        assert _sanitise_last_error("upstream 502", 200) == "upstream 502"
-
-    def test_collapses_whitespace_and_newlines(self) -> None:
-        raw = "Traceback:\n  File 'x'\n  ValueError: boom"
-        assert _sanitise_last_error(raw, 200) == "Traceback: File 'x' ValueError: boom"
-
-    def test_truncates_when_longer_than_max_len(self) -> None:
-        raw = "x" * 500
-        result = _sanitise_last_error(raw, 50)
-        assert result is not None
-        # Exactly max_len characters, including the ellipsis sentinel.
-        assert len(result) == 50
-        assert result.endswith("\u2026")
+# NOTE: unit tests for the internal ``_sanitise_last_error`` helper live in
+# ``tests/test_duckdb_store.py`` to avoid coupling MCP feed tests to a private
+# store implementation detail.

--- a/tests/test_mcp_feeds.py
+++ b/tests/test_mcp_feeds.py
@@ -111,12 +111,14 @@ class FakeSourceStore:
     ) -> bool:
         from datetime import timedelta
 
+        from distillery.store.duckdb import _sanitise_last_error
+
         for src in self._sources:
             if src["url"] != url:
                 continue
             src["last_polled_at"] = polled_at.isoformat()
             src["last_item_count"] = int(item_count)
-            src["last_error"] = error
+            src["last_error"] = _sanitise_last_error(error, 200)
             src["next_poll_at"] = (
                 polled_at + timedelta(minutes=src["poll_interval_minutes"])
             ).isoformat()

--- a/tests/test_mcp_feeds.py
+++ b/tests/test_mcp_feeds.py
@@ -31,6 +31,7 @@ from distillery.mcp.tools.feeds import (
     _handle_poll,
     _handle_watch,
 )
+from distillery.store.duckdb import _sanitise_last_error
 
 pytestmark = pytest.mark.unit
 
@@ -66,7 +67,10 @@ class FakeSourceStore:
         self._sources: list[dict[str, Any]] = []
 
     async def list_feed_sources(self) -> list[dict[str, Any]]:
-        return list(self._sources)
+        # Deep-copy so callers mutating the returned dicts do not affect
+        # subsequent lookups — mirrors DuckDBStore, which rebuilds the dicts
+        # from the underlying rows on every call.
+        return [dict(s) for s in self._sources]
 
     async def add_feed_source(
         self,
@@ -84,6 +88,10 @@ class FakeSourceStore:
             "label": label,
             "poll_interval_minutes": poll_interval_minutes,
             "trust_weight": trust_weight,
+            "last_polled_at": None,
+            "last_item_count": 0,
+            "last_error": None,
+            "next_poll_at": None,
         }
         self._sources.append(entry)
         return entry
@@ -92,6 +100,28 @@ class FakeSourceStore:
         before = len(self._sources)
         self._sources = [s for s in self._sources if s["url"] != url]
         return len(self._sources) < before
+
+    async def record_poll_status(
+        self,
+        url: str,
+        *,
+        polled_at: datetime,
+        item_count: int,
+        error: str | None,
+    ) -> bool:
+        from datetime import timedelta
+
+        for src in self._sources:
+            if src["url"] != url:
+                continue
+            src["last_polled_at"] = polled_at.isoformat()
+            src["last_item_count"] = int(item_count)
+            src["last_error"] = error
+            src["next_poll_at"] = (
+                polled_at + timedelta(minutes=src["poll_interval_minutes"])
+            ).isoformat()
+            return True
+        return False
 
 
 class FailingSourceStore:
@@ -155,6 +185,74 @@ class TestHandleWatchList:
         data = parse(result)
         assert data["error"] is True
         assert data["code"] == "WATCH_ERROR"
+
+    async def test_list_includes_liveness_fields_for_never_polled_source(self) -> None:
+        """Newly added sources expose liveness keys with null/zero defaults."""
+        store = FakeSourceStore()
+        await store.add_feed_source(
+            url="https://example.com/rss",
+            source_type="rss",
+            poll_interval_minutes=60,
+        )
+        result = await _handle_watch(store=store, arguments={"action": "list"})
+        data = parse(result)
+        src = data["sources"][0]
+        # New liveness fields must be present in the payload.
+        assert "last_polled_at" in src
+        assert "last_item_count" in src
+        assert "last_error" in src
+        assert "next_poll_at" in src
+        # Defaults for an unpolled source.
+        assert src["last_polled_at"] is None
+        assert src["last_item_count"] == 0
+        assert src["last_error"] is None
+        assert src["next_poll_at"] is None
+
+    async def test_list_surfaces_recorded_poll_success(self) -> None:
+        """After a successful poll the liveness fields reflect the outcome."""
+        store = FakeSourceStore()
+        await store.add_feed_source(
+            url="https://example.com/rss",
+            source_type="rss",
+            poll_interval_minutes=30,
+        )
+        polled_at = datetime(2026, 4, 16, 12, 0, tzinfo=UTC)
+        assert await store.record_poll_status(
+            "https://example.com/rss",
+            polled_at=polled_at,
+            item_count=7,
+            error=None,
+        )
+
+        result = await _handle_watch(store=store, arguments={"action": "list"})
+        src = parse(result)["sources"][0]
+        assert src["last_polled_at"] == polled_at.isoformat()
+        assert src["last_item_count"] == 7
+        assert src["last_error"] is None
+        # next_poll_at = last_polled_at + poll_interval_minutes
+        assert src["next_poll_at"] == "2026-04-16T12:30:00+00:00"
+
+    async def test_list_surfaces_last_error_when_poll_fails(self) -> None:
+        """When a poll fails the error string is surfaced on the list payload."""
+        store = FakeSourceStore()
+        await store.add_feed_source(
+            url="https://example.com/rss",
+            source_type="rss",
+        )
+        polled_at = datetime(2026, 4, 16, 12, 0, tzinfo=UTC)
+        await store.record_poll_status(
+            "https://example.com/rss",
+            polled_at=polled_at,
+            item_count=0,
+            error="Connection refused: upstream 502",
+        )
+
+        result = await _handle_watch(store=store, arguments={"action": "list"})
+        src = parse(result)["sources"][0]
+        assert src["last_error"] == "Connection refused: upstream 502"
+        assert src["last_item_count"] == 0
+        assert src["last_polled_at"] == polled_at.isoformat()
+        assert src["next_poll_at"] is not None
 
 
 # ---------------------------------------------------------------------------
@@ -727,3 +825,33 @@ class TestHandleSuggestSources:
         assert "suggestion_context" in data
         assert "watched_sources" in data
         assert "entry_count" in data
+
+
+# ---------------------------------------------------------------------------
+# _sanitise_last_error — helper that truncates + sanitises poll error strings
+# ---------------------------------------------------------------------------
+
+
+class TestSanitiseLastError:
+    def test_none_returns_none(self) -> None:
+        assert _sanitise_last_error(None, 200) is None
+
+    def test_empty_returns_none(self) -> None:
+        # An all-whitespace input collapses to an empty string → None so
+        # a successful poll clears any previous error.
+        assert _sanitise_last_error("   \n\t", 200) is None
+
+    def test_short_error_is_preserved(self) -> None:
+        assert _sanitise_last_error("upstream 502", 200) == "upstream 502"
+
+    def test_collapses_whitespace_and_newlines(self) -> None:
+        raw = "Traceback:\n  File 'x'\n  ValueError: boom"
+        assert _sanitise_last_error(raw, 200) == "Traceback: File 'x' ValueError: boom"
+
+    def test_truncates_when_longer_than_max_len(self) -> None:
+        raw = "x" * 500
+        result = _sanitise_last_error(raw, 50)
+        assert result is not None
+        # Exactly max_len characters, including the ellipsis sentinel.
+        assert len(result) == 50
+        assert result.endswith("\u2026")

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -764,3 +764,98 @@ class TestBuildAdapterGitHubToken:
             assert "ghp_secrettoken9999" not in record.getMessage(), (
                 "Raw token must not appear in log output"
             )
+
+
+# ---------------------------------------------------------------------------
+# FeedPoller._persist_poll_status — persists liveness metadata per poll
+# ---------------------------------------------------------------------------
+
+
+class TestPersistPollStatus:
+    async def test_records_successful_poll_on_store(self) -> None:
+        """After poll() the store receives record_poll_status with success details."""
+        items = [_make_feed_item(item_id="id1", title="Test", content="Body")]
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.0)
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            async def _find_similar(content: str, threshold: float, limit: int) -> list:
+                if threshold == 0.95:
+                    return []
+                return [_make_search_result(score=0.9)]
+
+            store.find_similar.side_effect = _find_similar
+            poller = FeedPoller(store=store, config=cfg)
+            await poller.poll()
+
+        store.record_poll_status.assert_called_once()
+        call = store.record_poll_status.call_args
+        assert call.args[0] == "https://example.com/rss"
+        assert call.kwargs["item_count"] == 1
+        assert call.kwargs["error"] is None
+
+    async def test_records_error_on_adapter_failure(self) -> None:
+        """A fetch failure is persisted via record_poll_status with the error string."""
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src])
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.side_effect = RuntimeError("network error")
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+            await poller.poll()
+
+        store.record_poll_status.assert_called_once()
+        call = store.record_poll_status.call_args
+        assert call.args[0] == "https://example.com/rss"
+        assert call.kwargs["item_count"] == 0
+        assert call.kwargs["error"] is not None
+        assert "network error" in call.kwargs["error"]
+
+    async def test_persist_failure_is_swallowed(self) -> None:
+        """A failing record_poll_status does not break the poll cycle."""
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        store.record_poll_status.side_effect = RuntimeError("DB unreachable")
+        cfg = _make_config(sources=[src], digest_threshold=0.0)
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = []
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        # Poll returned a normal summary despite the persistence failure.
+        assert summary.sources_polled == 1
+
+    async def test_missing_recorder_method_is_ignored(self) -> None:
+        """Stores predating the protocol addition (no record_poll_status) don't crash."""
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        # Use MagicMock (not AsyncMock) so getattr(store, "record_poll_status", None)
+        # returns the default None for missing attrs.  spec limits attribute access.
+        store = MagicMock(spec=["find_similar", "list_entries", "store", "list_feed_sources"])
+        store.find_similar = AsyncMock(return_value=[])
+        store.list_entries = AsyncMock(return_value=[])
+        store.store = AsyncMock(return_value="eid")
+        store.list_feed_sources = AsyncMock(return_value=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.0)
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = []
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.sources_polled == 1


### PR DESCRIPTION
## Summary

Fixes #310. Enriches the `distillery_watch(action='list')` payload with per-source liveness metadata so operators can answer "is this feed working?" without a separate sync-status tool.

New fields returned per source:
- `last_polled_at` (ISO 8601 timestamp or `null`)
- `last_item_count` (int — items ingested on last poll)
- `last_error` (str or `null` — whitespace-collapsed and truncated to 200 chars)
- `next_poll_at` (ISO 8601 timestamp — `last_polled_at + poll_interval_minutes`, or `null`)

## Changes

- **Migration 12** (`src/distillery/store/migrations.py`): adds nullable `last_polled_at TIMESTAMP`, `last_item_count INTEGER DEFAULT 0`, and `last_error VARCHAR` columns to `feed_sources`. Idempotent via `IF NOT EXISTS`.
- **Store** (`src/distillery/store/duckdb.py`): `list_feed_sources` now surfaces the four liveness fields (with `next_poll_at` computed from `poll_interval_minutes`). New `record_poll_status(url, *, polled_at, item_count, error)` method writes the outcome of each poll. Errors are sanitised (whitespace collapsed, truncated to 200 chars with ellipsis) before persistence to avoid leaking traceback fragments.
- **Protocol** (`src/distillery/store/protocol.py`): documents the enriched `list_feed_sources` contract and adds `record_poll_status` to the `DistilleryStore` protocol.
- **Poller** (`src/distillery/feeds/poller.py`): after each `_poll_source` result, calls `record_poll_status` with the outcome. Missing-method and persistence failures are swallowed so existing backends and transient DB errors never break the poll cycle. `FeedSourceConfig` construction filters the expanded dict so the new keys don't break `poller.poll`.
- **MCP handler** (`src/distillery/mcp/tools/feeds.py`): unchanged — the list action already passes the store payload through to the client, which now includes the new fields.

## Test plan

- [x] Unit tests for `_sanitise_last_error` covering truncation, whitespace collapse, and empty input
- [x] Unit tests for `_handle_watch(action='list')` asserting the payload exposes the new fields with correct defaults and surfaces `last_error` when a poll fails
- [x] Unit tests for `FeedPoller._persist_poll_status` on success, error, persistence failure, and missing-method cases
- [x] Integration tests (real DuckDB) for `record_poll_status` including long-error truncation and unknown-URL handling
- [x] `ruff check` / `ruff format` / `mypy --strict` all green
- [x] Full unit suite: 1341 passed (1 pre-existing unrelated failure in `test_cli_export_import::test_roundtrip_fidelity` — reproduces on `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feed sources now display liveness metadata: last polled time, last item count, last error (sanitised/truncated), and next scheduled poll.
  * Poll outcomes are persisted when available; persistence failures are handled gracefully.

* **Tests**
  * Added tests covering liveness fields, error sanitisation/truncation, persistence behavior, and resilience when persistence is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->