### PR TITLE
fix(mcp): alias source=<url> to feed_url filter in distillery_list (#335)

### DIFF
--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -50,7 +50,7 @@ See [`distillery.yaml.example`](https://github.com/norrietaylor/distillery/blob/
 | `distillery_store` | Store a new knowledge entry with content, tags, and metadata |
 | `distillery_get` | Retrieve a single entry by UUID |
 | `distillery_update` | Partially update an existing entry (tags, status, metadata) |
-| `distillery_list` | List entries with filtering, pagination, and optional review-queue enrichment (`output_mode="review"`) |
+| `distillery_list` | List entries with filtering, pagination, and optional review-queue enrichment (`output_mode="review"`). Accepts `source=<origin>` (e.g. `"import"`, `"claude-code"`) and `feed_url=<url>` (matches `metadata.source_url` written by the feed poller); passing a URL to `source=` is aliased to `feed_url`. |
 | **Discovery** | |
 | `distillery_search` | Hybrid BM25 + vector search with RRF fusion; returns ranked results (falls back to vector-only if FTS unavailable) |
 | `distillery_find_similar` | Find similar entries — supports dedup mode (`dedup_action=true`) and conflict detection (`conflict_check=true`) |

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -606,7 +606,10 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             archived, any]. Default hides archived; use "any" to include all.
           - verification (str, optional): Filter by verification. Valid: [unverified, testing, verified].
           - source (str, optional): Filter by origin. Valid: [claude-code, manual, import,
-            inference, documentation, external].
+            inference, documentation, external]. As a convenience, a URL-shaped value
+            (starting with "http://" or "https://") is aliased to ``feed_url`` so
+            ``source="https://hnrss.org/frontpage"`` matches feed items ingested from
+            that source (same semantics as passing ``feed_url=...``).
           - session_id (str, optional): Filter by session identifier.
           - date_from (str, optional): ISO 8601 lower bound on created_at.
           - date_to (str, optional): ISO 8601 upper bound on created_at.

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -1026,6 +1026,17 @@ async def _handle_list(
             "Fields 'group_by' and 'output' are mutually exclusive",
         )
 
+    # --- source=<url> aliasing ----------------------------------------------
+    # Issue #335: users often try `source="https://…/feed"` expecting it to
+    # match feed-ingested entries.  The `source` column actually stores the
+    # ingest origin (e.g. "import"), not the feed URL, so this silently
+    # returned 0 results.  Treat a URL-shaped `source` value as an alias
+    # for `feed_url` to remove the footgun.
+    aliased = _alias_source_url_to_feed_url(arguments)
+    if isinstance(aliased, list):
+        return aliased  # error response
+    arguments = aliased
+
     filters = _build_filters_from_arguments(arguments)
 
     # review mode implicitly filters to pending_review status (takes precedence
