### PR TITLE
fix(classification): suggest canonical entry_type on INVALID_PARAMS

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -813,6 +813,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - entry_id (str, required): UUID of the entry to classify.
           - entry_type (str, required): Assigned type. Valid: [session, bookmark, minutes,
             meeting, reference, idea, inbox, github, person, project, digest, feed].
+            Common intuitive aliases like ``"note"`` are NOT accepted but the
+            error response includes a ``details.suggestion`` pointing to the
+            canonical type (e.g. ``"note"`` -> ``"inbox"``).
           - confidence (float, required): Classification confidence (0-1). Entries below
             the configured threshold (default 0.6) go to pending_review.
           - reasoning (str, optional): Explanation of the classification decision.
@@ -820,7 +823,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - suggested_project (str, optional): Project to assign if entry has none.
 
         RETURNS (success): { id: str, entry_type: str, status: str, ... } (full updated entry)
-        RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "INTERNAL", message: "..." }
+        RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "INTERNAL",
+        message: "...", details?: { field, provided, allowed, suggestion? } }
 
         RELATED: distillery_resolve_review (to act on pending_review entries),
         distillery_list (with output_mode="review" to see the review queue)

--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -22,7 +22,7 @@ from distillery.mcp.tools._common import (
     validate_required,
     validate_type,
 )
-from distillery.mcp.tools.crud import _VALID_ENTRY_TYPES
+from distillery.mcp.tools.crud import _VALID_ENTRY_TYPES, _invalid_entry_type_response
 
 logger = logging.getLogger(__name__)
 
