### PR TITLE
fix(mcp): reserve dedup_action=merged for true fold cases (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Scheduling via Claude Code routines** — `/setup` and `/watch` skills now configure Claude Code routines instead of CronCreate jobs or GitHub Actions webhook scheduling. Three routines replace the previous approach: hourly feed poll, daily stale check, weekly maintenance (#272)
 - **`distillery_list` default `output_mode` is now `"summary"`** — previously `"full"`, which returned entire entry bodies and flooded agent context (e.g. ~6 KB per gh-sync entry × `limit=50` ≈ 300 KB). Summary mode returns `id`, `title` (derived from metadata or first line of content), `entry_type`, `tags`, `project`, `author`, `created_at`, `metadata`, `session_id`, and a `content_preview` truncated to ~200 chars. Pass `output_mode="full"` explicitly when the whole body is needed (#311).
+- **`distillery_store` `dedup_action` semantics tightened** — when a new row is persisted independently, `dedup_action` is now always `"stored"` (previously `"merged"` / `"linked"` when the top match crossed the merge or link threshold, even though a separate row was written). `"merged"` / `"linked"` are reserved for future behaviour where content is actually folded into an existing row or an explicit link is created without a new row. The similarity signal remains available via the informational `existing_entry_id` + `similarity` fields. Callers who want to avoid independent duplicates should call `distillery_find_similar(dedup_action=true)` before storing. (#332)
 
 ### Deprecated
 

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -134,18 +134,30 @@ async def _handle_store(
     Returns:
         list[types.TextContent]: MCP content list containing a JSON-serializable object with at least:
           - ``entry_id`` (str): the id the caller should reference — either the
-            newly persisted entry's id, or (when the call was auto-skipped /
-            effectively merged with an existing near-duplicate) the existing
-            entry's id.  Never a "ghost" id that cannot be retrieved.
+            newly persisted entry's id, or (when the call was auto-skipped due
+            to a near-duplicate above the skip threshold) the existing entry's
+            id.  Never a "ghost" id that cannot be retrieved.
           - ``persisted`` (bool): ``True`` if a new row was written, ``False``
             if the call was auto-skipped due to a near-duplicate.
-          - ``dedup_action`` (str): one of ``"stored"``, ``"skipped"``,
-            ``"merged"``, ``"linked"`` indicating how the new content
-            relates to existing entries.
+          - ``dedup_action`` (str): one of ``"stored"`` or ``"skipped"``.
+            ``"stored"`` means a new row was persisted (even if a similar
+            entry exists above the merge or link threshold — the similarity
+            is reported informationally via ``existing_entry_id`` and
+            ``similarity``).  ``"skipped"`` means no new row was created and
+            the caller is pointed at an existing near-duplicate.
 
-        When ``dedup_action != "stored"`` the response also includes
-        ``existing_entry_id`` (str) and ``similarity`` (float) so the caller
-        can pivot to the pre-existing entry.
+            ``"merged"`` and ``"linked"`` are reserved for future behaviour
+            where the server actually folds new content into an existing row
+            or creates an explicit link without a new row; they are not
+            returned by the current implementation because both outcomes
+            persist the new entry independently.
+
+        When a similar existing entry is found above the merge or link
+        threshold (but below the skip threshold), the response also includes
+        ``existing_entry_id`` (str) and ``similarity`` (float) as an
+        informational hint.  ``dedup_action`` remains ``"stored"`` — callers
+        who want to avoid independent duplicates should use
+        ``distillery_find_similar(dedup_action=true)`` before storing.
 
         May also include:
           - `warnings`: list of similar-entry summaries (id, score, content_preview) when near-duplicates were found,
@@ -381,16 +393,27 @@ async def _handle_store(
         return success_response({"entry_id": entry_id, "persisted": True, "dedup_action": "stored"})
 
     # --- determine dedup_action for the persisted entry ---------------------
-    # ``stored`` when no prior similar entry existed (or we lack thresholds).
-    # ``merged``/``linked`` annotate the caller that a near-match exists; the
-    # entry is still persisted — these are informational signals, not
-    # enforcement.  Only ``skipped`` (handled above) prevents persistence.
+    # When a new row is persisted independently, ``dedup_action`` is always
+    # ``"stored"`` — even if a similar entry exists above the merge/link
+    # threshold.  ``"merged"`` / ``"linked"`` are reserved for true fold
+    # cases (no separate row is created) and are not emitted by the current
+    # implementation.  The similarity signal is still surfaced via
+    # ``existing_entry_id`` + ``similarity`` when the top match crosses the
+    # link threshold, so callers can follow up (e.g. issue a
+    # ``distillery_find_similar(dedup_action=true)`` before future stores).
+    # Only ``"skipped"`` (handled above) prevents persistence.
     dedup_action = "stored"
-    if top_existing_id is not None and top_existing_score is not None:
-        if merge_threshold is not None and top_existing_score >= merge_threshold:
-            dedup_action = "merged"
-        elif link_threshold is not None and top_existing_score >= link_threshold:
-            dedup_action = "linked"
+    has_similar_hint = (
+        top_existing_id is not None
+        and top_existing_score is not None
+        and (
+            (merge_threshold is not None and top_existing_score >= merge_threshold)
+            or (link_threshold is not None and top_existing_score >= link_threshold)
+        )
+    )
+    # ``merge_threshold`` / ``link_threshold`` only drive ``has_similar_hint``.
+    # They no longer influence ``dedup_action``; see the reserved-semantics
+    # note above.
 
     # --- conflict check -------------------------------------------------------
     # Non-fatal: wrap in try/except so a conflict-checker failure never blocks
@@ -431,7 +454,7 @@ async def _handle_store(
                     "persisted": True,
                     "dedup_action": dedup_action,
                 }
-                if dedup_action != "stored" and top_existing_id is not None:
+                if has_similar_hint and top_existing_id is not None:
                     response_data["existing_entry_id"] = top_existing_id
                     if top_existing_score is not None:
                         response_data["similarity"] = round(top_existing_score, 4)
@@ -458,7 +481,7 @@ async def _handle_store(
         "persisted": True,
         "dedup_action": dedup_action,
     }
-    if dedup_action != "stored" and top_existing_id is not None:
+    if has_similar_hint and top_existing_id is not None:
         response["existing_entry_id"] = top_existing_id
         if top_existing_score is not None:
             response["similarity"] = round(top_existing_score, 4)

--- a/tests/test_store_dedup_response.py
+++ b/tests/test_store_dedup_response.py
@@ -1,14 +1,22 @@
-"""Tests for ``distillery_store`` dedup response contract (issue #314).
+"""Tests for ``distillery_store`` dedup response contract (issues #314, #332).
 
 Verifies that the ``_handle_store`` tool handler always surfaces:
 
 * ``persisted`` (bool)
-* ``dedup_action`` — one of ``stored`` / ``skipped`` / ``merged`` / ``linked``
+* ``dedup_action`` — one of ``stored`` or ``skipped``
 
-and that when a near-duplicate is auto-skipped the returned ``entry_id`` is
-the *existing* entry's id (never a ghost id that was never inserted), and
+When a near-duplicate is auto-skipped the returned ``entry_id`` is the
+*existing* entry's id (never a ghost id that was never inserted), and
 ``existing_entry_id`` plus ``similarity`` are supplied so the caller can
 pivot.
+
+Per issue #332, when a new row IS persisted independently, ``dedup_action``
+is always ``"stored"`` regardless of similarity to existing entries.  The
+similarity signal is surfaced via the informational ``existing_entry_id`` /
+``similarity`` fields when the top match crosses the merge or link
+threshold, but ``dedup_action`` stays ``"stored"`` to honestly reflect that
+a separate row was created.  ``"merged"`` / ``"linked"`` are reserved for
+future behaviour where content is actually folded into an existing row.
 """
 
 from __future__ import annotations
@@ -63,7 +71,9 @@ def _make_config(
 
     The ``dedup_threshold`` (on DefaultsConfig) drives which similar entries
     ``_handle_store`` collects as warnings; the classification thresholds
-    drive the dedup_action classification (skipped/merged/linked).
+    drive the auto-skip decision and (per issue #332) whether the response
+    carries an informational ``existing_entry_id`` / ``similarity`` hint.
+    ``dedup_action`` is only ever ``"stored"`` or ``"skipped"``.
     """
     return DistilleryConfig(
         storage=StorageConfig(database_path=":memory:"),
@@ -219,16 +229,24 @@ class TestStoreNearDuplicateSkipped:
 
 
 # ---------------------------------------------------------------------------
-# Test: similar (merge band) -> persisted=True, dedup_action="merged"
+# Test: similar (merge band) -> persisted=True, dedup_action="stored" +
+#       informational existing_entry_id / similarity hint (issue #332)
 # ---------------------------------------------------------------------------
 
 
-class TestStoreDuplicateMerged:
-    async def test_merge_band_is_persisted_with_merged_action(
+class TestStoreDuplicateMergeBand:
+    async def test_merge_band_is_persisted_as_stored_with_similarity_hint(
         self,
         store: DuckDBStore,
         embedding_provider: ControlledEmbeddingProvider,
     ) -> None:
+        """A new row above the merge threshold is still reported as ``stored``.
+
+        Per issue #332, ``dedup_action`` must honestly reflect that a new
+        separate row was created.  The similarity to the existing entry is
+        still available via ``existing_entry_id`` + ``similarity`` as an
+        informational hint, but ``dedup_action`` stays ``"stored"``.
+        """
         existing_vec = _UNIT_A
         # Interpolate so cosine sim falls between merge (0.80) and skip (0.95)
         # normalized.  Raw cos from interp with t=0.3 ~ 0.89, normalised to
@@ -266,7 +284,9 @@ class TestStoreDuplicateMerged:
 
         assert data.get("error") is not True, data
         assert data["persisted"] is True
-        assert data["dedup_action"] == "merged"
+        # Per issue #332, a new independent row is always ``stored``.
+        assert data["dedup_action"] == "stored"
+        # The similarity signal remains as an informational hint.
         assert data["existing_entry_id"] == existing_id
         assert data["entry_id"] != existing_id  # new row was written
         assert data["similarity"] >= cfg.classification.dedup_merge_threshold
@@ -278,16 +298,23 @@ class TestStoreDuplicateMerged:
 
 
 # ---------------------------------------------------------------------------
-# Test: related (link band) -> persisted=True, dedup_action="linked"
+# Test: related (link band) -> persisted=True, dedup_action="stored" +
+#       informational existing_entry_id / similarity hint (issue #332)
 # ---------------------------------------------------------------------------
 
 
-class TestStoreRelatedLinked:
-    async def test_link_band_is_persisted_with_linked_action(
+class TestStoreRelatedLinkBand:
+    async def test_link_band_is_persisted_as_stored_with_similarity_hint(
         self,
         store: DuckDBStore,
         embedding_provider: ControlledEmbeddingProvider,
     ) -> None:
+        """A new row above the link threshold is still reported as ``stored``.
+
+        As with the merge band (issue #332), a new independent row must
+        report ``dedup_action="stored"`` — the link-band similarity is
+        surfaced informationally only.
+        """
         existing_vec = _UNIT_A
         interp = _interpolated_vector(_UNIT_A, _UNIT_B, 0.7)  # lower similarity
         cos_sim = _cosine(interp, existing_vec)
@@ -319,7 +346,9 @@ class TestStoreRelatedLinked:
 
         assert data.get("error") is not True, data
         assert data["persisted"] is True
-        assert data["dedup_action"] == "linked"
+        # Per issue #332, a new independent row is always ``stored``.
+        assert data["dedup_action"] == "stored"
+        # The similarity signal remains as an informational hint.
         assert data["existing_entry_id"] == existing_id
         assert data["entry_id"] != existing_id
         assert data["similarity"] >= cfg.classification.dedup_link_threshold


### PR DESCRIPTION
## Summary

Closes #332.

`distillery_store` previously returned `dedup_action="merged"` / `"linked"` whenever a similar entry crossed the merge or link threshold, even though a new separate row was always persisted. The label was misleading: callers got back a `entry_id` for the new row plus an `existing_entry_id` pointing at a different, independently-stored row, with no way to tell whether content was actually folded.

This PR tightens the semantics:

- When a NEW row is persisted independently, `dedup_action` is always `"stored"` — regardless of similarity to existing entries.
- `"merged"` / `"linked"` are reserved for future behaviour where the server folds new content into an existing row or creates an explicit link without a new row. Neither is emitted by the current implementation.
- The similarity signal is preserved via informational `existing_entry_id` + `similarity` fields, surfaced whenever the top match crosses the merge or link threshold.
- The auto-skip path (`persisted=false`, `dedup_action="skipped"`) is unchanged — that remains the only true non-store outcome.

## Changes

- `src/distillery/mcp/tools/crud.py` — drop `merged`/`linked` from the `_handle_store` response classification; introduce `has_similar_hint` to gate the informational `existing_entry_id` + `similarity` fields. Updated handler docstring to describe the new contract and explain that `merged`/`linked` are reserved.
- `tests/test_store_dedup_response.py` — updated the merge-band and link-band tests (now `TestStoreDuplicateMergeBand` / `TestStoreRelatedLinkBand`) to expect `dedup_action="stored"` while still asserting the informational hints. Module docstring updated.
- `CHANGELOG.md` — `[Unreleased]` entry under `Changed`.

## Test plan

- [x] `pytest tests/test_store_dedup_response.py -v` — 8/8 pass
- [x] `pytest -m unit` — 1559 pass, 2 skipped
- [x] `ruff check src/distillery/mcp/tools/crud.py tests/test_store_dedup_response.py` — clean
- [x] `ruff format --check src/distillery/mcp/tools/crud.py tests/test_store_dedup_response.py` — clean
- [x] mypy strict — no new errors introduced (one pre-existing error in `feeds/sync_jobs.py:328` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated storage function deduplication response behavior. When storing new entries, the response now consistently indicates `"stored"` status regardless of whether similarity scores cross merge or link thresholds. Similarity context remains available through response fields for informational purposes. Use the find_similar function to prevent duplicate entries from being created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->