### PR TITLE
feat(feeds): gh-sync returns async via server-side background job

### DIFF
--- a/docs/skills/gh-sync.md
+++ b/docs/skills/gh-sync.md
@@ -1,45 +1,46 @@
 # /gh-sync — GitHub Issue/PR Sync
 
-Syncs GitHub issues and pull requests from a repository into the Distillery knowledge base as searchable `github` entries. Each issue or PR becomes a knowledge entry with full metadata, cross-reference relations, and incremental sync support.
+Syncs GitHub issues and pull requests from a repository into the Distillery knowledge base as searchable `github` entries. The skill dispatches a background sync on the Distillery MCP server and returns immediately with a `job_id`; progress is checked on demand.
 
 ## Usage
 
 ```text
-/gh-sync owner/repo
-/gh-sync owner/repo --issues
-/gh-sync owner/repo --prs
-/gh-sync owner/repo --since 2026-01-01
+/gh-sync owner/repo                 # start a background sync
+/gh-sync status                     # list recent jobs
+/gh-sync status <job_id>            # check one job
+/gh-sync status <owner/repo>        # check latest job for this repo
 ```
 
-**Trigger phrases:** "sync GitHub", "import issues", "sync repo issues", "capture PR history"
+**Trigger phrases:** "sync GitHub", "import issues", "sync repo issues", "capture PR history", "how's the sync", "gh-sync status"
 
 ## When to Use
 
 - Capturing GitHub issues and PRs alongside session notes for traceable decisions
 - Making issue discussions and PR context searchable via `/recall` and `/pour`
-- Syncing only issues or only PRs for focused imports
-- Incrementally updating after previous syncs (only fetches items updated since last run)
+- Checking on a previously-started sync without re-running it
 
 ## What It Does
 
-1. **Fetches issues/PRs** from the GitHub API (respects rate limits)
-2. **Checks for existing entries** to avoid duplicates (incremental sync)
-3. **Creates `github` entries** with structured metadata (labels, assignees, state, milestone)
-4. **Adds relations** between related issues/PRs (cross-references, parent issues)
-5. **Tags entries** with `source/github/owner/repo` and label-derived tags
+1. **Dispatches an async job** on the Distillery MCP server (`distillery_gh_sync(background=true)`) and returns the `job_id` immediately.
+2. The server fetches issues/PRs from the GitHub API, respects rate limits, dedupes against `metadata.external_id`, creates new entries or updates existing ones, and wires `link` relations for cross-references.
+3. Status polls (`distillery_sync_status`) report `status`, `entries_created`, `entries_updated`, `pages_processed`, and any errors.
 
 ## Options
 
-| Flag | Description |
-|------|-------------|
-| `--issues` | Sync only issues (skip PRs) |
-| `--prs` | Sync only pull requests (skip issues) |
-| `--since DATE` | Only sync items updated after this date |
-| `--limit N` | Maximum number of items to sync |
+Currently the backend tool accepts only `url`, `author`, `project`, and `background`. The flags below were previously documented but are not wired through — they'll be noted as unsupported if supplied, and the sync will run without them:
+
+| Flag | Status |
+|------|--------|
+| `--issues` | not supported |
+| `--prs` | not supported |
+| `--since DATE` | not supported |
+| `--limit N` | not supported |
+| `--project <name>` | supported (overrides git-derived project) |
 
 ## Tips
 
-- Run incrementally — subsequent syncs only fetch items updated since the last run
-- Synced entries are searchable via `/recall` and synthesizable via `/pour`
-- Use `/investigate` to follow relationship chains across synced issues
-- Combine with `/watch add github:owner/repo` for ongoing event monitoring (different from `/gh-sync` which imports full issue/PR content)
+- The command returns in under a second — the sync runs in the background.
+- Ask "how's the sync going" or run `/gh-sync status` later to see progress.
+- Synced entries are searchable via `/recall` and synthesizable via `/pour`.
+- Use `/investigate` to follow relationship chains across synced issues.
+- Combine with `/watch add github:owner/repo` for ongoing event monitoring (different from `/gh-sync` which imports full issue/PR content).

--- a/skills/gh-sync/SKILL.md
+++ b/skills/gh-sync/SKILL.md
@@ -2,26 +2,22 @@
 name: gh-sync
 description: "Sync GitHub issues and pull requests into the Distillery knowledge base as searchable, linkable entries"
 allowed-tools:
-  - "mcp__*__distillery_store"
-  - "mcp__*__distillery_get"
-  - "mcp__*__distillery_update"
-  - "mcp__*__distillery_list"
-  - "mcp__*__distillery_relations"
+  - "mcp__*__distillery_gh_sync"
+  - "mcp__*__distillery_sync_status"
 context: fork
-effort: high
+effort: low
 ---
 
 <!-- Trigger phrases: gh-sync, /gh-sync, sync github, sync issues, sync prs, github sync, sync repo issues -->
 
-# gh-sync — GitHub Issue/PR Knowledge Tracking
+# gh-sync — GitHub Issue/PR Sync (async dispatch)
 
-gh-sync fetches issues and pull requests from a GitHub repository and stores them as searchable, linkable entries in the Distillery knowledge base. Each issue or PR becomes a `github` entry with full metadata, cross-reference relations, and incremental sync support.
+gh-sync dispatches a background GitHub sync to the Distillery MCP server. The server fetches issues and pull requests, stores them as `github` entries, dedupes, and wires cross-reference relations. The skill itself returns immediately with a `job_id`; status is checked on demand.
 
 ## When to Use
 
 - Capturing GitHub issues and PRs alongside session notes for traceable decisions (`/gh-sync owner/repo`)
