### PR TITLE
fix(mcp): make resolve_review idempotent for no-op transitions (#333)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -860,7 +860,11 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             github, person, project, digest, feed].
           - reviewer (str, optional): Reviewer identity for audit metadata.
 
-        RETURNS (success): { id: str, status: str, ... } (full updated entry)
+        RETURNS (success): { id: str, status: str, ... } (full updated entry).
+        When the requested action is a no-op (e.g. approve on an already-active
+        entry), the response also includes { already_in_state: true } and the
+        entry is returned unchanged (version is NOT bumped, reviewed_at /
+        archived_at are NOT rewritten).
         RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "FORBIDDEN" | "INTERNAL", message: "..." }
 
         RELATED: distillery_classify (to classify entries),

--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -187,6 +187,12 @@ async def _handle_resolve_review(
         actor.  If only ``reviewer`` is supplied (no actor), it becomes the
         *_by field for backward compatibility.
 
+    Idempotency (see issue #333): if the requested action would leave the
+    entry in its current state (approve-of-active, archive-of-archived, or
+    reclassify-to-same-type on a non-pending entry), the handler returns the
+    entry unchanged with an ``already_in_state: true`` marker.  ``version``
+    and ``reviewed_at`` / ``archived_at`` are not rewritten.
+
     Args:
         store: Initialised ``DuckDBStore``.
         arguments: Raw MCP tool arguments dict.  Recognised keys include
@@ -225,6 +231,31 @@ async def _handle_resolve_review(
             f"No entry found with id={entry_id!r}.",
             details={"entry_id": entry_id},
         )
+
+    # --- detect idempotent no-op transitions --------------------------------
+    # If the requested action would leave the entry in its current state,
+    # return it unchanged with an ``already_in_state`` marker rather than
+    # bumping ``version`` / rewriting ``reviewed_at`` (issue #333).
+    #
+    # A reclassify is only a no-op when the entry is *not* in pending_review
+    # (so the status would not flip to active) *and* ``new_entry_type``
+    # matches the current type — otherwise real work is performed.
+    new_type_preview = arguments.get("new_entry_type")
+    is_noop = (
+        (action == "approve" and entry.status == EntryStatus.ACTIVE)
+        or (action == "archive" and entry.status == EntryStatus.ARCHIVED)
+        or (
+            action == "reclassify"
+            and isinstance(new_type_preview, str)
+            and new_type_preview == entry.entry_type.value
+            and entry.status != EntryStatus.PENDING_REVIEW
+        )
+    )
+
+    if is_noop:
+        payload = entry.to_dict()
+        payload["already_in_state"] = True
+        return success_response(payload)
 
     # --- resolve actor vs reviewer -----------------------------------------
     # ``actor`` is the authenticated server identity (OAuth/git); ``reviewer``

--- a/tests/test_mcp_classify.py
+++ b/tests/test_mcp_classify.py
@@ -794,6 +794,155 @@ class TestResolveReviewTool:
         stale_keys = [k for k in metadata if k.endswith("_on_behalf_of") or k == "on_behalf_of"]
         assert stale_keys == [], f"Stale delegation keys found: {stale_keys}"
 
+    # ------------------------------------------------------------------
+    # Issue #333: idempotent no-op transitions
+    # ------------------------------------------------------------------
+
+    async def test_resolve_approve_is_idempotent_on_active_entry(self, store: DuckDBStore) -> None:
+        """Approving an already-active entry is a no-op (issue #333).
+
+        version must not bump, reviewed_at must not be rewritten, and the
+        response must carry the ``already_in_state`` marker so callers can
+        distinguish idempotent hits from real state transitions.
+        """
+        # Start pending_review, approve once to reach active with reviewed_at.
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        first = parse_mcp_response(
+            await _handle_resolve_review(
+                store, {"entry_id": entry_id, "action": "approve", "reviewer": "alice"}
+            )
+        )
+        assert first["status"] == "active"
+        first_version = first["version"]
+        first_reviewed_at = first["metadata"]["reviewed_at"]
+        first_reviewed_by = first["metadata"]["reviewed_by"]
+
+        # Second approve on active entry: must be a no-op.
+        second = parse_mcp_response(
+            await _handle_resolve_review(
+                store, {"entry_id": entry_id, "action": "approve", "reviewer": "bob"}
+            )
+        )
+        assert "error" not in second
+        assert second["already_in_state"] is True
+        assert second["status"] == "active"
+        assert second["version"] == first_version
+        assert second["metadata"]["reviewed_at"] == first_reviewed_at
+        # reviewed_by must not flip to the second caller.
+        assert second["metadata"]["reviewed_by"] == first_reviewed_by
+
+    async def test_resolve_archive_is_idempotent_on_archived_entry(
+        self, store: DuckDBStore
+    ) -> None:
+        """Archiving an already-archived entry is a no-op (issue #333)."""
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        first = parse_mcp_response(
+            await _handle_resolve_review(store, {"entry_id": entry_id, "action": "archive"})
+        )
+        assert first["status"] == "archived"
+        first_version = first["version"]
+        first_archived_at = first["metadata"]["archived_at"]
+
+        second = parse_mcp_response(
+            await _handle_resolve_review(store, {"entry_id": entry_id, "action": "archive"})
+        )
+        assert "error" not in second
+        assert second["already_in_state"] is True
+        assert second["status"] == "archived"
+        assert second["version"] == first_version
+        assert second["metadata"]["archived_at"] == first_archived_at
+
+    async def test_resolve_reclassify_is_idempotent_when_type_matches_and_active(
+        self, store: DuckDBStore
+    ) -> None:
+        """Reclassify to the same type on an active entry is a no-op (issue #333)."""
+        entry = make_entry(entry_type=EntryType.MEETING, status=EntryStatus.ACTIVE)
+        entry_id = await store.store(entry)
+        original_version = entry.version
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "meeting",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert "error" not in data
+        assert data["already_in_state"] is True
+        assert data["status"] == "active"
+        assert data["entry_type"] == "meeting"
+        assert data["version"] == original_version
+        # No reclassified_from should have been written.
+        assert "reclassified_from" not in data["metadata"]
+
+    async def test_resolve_reclassify_same_type_from_pending_still_runs(
+        self, store: DuckDBStore
+    ) -> None:
+        """Reclassify to the same type from pending_review still promotes to active.
+
+        This is *not* a no-op: the status flip is real work, so version must
+        bump and ``already_in_state`` must NOT be set.
+        """
+        entry = make_entry(entry_type=EntryType.MEETING, status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "meeting",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert "error" not in data
+        assert "already_in_state" not in data
+        assert data["status"] == "active"
+        assert data["entry_type"] == "meeting"
+        assert data["version"] > entry.version
+
+    async def test_resolve_reclassify_different_type_on_active_still_runs(
+        self, store: DuckDBStore
+    ) -> None:
+        """Reclassify to a different type on an active entry performs real work."""
+        entry = make_entry(entry_type=EntryType.INBOX, status=EntryStatus.ACTIVE)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "reference",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert "error" not in data
+        assert "already_in_state" not in data
+        assert data["entry_type"] == "reference"
+        assert data["metadata"]["reclassified_from"] == "inbox"
+        assert data["version"] > entry.version
+
+    async def test_resolve_reclassify_missing_new_entry_type_still_rejected(
+        self, store: DuckDBStore
+    ) -> None:
+        """Idempotency check must not swallow INVALID_PARAMS for missing new_entry_type."""
+        entry = make_entry(entry_type=EntryType.MEETING, status=EntryStatus.ACTIVE)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store, {"entry_id": entry_id, "action": "reclassify"}
+        )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
 
 # ---------------------------------------------------------------------------
 # End-to-end classification flow


### PR DESCRIPTION
## Summary

- `distillery_resolve_review` now detects no-op transitions (approve-of-active, archive-of-archived, reclassify-to-same-type on a non-pending entry) and returns the entry unchanged with an `already_in_state: true` marker.
- `version` is not bumped and `reviewed_at` / `archived_at` are not rewritten on no-op calls, so repeated approvals or archives are safe and cheap.
- Real transitions (e.g. approve of `pending_review`, reclassify to a different type, reclassify from `pending_review` to active) still bump `version` and update audit fields as before.

Closes #333

## Test plan

- [x] `pytest tests/test_mcp_classify.py` — all 60 tests pass (54 existing + 6 new)
- [x] `ruff check` / `ruff format` on edited files — clean
- [x] `mypy --strict` on edited files — no new errors
- [x] New tests cover: double-approve, double-archive, reclassify-to-same-type on active (all no-ops), reclassify-same-type from pending (still flips status), reclassify-to-different-type on active (still runs), reclassify without `new_entry_type` still rejected with `INVALID_PARAMS`.

## Notes

- Chose the idempotent approach (vs `INVALID_STATE` error) to match existing response-shape conventions and reduce friction for callers who might retry.
- Docstrings updated in both the handler and the tool registration in `server.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolve review actions (approve, archive, reclassify) now properly handle repeated invocations. When an action is performed on an entry already in the target state, the response indicates no change occurred and version numbers and audit timestamps are not updated.

* **Tests**
  * Added comprehensive test coverage for resolve review action behavior with repeated invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->