@@ -67,11 +67,7 @@ async def _handle_classify(
     confidence_raw = arguments["confidence"]
 
     if entry_type_str not in _VALID_ENTRY_TYPES:
-        return error_response(
-            "INVALID_PARAMS",
-            f"Invalid entry_type {entry_type_str!r}. "
-            f"Must be one of: {', '.join(sorted(_VALID_ENTRY_TYPES))}.",
-        )
+        return _invalid_entry_type_response(entry_type_str)
 
     if not isinstance(confidence_raw, (int, float)):
         return error_response("INVALID_PARAMS", "Field 'confidence' must be a number")
@@ -312,11 +308,7 @@ async def _handle_resolve_review(
                 "Field 'new_entry_type' is required when action='reclassify'.",
             )
         if new_type_str not in _VALID_ENTRY_TYPES:
-            return error_response(
-                "INVALID_PARAMS",
-                f"Invalid new_entry_type {new_type_str!r}. "
-                f"Must be one of: {', '.join(sorted(_VALID_ENTRY_TYPES))}.",
-            )
+            return _invalid_entry_type_response(new_type_str, field="new_entry_type")
         _clear_stale_delegation_keys(new_metadata)
         new_metadata["reclassified_from"] = entry.entry_type.value
         new_metadata["reviewed_at"] = now

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -66,6 +66,90 @@ _VALID_ENTRY_TYPES = {
     "feed",
 }
 
+
+# Common aliases callers reach for intuitively that don't map 1:1 to a
+# canonical entry_type. These are used only to surface a ``suggestion`` in the
+# INVALID_PARAMS error payload — they are NOT accepted as entry_type values.
+#
+# Rationale for each mapping:
+#   note / notes  -> ``inbox``   (unclassified jottings awaiting triage)
+#   task / todo   -> ``idea``    (open question / action item)
+#   issue / pr    -> ``github``  (GitHub artifacts have a dedicated type)
+#   article / url -> ``bookmark`` (saved external URLs)
+#   summary       -> ``digest``  (periodic summaries)
+#   doc / docs    -> ``reference`` (reference material)
+#   contact       -> ``person``  (people profiles)
+#   repo          -> ``project`` (project/repo records)
+_ENTRY_TYPE_ALIASES: dict[str, str] = {
+    "note": "inbox",
+    "notes": "inbox",
+    "task": "idea",
+    "todo": "idea",
+    "issue": "github",
+    "pr": "github",
+    "article": "bookmark",
+    "url": "bookmark",
+    "link": "bookmark",
+    "summary": "digest",
+    "doc": "reference",
+    "docs": "reference",
+    "contact": "person",
+    "repo": "project",
+}
+
+
+def _suggest_entry_type(value: Any) -> str | None:
+    """Return a suggested canonical entry_type for a rejected *value*, if any.
+
+    The match is case-insensitive and only considers exact string lookups in
+    the alias map — no fuzzy distance search. This keeps the suggestion stable
+    and predictable for tool callers.
+
+    Args:
+        value: The raw value that was rejected as an entry_type.
+
+    Returns:
+        A canonical ``EntryType`` string value (e.g. ``"inbox"``) if an alias
+        match was found, otherwise ``None``.
+    """
+    if not isinstance(value, str):
+        return None
+    return _ENTRY_TYPE_ALIASES.get(value.strip().lower())
+
+
+def _invalid_entry_type_response(
+    value: Any, *, field: str = "entry_type", prefix: str = ""
+) -> list[types.TextContent]:
+    """Build the standard INVALID_PARAMS response for an invalid *entry_type*.
+
+    When ``value`` matches a known alias (e.g. ``"note"`` -> ``"inbox"``), the
+    suggestion is surfaced both inline in the human-readable message *and* as
+    a structured ``details.suggestion`` field so programmatic callers can
+    retry automatically without parsing the message string.
+
+    Args:
+        value: The raw entry_type value that failed validation.
+        field: The field name to reference in the error message (e.g.
+            ``"entry_type"`` or ``"new_entry_type"``).
+        prefix: Optional prefix for the message (e.g. ``"entries[3] has "``).
+
+    Returns:
+        MCP error response content list ready to return from a tool handler.
+    """
+    allowed = ", ".join(sorted(_VALID_ENTRY_TYPES))
+    message = f"{prefix}Invalid {field} {value!r}. Must be one of: {allowed}."
+    details: dict[str, Any] = {
+        "field": field,
+        "provided": value,
+        "allowed": sorted(_VALID_ENTRY_TYPES),
+    }
+    suggestion = _suggest_entry_type(value)
+    if suggestion is not None:
+        message += f" Did you mean {suggestion!r}?"
+        details["suggestion"] = suggestion
+    return error_response("INVALID_PARAMS", message, details=details)
+
+
 # Valid status values (mirrors EntryStatus enum).
 _VALID_STATUSES = {"active", "pending_review", "archived"}
 
@@ -184,11 +268,7 @@ async def _handle_store(
 
     entry_type_str = arguments["entry_type"]
     if entry_type_str not in _VALID_ENTRY_TYPES:
-        return error_response(
-            "INVALID_PARAMS",
-            f"Invalid entry_type {entry_type_str!r}. "
-            f"Must be one of: {', '.join(sorted(_VALID_ENTRY_TYPES))}.",
-        )
+        return _invalid_entry_type_response(entry_type_str)
 
     tags_err = validate_type(arguments, "tags", list, "list of strings")
     if tags_err:
@@ -549,11 +629,7 @@ async def _handle_store_batch(
 
         entry_type_str = item.get("entry_type", "inbox")
         if entry_type_str not in _VALID_ENTRY_TYPES:
-            return error_response(
-                "INVALID_PARAMS",
-                f"entries[{idx}] has invalid entry_type {entry_type_str!r}. "
-                f"Must be one of: {', '.join(sorted(_VALID_ENTRY_TYPES))}.",
-            )
+            return _invalid_entry_type_response(entry_type_str, prefix=f"entries[{idx}] has ")
 
         source_str = str(item.get("source", EntrySource.CLAUDE_CODE.value))
         if source_str not in _VALID_SOURCES:
@@ -816,11 +892,7 @@ async def _handle_update(
     if "entry_type" in updates:
         et_str = updates["entry_type"]
         if et_str not in _VALID_ENTRY_TYPES:
-            return error_response(
-                "INVALID_PARAMS",
-                f"Invalid entry_type {et_str!r}. "
-                f"Must be one of: {', '.join(sorted(_VALID_ENTRY_TYPES))}.",
-            )
+            return _invalid_entry_type_response(et_str)
         updates["entry_type"] = EntryType(et_str)
 
     if "status" in updates:
@@ -1413,11 +1485,7 @@ async def _handle_correct(
     # --- resolve fields (inherit from original if not provided) -------------
     entry_type_str = arguments.get("entry_type", original.entry_type.value)
     if entry_type_str not in _VALID_ENTRY_TYPES:
-        return error_response(
-            "INVALID_PARAMS",
-            f"Invalid entry_type {entry_type_str!r}. "
-            f"Must be one of: {', '.join(sorted(_VALID_ENTRY_TYPES))}.",
-        )
+        return _invalid_entry_type_response(entry_type_str)
 
     author = arguments.get("author", original.author)
     project = arguments.get("project", original.project)
@@ -1518,6 +1586,9 @@ __all__ = [
     "_apply_default_status_filter",
     "_DEFAULT_VISIBLE_STATUSES",
     "_VALID_ENTRY_TYPES",
+    "_ENTRY_TYPE_ALIASES",
+    "_suggest_entry_type",
+    "_invalid_entry_type_response",
     "_VALID_STATUSES",
     "_VALID_VERIFICATIONS",
     "_VALID_SOURCES",

--- a/tests/test_bulk_ingest.py
+++ b/tests/test_bulk_ingest.py
@@ -127,6 +127,26 @@ async def test_handle_store_batch_invalid_entry_type() -> None:
 
 
 @pytest.mark.unit
+async def test_handle_store_batch_entry_type_note_suggests_inbox() -> None:
+    """Issue #345: bulk ingest also surfaces the 'note' -> 'inbox' suggestion."""
+    store = _make_mock_store()
+    result = await _handle_store_batch(
+        store=store,
+        arguments={
+            "entries": [
+                {"content": "text", "author": "alice", "entry_type": "note"},
+            ],
+        },
+    )
+    data = parse_mcp_response(result)
+    assert data["error"] is True
+    assert data["code"] == "INVALID_PARAMS"
+    assert data["details"]["suggestion"] == "inbox"
+    # The prefixed message keeps per-entry context.
+    assert "entries[0]" in data["message"]
+
+
+@pytest.mark.unit
 async def test_handle_store_batch_empty_list() -> None:
     """Empty entries list should return count=0 without calling store."""
     store = _make_mock_store()

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -205,6 +205,24 @@ async def test_correct_invalid_entry_type(store: DuckDBStore, original_entry: st
     assert data["code"] == "INVALID_PARAMS"
 
 
+async def test_correct_invalid_entry_type_note_suggests_inbox(
+    store: DuckDBStore, original_entry: str
+) -> None:
+    """Issue #345: 'note' alias surfaces 'inbox' suggestion on correction path too."""
+    result = await _handle_correct(
+        store=store,
+        arguments={
+            "wrong_entry_id": original_entry,
+            "content": "Fixed.",
+            "entry_type": "note",
+        },
+    )
+    data = parse_mcp_response(result)
+    assert data["error"] is True
+    assert data["code"] == "INVALID_PARAMS"
+    assert data["details"]["suggestion"] == "inbox"
+
+
 async def test_correct_empty_tags_clears(store: DuckDBStore, original_entry: str) -> None:
     """Passing tags=[] explicitly clears tags instead of inheriting."""
     result = await _handle_correct(

--- a/tests/test_entry_type_suggestions.py
+++ b/tests/test_entry_type_suggestions.py
@@ -1,0 +1,141 @@
+"""Unit tests for the entry_type alias / suggestion helpers (issue #345).
+
+Covers :func:`distillery.mcp.tools.crud._suggest_entry_type` and the
+:func:`distillery.mcp.tools.crud._invalid_entry_type_response` helper that
+wraps it into a structured INVALID_PARAMS response.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from distillery.mcp.tools.crud import (
+    _ENTRY_TYPE_ALIASES,
+    _VALID_ENTRY_TYPES,
+    _invalid_entry_type_response,
+    _suggest_entry_type,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestSuggestEntryType:
+    """Tests for the pure alias-lookup helper."""
+
+    def test_note_maps_to_inbox(self) -> None:
+        """Issue #345: the canonical example — ``'note'`` resolves to ``'inbox'``."""
+        assert _suggest_entry_type("note") == "inbox"
+
+    def test_case_insensitive(self) -> None:
+        """Aliases match case-insensitively."""
+        assert _suggest_entry_type("Note") == "inbox"
+        assert _suggest_entry_type("NOTE") == "inbox"
+        assert _suggest_entry_type("NoTeS") == "inbox"
+
+    def test_strips_whitespace(self) -> None:
+        """Surrounding whitespace is trimmed before lookup."""
+        assert _suggest_entry_type("  note  ") == "inbox"
+
+    @pytest.mark.parametrize(
+        "alias,expected",
+        [
+            ("task", "idea"),
+            ("todo", "idea"),
+            ("issue", "github"),
+            ("pr", "github"),
+            ("article", "bookmark"),
+            ("url", "bookmark"),
+            ("link", "bookmark"),
+            ("summary", "digest"),
+            ("doc", "reference"),
+            ("docs", "reference"),
+            ("contact", "person"),
+            ("repo", "project"),
+        ],
+    )
+    def test_covers_common_aliases(self, alias: str, expected: str) -> None:
+        """Each alias resolves to a canonical entry_type."""
+        assert _suggest_entry_type(alias) == expected
+
+    def test_unknown_value_returns_none(self) -> None:
+        """Unknown strings do not produce a suggestion."""
+        assert _suggest_entry_type("completely_bogus") is None
+        assert _suggest_entry_type("") is None
+
+    def test_non_string_returns_none(self) -> None:
+        """Non-string inputs cannot be aliases; return ``None`` rather than raising."""
+        assert _suggest_entry_type(None) is None
+        assert _suggest_entry_type(42) is None
+        assert _suggest_entry_type(["note"]) is None
+
+    def test_every_alias_target_is_canonical(self) -> None:
+        """Every alias must point at a real canonical entry_type.
+
+        Regression guard: if someone adds an alias pointing at a typo or a
+        removed type, this test catches it immediately.
+        """
+        for alias, target in _ENTRY_TYPE_ALIASES.items():
+            assert target in _VALID_ENTRY_TYPES, (
+                f"alias {alias!r} targets {target!r} which is not in _VALID_ENTRY_TYPES"
+            )
+
+    def test_no_alias_is_itself_canonical(self) -> None:
+        """An alias must not collide with a canonical type (would be dead code)."""
+        for alias in _ENTRY_TYPE_ALIASES:
+            assert alias not in _VALID_ENTRY_TYPES, (
+                f"alias {alias!r} is already a canonical entry_type — remove it from the map"
+            )
+
+
+class TestInvalidEntryTypeResponse:
+    """Tests for the structured INVALID_PARAMS response builder."""
+
+    @staticmethod
+    def _parse(response: list) -> dict:  # type: ignore[type-arg]
+        assert len(response) == 1
+        return json.loads(response[0].text)
+
+    def test_basic_shape_with_suggestion(self) -> None:
+        payload = self._parse(_invalid_entry_type_response("note"))
+        assert payload["error"] is True
+        assert payload["code"] == "INVALID_PARAMS"
+        assert "note" in payload["message"]
+        assert "inbox" in payload["message"]
+        assert "Did you mean" in payload["message"]
+        details = payload["details"]
+        assert details["field"] == "entry_type"
+        assert details["provided"] == "note"
+        assert details["suggestion"] == "inbox"
+        assert sorted(details["allowed"]) == sorted(_VALID_ENTRY_TYPES)
+
+    def test_no_suggestion_for_unknown_value(self) -> None:
+        payload = self._parse(_invalid_entry_type_response("bogus"))
+        assert payload["code"] == "INVALID_PARAMS"
+        # The message omits the "Did you mean" sentence entirely — no empty hint.
+        assert "Did you mean" not in payload["message"]
+        assert "suggestion" not in payload["details"]
+        # But ``allowed`` is always surfaced so clients can recover without
+        # reparsing the message string.
+        assert "inbox" in payload["details"]["allowed"]
+
+    def test_custom_field_label(self) -> None:
+        """Reclassify path uses ``new_entry_type`` — that name must appear in both message and details."""
+        payload = self._parse(_invalid_entry_type_response("note", field="new_entry_type"))
+        assert "new_entry_type" in payload["message"]
+        assert payload["details"]["field"] == "new_entry_type"
+        assert payload["details"]["suggestion"] == "inbox"
+
+    def test_message_prefix_for_batch_context(self) -> None:
+        """Batch ingest uses a prefix so callers know which item failed."""
+        payload = self._parse(_invalid_entry_type_response("note", prefix="entries[3] has "))
+        assert payload["message"].startswith("entries[3] has Invalid entry_type")
+        assert payload["details"]["suggestion"] == "inbox"
+
+    def test_non_string_value_has_no_suggestion(self) -> None:
+        """A non-string rejected value still produces a stable error (no crash)."""
+        payload = self._parse(_invalid_entry_type_response(42))
+        assert payload["code"] == "INVALID_PARAMS"
+        assert payload["details"]["provided"] == 42
+        assert "suggestion" not in payload["details"]

--- a/tests/test_mcp_classify.py
+++ b/tests/test_mcp_classify.py
@@ -231,6 +231,46 @@ class TestClassifyTool:
         data = parse_mcp_response(response)
         assert data["error"] is True
         assert data["code"] == "INVALID_PARAMS"
+        # Unknown values that don't match an alias carry no suggestion but
+        # must still include the allowed list for client introspection.
+        assert "suggestion" not in data.get("details", {})
+        assert "inbox" in data["details"]["allowed"]
+        assert data["details"]["field"] == "entry_type"
+        assert data["details"]["provided"] == "bogus_type"
+
+    async def test_classify_suggests_inbox_for_note_alias(
+        self, store: DuckDBStore, config: DistilleryConfig
+    ) -> None:
+        """Issue #345: 'note' -> 'inbox' suggestion in details + inline message."""
+        entry = make_entry(content="Some jotting")
+        entry_id = await store.store(entry)
+
+        response = await _handle_classify(
+            store,
+            config,
+            {"entry_id": entry_id, "entry_type": "note", "confidence": 0.9},
+        )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert data["details"]["suggestion"] == "inbox"
+        assert "inbox" in data["message"]
+
+    async def test_classify_suggestion_is_case_insensitive(
+        self, store: DuckDBStore, config: DistilleryConfig
+    ) -> None:
+        """Aliases match case-insensitively so 'Note' / 'NOTES' also resolve."""
+        entry = make_entry(content="Some jotting")
+        entry_id = await store.store(entry)
+
+        response = await _handle_classify(
+            store,
+            config,
+            {"entry_id": entry_id, "entry_type": "NOTES", "confidence": 0.9},
+        )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["details"]["suggestion"] == "inbox"
 
     async def test_classify_validates_confidence_out_of_range(
         self, store: DuckDBStore, config: DistilleryConfig
@@ -485,6 +525,25 @@ class TestResolveReviewTool:
         data = parse_mcp_response(response)
         assert data["error"] is True
         assert data["code"] == "INVALID_PARAMS"
+
+    async def test_resolve_reclassify_suggests_alias_for_note(self, store: DuckDBStore) -> None:
+        """Reclassify rejection for a known alias surfaces the canonical target."""
+        entry = make_entry(status=EntryStatus.PENDING_REVIEW)
+        entry_id = await store.store(entry)
+
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": entry_id,
+                "action": "reclassify",
+                "new_entry_type": "note",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert data["details"]["field"] == "new_entry_type"
+        assert data["details"]["suggestion"] == "inbox"
 
     async def test_resolve_returns_not_found_for_missing_entry(self, store: DuckDBStore) -> None:
         response = await _handle_resolve_review(


### PR DESCRIPTION
## Summary

Closes #345.

When callers pass an intuitive-but-invalid ``entry_type`` (e.g. ``note``), the ``INVALID_PARAMS`` response now includes a ``details.suggestion`` field pointing at the closest canonical type, and the same hint inline in the human-readable message ("Did you mean 'inbox'?").

### Approach

Went with **option 2** (suggestion field) over **option 1** (add ``note`` as a first-class type). Rationale:

- Option 1 would touch the enum, every schema, the classification engine/prompt, docs, skills, and every existing test that enumerates canonical types. It also conflates "note" with ``session`` vs ``inbox`` vs ``minutes`` depending on the caller's intent, so baking it in as a synonym picks a winner arbitrarily.
- Option 2 is one new helper (``_invalid_entry_type_response``) reused across the five rejection sites in ``tools/crud.py`` and ``tools/classify.py``, plus a tiny alias map. The canonical set stays exactly as-is; we just give callers a clear remediation path.

### Aliases added (suggestion-only — NOT accepted as values)

| alias | suggestion |
|-------|------------|
| note, notes | inbox |
| task, todo | idea |
| issue, pr | github |
| article, url, link | bookmark |
| summary | digest |
| doc, docs | reference |
| contact | person |
| repo | project |

### Error response shape (new)

```json
{
  "error": true,
  "code": "INVALID_PARAMS",
  "message": "Invalid entry_type 'note'. Must be one of: ... . Did you mean 'inbox'?",
  "details": {
    "field": "entry_type",
    "provided": "note",
    "allowed": ["bookmark", "digest", "feed", "github", "idea", "inbox", "meeting", "minutes", "person", "project", "reference", "session"],
    "suggestion": "inbox"
  }
}
```

``details`` is emitted even for unknown values (just without ``suggestion``) so clients never need to parse the message string.

## Test plan

- [x] Unit tests for ``_suggest_entry_type`` and ``_invalid_entry_type_response`` (``tests/test_entry_type_suggestions.py``) — covers case-insensitivity, whitespace stripping, non-string inputs, every alias, and a regression guard asserting no alias collides with a canonical type.
- [x] Integration tests on the classify + reclassify paths (``tests/test_mcp_classify.py``) — verifies ``details.suggestion == "inbox"`` for ``entry_type: "note"`` and the reclassify ``new_entry_type: "note"`` path.
- [x] Integration test on the correction path (``tests/test_corrections.py``).
- [x] Integration test on the bulk-ingest path (``tests/test_bulk_ingest.py``) — confirms the per-item prefix is preserved.
- [x] ``ruff check src/ tests/`` clean.
- [x] ``ruff format --check`` clean on touched files.
- [x] ``mypy --strict src/distillery/`` clean (60 files).
- [x] Full ``pytest`` green (2322 passed, 73 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invalid entry type inputs now receive helpful suggestions matching common aliases to canonical types (e.g., "note" → "inbox").
  * Error responses now include structured details with field information, suggestions, and the full list of allowed types.

* **Documentation**
  * Updated documentation to clarify that common intuitive type aliases are not accepted and that errors will include helpful suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->