-- Syncing only issues (`/gh-sync owner/repo --issues`) or only PRs (`/gh-sync owner/repo --prs`)
-- Incrementally updating after previous syncs (only fetches items updated since last run)
+- Checking progress of a running or recent sync (`/gh-sync status [job_id]`)
 - "sync github issues", "capture PR history", "make issues searchable", "track github decisions"
 
 ## Process
@@ -32,209 +28,109 @@ See CONVENTIONS.md — skip if already confirmed this conversation.
 
 ### Step 2: Parse Arguments
 
-If no repository argument is provided, ask:
+Detect the flow from the first argument:
 
-> Which GitHub repository would you like to sync? (e.g., `owner/repo` or `https://github.com/owner/repo`)
+| First token | Flow | Next steps |
+|-------------|------|------------|
+| `status` | **Status (all)** if no second token → Step 4 | |
+| `status <job_id>` or `status <source_url>` | **Status (one)** → Step 4 | |
+| anything else | **Start sync** → Step 3 (treat as `owner/repo` or GitHub URL) | |
 
-Extract from arguments:
-
-| Argument / Flag | Description |
-|-----------------|-------------|
-| `owner/repo` | Repository slug or full GitHub URL (required) |
-| `--issues` | Sync issues only (exclude PRs) |
-| `--prs` | Sync PRs only (exclude issues) |
-| `--project <name>` | Tag synced entries under this project (overrides git-derived project) |
-
-If both `--issues` and `--prs` are provided, sync both (equivalent to providing neither).
-
-Determine author & project per CONVENTIONS.md. The `owner/repo` argument must be validated as a recognisable slug (e.g. `org/repo`) or GitHub URL. If invalid, report:
+For the start flow, validate `owner/repo` or full GitHub URL. If invalid, report:
 
 ```
 Error: Invalid repository format. Expected "owner/repo" or "https://github.com/owner/repo".
 ```
 
-and stop.
+and stop. If no argument at all, ask:
 
-### Step 3: Check for Existing Sync State
+> Which GitHub repository would you like to sync? (e.g., `owner/repo` or `https://github.com/owner/repo`)
 
-Query for any previously synced entries from this repository to determine if this is an incremental sync:
+Determine `author` and `project` per CONVENTIONS.md. Accept an optional `--project <name>` flag to override the git-derived project.
 
-```python
-distillery_list(
-    entry_type="github",
-    limit=1,
-    # metadata filter — look for entries from this repo
-)
-```
+Flags `--issues`, `--prs`, `--since`, `--limit` are **not currently passed through** — the backend tool does not accept them. If the user supplies one, note that it's not yet supported and proceed with a full sync (or ask whether to continue).
 
-Report one of:
-- `First sync for {owner}/{repo} — fetching all open and closed items.`
-- `Incremental sync for {owner}/{repo} — fetching items updated since last sync.`
+### Step 3: Start Background Sync
 
-The `GitHubSyncAdapter` (invoked internally by the MCP backend) tracks the last sync timestamp via the store metadata table. The skill surfaces the state to the user but does not manage the timestamp directly.
-
-### Step 4: Retrieve Existing Entries for Dedup
-
-Before processing, retrieve the list of already-synced entries for this repository so that updates are routed correctly:
+Call the server tool in background mode:
 
 ```python
-distillery_list(
-    entry_type="github",
-    limit=500,
-    output_mode="full",
-    # scope to the target repo
-)
-```
-
-Note the `total_count` field from the response. If `total_count > 500`, paginate by calling `distillery_list` with increasing `offset` (500, 1000, ...) until all entries are retrieved.
-
-Use the `metadata.external_id` field of each returned entry to build a lookup map: `{external_id: entry_id}`. This map determines whether an incoming item should be stored (new) or updated (existing).
-
-### Step 5: Sync Issues and PRs
-
-For each item fetched from GitHub (handled by the backend sync adapter):
-
-**5a. Determine item type:**
-
-Each GitHub item is either an issue or a PR. Items with a `pull_request` key in the API response are PRs; all others are issues.
-
-Apply the filter:
-- `--issues` flag: skip items where `ref_type == "pr"`
-- `--prs` flag: skip items where `ref_type == "issue"`
-- No flag (or both): process all items
-
-**5b. Check for existing entry:**
-
-Look up `metadata.external_id` (format: `{owner}/{repo}#issue-{number}` or `{owner}/{repo}#pr-{number}`) in the dedup map built in Step 4.
-
-**If not found (new entry):**
-
-```python
-distillery_store(
-    content="<title + body + top comments, markdown-formatted>",
-    entry_type="github",
+distillery_gh_sync(
+    url="<owner/repo or URL>",
     author="<author>",
-    project="<project>",
-    tags=["<label1>", "<label2>", ...],
-    metadata={
-        "repo": "<owner>/<repo>",
-        "ref_type": "<issue|pr>",
-        "ref_number": <number>,
-        "title": "<title>",
-        "url": "<html_url>",
-        "state": "<open|closed>",
-        "labels": ["<label>", ...],
-        "assignees": ["<login>", ...],
-        "external_id": "<owner>/<repo>#<ref_type>-<number>"
-    }
+    project="<project>",        # omit if unset
+    background=true,
 )
 ```
 
