### PR TITLE
fix(feeds,store): populate liveness fields across poll and sync paths (#334)

### DIFF
--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -577,10 +577,13 @@ class FeedPoller:
         columns after each source poll so ``distillery_watch(action=
         'list')`` can surface them without a separate status tool.
 
-        Any exception raised by ``record_poll_status`` is swallowed with a
-        debug log so that persistence failures do not mask poll results.
-        Backends that predate the protocol addition may not expose the
-        method — in that case we simply skip the update.
+        Any exception raised by ``record_poll_status`` is swallowed so
+        that persistence failures do not mask poll results, but we log at
+        ``WARNING`` with ``exc_info`` so operators can diagnose — a silent
+        failure here was the root cause of liveness fields staying ``NULL``
+        in production (issue #334).  Backends that predate the protocol
+        addition may not expose the method — in that case we simply skip
+        the update.
         """
         recorder = getattr(self._store, "record_poll_status", None)
         if recorder is None:
@@ -597,7 +600,7 @@ class FeedPoller:
                 error=error_msg,
             )
         except Exception:  # noqa: BLE001
-            logger.debug(
+            logger.warning(
                 "FeedPoller: failed to persist poll status for %s",
                 result.source_url,
                 exc_info=True,

--- a/src/distillery/feeds/sync_jobs.py
+++ b/src/distillery/feeds/sync_jobs.py
@@ -171,6 +171,7 @@ async def run_sync_job_async(
     job: SyncJob,
     tracker: SyncJobTracker,
     sync_coro: Any,
+    store: Any | None = None,
 ) -> None:
     """Execute a sync coroutine as a background task and update job state.
 
@@ -184,6 +185,14 @@ async def run_sync_job_async(
             ``updated``, ``relations_created``, ``pages_processed``, and
             ``errors`` attributes (e.g. ``GitHubSyncAdapter.sync()`` or
             ``GitHubSyncAdapter.sync_batched()``).
+        store: Optional :class:`DistilleryStore` used to record liveness
+            metadata (``last_polled_at``, ``last_item_count``,
+            ``last_error``) on the matching ``feed_sources`` row once the
+            sync finishes.  When provided the runner mirrors what
+            :meth:`FeedPoller._persist_poll_status` does for scheduled
+            polls — without this call, sources that only ever backfilled
+            via ``sync_history=True`` would surface as "never polled" to
+            ``distillery_watch(action='list')`` (issue #334).
     """
     tracker.mark_running(job.job_id)
     try:
@@ -201,6 +210,12 @@ async def run_sync_job_async(
             job.entries_created,
             job.entries_updated,
         )
+        await _record_sync_liveness(
+            store,
+            source_url=job.source_url,
+            item_count=result.created + result.updated,
+            error=result.errors[0] if result.errors else None,
+        )
     except Exception:  # noqa: BLE001
         error_msg = "Sync job failed"
         logger.exception(
@@ -213,3 +228,43 @@ async def run_sync_job_async(
         # mark_failed only sets status/completed_at/error_message, so progress
         # fields (entries_created, entries_updated, etc.) are retained.
         tracker.mark_failed(job.job_id, error_msg)
+        await _record_sync_liveness(
+            store,
+            source_url=job.source_url,
+            item_count=job.entries_created + job.entries_updated,
+            error=error_msg,
+        )
+
+
+async def _record_sync_liveness(
+    store: Any | None,
+    *,
+    source_url: str,
+    item_count: int,
+    error: str | None,
+) -> None:
+    """Write poll-status liveness for a completed bulk-sync job.
+
+    Kept separate from :func:`run_sync_job_async` so persistence failures do
+    not mask sync-job state changes.  A missing ``record_poll_status`` on
+    the store (older backend) or a raised exception is logged at
+    ``WARNING`` and then swallowed.
+    """
+    if store is None:
+        return
+    recorder = getattr(store, "record_poll_status", None)
+    if recorder is None:
+        return
+    try:
+        await recorder(
+            source_url,
+            polled_at=datetime.now(tz=UTC),
+            item_count=item_count,
+            error=error,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Sync job liveness persistence failed for %s",
+            source_url,
+            exc_info=True,
+        )

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -372,7 +372,13 @@ async def _handle_watch(
                     job.entries_updated += updated
 
                 sync_coro = adapter.sync_batched(on_page=_on_page)
-                asyncio.create_task(run_sync_job_async(job, tracker, sync_coro))
+                # Pass ``store`` so ``run_sync_job_async`` can record liveness
+                # metadata (``last_polled_at``/``last_item_count``/``last_error``)
+                # once the bulk sync finishes — otherwise sources that only
+                # ever backfilled via ``sync_history=True`` would surface as
+                # "never polled" to ``distillery_watch(action='list')`` even
+                # after thousands of entries were ingested (issue #334).
+                asyncio.create_task(run_sync_job_async(job, tracker, sync_coro, store))
                 response_data["sync_job"] = job.to_dict()
                 response_data["message"] = (
                     "Feed source added. History sync started in background "

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2139,11 +2139,22 @@ class DuckDBStore:
         if item_count_int < 0:
             raise ValueError(f"item_count must be non-negative, got: {item_count_int}")
         truncated = _sanitise_last_error(error, self._LAST_ERROR_MAX_LEN)
+        # DuckDB's ``TIMESTAMP`` column is timezone-naive — a tz-aware value
+        # can be silently coerced or rejected depending on the driver version,
+        # which in production surfaced as ``last_polled_at`` staying ``NULL``
+        # despite a successful poll (issue #334).  Normalise to naive UTC so
+        # the stored value matches what ``_sync_list_feed_sources`` expects
+        # (see the naive-UTC reattachment around line 2054).
+        polled_at_naive = (
+            polled_at.astimezone(UTC).replace(tzinfo=None)
+            if polled_at.tzinfo is not None
+            else polled_at
+        )
         result = self._conn.execute(
             "UPDATE feed_sources "
             "SET last_polled_at = ?, last_item_count = ?, last_error = ? "
             "WHERE url = ? RETURNING url",
-            [polled_at, item_count_int, truncated, url],
+            [polled_at_naive, item_count_int, truncated, url],
         )
         return len(result.fetchall()) > 0
 

--- a/tests/test_async_sync_pipeline.py
+++ b/tests/test_async_sync_pipeline.py
@@ -199,6 +199,106 @@ class TestRunSyncJobAsync:
         # Error message is sanitized (does not leak exception detail).
         assert job.error_message == "Sync job failed"
 
+    @pytest.mark.unit
+    async def test_successful_sync_records_liveness_on_store(self) -> None:
+        """After a successful bulk sync the store receives ``record_poll_status``.
+
+        Regression test for issue #334: feeds added with ``sync_history=True``
+        were never reaching ``FeedPoller.poll`` so ``last_polled_at`` stayed
+        ``NULL``.  ``run_sync_job_async`` now writes liveness directly when a
+        store is provided.
+        """
+        from datetime import UTC, datetime
+        from unittest.mock import AsyncMock
+
+        tracker = SyncJobTracker()
+        job = tracker.create_job(source_url="owner/repo", source_type="github")
+        store = AsyncMock()
+
+        async def mock_sync() -> SyncResult:
+            return SyncResult(
+                repo="owner/repo",
+                created=5,
+                updated=2,
+                relations_created=1,
+                sync_timestamp=datetime.now(tz=UTC),
+                pages_processed=1,
+            )
+
+        await run_sync_job_async(job, tracker, mock_sync(), store)
+        store.record_poll_status.assert_awaited_once()
+        call = store.record_poll_status.call_args
+        assert call.args[0] == "owner/repo"
+        # Liveness item_count sums created + updated: the source is alive so
+        # long as it produced any activity.
+        assert call.kwargs["item_count"] == 7
+        assert call.kwargs["error"] is None
+
+    @pytest.mark.unit
+    async def test_failed_sync_records_liveness_error(self) -> None:
+        """A failed bulk sync must still update ``last_error`` on the store."""
+        from unittest.mock import AsyncMock
+
+        tracker = SyncJobTracker()
+        job = tracker.create_job(source_url="owner/repo", source_type="github")
+        store = AsyncMock()
+
+        async def failing_sync() -> SyncResult:
+            raise RuntimeError("API down")
+
+        await run_sync_job_async(job, tracker, failing_sync(), store)
+        store.record_poll_status.assert_awaited_once()
+        call = store.record_poll_status.call_args
+        assert call.args[0] == "owner/repo"
+        assert call.kwargs["error"] == "Sync job failed"
+
+    @pytest.mark.unit
+    async def test_liveness_persistence_failure_is_swallowed(self) -> None:
+        """A failing ``record_poll_status`` must not mask sync-job completion."""
+        from datetime import UTC, datetime
+        from unittest.mock import AsyncMock
+
+        tracker = SyncJobTracker()
+        job = tracker.create_job(source_url="owner/repo", source_type="github")
+        store = AsyncMock()
+        store.record_poll_status.side_effect = RuntimeError("DB unreachable")
+
+        async def mock_sync() -> SyncResult:
+            return SyncResult(
+                repo="owner/repo",
+                created=1,
+                updated=0,
+                relations_created=0,
+                sync_timestamp=datetime.now(tz=UTC),
+                pages_processed=1,
+            )
+
+        await run_sync_job_async(job, tracker, mock_sync(), store)
+        # Job still transitions to COMPLETED despite the liveness failure.
+        assert job.status == SyncJobStatus.COMPLETED
+
+    @pytest.mark.unit
+    async def test_no_store_skips_liveness_call(self) -> None:
+        """Backwards-compat: calls without a store argument must still succeed."""
+        from datetime import UTC, datetime
+
+        tracker = SyncJobTracker()
+        job = tracker.create_job(source_url="owner/repo", source_type="github")
+
+        async def mock_sync() -> SyncResult:
+            return SyncResult(
+                repo="owner/repo",
+                created=1,
+                updated=0,
+                relations_created=0,
+                sync_timestamp=datetime.now(tz=UTC),
+                pages_processed=1,
+            )
+
+        # No store argument — must not raise.
+        await run_sync_job_async(job, tracker, mock_sync())
+        assert job.status == SyncJobStatus.COMPLETED
+
 
 # ---------------------------------------------------------------------------
 # SyncResult tests

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -731,6 +731,35 @@ class TestFeedSourceLiveness:
         )
         assert result is False
 
+    async def test_record_poll_status_accepts_tz_aware_datetime(self, store: DuckDBStore) -> None:
+        """A tz-aware UTC datetime must round-trip via ``list_feed_sources``.
+
+        Regression test for issue #334: DuckDB's naive ``TIMESTAMP`` column
+        previously silently rejected or coerced tz-aware values which made
+        ``last_polled_at`` stay ``NULL`` despite successful poll writes.
+        """
+        await store.add_feed_source(
+            url="https://example.com/rss",
+            source_type="rss",
+            poll_interval_minutes=60,
+        )
+        polled_at = datetime(2026, 4, 18, 9, 30, tzinfo=UTC)
+        updated = await store.record_poll_status(
+            "https://example.com/rss",
+            polled_at=polled_at,
+            item_count=12,
+            error=None,
+        )
+        assert updated is True
+
+        src = (await store.list_feed_sources())[0]
+        assert src["last_polled_at"] is not None
+        # The stored value reattaches UTC on read — must equal the tz-aware
+        # input exactly (no drift, no None).
+        assert src["last_polled_at"] == polled_at.isoformat()
+        assert src["last_item_count"] == 12
+        assert src["next_poll_at"] == "2026-04-18T10:30:00+00:00"
+
 
 # ---------------------------------------------------------------------------
 # Hybrid search (BM25 + vector RRF fusion with recency decay)


### PR DESCRIPTION
## Summary

`distillery_watch(action="list")` surfaces per-source liveness fields (`last_polled_at`, `last_item_count`, `last_error`, `next_poll_at`) but in production they stayed null/0 even though `distillery_status.last_feed_poll` reported recent polls and 4463+ feed entries existed. Two independent bugs were combining to silence every write. This PR fixes both.

### A. Make `record_poll_status` writes reliable

- **`src/distillery/store/duckdb.py`**: `_sync_record_poll_status` now normalises a tz-aware `polled_at` to naive UTC (`astimezone(UTC).replace(tzinfo=None)`) before the `UPDATE`. DuckDB's `TIMESTAMP` column is naive; depending on driver version a tz-aware value was silently coerced or rejected, which is why the column stayed `NULL`. The read path (`_sync_list_feed_sources`) already reattaches UTC on read, so the round-trip is now consistent.
- **`src/distillery/feeds/poller.py`**: `FeedPoller._persist_poll_status` upgrades the swallowed-exception branch from `logger.debug(...)` to `logger.warning(..., exc_info=True)`. A silent persistence failure was exactly what hid this bug in production — `WARNING` lets operators see the root cause without turning on verbose logging.

### B. Record liveness from bulk-sync paths too

`sync_history=True` does not go through `FeedPoller.poll()` — it runs `GitHubSyncAdapter.sync_batched` via `run_sync_job_async`. A feed that only ever backfilled showed "never polled" forever, even with thousands of rows ingested.

- **`src/distillery/feeds/sync_jobs.py`**: `run_sync_job_async` accepts an optional `store` and, on completion (success or failure), calls `store.record_poll_status(url, polled_at=now, item_count=created+updated, error=...)`. Liveness-write failures are logged at `WARNING` and swallowed so they cannot mask the sync-job status. A new `_record_sync_liveness` helper keeps the logic isolated and backwards-compatible with stores that predate the protocol addition.
- **`src/distillery/mcp/tools/feeds.py`**: threads `store` into the `run_sync_job_async` call for `sync_history=True`. The sync adapter (`github_sync.py`) stays a pure adapter — the hook lives in the caller.

### Tests

- `tests/test_duckdb_store.py::TestFeedSourceLiveness::test_record_poll_status_accepts_tz_aware_datetime` — a tz-aware UTC datetime round-trips via `list_feed_sources` with no drift (regression test for the silent DuckDB coercion).
- `tests/test_async_sync_pipeline.py::TestRunSyncJobAsync` — four new tests: liveness written on success, on failure (`error="Sync job failed"`), persistence failure swallowed, and a no-store call stays a pure no-op for backwards compat.

Closes #334.

## Test plan

- [x] `ruff format src/ tests/` and `ruff check src/ tests/` pass
- [x] `mypy --strict src/distillery/` — no new errors attributable to this patch (pre-existing third-party import warnings unchanged)
- [x] `pytest tests/test_duckdb_store.py::TestFeedSourceLiveness tests/test_async_sync_pipeline.py::TestRunSyncJobAsync tests/test_poller.py::TestPersistPollStatus tests/test_mcp_feeds.py tests/test_bulk_ingest.py` — 69 passed
- [x] Full suite: 2256 passed, 74 skipped; 4 pre-existing failures all cascade from a sandbox-only DuckDB FTS extension download (`HTTP 403` on `extensions.duckdb.org`) and are unrelated to this change
- [ ] Manual verify on a fresh install: add a feed with `sync_history=True`, confirm `distillery_watch(action="list")` shows non-null `last_polled_at`/`last_item_count` once the background job finishes
- [ ] Manual verify on a polled feed: run a poll, confirm the liveness fields update and that any `record_poll_status` exception surfaces at `WARNING` in the server log

https://claude.ai/code/session_01WhiPvxEYMk8PpAehk2iTZT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feed sync operations now record liveness metadata, including last polled time, processed item counts, and error details.

* **Bug Fixes**
  * Improved error logging visibility for poll status persistence issues.
  * Fixed timezone-aware datetime handling when recording poll timestamps.

* **Tests**
  * Added tests validating liveness metadata persistence and timezone datetime handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->