@@ -1211,6 +1222,62 @@ def _apply_default_status_filter(
     return filters
 
 
+def _looks_like_url(value: Any) -> bool:
+    """Return True when *value* is a str that starts with ``http://`` or ``https://``.
+
+    Used to detect when a caller has passed a feed URL into the ``source``
+    parameter of ``distillery_list`` — a common footgun where ``source`` is
+    the more discoverable name but only filters on the entry-origin column
+    (e.g. ``"import"``).  See :func:`_alias_source_url_to_feed_url`.
+    """
+    if not isinstance(value, str):
+        return False
+    return value.startswith("http://") or value.startswith("https://")
+
+
+def _alias_source_url_to_feed_url(
+    arguments: dict[str, Any],
+) -> dict[str, Any] | list[types.TextContent]:
+    """Transparently route ``source=<url>`` to the ``feed_url`` filter.
+
+    When the caller passes a URL-shaped value (``http://…`` or ``https://…``)
+    as the ``source`` argument, treat it as an alias for ``feed_url``.  This
+    removes a silent-zero footgun where users try ``source="https://…/feed"``
+    expecting to see feed items but get an empty result because the
+    ``source`` column stores ingest origin (``"import"``), not the feed URL.
+
+    Returns a possibly-mutated copy of *arguments* when aliasing is needed.
+    Returns the original dict when no aliasing applies.  Returns an MCP
+    error response list when both ``source`` (URL-shaped) and ``feed_url``
+    were provided with different values.
+
+    The non-URL ``source`` behaviour is unchanged — strings like
+    ``"import"`` / ``"claude-code"`` continue to filter on the ``source``
+    column as before.
+    """
+    source = arguments.get("source")
+    feed_url = arguments.get("feed_url")
+
+    if not _looks_like_url(source):
+        return arguments
+
+    if feed_url is not None and feed_url != source:
+        return error_response(
+            "INVALID_PARAMS",
+            "Field 'source' is a URL and 'feed_url' is also set to a different "
+            "URL. Pass only one, or set both to the same value. "
+            "(URL-shaped 'source' is aliased to 'feed_url'.)",
+            details={"source": source, "feed_url": feed_url},
+        )
+
+    # Route URL-shaped source to feed_url and drop the original source value
+    # so it isn't also translated to a (never-matching) source-column filter.
+    aliased = dict(arguments)
+    aliased["feed_url"] = source
+    aliased.pop("source", None)
+    return aliased
+
+
 def _build_filters_from_arguments(arguments: dict[str, Any]) -> dict[str, Any] | None:
     """Extract known filter keys from *arguments* into a filters dict.
 
@@ -1221,7 +1288,9 @@ def _build_filters_from_arguments(arguments: dict[str, Any]) -> dict[str, Any] |
     The ``feed_url`` key is translated to a ``metadata.source_url`` filter so
     callers can retrieve entries ingested from a registered feed source
     (poller writes ``metadata.source_url`` to match the registry URL, while
-    the entry's ``source`` column is set to ``import``).
+    the entry's ``source`` column is set to ``import``).  URL-shaped
+    ``source`` values are routed to ``feed_url`` upstream by
+    :func:`_alias_source_url_to_feed_url`.
 
     Args:
         arguments: The tool argument dict.

--- a/tests/test_list_output_modes.py
+++ b/tests/test_list_output_modes.py
@@ -458,15 +458,25 @@ class TestSourceUrlAliasesToFeedUrl:
         assert src_ids == feed_ids
 
     async def test_source_http_url_also_aliased(self, populated_store) -> None:
-        # http:// (not just https://) should also be treated as a URL.
-        # Use an RSS-shaped URL that exists in the fixture.
+        # http:// (not just https://) must also trigger the URL alias.  Add a
+        # dedicated http-scheme entry so the assertion is unambiguous.
+        http_feed_url = "http://example.com/rss"
+        await populated_store.store(
+            make_entry(
+                content="HTTP feed item",
+                entry_type=EntryType.FEED,
+                source=EntrySource.MANUAL,
+                author="bob",
+                metadata={"source_url": http_feed_url, "source_type": "rss"},
+            )
+        )
         result = await _handle_list(
             store=populated_store,
-            arguments={"limit": 10, "source": "https://example.com/rss"},
+            arguments={"limit": 10, "source": http_feed_url},
         )
         data = parse_mcp_response(result)
         assert data["count"] == 1
-        assert data["entries"][0]["metadata"]["source_url"] == "https://example.com/rss"
+        assert data["entries"][0]["metadata"]["source_url"] == http_feed_url
 
     async def test_source_internal_value_still_works(self, populated_store) -> None:
         # "import" is a real EntrySource enum value and must keep filtering on

--- a/tests/test_list_output_modes.py
+++ b/tests/test_list_output_modes.py
@@ -401,16 +401,113 @@ class TestListFeedUrlFilter:
             assert entry["entry_type"] == "feed"
             assert entry["metadata"]["source_url"] == "https://github.com/org/repo"
 
-    async def test_source_filter_unchanged_semantics(self, populated_store) -> None:
-        # Regression guard: source=<url> must NOT magically match feed items.
-        # It still filters by EntrySource column (claude-code, manual, import, …).
+    async def test_source_non_url_filters_origin_column(self, populated_store) -> None:
+        # Non-URL source values still filter on the internal `source` column —
+        # e.g. "claude-code" matches the session entry ingested with
+        # EntrySource.CLAUDE_CODE, not any feed item.
+        result = await _handle_list(
+            store=populated_store,
+            arguments={
+                "limit": 10,
+                "source": "claude-code",
+            },
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error"), data
+        assert data["count"] == 1
+        assert data["entries"][0]["entry_type"] == "session"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: source=<url> aliases to feed_url (issue #335)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSourceUrlAliasesToFeedUrl:
+    """Verify source=<url> routes to the feed_url filter.
+
+    Issue #335: ``source`` is the more discoverable name and users instinctively
+    pass a feed URL to it.  The previous behaviour silently returned 0 entries
+    because the ``source`` column stores the ingest origin (``"import"``), not
+    the feed URL.  URL-shaped ``source`` values are now aliased to ``feed_url``
+    so the tool matches user intent.
+    """
+
+    async def test_source_url_matches_same_entries_as_feed_url(self, populated_store) -> None:
+        src_result = await _handle_list(
+            store=populated_store,
+            arguments={"limit": 10, "source": "https://github.com/org/repo"},
+        )
+        feed_result = await _handle_list(
+            store=populated_store,
+            arguments={"limit": 10, "feed_url": "https://github.com/org/repo"},
+        )
+        src_data = parse_mcp_response(src_result)
+        feed_data = parse_mcp_response(feed_result)
+
+        assert not src_data.get("error"), src_data
+        assert not feed_data.get("error"), feed_data
+        # source=<URL> must return the same entries as feed_url=<URL>.
+        assert src_data["count"] == feed_data["count"], (src_data, feed_data)
+        assert src_data["total_count"] == feed_data["total_count"]
+        assert feed_data["count"] == 2  # sanity check on fixture shape
+
+        src_ids = sorted(e["id"] for e in src_data["entries"])
+        feed_ids = sorted(e["id"] for e in feed_data["entries"])
+        assert src_ids == feed_ids
+
+    async def test_source_http_url_also_aliased(self, populated_store) -> None:
+        # http:// (not just https://) should also be treated as a URL.
+        # Use an RSS-shaped URL that exists in the fixture.
+        result = await _handle_list(
+            store=populated_store,
+            arguments={"limit": 10, "source": "https://example.com/rss"},
+        )
+        data = parse_mcp_response(result)
+        assert data["count"] == 1
+        assert data["entries"][0]["metadata"]["source_url"] == "https://example.com/rss"
+
+    async def test_source_internal_value_still_works(self, populated_store) -> None:
+        # "import" is a real EntrySource enum value and must keep filtering on
+        # the source column — not be treated as a URL.
+        result = await _handle_list(
+            store=populated_store,
+            arguments={"limit": 10, "source": "import"},
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error"), data
+        # The populated_store fixture uses EntrySource.MANUAL for the feed
+        # items and EntrySource.CLAUDE_CODE for the session, so "import"
+        # returns 0 — but the key assertion is that this did NOT error and
+        # the filter landed on the `source` column, not feed_url.
+        assert data["count"] == 0
+
+    async def test_both_source_url_and_feed_url_same_value(self, populated_store) -> None:
+        # When both are provided and agree, the call succeeds.
         result = await _handle_list(
             store=populated_store,
             arguments={
                 "limit": 10,
                 "source": "https://github.com/org/repo",
+                "feed_url": "https://github.com/org/repo",
             },
         )
         data = parse_mcp_response(result)
-        # No entry's `source` column equals this URL, so the count is 0.
-        assert data["count"] == 0
+        assert not data.get("error"), data
+        assert data["count"] == 2
+
+    async def test_both_source_url_and_feed_url_differ_errors(self, populated_store) -> None:
+        # Disagreement between URL-shaped `source` and explicit `feed_url`
+        # yields INVALID_PARAMS rather than silently picking one.
+        result = await _handle_list(
+            store=populated_store,
+            arguments={
+                "limit": 10,
+                "source": "https://github.com/org/repo",
+                "feed_url": "https://example.com/rss",
+            },
+        )
+        data = parse_mcp_response(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"


### PR DESCRIPTION
## Summary

Closes #335.

`distillery_list(source="https://…/feed")` is a discoverable call shape that silently returned 0 entries because the `source` column stores ingest origin (`"import"`), not the feed URL. The existing `feed_url` param works but is less obvious.

Fix: when `source` looks like a URL (starts with `http://` or `https://`), route it to the `feed_url` filter (i.e. `metadata.source_url`) so it matches feed items, per owner preference (option 1 on the issue).

- `list(source="https://…")` now returns the same entries as `list(feed_url="https://…")`.
- `list(source="import")` / `list(source="claude-code")` still filter on the internal `source` column (non-URL values unchanged).
- When both `source` (URL) and `feed_url` are given and differ, returns `INVALID_PARAMS` rather than silently picking one. Same value is accepted.
- `feed_url` kept as-is for backward compatibility.

## Changes

- `src/distillery/mcp/tools/crud.py`: new `_alias_source_url_to_feed_url` helper invoked at top of `_handle_list`; updated `_build_filters_from_arguments` docstring.
- `src/distillery/mcp/server.py`: updated `source` param description on `distillery_list`.
- `docs/getting-started/mcp-setup.md`: surfaced `source=<url>` aliasing in the tool table.
- `tests/test_list_output_modes.py`: replaced the stale "source=<url> returns 0" regression guard with a new `TestSourceUrlAliasesToFeedUrl` class covering same-as-feed-url, http scheme, non-URL passthrough, both-same-value, and both-differ error paths.

## Test plan

- [x] `pytest -m unit` (1563 passed)
- [x] `pytest` (2271 passed, 73 skipped)
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `mypy --strict src/distillery/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add `feed_url` filter to list tool and treat URL-shaped `source` inputs as aliases for `feed_url` for easier feed-based filtering.

* **Documentation**
  * Update user docs to describe the new `feed_url` parameter and the URL-as-source aliasing behavior.

* **Bug Fixes / Validation**
  * Requests that supply both `source` (as a URL) and a differing `feed_url` now fail validation to prevent ambiguous filtering.

* **Tests**
  * Added tests covering URL aliasing, non-URL source behavior, and conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->