-**If found (existing entry):**
+Read `sync_job.job_id` from the response. Report:
+
+```
+Started gh-sync job <job_id> for <owner/repo>.
+Running in the background — ask "how's the sync" or run `/gh-sync status <job_id>` to check.
+```
+
+Stop. Do NOT poll `distillery_sync_status` in this turn — the point of the async path is to return fast.
+
+### Step 4: Status
+
+Two sub-flows:
+
+**4a. Single job** (`status <id>` or `status <url>`):
 
 ```python
-distillery_update(
-    entry_id="<existing_entry_id>",
-    content="<updated content>",
-    metadata={
-        "state": "<current state>",
-        "labels": ["<label>", ...],
-        "assignees": ["<login>", ...]
-    }
-)
+distillery_sync_status(job_id="<id>")   # if looks like a UUID
+# or
+distillery_sync_status(source_url="<url>")
 ```
 
-**5c. Create cross-reference relations:**
+Render the response as a one-liner:
 
-After storing or updating, parse the entry content for cross-reference patterns (`#123`, `Closes #123`, `Fixes #123`, `Resolves #123`). For each referenced number found:
+```
+<job_id> (<source_url>): <status> — <entries_created> new, <entries_updated> updated, <pages_processed> pages. <elapsed>
+```
 
-1. Look up the external_id `{owner}/{repo}#issue-{ref}` and `{owner}/{repo}#pr-{ref}` in the dedup map
-2. If found, create a `link` relation between the current entry and the referenced entry:
+If `error_message` is set, surface it verbatim on a second line and suggest re-running.
+
+**4b. All recent jobs** (`status` alone):
 
 ```python
-distillery_relations(
-    action="add",
-    from_id="<current_entry_id>",
-    to_id="<referenced_entry_id>",
-    relation_type="link"
-)
+distillery_sync_status()
 ```
 
-Skip self-references (where `ref_number == current_number`). Skip if target entry not found in the knowledge base. Relation creation failures are non-fatal — log and continue.
+Render as a table of the top 5 rows sorted by `created_at desc`:
 
-Track count of relations created for the summary report.
-
-### Step 6: Confirm
-
-Display the sync summary:
-
-```
-Synced {N} issues, {M} PRs from {owner}/{repo}. {K} new, {L} updated. {R} cross-reference relations created.
-```
-
-Where:
-- `N` = count of issues processed (0 if `--prs` only)
-- `M` = count of PRs processed (0 if `--issues` only)
-- `K` = count of new entries stored
-- `L` = count of existing entries updated
-- `R` = count of `link` relations created
-
-If no items were found (e.g., empty repository or all items already up to date), display:
-
-```
-No new or updated items found for {owner}/{repo} since last sync.
-```
+| job_id (short) | source_url | status | new | updated | created_at |
+|----------------|------------|--------|-----|---------|------------|
 
 ## Output Format
 
-```
-gh-sync: {owner}/{repo}
-Fetching {"all items" | "issues only" | "PRs only"}...
-
-{First sync | Incremental sync} — {N} items retrieved from GitHub API.
-
-Processing:
-  Issues: {N} ({K} new, {L} updated)
-  PRs:    {M} ({K} new, {L} updated)
-  Relations: {R} cross-reference links created
-
-Synced {total_N} issues, {total_M} PRs from {owner}/{repo}. {K} new, {L} updated. {R} cross-reference relations created.
-```
-
-Example:
+**Start flow:**
 
 ```
-gh-sync: norrietaylor/distillery
-Fetching all items...
-
-Incremental sync — 12 items retrieved from GitHub API.
-
-Processing:
-  Issues: 8 (3 new, 5 updated)
-  PRs:    4 (2 new, 2 updated)
-  Relations: 6 cross-reference links created
-
-Synced 8 issues, 4 PRs from norrietaylor/distillery. 5 new, 7 updated. 6 cross-reference relations created.
+gh-sync: <owner/repo>
+Started job <job_id> in background.
+Check with: /gh-sync status <job_id>
 ```
+
+**Status (single):**
+
+```
+<job_id> (<owner/repo>): <status>
+  <entries_created> new, <entries_updated> updated, <pages_processed> pages
+  [if errors]: <error_message>
+```
+
+**Status (list):** markdown table as above.
 
 ## Rules
 
