### PR TITLE
feat(mcp): add distillery_status tool (#313)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Distillery
 
-Distillery is a knowledge-base system for Claude Code. It stores, searches, and classifies knowledge entries using DuckDB with vector similarity search (VSS/HNSW). It includes ambient intelligence features that poll external feeds (GitHub, RSS) and score relevance using embeddings. It exposes functionality via an MCP server (stdio or streamable-HTTP transport) with 12 tools, orchestrated by 14 Claude Code skills (`/distill`, `/recall`, `/pour`, `/bookmark`, `/minutes`, `/classify`, `/watch`, `/radar`, `/tune`, `/digest`, `/gh-sync`, `/investigate`, `/briefing`, `/setup`). HTTP transport supports GitHub OAuth for team access. REST webhook endpoints (`/hooks/poll`, `/hooks/rescore`, `/hooks/classify-batch`, `/api/maintenance`) run alongside the MCP server for automated scheduling via GitHub Actions cron.
+Distillery is a knowledge-base system for Claude Code. It stores, searches, and classifies knowledge entries using DuckDB with vector similarity search (VSS/HNSW). It includes ambient intelligence features that poll external feeds (GitHub, RSS) and score relevance using embeddings. It exposes functionality via an MCP server (stdio or streamable-HTTP transport) with 16 tools, orchestrated by 14 Claude Code skills (`/distill`, `/recall`, `/pour`, `/bookmark`, `/minutes`, `/classify`, `/watch`, `/radar`, `/tune`, `/digest`, `/gh-sync`, `/investigate`, `/briefing`, `/setup`). HTTP transport supports GitHub OAuth for team access. REST webhook endpoints (`/hooks/poll`, `/hooks/rescore`, `/hooks/classify-batch`, `/api/maintenance`) run alongside the MCP server for automated scheduling via GitHub Actions cron.
 
 ## Commands
 
@@ -51,7 +51,7 @@ Four-layer design:
 ```text
 Skills (skills/<name>/SKILL.md)  →  slash commands users invoke
     ↓
-MCP Server (src/distillery/mcp/server.py)  →  12 tools over stdio or HTTP (FastMCP 2.x/3.x)
+MCP Server (src/distillery/mcp/server.py)  →  16 tools over stdio or HTTP (FastMCP 2.x/3.x)
 Webhook API (src/distillery/mcp/webhooks.py) →  /hooks/poll, /hooks/rescore, /hooks/classify-batch, /api/maintenance (bearer auth)
     ↓
 Core Protocols (store/protocol.py, embedding/protocol.py)  →  typed Protocol interfaces

--- a/src/distillery/mcp/__main__.py
+++ b/src/distillery/mcp/__main__.py
@@ -165,6 +165,7 @@ def main(argv: list[str] | None = None) -> int:
             # reads the store from the server's shared state so it works
             # even though the store is only initialised at first request.
             _shared_ref = server._distillery_shared  # type: ignore[attr-defined]
+            _shared_ref["transport"] = "http"
 
             async def _auth_audit_cb(
                 user_id: str,
@@ -249,6 +250,7 @@ def main(argv: list[str] | None = None) -> int:
             uv_server.run()
         else:
             server = create_server(config=config)
+            server._distillery_shared["transport"] = "stdio"  # type: ignore[attr-defined]
             asyncio.run(server.run_stdio_async(show_banner=False))
 
         return 0

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1,4 +1,4 @@
-"""MCP server for Distillery — 15 tools over stdio or HTTP.
+"""MCP server for Distillery — 16 tools over stdio or HTTP.
 
 Handlers live in ``src/distillery/mcp/tools/`` (crud, search, classify, quality,
 analytics, feeds, configure, meta). This module owns: FastMCP app creation,
@@ -17,6 +17,7 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from typing import Any, cast
 
 from fastmcp import Context, FastMCP  # noqa: F401
@@ -57,6 +58,7 @@ from distillery.mcp.tools.feeds import (
 from distillery.mcp.tools.feeds import (
     _handle_store_batch as _handle_feed_store_batch,
 )
+from distillery.mcp.tools.meta import _handle_status
 from distillery.mcp.tools.quality import (
     run_conflict_discovery,
     run_conflict_evaluation,
@@ -102,6 +104,7 @@ __all__ = [
     "_handle_feed_store_batch",
     "_handle_sync_status",
     "_handle_relations",
+    "_handle_status",
 ]
 
 
@@ -195,6 +198,11 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                         )
                 await store.set_metadata("feeds_seeded", "true")
             _shared.update(store=store, config=config, embedding_provider=ep)
+            # Record startup timestamp for distillery_status uptime reporting.
+            # Stored in shared state (not replaced on subsequent lifespan entries
+            # for stateless HTTP sessions).
+            if "started_at" not in _shared:
+                _shared["started_at"] = datetime.now(UTC)
             logger.info(
                 "Distillery MCP server ready (db=%s, embedding=%s)",
                 db,
@@ -991,6 +999,51 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         return await _handle_configure(
             config=c["config"],
             arguments={"section": section, "key": key, "value": value},
+        )
+
+    @server.tool
+    async def distillery_status(ctx: Context) -> list[types.TextContent]:
+        """Return a lightweight in-protocol health/metadata probe.
+
+        USE WHEN: verifying MCP connectivity (e.g. from the ``/setup`` wizard)
+        without relying on the HTTP-only ``/health`` endpoint. Works uniformly
+        on stdio and HTTP transports.
+
+        PARAMS: (none)
+
+        RETURNS (success): {
+            status: "ok",
+            version: str,                 # distillery package version
+            build_sha: str,               # git SHA (or "dev")
+            transport: "stdio" | "http" | "unknown",
+            tool_count: int,              # number of registered MCP tools
+            store: { entry_count: int | null, db_size_bytes: int | null },
+            embedding_provider: str,      # model name or provider class name
+            last_feed_poll: { source_count: int, last_poll_at: str | null },
+            uptime_seconds?: int          # seconds since server startup
+        }
+
+        RELATED: distillery_metrics (for deep activity/quality metrics),
+        distillery_configure (to inspect/adjust runtime configuration)
+        """
+        c = _lc(ctx)
+        try:
+            tools = await server.list_tools()
+            tool_count = len(tools)
+        except Exception:  # noqa: BLE001
+            logger.debug("distillery_status: server.list_tools() failed", exc_info=True)
+            tool_count = 0
+        # Read transport from _shared (set by __main__.py post-construction);
+        # fall back to the lifespan-scoped copy if present.
+        transport = _shared.get("transport") or c.get("transport")
+        started_at = _shared.get("started_at") or c.get("started_at")
+        return await _handle_status(
+            store=c["store"],
+            config=c["config"],
+            embedding_provider=c["embedding_provider"],
+            tool_count=tool_count,
+            transport=transport,
+            started_at=started_at,
         )
 
     @server.resource("distillery://schemas/entry-types")

--- a/src/distillery/mcp/tools/__init__.py
+++ b/src/distillery/mcp/tools/__init__.py
@@ -9,7 +9,7 @@ Domain modules:
                    suggest_sources), type_schemas
   - feeds.py     — watch, poll, rescore
   - configure.py — distillery_configure runtime config tool
-  - meta.py      — reserved for future cross-cutting tool concerns
+  - meta.py      — distillery_status (server/health metadata probe)
   - _common.py   — shared helpers (error/success response, validation)
   - _errors.py   — standardized error code constants
 
@@ -42,6 +42,7 @@ from distillery.mcp.tools.feeds import (
     _handle_sync_status,
     _handle_watch,
 )
+from distillery.mcp.tools.meta import _handle_status
 from distillery.mcp.tools.quality import (
     run_conflict_discovery,
     run_conflict_evaluation,
@@ -55,6 +56,7 @@ from distillery.mcp.tools.search import (
 
 __all__ = [
     "_handle_configure",
+    "_handle_status",
     "_handle_classify",
     "_handle_resolve_review",
     "_handle_get",

--- a/src/distillery/mcp/tools/meta.py
+++ b/src/distillery/mcp/tools/meta.py
@@ -1,7 +1,135 @@
-"""Meta/cross-cutting tool utilities — reserved for future use.
+"""Meta/cross-cutting tool handlers for the Distillery MCP server.
 
-This module is reserved for future cross-cutting tool concerns such as
-tool introspection, capability negotiation, or shared metadata helpers.
+Implements the following tools:
+  - distillery_status: Lightweight in-protocol health/metadata probe used by
+    ``/setup`` and other skills to verify MCP connectivity without requiring
+    an out-of-band HTTP ``/health`` curl.  Returns server version, transport,
+    tool count, basic store stats, and embedding provider name.
 """
 
-# No handlers defined yet — reserved per spec §Unit 1.
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from mcp import types
+
+from distillery.config import DistilleryConfig
+from distillery.mcp.tools._common import success_response
+
+logger = logging.getLogger(__name__)
+
+
+def _is_remote_db_path(path: str) -> bool:
+    """Return True for S3 or MotherDuck URIs that should not be treated as local paths."""
+    return path.startswith("s3://") or path.startswith("md:")
+
+
+def _db_size_bytes(config: DistilleryConfig) -> int | None:
+    """Return the database file size in bytes, or None for remote/in-memory paths."""
+    raw = config.storage.database_path
+    if raw == ":memory:" or _is_remote_db_path(raw):
+        return None
+    try:
+        return Path(os.path.expanduser(raw)).stat().st_size
+    except OSError:
+        return None
+
+
+async def _handle_status(
+    *,
+    store: Any,
+    config: DistilleryConfig,
+    embedding_provider: Any,
+    tool_count: int,
+    transport: str | None,
+    started_at: datetime | None,
+) -> list[types.TextContent]:
+    """Handle the ``distillery_status`` tool.
+
+    Returns a lightweight health/metadata payload suitable for the ``/setup``
+    wizard to verify MCP connectivity in-protocol (rather than curling the
+    HTTP-only ``/health`` endpoint).
+
+    Args:
+        store: Initialised storage backend.
+        config: Loaded :class:`~distillery.config.DistilleryConfig`.
+        embedding_provider: Active embedding provider (used for its name).
+        tool_count: Number of MCP tools registered on the current server.
+        transport: ``"stdio"`` or ``"http"`` when known, else ``None``.
+        started_at: Server startup timestamp (UTC); ``None`` if unknown.
+
+    Returns:
+        MCP content list with a single JSON ``TextContent`` block.
+    """
+    from distillery import __build_sha__, __version__
+
+    payload: dict[str, Any] = {
+        "status": "ok",
+        "version": __version__,
+        "build_sha": __build_sha__,
+        "transport": transport if transport in ("stdio", "http") else "unknown",
+        "tool_count": int(tool_count),
+    }
+
+    # --- store stats ---------------------------------------------------------
+    entry_count: int | None = None
+    try:
+        conn = getattr(store, "connection", None)
+        if conn is not None:
+            row = conn.execute("SELECT COUNT(*) FROM entries").fetchone()
+            entry_count = int(row[0]) if row else 0
+    except Exception:  # noqa: BLE001
+        logger.debug("distillery_status: entry_count query failed", exc_info=True)
+
+    db_size = _db_size_bytes(config)
+    store_info: dict[str, Any] = {
+        "entry_count": entry_count,
+        "db_size_bytes": db_size,
+    }
+    payload["store"] = store_info
+
+    # --- embedding provider --------------------------------------------------
+    payload["embedding_provider"] = (
+        getattr(embedding_provider, "model_name", None) or type(embedding_provider).__name__
+    )
+
+    # --- feed poll summary (optional, best-effort) ---------------------------
+    feed_summary: dict[str, Any] = {"source_count": 0, "last_poll_at": None}
+    try:
+        sources = await store.list_feed_sources()
+        feed_summary["source_count"] = len(sources)
+    except Exception:  # noqa: BLE001
+        logger.debug("distillery_status: list_feed_sources failed", exc_info=True)
+
+    with contextlib.suppress(Exception):
+        raw_audit = await store.get_metadata("webhook_audit:poll")
+        if raw_audit:
+            try:
+                audit = json.loads(raw_audit)
+                if isinstance(audit, dict) and isinstance(audit.get("timestamp"), str):
+                    feed_summary["last_poll_at"] = audit["timestamp"]
+            except (TypeError, ValueError):
+                pass
+    payload["last_feed_poll"] = feed_summary
+
+    # --- uptime --------------------------------------------------------------
+    if started_at is not None:
+        try:
+            if started_at.tzinfo is None:
+                started_aware = started_at.replace(tzinfo=UTC)
+            else:
+                started_aware = started_at
+            payload["uptime_seconds"] = int((datetime.now(UTC) - started_aware).total_seconds())
+        except Exception:  # noqa: BLE001
+            logger.debug("distillery_status: uptime calculation failed", exc_info=True)
+
+    return success_response(payload)
+
+
+__all__ = ["_handle_status"]

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -32,7 +32,7 @@ MCP_HEADERS = {
     "Accept": "application/json, text/event-stream",
 }
 
-# 15-tool API (13 from api-hardening + gh_sync + sync_status from async-sync-pipeline).
+# 16-tool API (15 prior + distillery_status from #313).
 EXPECTED_TOOLS = {
     "distillery_store",
     "distillery_store_batch",
@@ -49,6 +49,7 @@ EXPECTED_TOOLS = {
     "distillery_relations",
     "distillery_gh_sync",
     "distillery_sync_status",
+    "distillery_status",
 }
 
 
@@ -161,7 +162,7 @@ class TestAllToolsAccessibleOverHttp:
             assert "result" in data, f"Expected result in: {data}"
             tools = data["result"]["tools"]
             tool_names = {t["name"] for t in tools}
-            assert len(tool_names) == 15, f"Expected 15 tools, got {len(tool_names)}: {tool_names}"
+            assert len(tool_names) == 16, f"Expected 16 tools, got {len(tool_names)}: {tool_names}"
             assert tool_names == EXPECTED_TOOLS, (
                 f"Tool mismatch.\nExpected: {EXPECTED_TOOLS}\nGot: {tool_names}"
             )

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -2,7 +2,7 @@
 
 Tests verify:
 - HTTP server starts and responds to MCP initialize
-- All 19 tools are accessible over HTTP transport
+- All 16 tools are accessible over HTTP transport
 - Stateless HTTP singleton: two requests share same store instance
 - stdio mode (no flags) backward compatibility
 """
@@ -145,7 +145,7 @@ class TestHttpServerStarts:
 
 class TestAllToolsAccessibleOverHttp:
     async def test_all_tools_accessible_over_http(self) -> None:
-        """All 19 tools appear in tools/list response over HTTP."""
+        """All 16 tools appear in tools/list response over HTTP."""
         port = _free_port()
         config = _make_server_config()
         uv_server, task = await _start_http_server(port, config)

--- a/tests/test_mcp_meta.py
+++ b/tests/test_mcp_meta.py
@@ -1,0 +1,182 @@
+"""Unit tests for the ``distillery_status`` MCP tool handler (issue #313)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from distillery import __version__
+from distillery.config import (
+    DistilleryConfig,
+    EmbeddingConfig,
+    StorageConfig,
+)
+from distillery.mcp.tools.meta import _handle_status
+from distillery.store.duckdb import DuckDBStore
+
+pytestmark = pytest.mark.unit
+
+
+def _parse(result: list[Any]) -> dict[str, Any]:
+    """Parse the JSON payload from a single-item MCP TextContent list."""
+    assert len(result) == 1
+    return json.loads(result[0].text)  # type: ignore[no-any-return]
+
+
+class _FakeEmbeddingProvider:
+    """Minimal stand-in with a ``model_name`` attribute."""
+
+    model_name = "fake-embed-v1"
+    dimensions = 4
+
+
+@pytest.fixture
+async def store(mock_embedding_provider):  # type: ignore[no-untyped-def]
+    """Initialised in-memory DuckDBStore."""
+    s = DuckDBStore(db_path=":memory:", embedding_provider=mock_embedding_provider)
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+@pytest.fixture
+def config() -> DistilleryConfig:
+    return DistilleryConfig(
+        storage=StorageConfig(database_path=":memory:"),
+        embedding=EmbeddingConfig(provider="", model="stub", dimensions=4),
+    )
+
+
+class TestDistilleryStatus:
+    """Verify the ``distillery_status`` payload shape and basic semantics."""
+
+    async def test_returns_expected_top_level_keys(
+        self,
+        store: DuckDBStore,
+        config: DistilleryConfig,
+    ) -> None:
+        """The response must expose the keys the /setup skill depends on."""
+        result = await _handle_status(
+            store=store,
+            config=config,
+            embedding_provider=_FakeEmbeddingProvider(),
+            tool_count=16,
+            transport="stdio",
+            started_at=datetime.now(UTC) - timedelta(seconds=5),
+        )
+        data = _parse(result)
+
+        # Required top-level keys.
+        for key in (
+            "status",
+            "version",
+            "transport",
+            "tool_count",
+            "store",
+            "embedding_provider",
+            "last_feed_poll",
+        ):
+            assert key in data, f"missing top-level key: {key!r}"
+
+        # Shape / type assertions (no hard-coded counts for entries/sources).
+        assert data["status"] == "ok"
+        assert data["version"] == __version__
+        assert data["transport"] == "stdio"
+        assert isinstance(data["tool_count"], int)
+        assert data["tool_count"] >= 1
+
+        assert isinstance(data["store"], dict)
+        assert "entry_count" in data["store"]
+        assert "db_size_bytes" in data["store"]
+        assert isinstance(data["store"]["entry_count"], int)
+        assert data["store"]["entry_count"] >= 0
+
+        assert isinstance(data["embedding_provider"], str)
+        assert data["embedding_provider"]  # non-empty
+
+        assert isinstance(data["last_feed_poll"], dict)
+        assert "source_count" in data["last_feed_poll"]
+        assert "last_poll_at" in data["last_feed_poll"]
+        assert isinstance(data["last_feed_poll"]["source_count"], int)
+        assert data["last_feed_poll"]["source_count"] >= 0
+
+        # Uptime should be reported when started_at was passed.
+        assert "uptime_seconds" in data
+        assert isinstance(data["uptime_seconds"], int)
+        assert data["uptime_seconds"] >= 0
+
+    async def test_unknown_transport_when_not_provided(
+        self,
+        store: DuckDBStore,
+        config: DistilleryConfig,
+    ) -> None:
+        """Missing transport info should surface as 'unknown'."""
+        result = await _handle_status(
+            store=store,
+            config=config,
+            embedding_provider=_FakeEmbeddingProvider(),
+            tool_count=16,
+            transport=None,
+            started_at=None,
+        )
+        data = _parse(result)
+        assert data["transport"] == "unknown"
+        # uptime_seconds omitted when started_at is None.
+        assert "uptime_seconds" not in data
+
+    async def test_http_transport_is_reported(
+        self,
+        store: DuckDBStore,
+        config: DistilleryConfig,
+    ) -> None:
+        result = await _handle_status(
+            store=store,
+            config=config,
+            embedding_provider=_FakeEmbeddingProvider(),
+            tool_count=16,
+            transport="http",
+            started_at=None,
+        )
+        data = _parse(result)
+        assert data["transport"] == "http"
+
+    async def test_embedding_provider_falls_back_to_class_name(
+        self,
+        store: DuckDBStore,
+        config: DistilleryConfig,
+    ) -> None:
+        """When the provider lacks ``model_name``, the class name is used."""
+
+        class _Nameless:
+            pass
+
+        result = await _handle_status(
+            store=store,
+            config=config,
+            embedding_provider=_Nameless(),
+            tool_count=1,
+            transport="stdio",
+            started_at=None,
+        )
+        data = _parse(result)
+        assert data["embedding_provider"] == "_Nameless"
+
+
+class TestDistilleryStatusRegistration:
+    """The tool must be registered alongside the existing 15 tools."""
+
+    async def test_distillery_status_registered(self) -> None:
+        from distillery.mcp.server import create_server
+
+        server = create_server(
+            DistilleryConfig(
+                storage=StorageConfig(database_path=":memory:"),
+                embedding=EmbeddingConfig(provider="", model="stub", dimensions=4),
+            )
+        )
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+        assert "distillery_status" in names

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,6 +1,6 @@
 """Tests for the Distillery MCP server (T04.4 / T02.3).
 
-Tests cover the 17 registered MCP tools via direct handler calls with a mock
+Tests cover the 16 registered MCP tools via direct handler calls with a mock
 store and deterministic embedding provider:
 
   store -> search -> get -> update -> find_similar -> list -> status
@@ -9,7 +9,7 @@ The test harness exercises the server handlers directly without requiring a
 running stdio transport.  All handlers are async functions that accept a
 store object and an arguments dict -- this is the natural unit-test seam.
 
-Also exercises the ``create_server`` factory to confirm all 17 tools are
+Also exercises the ``create_server`` factory to confirm all 16 tools are
 registered and the lifespan context initialises state correctly.
 
 Tools removed from MCP surface (now webhooks or internal handlers):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -666,7 +666,7 @@ class TestCreateServer:
         tools = await server.list_tools()
         tool_names = {t.name for t in tools}
 
-        # 15-tool consolidated API (12 from #196 + store_batch, gh_sync, sync_status)
+        # 16-tool consolidated API (15 prior + distillery_status from #313)
         expected = {
             "distillery_store",
             "distillery_store_batch",
@@ -683,6 +683,7 @@ class TestCreateServer:
             "distillery_relations",
             "distillery_gh_sync",
             "distillery_sync_status",
+            "distillery_status",
         }
         assert expected == tool_names, (
             f"Tool mismatch — extra: {tool_names - expected}, missing: {expected - tool_names}"
@@ -747,13 +748,13 @@ class TestRemovedTools:
             )
 
     async def test_removed_tools_count_unchanged(self) -> None:
-        """Exactly 15 tools must be registered — consolidated analytics tools."""
+        """Exactly 16 tools must be registered — consolidated analytics tools + status."""
         config = DistilleryConfig(
             storage=StorageConfig(database_path=":memory:"),
             embedding=EmbeddingConfig(provider="", model="stub", dimensions=4),
         )
         server = create_server(config)
         tools = await server.list_tools()
-        assert len(tools) == 15, (
-            f"Expected 15 registered tools, got {len(tools)}: {sorted(t.name for t in tools)}"
+        assert len(tools) == 16, (
+            f"Expected 16 registered tools, got {len(tools)}: {sorted(t.name for t in tools)}"
         )


### PR DESCRIPTION
## Summary

- Adds a lightweight `distillery_status` MCP tool so `/setup` and other skills can verify connectivity and read basic server metadata via the protocol, instead of curling the HTTP-only `/health` endpoint (closes #313).
- The tool returns version, build SHA, transport (`stdio` / `http` / `unknown`), tool count, store stats (entry_count, db_size_bytes), embedding provider name, a feed poll summary, and optional uptime seconds.
- Transport is propagated from `__main__.py` into server shared state so the tool reports the active transport uniformly on stdio and HTTP.
- `CLAUDE.md` tool count updated from 12 to 16 to match the current server (15 prior + `distillery_status`).

## Test plan

- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `PYTHONPATH=$PWD/src python -m mypy --strict src/distillery/`
- [x] `PYTHONPATH=$PWD/src python -m pytest tests/test_mcp_meta.py tests/test_mcp_server.py -q -x -m unit`
- [x] All 235 MCP-scoped unit tests pass
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `distillery_status` tool providing server health and metadata, including uptime, transport mode, tool inventory, database statistics, embedding provider details, and webhook activity.

* **Tests**
  * Updated test expectations to reflect 16 available MCP tools (previously 15).
  * Added comprehensive test coverage for the new status tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->