### PR TITLE
fix(mcp): surface persisted flag and auto-skip near-duplicate stores (#314)

### DIFF
--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -132,7 +132,22 @@ async def _handle_store(
         cfg (DistilleryConfig | None): Optional configuration used to derive classification/conflict thresholds; when omitted a default conflict threshold of 0.60 is used.
 
     Returns:
-        list[types.TextContent]: MCP content list containing a JSON-serializable object with at least `entry_id`. May also include:
+        list[types.TextContent]: MCP content list containing a JSON-serializable object with at least:
+          - ``entry_id`` (str): the id the caller should reference — either the
+            newly persisted entry's id, or (when the call was auto-skipped /
+            effectively merged with an existing near-duplicate) the existing
+            entry's id.  Never a "ghost" id that cannot be retrieved.
+          - ``persisted`` (bool): ``True`` if a new row was written, ``False``
+            if the call was auto-skipped due to a near-duplicate.
+          - ``dedup_action`` (str): one of ``"stored"``, ``"skipped"``,
+            ``"merged"``, ``"linked"`` indicating how the new content
+            relates to existing entries.
+
+        When ``dedup_action != "stored"`` the response also includes
+        ``existing_entry_id`` (str) and ``similarity`` (float) so the caller
+        can pivot to the pre-existing entry.
+
+        May also include:
           - `warnings`: list of similar-entry summaries (id, score, content_preview) when near-duplicates were found,
           - `warning_message`: human-readable summary of warnings,
           - `conflicts`: list of conflict candidate objects (entry_id, content_preview, similarity_score, conflict_reasoning),
@@ -281,27 +296,40 @@ async def _handle_store(
     except Exception as exc:  # noqa: BLE001
         return error_response("INVALID_PARAMS", f"Failed to construct entry: {exc}")
 
-    # --- persist ------------------------------------------------------------
-    try:
-        entry_id = await store.store(entry)
-    except Exception as exc:  # noqa: BLE001
-        logger.exception("Error storing entry")
-        return error_response("INTERNAL", f"Failed to store entry: {exc}")
+    # --- pre-persist dedup check (summary mode skips this) ------------------
+    # Run dedup BEFORE persistence so that near-duplicates (score >= skip
+    # threshold) can be auto-skipped.  Auto-skip returns the existing entry's
+    # id — never a "ghost" id that was never inserted — together with
+    # ``persisted=False`` and ``dedup_action="skipped"`` so the caller knows
+    # to pivot to the existing entry.
+    skip_threshold: float | None = None
+    merge_threshold: float | None = None
+    link_threshold: float | None = None
+    if cfg is not None:
+        skip_threshold = cfg.classification.dedup_skip_threshold
+        merge_threshold = cfg.classification.dedup_merge_threshold
+        link_threshold = cfg.classification.dedup_link_threshold
 
-    # --- summary mode: skip dedup/conflict, return early --------------------
-    if output_mode == "summary":
-        return success_response({"entry_id": entry_id})
-
-    # --- deduplication check ------------------------------------------------
+    top_existing_id: str | None = None
+    top_existing_score: float | None = None
     warnings: list[dict[str, Any]] = []
-    try:
-        similar = await store.find_similar(
-            content=entry.content,
-            threshold=float(dedup_threshold),
-            limit=dedup_limit + 1,  # +1 because the new entry itself may appear
-        )
-        for result in similar:
-            if result.entry.id != entry_id:
+
+    if output_mode != "summary":
+        try:
+            similar = await store.find_similar(
+                content=entry.content,
+                threshold=float(dedup_threshold),
+                limit=dedup_limit,
+            )
+            for result in similar:
+                # At this point the new entry has not been inserted yet, so
+                # every result is an existing entry.  Still guard against
+                # degenerate cases where the store returns the same id.
+                if result.entry.id == entry.id:
+                    continue
+                if top_existing_id is None:
+                    top_existing_id = result.entry.id
+                    top_existing_score = float(result.score)
                 warnings.append(
                     {
                         "similar_entry_id": result.entry.id,
@@ -311,9 +339,54 @@ async def _handle_store(
                 )
                 if len(warnings) >= dedup_limit:
                     break
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("find_similar failed during dedup check: %s", exc)
+            # Non-fatal: fall through with no warnings and persist normally.
+
+    # --- auto-skip: near-duplicate, do NOT persist --------------------------
+    if (
+        skip_threshold is not None
+        and top_existing_id is not None
+        and top_existing_score is not None
+        and top_existing_score >= skip_threshold
+    ):
+        skip_response: dict[str, Any] = {
+            "entry_id": top_existing_id,
+            "persisted": False,
+            "dedup_action": "skipped",
+            "existing_entry_id": top_existing_id,
+            "similarity": round(top_existing_score, 4),
+        }
+        if warnings:
+            skip_response["warnings"] = warnings
+            skip_response["warning_message"] = (
+                f"Skipped as near-duplicate (score={top_existing_score:.3f}) "
+                f"of existing entry {top_existing_id!r}."
+            )
+        return success_response(skip_response)
+
+    # --- persist ------------------------------------------------------------
+    try:
+        entry_id = await store.store(entry)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("find_similar failed during dedup check: %s", exc)
-        # Non-fatal: still return the stored entry_id.
+        logger.exception("Error storing entry")
+        return error_response("INTERNAL", f"Failed to store entry: {exc}")
+
+    # --- summary mode: skip conflict, return early --------------------------
+    if output_mode == "summary":
+        return success_response({"entry_id": entry_id, "persisted": True, "dedup_action": "stored"})
+
+    # --- determine dedup_action for the persisted entry ---------------------
+    # ``stored`` when no prior similar entry existed (or we lack thresholds).
+    # ``merged``/``linked`` annotate the caller that a near-match exists; the
+    # entry is still persisted — these are informational signals, not
+    # enforcement.  Only ``skipped`` (handled above) prevents persistence.
+    dedup_action = "stored"
+    if top_existing_id is not None and top_existing_score is not None:
+        if merge_threshold is not None and top_existing_score >= merge_threshold:
+            dedup_action = "merged"
+        elif link_threshold is not None and top_existing_score >= link_threshold:
+            dedup_action = "linked"
 
     # --- conflict check -------------------------------------------------------
     # Non-fatal: wrap in try/except so a conflict-checker failure never blocks
@@ -349,7 +422,15 @@ async def _handle_store(
                     }
                 )
             if conflicts:
-                response_data: dict[str, Any] = {"entry_id": entry_id}
+                response_data: dict[str, Any] = {
+                    "entry_id": entry_id,
+                    "persisted": True,
+                    "dedup_action": dedup_action,
+                }
+                if dedup_action != "stored" and top_existing_id is not None:
+                    response_data["existing_entry_id"] = top_existing_id
+                    if top_existing_score is not None:
+                        response_data["similarity"] = round(top_existing_score, 4)
                 if warnings:
                     response_data["warnings"] = warnings
                     response_data["warning_message"] = (
@@ -368,7 +449,15 @@ async def _handle_store(
         logger.warning("Conflict check failed during store: %s", exc)
         # Non-fatal: fall through and return the entry_id without conflict info.
 
-    response: dict[str, Any] = {"entry_id": entry_id}
+    response: dict[str, Any] = {
+        "entry_id": entry_id,
+        "persisted": True,
+        "dedup_action": dedup_action,
+    }
+    if dedup_action != "stored" and top_existing_id is not None:
+        response["existing_entry_id"] = top_existing_id
+        if top_existing_score is not None:
+            response["similarity"] = round(top_existing_score, 4)
     if warnings:
         response["warnings"] = warnings
         response["warning_message"] = (
@@ -401,7 +490,12 @@ async def _handle_store_batch(
         created_by: Ownership identifier (from auth layer).
 
     Returns:
-        A structured MCP success or error response.
+        A structured MCP success or error response.  On success the payload
+        contains ``entry_ids`` (list[str], preserved for backward
+        compatibility), ``count`` (int), and ``results`` — a per-entry list
+        of ``{"entry_id", "persisted", "dedup_action"}`` dicts.  Because the
+        batch path never runs deduplication, every entry is reported as
+        ``persisted=True`` with ``dedup_action="stored"``.
     """
     from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
     from distillery.models import Entry, EntrySource, EntryType
@@ -502,7 +596,7 @@ async def _handle_store_batch(
         built.append(entry)
 
     if not built:
-        return success_response({"entry_ids": [], "count": 0})
+        return success_response({"entry_ids": [], "results": [], "count": 0})
 
     # --- db size check (same guard as _handle_store) -------------------------
     if cfg is not None and cfg.rate_limit.max_db_size_mb > 0:
@@ -536,7 +630,12 @@ async def _handle_store_batch(
         logger.exception("Error in store_batch")
         return error_response("INTERNAL", f"Failed to batch-store entries: {exc}")
 
-    return success_response({"entry_ids": entry_ids, "count": len(entry_ids)})
+    # Batch-store does not run deduplication; every persisted entry is
+    # reported with ``persisted=True`` and ``dedup_action="stored"``.  This
+    # keeps the batch response shape aligned with the single-entry
+    # ``distillery_store`` response so callers can rely on the same keys.
+    results = [{"entry_id": eid, "persisted": True, "dedup_action": "stored"} for eid in entry_ids]
+    return success_response({"entry_ids": entry_ids, "results": results, "count": len(entry_ids)})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -365,14 +365,18 @@ class TestMCPStoreConflictDetection:
         store: DuckDBStore,
         embedding_provider: ControlledEmbeddingProvider,
     ) -> None:
-        """When an existing entry has cosine similarity above conflict_threshold,
-        distillery_store returns conflicts in the response."""
+        """When an existing entry has cosine similarity above conflict_threshold
+        but below the dedup skip threshold, distillery_store returns conflicts
+        in the response.
+        """
         existing_text = "Cats are nocturnal animals that hunt at night"
         new_text = "Cats are diurnal animals that are active during the day"
 
-        # Register identical vectors so similarity = 1.0 (well above threshold)
+        # Use an interpolated vector so similarity lands above conflict_threshold
+        # (0.60) but below the dedup skip threshold (0.95). t=0.4 yields
+        # raw cosine ~0.83, normalised to ~0.916 — above conflict, below skip.
         embedding_provider.register(existing_text, _UNIT_A)
-        embedding_provider.register(new_text, _UNIT_A)
+        embedding_provider.register(new_text, _interpolated_vector(_UNIT_A, _UNIT_B, 0.4))
 
         existing_entry = make_entry(content=existing_text)
         await store.store(existing_entry)
@@ -390,6 +394,8 @@ class TestMCPStoreConflictDetection:
         data = parse_mcp_response(response)
 
         assert "entry_id" in data
+        # The entry must have been persisted — similarity is below skip.
+        assert data.get("persisted") is True
         assert "conflicts" in data
         assert len(data["conflicts"]) >= 1
         # Each conflict entry must have required fields

--- a/tests/test_eval_unit.py
+++ b/tests/test_eval_unit.py
@@ -810,10 +810,17 @@ class TestMCPBridgeAsync:
         bridge = await MCPBridge.create(seed_entries=seeds)
         seed_count = await bridge.count_stored_entries()
 
-        # Store one more via tool call.
+        # Store one more via tool call.  Pass dedup_threshold above the max
+        # possible normalised similarity so the hash-based stub embedding
+        # cannot spuriously trip auto-skip dedup between unrelated strings.
         await bridge.call_tool(
             "distillery_store",
-            {"content": "new entry", "entry_type": "session", "author": "test"},
+            {
+                "content": "new entry",
+                "entry_type": "session",
+                "author": "test",
+                "dedup_threshold": 1.01,
+            },
         )
         new_entries = await bridge.count_entries_since_seed(seed_count)
         assert new_entries == 1

--- a/tests/test_store_dedup_response.py
+++ b/tests/test_store_dedup_response.py
@@ -1,0 +1,403 @@
+"""Tests for ``distillery_store`` dedup response contract (issue #314).
+
+Verifies that the ``_handle_store`` tool handler always surfaces:
+
+* ``persisted`` (bool)
+* ``dedup_action`` — one of ``stored`` / ``skipped`` / ``merged`` / ``linked``
+
+and that when a near-duplicate is auto-skipped the returned ``entry_id`` is
+the *existing* entry's id (never a ghost id that was never inserted), and
+``existing_entry_id`` plus ``similarity`` are supplied so the caller can
+pivot.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from distillery.config import (
+    ClassificationConfig,
+    DefaultsConfig,
+    DistilleryConfig,
+    EmbeddingConfig,
+    RateLimitConfig,
+    StorageConfig,
+)
+from distillery.mcp.tools.crud import _handle_store, _handle_store_batch
+from distillery.store.duckdb import DuckDBStore
+from tests.conftest import ControlledEmbeddingProvider, make_entry, parse_mcp_response
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def embedding_provider(controlled_embedding_provider):
+    """Alias for the 8-dim controlled embedding provider."""
+    return controlled_embedding_provider
+
+
+@pytest.fixture
+async def store(embedding_provider) -> DuckDBStore:  # type: ignore[return]
+    s = DuckDBStore(db_path=":memory:", embedding_provider=embedding_provider)
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+def _make_config(
+    *,
+    skip: float = 0.95,
+    merge: float = 0.80,
+    link: float = 0.60,
+    dedup_threshold: float = 0.60,
+    dedup_limit: int = 5,
+) -> DistilleryConfig:
+    """Build a DistilleryConfig with controllable dedup thresholds.
+
+    The ``dedup_threshold`` (on DefaultsConfig) drives which similar entries
+    ``_handle_store`` collects as warnings; the classification thresholds
+    drive the dedup_action classification (skipped/merged/linked).
+    """
+    return DistilleryConfig(
+        storage=StorageConfig(database_path=":memory:"),
+        embedding=EmbeddingConfig(provider="", model="controlled-8d", dimensions=8),
+        classification=ClassificationConfig(
+            confidence_threshold=0.6,
+            dedup_skip_threshold=skip,
+            dedup_merge_threshold=merge,
+            dedup_link_threshold=link,
+            dedup_limit=dedup_limit,
+        ),
+        defaults=DefaultsConfig(
+            dedup_threshold=dedup_threshold,
+            dedup_limit=dedup_limit,
+        ),
+        rate_limit=RateLimitConfig(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper vectors
+# ---------------------------------------------------------------------------
+
+_UNIT_A = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+_UNIT_B = [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def _interpolated_vector(a: list[float], b: list[float], t: float) -> list[float]:
+    """Return an L2-normalised vector between *a* and *b* (t=0 -> a, t=1 -> b)."""
+    vec = [a[i] * (1.0 - t) + b[i] * t for i in range(len(a))]
+    magnitude = math.sqrt(sum(x * x for x in vec))
+    return [x / magnitude for x in vec]
+
+
+def _cosine(u: list[float], v: list[float]) -> float:
+    return sum(a * b for a, b in zip(u, v, strict=True))
+
+
+# ---------------------------------------------------------------------------
+# Test: fresh entry -> persisted=True, dedup_action="stored"
+# ---------------------------------------------------------------------------
+
+
+class TestStoreFreshEntry:
+    async def test_fresh_entry_is_persisted_and_stored(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        embedding_provider.register("A brand new thought", _UNIT_A)
+        cfg = _make_config()
+
+        result = await _handle_store(
+            store,
+            {
+                "content": "A brand new thought",
+                "entry_type": "idea",
+                "author": "alice",
+            },
+            cfg=cfg,
+        )
+        data = parse_mcp_response(result)
+
+        assert data.get("error") is not True, data
+        assert "entry_id" in data
+        assert data["persisted"] is True
+        assert data["dedup_action"] == "stored"
+        assert "existing_entry_id" not in data
+        assert "similarity" not in data
+
+        # The returned entry_id must resolve via store.get
+        fetched = await store.get(data["entry_id"])
+        assert fetched is not None
+        assert fetched.content == "A brand new thought"
+
+
+# ---------------------------------------------------------------------------
+# Test: near-dup (sim >= 0.95) -> persisted=False, dedup_action="skipped"
+# ---------------------------------------------------------------------------
+
+
+class TestStoreNearDuplicateSkipped:
+    async def test_near_duplicate_is_auto_skipped(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        # Seed an existing entry
+        existing_text = "Existing near-duplicate source"
+        new_text = "Near-duplicate new arrival"
+        embedding_provider.register(existing_text, _UNIT_A)
+        embedding_provider.register(new_text, _UNIT_A)  # identical cos sim = 1.0
+
+        existing_entry = make_entry(content=existing_text, author="bob")
+        existing_id = await store.store(existing_entry)
+
+        cfg = _make_config(skip=0.95, dedup_threshold=0.60)
+        result = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "idea",
+                "author": "alice",
+            },
+            cfg=cfg,
+        )
+        data = parse_mcp_response(result)
+
+        assert data.get("error") is not True, data
+        assert data["persisted"] is False
+        assert data["dedup_action"] == "skipped"
+        assert data["existing_entry_id"] == existing_id
+        # entry_id must be the existing one (not a ghost)
+        assert data["entry_id"] == existing_id
+        assert "similarity" in data
+        assert data["similarity"] >= 0.95
+
+        # Only one entry should exist in the store: the pre-existing one.
+        fetched = await store.get(existing_id)
+        assert fetched is not None
+        # ``count_entries`` reports the total — it must still be 1.
+        total = await store.count_entries(filters=None)
+        assert total == 1
+
+    async def test_skipped_entry_id_is_retrievable(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        """The id returned on skip must be retrievable via store.get — no ghost ids."""
+        existing_text = "Prior note"
+        new_text = "Prior note duplicate"
+        embedding_provider.register(existing_text, _UNIT_A)
+        embedding_provider.register(new_text, _UNIT_A)
+
+        existing_id = await store.store(make_entry(content=existing_text))
+
+        cfg = _make_config(skip=0.95, dedup_threshold=0.60)
+        result = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "idea",
+                "author": "alice",
+            },
+            cfg=cfg,
+        )
+        data = parse_mcp_response(result)
+        assert data["persisted"] is False
+        entry = await store.get(data["entry_id"])
+        assert entry is not None
+        assert entry.id == existing_id
+
+
+# ---------------------------------------------------------------------------
+# Test: similar (merge band) -> persisted=True, dedup_action="merged"
+# ---------------------------------------------------------------------------
+
+
+class TestStoreDuplicateMerged:
+    async def test_merge_band_is_persisted_with_merged_action(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        existing_vec = _UNIT_A
+        # Interpolate so cosine sim falls between merge (0.80) and skip (0.95)
+        # normalized.  Raw cos from interp with t=0.3 ~ 0.89, normalised to
+        # (0.89 + 1) / 2 = ~0.945.  We widen bands around norm_sim to avoid
+        # flakiness.
+        interp = _interpolated_vector(_UNIT_A, _UNIT_B, 0.3)
+        cos_sim = _cosine(interp, existing_vec)
+        norm_sim = (cos_sim + 1.0) / 2.0
+
+        existing_text = "Merge band existing content"
+        new_text = "Merge band arriving content"
+        embedding_provider.register(existing_text, existing_vec)
+        embedding_provider.register(new_text, interp)
+
+        existing_id = await store.store(make_entry(content=existing_text))
+
+        # Thresholds: skip above norm_sim (no skip), merge below norm_sim
+        # (so score lands in merge band), link very low.
+        cfg = _make_config(
+            skip=norm_sim + 0.01,
+            merge=norm_sim - 0.01,
+            link=0.0,
+            dedup_threshold=0.0,
+        )
+        result = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "idea",
+                "author": "alice",
+            },
+            cfg=cfg,
+        )
+        data = parse_mcp_response(result)
+
+        assert data.get("error") is not True, data
+        assert data["persisted"] is True
+        assert data["dedup_action"] == "merged"
+        assert data["existing_entry_id"] == existing_id
+        assert data["entry_id"] != existing_id  # new row was written
+        assert data["similarity"] >= cfg.classification.dedup_merge_threshold
+
+        # The newly written id must be retrievable.
+        new_entry = await store.get(data["entry_id"])
+        assert new_entry is not None
+        assert new_entry.content == new_text
+
+
+# ---------------------------------------------------------------------------
+# Test: related (link band) -> persisted=True, dedup_action="linked"
+# ---------------------------------------------------------------------------
+
+
+class TestStoreRelatedLinked:
+    async def test_link_band_is_persisted_with_linked_action(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        existing_vec = _UNIT_A
+        interp = _interpolated_vector(_UNIT_A, _UNIT_B, 0.7)  # lower similarity
+        cos_sim = _cosine(interp, existing_vec)
+        norm_sim = (cos_sim + 1.0) / 2.0
+
+        existing_text = "Link band existing content"
+        new_text = "Link band arriving content"
+        embedding_provider.register(existing_text, existing_vec)
+        embedding_provider.register(new_text, interp)
+
+        existing_id = await store.store(make_entry(content=existing_text))
+
+        cfg = _make_config(
+            skip=0.99,
+            merge=norm_sim + 0.01,
+            link=norm_sim - 0.01,
+            dedup_threshold=0.0,
+        )
+        result = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "idea",
+                "author": "alice",
+            },
+            cfg=cfg,
+        )
+        data = parse_mcp_response(result)
+
+        assert data.get("error") is not True, data
+        assert data["persisted"] is True
+        assert data["dedup_action"] == "linked"
+        assert data["existing_entry_id"] == existing_id
+        assert data["entry_id"] != existing_id
+        assert data["similarity"] >= cfg.classification.dedup_link_threshold
+        assert data["similarity"] < cfg.classification.dedup_merge_threshold
+
+
+# ---------------------------------------------------------------------------
+# Test: summary output_mode returns the new response contract too
+# ---------------------------------------------------------------------------
+
+
+class TestStoreSummaryMode:
+    async def test_summary_mode_includes_persisted_and_action(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        embedding_provider.register("summary mode content", _UNIT_A)
+        cfg = _make_config()
+
+        result = await _handle_store(
+            store,
+            {
+                "content": "summary mode content",
+                "entry_type": "idea",
+                "author": "alice",
+                "output_mode": "summary",
+            },
+            cfg=cfg,
+        )
+        data = parse_mcp_response(result)
+        assert data.get("error") is not True, data
+        assert "entry_id" in data
+        assert data["persisted"] is True
+        assert data["dedup_action"] == "stored"
+
+
+# ---------------------------------------------------------------------------
+# Test: store_batch results include per-item persisted / dedup_action
+# ---------------------------------------------------------------------------
+
+
+class TestStoreBatchResponseShape:
+    async def test_batch_results_include_persisted_and_action(
+        self,
+        store: DuckDBStore,
+    ) -> None:
+        result = await _handle_store_batch(
+            store=store,
+            arguments={
+                "entries": [
+                    {"content": "Batch first", "author": "alice", "entry_type": "inbox"},
+                    {"content": "Batch second", "author": "bob", "entry_type": "idea"},
+                ],
+            },
+        )
+        data = parse_mcp_response(result)
+        assert data.get("error") is not True, data
+        assert data["count"] == 2
+        assert len(data["entry_ids"]) == 2
+        assert "results" in data
+        assert len(data["results"]) == 2
+        for item in data["results"]:
+            assert item["persisted"] is True
+            assert item["dedup_action"] == "stored"
+            assert "entry_id" in item
+        # Sanity: results and entry_ids align in order
+        assert [r["entry_id"] for r in data["results"]] == data["entry_ids"]
+
+    async def test_batch_empty_list_has_results_key(
+        self,
+        store: DuckDBStore,
+    ) -> None:
+        result = await _handle_store_batch(
+            store=store,
+            arguments={"entries": []},
+        )
+        data = parse_mcp_response(result)
+        assert data["entry_ids"] == []
+        assert data["results"] == []
+        assert data["count"] == 0


### PR DESCRIPTION
## Summary

Fixes #314 — ``distillery_store`` previously returned a fresh ``entry_id`` even when the entry was not persisted (dedup auto-skip), causing downstream ``distillery_get`` / ``distillery_update`` / ``distillery_classify`` calls to fail with ``NOT_FOUND``.

The ``distillery_store`` response now always includes:

- ``persisted`` (bool)
- ``dedup_action`` — one of ``stored`` / ``skipped`` / ``merged`` / ``linked``

When a near-duplicate is detected (top similarity >= ``dedup_skip_threshold``, default 0.95):

- The entry is **not** persisted.
- ``entry_id`` points at the existing entry (never a ghost id).
- ``existing_entry_id`` and ``similarity`` are included so callers can pivot.

``merged`` / ``linked`` are informational: the entry is still persisted and ``entry_id`` is the new row's id; ``existing_entry_id`` / ``similarity`` are included to surface the nearest match.

``distillery_store_batch`` gains a per-item ``results`` list (``[{entry_id, persisted, dedup_action}, ...]``) alongside the existing backward-compatible ``entry_ids`` and ``count``.

## Test plan

- [x] New unit suite ``tests/test_store_dedup_response.py`` covers fresh / skipped / merged / linked / summary-mode / batch paths
- [x] Verified skipped ``entry_id`` resolves via ``store.get`` (no ghosts)
- [x] ``ruff check`` + ``ruff format`` pass
- [x] ``mypy --strict`` passes (60 source files)
- [x] All unit tests pass (1460) — excluding preexisting ``test_cli_export_import::test_roundtrip_fidelity`` TZ failure on staging
- [x] All integration tests pass (674) — same exclusion
- [x] Adjusted ``test_conflict.py`` to use an interpolated vector (cos ~0.92) so conflicts path still exercised below skip threshold
- [x] Adjusted ``test_eval_unit.py::test_count_entries_since_seed`` to pass ``dedup_threshold=1.01`` to avoid hash-seed-dependent collisions in the stub embedding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Store responses now include deduplication status, showing whether entries were saved, skipped as duplicates, merged, or linked, along with similarity metrics.
  * Duplicate detection now occurs before storage, preventing redundant entries from being saved.
  * Batch operations return individual deduplication details for each entry, consistent with single-entry responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->