-- NEVER use Bash, Python, or any tool not listed in allowed-tools
-- If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.
-- Exception: `distillery_relations(action="add", ...)` failures are non-fatal — log, continue, and report in the summary.
-- `owner/repo` argument is required — ask if not provided
-- `--issues` and `--prs` can be combined (equivalent to syncing both)
-- Never store duplicate entries — always check `metadata.external_id` before storing
-- Use `entry_type="github"` for all synced entries
-- `metadata.external_id` format: `{owner}/{repo}#issue-{number}` or `{owner}/{repo}#pr-{number}`
-- Required metadata fields: `repo`, `ref_type`, `ref_number`, `title`, `url`, `state`
-- Labels are normalised to tags: lowercase, spaces and underscores become hyphens, consecutive hyphens collapsed, leading/trailing hyphens stripped, non-conforming labels dropped
-- Entry content: `# {title}\n\n{body}\n\n**{commenter}**: {comment}` (top 10 comments max)
-- Cross-reference relation creation is non-fatal — continue on failure, report in summary
-- Self-references (an issue referencing its own number) are skipped
-- `GITHUB_TOKEN` is read from environment by the backend adapter — not handled by the skill
-- This skill does not filter by project on read (all `github` entries for the repo are dedup candidates)
-- Apply `--project` to all `distillery_store` and `distillery_update` calls when provided
-- On MCP errors, see CONVENTIONS.md error handling — display and stop
-- No retry loops — report errors and stop
-- Display-only summary — this skill does not store its own output as a knowledge entry
+- ONLY use `distillery_gh_sync` and `distillery_sync_status`. Do NOT hand-roll fetch/dedup/store — the server does it.
+- Always pass `background=true` on `distillery_gh_sync`. Never call it synchronously.
+- NEVER poll `distillery_sync_status` in a loop within one skill turn. If the user wants to "wait", tell them to re-run `/gh-sync status <id>` after a minute.
+- On `distillery_gh_sync` error: surface the error verbatim and STOP. No retries.
+- `owner/repo` argument is required for the start flow — ask if not provided.
+- `--issues`, `--prs`, `--since`, `--limit` are not currently supported by the backend tool. Warn the user if supplied.
+- Apply `--project` to the `project=` parameter when provided; otherwise use the git-derived project from CONVENTIONS.md.
+- `GITHUB_TOKEN` is read from environment by the backend adapter — not handled by the skill.
+- Display-only summaries — this skill does not store its own output as a knowledge entry.

--- a/src/distillery/feeds/sync_jobs.py
+++ b/src/distillery/feeds/sync_jobs.py
@@ -2,8 +2,15 @@
 
 When a feed source is added with ``sync_history=True``, the import runs as a
 background :mod:`asyncio` task instead of blocking the MCP tool response.  This
-module provides an in-memory job registry that tracks status, progress, and
-results so callers can check on running imports.
+module provides a registry that tracks status, progress, and results so
+callers can check on running imports.
+
+The tracker is backed by an in-memory dict for hot reads plus (when a
+:class:`~distillery.store.duckdb.DuckDBStore` is attached) write-through
+persistence to the ``sync_jobs`` table. On server startup, :meth:`hydrate`
+reloads recent rows and marks any ``pending`` / ``running`` jobs as
+``failed`` with ``error_message="interrupted by server restart"`` — the
+asyncio tasks backing them don't survive a restart.
 
 Job lifecycle::
 
@@ -12,10 +19,12 @@ Job lifecycle::
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import uuid
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Any
 
@@ -87,16 +96,128 @@ class SyncJob:
         }
 
 
+_HYDRATE_HORIZON_HOURS = 24
+
+_INSERT_SYNC_JOB = """
+INSERT INTO sync_jobs (
+    job_id, source_url, source_type, status, created_at,
+    started_at, completed_at,
+    entries_created, entries_updated, relations_created, pages_processed,
+    errors, error_message, result
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (job_id) DO UPDATE SET
+    status = EXCLUDED.status,
+    started_at = EXCLUDED.started_at,
+    completed_at = EXCLUDED.completed_at,
+    entries_created = EXCLUDED.entries_created,
+    entries_updated = EXCLUDED.entries_updated,
+    relations_created = EXCLUDED.relations_created,
+    pages_processed = EXCLUDED.pages_processed,
+    errors = EXCLUDED.errors,
+    error_message = EXCLUDED.error_message,
+    result = EXCLUDED.result
+"""
+
+_SELECT_RECENT_SYNC_JOBS = """
+SELECT job_id, source_url, source_type, status, created_at,
+       started_at, completed_at,
+       entries_created, entries_updated, relations_created, pages_processed,
+       errors, error_message, result
+FROM sync_jobs
+WHERE created_at > ?
+ORDER BY created_at DESC
+"""
+
+
+def _job_from_row(row: tuple[Any, ...]) -> SyncJob:
+    """Rebuild a :class:`SyncJob` from a DuckDB row (SELECT order above)."""
+    (
+        job_id,
+        source_url,
+        source_type,
+        status,
+        created_at,
+        started_at,
+        completed_at,
+        entries_created,
+        entries_updated,
+        relations_created,
+        pages_processed,
+        errors_raw,
+        error_message,
+        result_raw,
+    ) = row
+
+    errors: list[str] = []
+    if errors_raw:
+        try:
+            parsed = json.loads(errors_raw)
+            if isinstance(parsed, list):
+                errors = [str(e) for e in parsed]
+        except (TypeError, ValueError):
+            errors = []
+
+    result: dict[str, Any] | None = None
+    if result_raw:
+        try:
+            parsed = json.loads(result_raw)
+            if isinstance(parsed, dict):
+                result = parsed
+        except (TypeError, ValueError):
+            result = None
+
+    # DuckDB returns datetimes as tz-aware for TIMESTAMPTZ; defend against
+    # naïve values by attaching UTC.
+    def _as_utc(dt: datetime | None) -> datetime | None:
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=UTC)
+        return dt
+
+    return SyncJob(
+        job_id=str(job_id),
+        source_url=str(source_url),
+        source_type=str(source_type),
+        status=SyncJobStatus(str(status)),
+        created_at=_as_utc(created_at) or datetime.now(tz=UTC),
+        started_at=_as_utc(started_at),
+        completed_at=_as_utc(completed_at),
+        entries_created=int(entries_created or 0),
+        entries_updated=int(entries_updated or 0),
+        relations_created=int(relations_created or 0),
+        pages_processed=int(pages_processed or 0),
+        errors=errors,
+        error_message=str(error_message) if error_message is not None else None,
+        result=result,
+    )
+
+
 class SyncJobTracker:
