### PR TITLE
fix(plugin): document user-scope override for self-hosters (#235)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -26,18 +26,12 @@
       "description": "GitHub OAuth app client secret for team access. Found alongside the client ID in your OAuth App settings",
       "type": "string",
       "sensitive": true
-    },
-    "distillery_mcp_url": {
-      "title": "Distillery MCP URL",
-      "description": "URL of the Distillery MCP server. Defaults to the hosted demo for onboarding. Self-hosters should set this to their own instance URL (e.g. http://localhost:8787/mcp). The hosted demo is for evaluation only — do not store sensitive data.",
-      "type": "string",
-      "default": "https://distillery-mcp.fly.dev/mcp"
     }
   },
   "mcpServers": {
     "distillery": {
       "type": "http",
-      "url": "${user_config.distillery_mcp_url}"
+      "url": "https://distillery-mcp.fly.dev/mcp"
     }
   },
   "hooks": {

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -116,7 +116,11 @@ To configure manually, add to `~/.claude/settings.json`:
 
 Deploy your own Distillery server with GitHub OAuth. See [Operator Deployment](../team/deployment.md) for setup and the [distill_ops](https://github.com/norrietaylor/distill_ops) repo for platform-specific guides (Fly.io, Prefect Horizon).
 
-To point the plugin at your own instance, set the `distillery_mcp_url` plugin config field at enable time. Claude Code prompts for userConfig values when you enable the plugin, and the value is substituted into the plugin's MCP server registration automatically. Leave it at the default to use the hosted demo.
+To override the plugin's default demo URL, register your own MCP server at user scope. This shadows the plugin registration:
+
+```bash
+claude mcp add distillery --scope user --transport http --url https://your-instance.example.com/mcp
+```
 
 ## Remote Auto-Poll Setup
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -233,21 +233,15 @@ class TestPluginMCPServers:
         server = manifest["mcpServers"]["distillery"]
         assert "url" in server
 
-    def test_distillery_server_url_uses_user_config(self) -> None:
-        """The distillery server URL must reference the userConfig template variable.
+    def test_distillery_server_url_is_hardcoded_fly_url(self) -> None:
+        """The distillery server URL must be the hardcoded Fly.io hosted URL.
 
-        ${user_config.<key>} interpolation is supported in mcpServers.*.url for
-        HTTP-type servers per the Claude Code plugin reference. Self-hosters override
-        the URL by setting the distillery_mcp_url userConfig field at plugin enable
-        time. The default resolves to the hosted Fly.io demo.
+        Note: ${user_config.<key>} interpolation is NOT supported in mcpServers.url.
+        Self-hosters should override via: claude mcp add distillery --scope user
         """
         manifest = load_plugin_manifest()
         server = manifest["mcpServers"]["distillery"]
-        assert server["url"] == "${user_config.distillery_mcp_url}"
-        assert (
-            manifest["userConfig"]["distillery_mcp_url"]["default"]
-            == "https://distillery-mcp.fly.dev/mcp"
-        )
+        assert server["url"] == "https://distillery-mcp.fly.dev/mcp"
 
     def test_distillery_server_no_unsupported_fields(self) -> None:
         """The distillery server must not contain fields unsupported by the plugin schema."""


### PR DESCRIPTION
## Summary

Closes #235. Supersedes #294.

Self-hosters can override the plugin's default demo MCP URL by registering a user-scope MCP server that shadows the plugin's registration:

```bash
claude mcp add distillery --scope user --transport http --url https://your-instance.example.com/mcp
```

The plugin itself keeps a hardcoded demo URL. Version bumped to 0.3.3.

## Background — Why Not `${user_config.*}` Interpolation?

The initial attempt on #294 used `"url": "${user_config.distillery_mcp_url}"` with a default value, which is documented as supported in the [Claude Code plugin reference](https://code.claude.com/docs/en/plugins-reference.md#user-configuration). In empirical testing on the hosted plugin install, this path fails:

```
Plugin MCP server error - generic-error: Plugin option "distillery_mcp_url" isn't set.
```

The interpolation engine requires an explicitly set value and does **not** fall back to the `default` declared in the manifest. Since `default` values suppress the enable-time prompt, new installs never get a chance to populate the field — resulting in a broken MCP server for the exact demo-first UX the plugin is trying to provide.

Until Claude Code fixes the default-substitution behavior, the hardcoded URL + user-scope override pattern is the only path that works for all three personas (evaluator, self-hoster, local dev).

## Changes

- `.claude-plugin/plugin.json` — keep hardcoded `https://distillery-mcp.fly.dev/mcp`; no `distillery_mcp_url` userConfig field
- `docs/getting-started/plugin-install.md` — document `claude mcp add --scope user` override for self-hosters
- `tests/test_plugin.py` — assert the hardcoded URL; comment documents why interpolation is not used

This PR reverts commit 7c764a9 from #294 (which restored the broken interpolation approach). The net result is equivalent to the state CodeRabbit approved on #294 at commit 9f3ab05, repackaged as a clean PR targeting main.

## Test Plan

- [x] \`pytest tests/test_plugin.py\` passes (51/51)
- [ ] Fresh plugin install — verify \`claude mcp list\` + a session-level test tool call hit the hosted demo
- [ ] Self-host override — run \`claude mcp add distillery --scope user --url <other-url>\`, confirm that URL takes precedence

## Follow-ups

- File a Claude Code upstream bug: \`\${user_config.*}\` interpolation should fall back to the manifest \`default\` when the value is unset (or: default values should trigger enable-time prompts with the default prefilled)
- #330 — separate issue for stale tool count and self-host guidance in auto-poll docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide: self-hosted Distillery servers are now configured via command-line interface instead of plugin settings. Users can override the default hosted endpoint using the `claude mcp add distillery` command.

* **Chores**
  * Distillery MCP server now uses a fixed hosted endpoint by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->