### PR TITLE
fix(ci): correct staging-deploy PR comment URL rendering and /mcp method note

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -119,16 +119,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # Use --body-file with a quoted heredoc so Markdown backticks are
+          # passed through literally without bash's escape-dance. The old
+          # --body "…\`url\`…" form leaked the backslash into the rendered
+          # comment (visible as %5C%60 in server access logs), so link-preview
+          # crawlers slurped the trailing \` into the URL and hit fresh 404s
+          # on every deploy. GitHub Actions expands ${{ … }} before bash runs,
+          # so a quoted heredoc is safe for all the values we need.
           gh pr comment "${{ steps.pr.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
-            --body "⏳ Staging deploy pending review — resolved head SHA \`${{ steps.pr.outputs.head_sha }}\`. A repo collaborator must approve the \`staging-deploy\` environment before the image is built: ${RUN_URL}
+            --body-file - <<'EOF'
+          ⏳ Staging deploy pending review — resolved head SHA `${{ steps.pr.outputs.head_sha }}`. A repo collaborator must approve the `staging-deploy` environment before the image is built: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
           Once deployed, staging will be reachable at:
-          - Web / claude.ai: \`https://distillery-mcp-dev.fly.dev/mcp\`
-          - Health check: \`https://distillery-mcp-dev.fly.dev/.well-known/oauth-authorization-server\`
+          - Web / claude.ai: `https://distillery-mcp-dev.fly.dev/mcp`
+          - Health check: `https://distillery-mcp-dev.fly.dev/.well-known/oauth-authorization-server`
 
-          (note the \`/mcp\` path — the bare hostname returns 404)"
+          (note the `/mcp` path — `GET /mcp` returns 405 (MCP only accepts POST), and the bare hostname returns 404)
+          EOF
 
   # ──────────────────────────────────────────────────────────────────
   # Job 1b: Build and push the staging image.
@@ -210,16 +218,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # See the "Announce pending approval" step for why we use
+          # --body-file + a quoted heredoc here instead of --body "…\`…\`…".
           gh pr comment "${{ needs.resolve.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
-            --body "🚀 Staging deploy dispatched — image \`${{ needs.resolve.outputs.image_tag }}\` pushed. Build log: ${RUN_URL}. Fly deploy is handled in [distill_ops staging-deploy](https://github.com/norrietaylor/distill_ops/actions/workflows/staging-deploy.yml); it will comment back when the app is healthy.
+            --body-file - <<'EOF'
+          🚀 Staging deploy dispatched — image `${{ needs.resolve.outputs.image_tag }}` pushed. Build log: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}. Fly deploy is handled in [distill_ops staging-deploy](https://github.com/norrietaylor/distill_ops/actions/workflows/staging-deploy.yml); it will comment back when the app is healthy.
 
           **Staging endpoint** (once healthy):
-          - MCP URL: \`https://distillery-mcp-dev.fly.dev/mcp\`  ← use this to connect from Claude Code / claude.ai
+          - MCP URL: `https://distillery-mcp-dev.fly.dev/mcp`  ← use this to connect from Claude Code / claude.ai
           - Health check: https://distillery-mcp-dev.fly.dev/.well-known/oauth-authorization-server
 
-          The \`/mcp\` path suffix is required — the bare hostname returns 404."
+          The `/mcp` path suffix is required — `GET /mcp` returns 405 (MCP only accepts POST), and the bare hostname returns 404.
+          EOF
 
   # ──────────────────────────────────────────────────────────────────
   # Job 2: /teardown-staging via comment


### PR DESCRIPTION
## Summary

Fixes two issues in the PR comment templates in `.github/workflows/staging-deploy.yml` (the approval-pending and dispatch-confirmation comments):

1. **Backtick escapes leaking into crawled URLs.** The old `--body "…\`url\`…"` form left the backslash in the rendered Markdown (visible as `%5C%60` in server access logs), so link-preview crawlers grabbed the URL with the trailing escaped backtick and hit `GET /mcp%5C%60 → 404` on every deploy. Switched both comments to `gh pr comment --body-file -` with a quoted heredoc so the Markdown passes through literally.

2. **Wrong status code in the `/mcp` path note.** Both comments said "the bare hostname returns 404". In fact `GET /mcp` returns **405 Method Not Allowed** (MCP streamable-http only accepts POST); it's `GET /` on the bare hostname that returns 404. Reworded to: `` `GET /mcp` `` returns 405 (MCP only accepts POST), and the bare hostname returns 404.

## Diff snippet (dispatch-confirmation comment)

Before:

```yaml
--body "🚀 Staging deploy dispatched — image \`${{ needs.resolve.outputs.image_tag }}\` pushed. […]
- MCP URL: \`https://distillery-mcp-dev.fly.dev/mcp\`  ← use this […]
The \`/mcp\` path suffix is required — the bare hostname returns 404."
```

After:

```yaml
--body-file - <<'EOF'
🚀 Staging deploy dispatched — image `${{ needs.resolve.outputs.image_tag }}` pushed. […]
- MCP URL: `https://distillery-mcp-dev.fly.dev/mcp`  ← use this […]
The `/mcp` path suffix is required — `GET /mcp` returns 405 (MCP only accepts POST), and the bare hostname returns 404.
EOF
```

The approval-pending comment in the `resolve` job gets the same treatment.

Fixes #350

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/staging-deploy.yml'))"` parses cleanly
- [x] `bash -n` on each `run:` block (with `${{ … }}` stubbed) — heredoc `EOF` lands at column 0 after YAML block-scalar indent stripping
- [x] `ruff check`, `ruff format --check`, `mypy --strict` clean (no Python touched)
- [ ] Live verification on next staging deploy: confirm the next `/deploy-staging` comment renders `` `https://…/mcp` `` as plain Markdown inline-code without a trailing `\` in the rendered HTML / Fly access logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the staging deployment workflow to improve pull request comment formatting and clarity in automated deployment notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->