-    """In-memory registry of background sync jobs.
+    """Registry of background sync jobs.
+
+    The in-memory dict is the primary hot-read surface. When a store is
+    attached (via :meth:`attach_store`, or passed to the constructor),
+    every state transition is mirrored to the ``sync_jobs`` table.
+    Persistence failures are logged and swallowed — they never abort an
+    in-memory update.
 
     Safe for use with asyncio tasks (cooperative concurrency on a single
-    thread).  Jobs are kept in memory and are lost on process restart
-    (acceptable for MCP server lifecycle).
+    thread). DuckDB writes block the event loop briefly (<1 ms); acceptable
+    for the single-row transitions here.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, store: Any | None = None) -> None:
         self._jobs: dict[str, SyncJob] = {}
+        self._store: Any | None = store
+
+    def attach_store(self, store: Any) -> None:
+        """Attach a store for write-through persistence.
+
+        Intended to be called from the MCP server lifespan once the
+        :class:`~distillery.store.duckdb.DuckDBStore` has been initialised.
+        """
+        self._store = store
 
     def create_job(self, source_url: str, source_type: str) -> SyncJob:
         """Create and register a new pending sync job.
@@ -110,6 +231,7 @@ class SyncJobTracker:
         """
         job = SyncJob(source_url=source_url, source_type=source_type)
         self._jobs[job.job_id] = job
+        self._persist_snapshot(job)
         return job
 
     def get_job(self, job_id: str) -> SyncJob | None:
@@ -137,25 +259,137 @@ class SyncJobTracker:
     def mark_running(self, job_id: str) -> None:
         """Transition a job to running status."""
         job = self._jobs.get(job_id)
-        if job is not None:
-            job.status = SyncJobStatus.RUNNING
-            job.started_at = datetime.now(tz=UTC)
+        if job is None:
+            return
+        job.status = SyncJobStatus.RUNNING
+        job.started_at = datetime.now(tz=UTC)
+        self._persist_snapshot(job)
 
     def mark_completed(self, job_id: str, result: dict[str, Any] | None = None) -> None:
         """Transition a job to completed status."""
         job = self._jobs.get(job_id)
-        if job is not None:
-            job.status = SyncJobStatus.COMPLETED
-            job.completed_at = datetime.now(tz=UTC)
-            job.result = result
+        if job is None:
+            return
+        job.status = SyncJobStatus.COMPLETED
+        job.completed_at = datetime.now(tz=UTC)
+        job.result = result
+        self._persist_snapshot(job)
 
     def mark_failed(self, job_id: str, error: str) -> None:
         """Transition a job to failed status."""
         job = self._jobs.get(job_id)
-        if job is not None:
-            job.status = SyncJobStatus.FAILED
-            job.completed_at = datetime.now(tz=UTC)
-            job.error_message = error
+        if job is None:
+            return
+        job.status = SyncJobStatus.FAILED
+        job.completed_at = datetime.now(tz=UTC)
+        job.error_message = error
+        self._persist_snapshot(job)
+
+    def update_progress(
+        self,
+        job_id: str,
+        pages_processed: int,
+        created_delta: int,
+        updated_delta: int,
+    ) -> None:
+        """Record per-page progress for a running job.
+
+        Mirrors what the legacy ``_on_page`` inline callback used to do
+        (absolute ``pages_processed``, accumulated ``entries_created`` /
+        ``entries_updated``) but also write-throughs to the DB so restart
+        hydration sees accurate intermediate progress.
+        """
+        job = self._jobs.get(job_id)
+        if job is None:
+            return
+        job.pages_processed = pages_processed
+        job.entries_created += created_delta
+        job.entries_updated += updated_delta
+        self._persist_snapshot(job)
+
+    async def hydrate(self) -> int:
+        """Load recent rows from DB into memory and reconcile dangling jobs.
+
+        Any jobs whose persisted status is ``pending`` or ``running`` are
+        stale (their asyncio task didn't survive the restart); they're
+        rewritten as ``failed`` with ``error_message="interrupted by server
+        restart"``.
+
+        Returns:
+            Number of jobs reconciled as interrupted. Zero when no store
+            is attached.
+        """
+        if self._store is None:
+            return 0
+
+        cutoff = datetime.now(tz=UTC) - timedelta(hours=_HYDRATE_HORIZON_HOURS)
+        try:
+            rows = await asyncio.to_thread(
+                lambda: self._store.connection.execute(
+                    _SELECT_RECENT_SYNC_JOBS, [cutoff]
+                ).fetchall()
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("SyncJobTracker.hydrate: failed to load sync_jobs")
+            return 0
+
+        interrupted = 0
+        for row in rows:
+            try:
+                job = _job_from_row(row)
+            except Exception:  # noqa: BLE001
+                logger.exception("SyncJobTracker.hydrate: skipping malformed row")
+                continue
+            self._jobs[job.job_id] = job
+            if job.status in (SyncJobStatus.PENDING, SyncJobStatus.RUNNING):
+                job.status = SyncJobStatus.FAILED
+                job.completed_at = datetime.now(tz=UTC)
+                job.error_message = "interrupted by server restart"
+                self._persist_snapshot(job)
+                interrupted += 1
+
+        if interrupted:
+            logger.info(
+                "SyncJobTracker.hydrate: marked %d dangling jobs as interrupted",
+                interrupted,
+            )
+        return interrupted
+
+    # ------------------------------------------------------------------
+    # Persistence helpers (no-ops when no store is attached)
+    # ------------------------------------------------------------------
+
+    def _persist_snapshot(self, job: SyncJob) -> None:
+        """Write the full job row to DB via UPSERT. Silent on failure."""
+        if self._store is None:
+            return
+        try:
+            errors_json = json.dumps(job.errors) if job.errors else None
+            result_json = json.dumps(job.result) if job.result is not None else None
+            self._store.connection.execute(
+                _INSERT_SYNC_JOB,
+                [
+                    job.job_id,
+                    job.source_url,
+                    job.source_type,
+                    str(job.status),
+                    job.created_at,
+                    job.started_at,
+                    job.completed_at,
+                    job.entries_created,
+                    job.entries_updated,
+                    job.relations_created,
+                    job.pages_processed,
+                    errors_json,
+                    job.error_message,
+                    result_json,
+                ],
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "SyncJobTracker: failed to persist snapshot for job %s",
+                job.job_id,
+            )
 
 
 # Module-level singleton for the MCP server process.

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -197,6 +197,21 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                             trust_weight=src.trust_weight,
                         )
                 await store.set_metadata("feeds_seeded", "true")
+            # Wire the sync-job tracker to the store and reconcile any
+            # background jobs interrupted by a prior restart.
+            from distillery.feeds.sync_jobs import get_tracker
+
+            tracker = get_tracker()
+            tracker.attach_store(store)
+            try:
+                interrupted = await tracker.hydrate()
+                if interrupted:
+                    logger.info(
+                        "Marked %d sync jobs as interrupted during startup hydration",
+                        interrupted,
+                    )
+            except Exception:  # noqa: BLE001
+                logger.exception("Sync-job tracker hydration failed (non-fatal)")
             _shared.update(store=store, config=config, embedding_provider=ep)
             # Record startup timestamp for distillery_status uptime reporting.
             # Stored in shared state (not replaced on subsequent lifespan entries

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -336,9 +336,7 @@ async def _handle_watch(
                 job = tracker.create_job(source_url=url, source_type=source_type)
 
                 def _on_page(page_num: int, created: int, updated: int) -> None:
-                    job.pages_processed = page_num
-                    job.entries_created += created
-                    job.entries_updated += updated
+                    tracker.update_progress(job.job_id, page_num, created, updated)
 
                 sync_coro = adapter.sync_batched(on_page=_on_page)
                 asyncio.create_task(run_sync_job_async(job, tracker, sync_coro))
@@ -698,9 +696,7 @@ async def _handle_gh_sync(
         job = tracker.create_job(source_url=url, source_type="github")
 
         def _on_page(page_num: int, created: int, updated: int) -> None:
-            job.pages_processed = page_num
-            job.entries_created += created
-            job.entries_updated += updated
+            tracker.update_progress(job.job_id, page_num, created, updated)
 
         sync_coro = adapter.sync_batched(on_page=_on_page)
         asyncio.create_task(run_sync_job_async(job, tracker, sync_coro))

--- a/src/distillery/store/migrations.py
+++ b/src/distillery/store/migrations.py
@@ -365,6 +365,44 @@ def add_feed_source_liveness(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> 
     logger.info("Migration 12: feed_sources liveness columns added")
 
 
+_CREATE_SYNC_JOBS_TABLE = """
+CREATE TABLE IF NOT EXISTS sync_jobs (
+    job_id            VARCHAR PRIMARY KEY,
+    source_url        VARCHAR NOT NULL,
+    source_type       VARCHAR NOT NULL,
+    status            VARCHAR NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL,
+    started_at        TIMESTAMPTZ,
+    completed_at      TIMESTAMPTZ,
+    entries_created   INTEGER NOT NULL DEFAULT 0,
+    entries_updated   INTEGER NOT NULL DEFAULT 0,
+    relations_created INTEGER NOT NULL DEFAULT 0,
+    pages_processed   INTEGER NOT NULL DEFAULT 0,
+    errors            VARCHAR,
+    error_message     VARCHAR,
+    result            VARCHAR
+);
+"""
+
+_CREATE_SYNC_JOBS_CREATED_AT_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_sync_jobs_created_at
+ON sync_jobs (created_at);
+"""
+
+
+def create_sync_jobs(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
+    """Migration 13: Create the ``sync_jobs`` table.
+
+    Backs the :class:`distillery.feeds.sync_jobs.SyncJobTracker` so background
+    gh-sync / feed-history jobs survive server restarts. Fields mirror
+    :class:`distillery.feeds.sync_jobs.SyncJob`; ``errors`` and ``result``
+    are JSON-encoded strings.
+    """
+    conn.execute(_CREATE_SYNC_JOBS_TABLE)
+    conn.execute(_CREATE_SYNC_JOBS_CREATED_AT_INDEX)
+    logger.info("Migration 13: sync_jobs table created")
+
+
 # ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
@@ -382,6 +420,7 @@ MIGRATIONS: dict[int, MigrationFunc] = {
     10: add_verification,
     11: add_session_id,
     12: add_feed_source_liveness,
+    13: create_sync_jobs,
 }
 """Ordered mapping of schema version to migration function.
 

--- a/tests/test_async_sync_pipeline.py
+++ b/tests/test_async_sync_pipeline.py
@@ -156,6 +156,212 @@ class TestSyncJobTracker:
 
 
 # ---------------------------------------------------------------------------
+# SyncJobTracker DuckDB persistence tests
+# ---------------------------------------------------------------------------
+
+
+def _count_sync_jobs(store: Any, job_id: str) -> int:
+    """Helper: count rows in sync_jobs for a given job_id."""
+    row = store.connection.execute(
+        "SELECT COUNT(*) FROM sync_jobs WHERE job_id = ?", [job_id]
+    ).fetchone()
+    return int(row[0])
+
+
+def _fetch_sync_job_row(store: Any, job_id: str) -> dict[str, Any] | None:
+    """Helper: return the sync_jobs row for a given job_id as a dict."""
+    row = store.connection.execute(
+        """SELECT job_id, source_url, source_type, status, entries_created,
+                  entries_updated, pages_processed, error_message, result, errors
+           FROM sync_jobs WHERE job_id = ?""",
+        [job_id],
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "job_id": row[0],
+        "source_url": row[1],
+        "source_type": row[2],
+        "status": row[3],
+        "entries_created": row[4],
+        "entries_updated": row[5],
+        "pages_processed": row[6],
+        "error_message": row[7],
+        "result": row[8],
+        "errors": row[9],
+    }
+
+
+class TestSyncJobTrackerPersistence:
+    """Write-through persistence and restart hydration."""
+
+    @pytest.mark.integration
+    async def test_create_job_writes_row(self, store) -> None:  # type: ignore[no-untyped-def]
+        tracker = SyncJobTracker(store=store)
+        job = tracker.create_job(source_url="owner/repo", source_type="github")
+        row = _fetch_sync_job_row(store, job.job_id)
+        assert row is not None
+        assert row["status"] == "pending"
+        assert row["source_url"] == "owner/repo"
+        assert row["source_type"] == "github"
+
+    @pytest.mark.integration
+    async def test_state_transitions_persist(self, store) -> None:  # type: ignore[no-untyped-def]
+        tracker = SyncJobTracker(store=store)
+        job = tracker.create_job(source_url="owner/repo", source_type="github")
+
+        tracker.mark_running(job.job_id)
+        row = _fetch_sync_job_row(store, job.job_id)
+        assert row is not None
+        assert row["status"] == "running"
+
+        tracker.mark_completed(job.job_id, result={"created": 3, "updated": 1})
+        row = _fetch_sync_job_row(store, job.job_id)
+        assert row is not None
+        assert row["status"] == "completed"
+        assert row["result"] is not None
+        assert json.loads(row["result"])["created"] == 3
+
+    @pytest.mark.integration
+    async def test_mark_failed_persists_error(self, store) -> None:  # type: ignore[no-untyped-def]
+        tracker = SyncJobTracker(store=store)
+        job = tracker.create_job(source_url="owner/repo", source_type="github")
+        tracker.mark_running(job.job_id)
+        tracker.mark_failed(job.job_id, error="API down")
+        row = _fetch_sync_job_row(store, job.job_id)
+        assert row is not None
+        assert row["status"] == "failed"
+        assert row["error_message"] == "API down"
+
+    @pytest.mark.integration
+    async def test_update_progress_accumulates(self, store) -> None:  # type: ignore[no-untyped-def]
+        tracker = SyncJobTracker(store=store)
+        job = tracker.create_job(source_url="owner/repo", source_type="github")
+        tracker.update_progress(job.job_id, pages_processed=1, created_delta=5, updated_delta=2)
+        tracker.update_progress(job.job_id, pages_processed=2, created_delta=3, updated_delta=0)
+
+        row = _fetch_sync_job_row(store, job.job_id)
+        assert row is not None
+        assert row["pages_processed"] == 2
+        assert row["entries_created"] == 8  # 5 + 3
+        assert row["entries_updated"] == 2  # 2 + 0
+
+    @pytest.mark.integration
+    async def test_attach_store_after_construction(self, store) -> None:  # type: ignore[no-untyped-def]
+        """attach_store() after construction lights up persistence."""
+        tracker = SyncJobTracker()  # no store yet
+        job = tracker.create_job(source_url="a/b", source_type="github")
+        assert _count_sync_jobs(store, job.job_id) == 0  # no persistence yet
+
+        tracker.attach_store(store)
+        # Subsequent transitions should persist the full snapshot.
+        tracker.mark_running(job.job_id)
+        row = _fetch_sync_job_row(store, job.job_id)
+        assert row is not None
+        assert row["status"] == "running"
+
+    @pytest.mark.integration
+    async def test_persistence_failure_is_silent(
+        self,
+        store,  # type: ignore[no-untyped-def]
+        caplog,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """A DB error during persistence must not abort the in-memory update."""
+        tracker = SyncJobTracker(store=store)
+        job = tracker.create_job(source_url="a/b", source_type="github")
+
+        # Force a persistence error by dropping the table between transitions.
+        store.connection.execute("DROP TABLE sync_jobs")
+        caplog.clear()
+        # Should not raise — in-memory state still updates.
+        tracker.mark_running(job.job_id)
+        assert tracker.get_job(job.job_id).status == SyncJobStatus.RUNNING  # type: ignore[union-attr]
+        assert any(
+            "failed to persist snapshot" in rec.message.lower() for rec in caplog.records
+        )
+
+    @pytest.mark.integration
+    async def test_hydrate_no_op_without_store(self) -> None:
+        tracker = SyncJobTracker()
+        interrupted = await tracker.hydrate()
+        assert interrupted == 0
+
+    @pytest.mark.integration
+    async def test_hydrate_marks_running_as_interrupted(self, store) -> None:  # type: ignore[no-untyped-def]
+        """Jobs with status=running at hydrate-time are reconciled as failed."""
+        # Seed the DB directly to simulate a pre-restart running job.
+        from datetime import UTC, datetime
+
+        job_id = "seeded-running-job"
+        store.connection.execute(
+            """INSERT INTO sync_jobs
+               (job_id, source_url, source_type, status, created_at,
+                started_at, entries_created, entries_updated)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                job_id,
+                "owner/repo",
+                "github",
+                "running",
+                datetime.now(tz=UTC),
+                datetime.now(tz=UTC),
+                2,
+                0,
+            ],
+        )
+
+        tracker = SyncJobTracker(store=store)
+        interrupted = await tracker.hydrate()
+        assert interrupted == 1
+
+        # Verify both the in-memory copy and the persisted row are updated.
+        job = tracker.get_job(job_id)
+        assert job is not None
+        assert job.status == SyncJobStatus.FAILED
+        assert job.error_message == "interrupted by server restart"
+        assert job.entries_created == 2  # preserved partial progress
+
+        row = _fetch_sync_job_row(store, job_id)
+        assert row is not None
+        assert row["status"] == "failed"
+        assert row["error_message"] == "interrupted by server restart"
+
+    @pytest.mark.integration
+    async def test_hydrate_preserves_completed_jobs(self, store) -> None:  # type: ignore[no-untyped-def]
+        """Completed jobs survive hydration unchanged and are visible via get_job."""
+        from datetime import UTC, datetime
+
+        job_id = "seeded-completed-job"
+        store.connection.execute(
+            """INSERT INTO sync_jobs
+               (job_id, source_url, source_type, status, created_at,
+                completed_at, entries_created, entries_updated, result)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                job_id,
+                "owner/repo",
+                "github",
+                "completed",
+                datetime.now(tz=UTC),
+                datetime.now(tz=UTC),
+                7,
+                2,
+                json.dumps({"created": 7, "updated": 2}),
+            ],
+        )
+
+        tracker = SyncJobTracker(store=store)
+        interrupted = await tracker.hydrate()
+        assert interrupted == 0
+
+        job = tracker.get_job(job_id)
+        assert job is not None
+        assert job.status == SyncJobStatus.COMPLETED
+        assert job.entries_created == 7
+        assert job.result == {"created": 7, "updated": 2}
+
+
+# ---------------------------------------------------------------------------
 # run_sync_job_async tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `/gh-sync` skill now dispatches to the existing server-side async path (`distillery_gh_sync(background=true)`) and returns immediately with a `job_id`. New `/gh-sync status [id]` sub-flow polls `distillery_sync_status`. Replaces the legacy skill that re-implemented fetch/dedupe/store in Claude's head.
- `SyncJobTracker` gains write-through persistence to a new `sync_jobs` table (migration 13). Minutes-long gh-sync jobs now survive fly.io restarts; startup hydration reconciles any `pending`/`running` rows as `failed` with `error_message=\"interrupted by server restart\"`.
- `_on_page` callbacks route through `tracker.update_progress(...)` so intermediate progress is persisted alongside in-memory mutation.

## Why

Filed against staging UX test (2026-04-17): `/gh-sync` blocked sessions for minutes. The server-side `distillery_gh_sync(background=True)` path already existed and was unused; the skill just didn't grant itself the tool. This PR fixes the skill and adds durability so dashboards / status polls stay accurate across deploys.

## Test plan

- [x] `pytest tests/test_async_sync_pipeline.py -x -q` — 36/36 pass (includes 9 new `TestSyncJobTrackerPersistence` cases)
- [x] `pytest tests/` full suite — 2269 passed, 73 skipped, 1 xfailed. The 1 deselected case (`test_cli_export_import.py::test_roundtrip_fidelity`) is a pre-existing TZ bug unrelated to this branch (off by 7h local-tz offset on expires_at roundtrip).
- [x] `pytest tests/test_store_migration.py` — migration version bump picked up cleanly (8/8 pass).
- [x] `ruff check` on all modified files — clean.
- [ ] Manual smoke after deploy: `/gh-sync norrietaylor/distillery` returns `job_id` in <1s; `distillery_sync_status(job_id=<id>)` shows `running` → `completed`.
- [ ] Manual restart test: start sync, restart fly machine mid-run, `distillery_sync_status(job_id=<id>)` returns row with `status=failed`, `error_message=\"interrupted by server restart\"`.

## Notes for reviewers

- Schema change: migration 13 adds `sync_jobs` table (job_id PK, JSON text for errors/result). Idempotent; runs automatically on next startup.
- The skill's `allowed-tools` frontmatter was narrowed to just `distillery_gh_sync` + `distillery_sync_status` — all other MCP tools are now handled server-side.
- Out of scope: `--issues`/`--prs`/`--since`/`--limit` filter flags are documented as unsupported (backend tool doesn't accept them); filed as a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub sync now operates asynchronously, returning a job ID immediately and running in the background.
  * Added `/gh-sync status` command to check sync progress and view metrics like entries created/updated and pages processed.
  * Sync jobs are now persisted and can be queried later for status and results.

* **Bug Fixes**
  * Sync jobs interrupted by server restarts are now automatically marked as failed with appropriate error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->