### PR TITLE
feat(mcp): omit conflict_prompt from distillery_store by default

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -315,6 +315,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         verification: str | None = None,
         expires_at: str | None = _UNSET,
         output_mode: str | None = None,
+        include_conflict_prompt: bool = False,
     ) -> list[types.TextContent]:
         """Store a new knowledge entry and return its ID with dedup/conflict information.
 
@@ -340,8 +341,15 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - expires_at (str, optional): ISO 8601 datetime; entries past expiry appear in stale results.
           - output_mode (str, optional, default="full"): Response verbosity.
             Valid: [full, summary]. Use "summary" for bulk imports to skip dedup/conflict checks.
+          - include_conflict_prompt (bool, optional, default=False): When true,
+            each conflict candidate carries the ~1–2 KB ``conflict_prompt``
+            LLM template required to round-trip through
+            ``distillery_find_similar(conflict_check=true)``. Defaults to
+            false to keep store responses small (issue #348).
 
-        RETURNS (success): { entry_id: str, warnings?: list, conflict_candidates?: list }
+        RETURNS (success): { entry_id: str, persisted: bool, dedup_action: str,
+            conflicts?: list[{entry_id, content_preview, similarity_score,
+            conflict_prompt?}], warnings?: list }
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
 
         RELATED: distillery_find_similar (for pre-store dedup checks),
@@ -353,6 +361,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             content=content,
             entry_type=entry_type,
             author=author,
+            include_conflict_prompt=include_conflict_prompt,
             **_omit_none(
                 project=project,
                 tags=tags,

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -128,7 +128,7 @@ async def _handle_store(
     Create and persist a new Entry from the provided arguments, run deduplication and a non-fatal conflict check, and return the stored entry id along with any warnings or conflict candidates.
 
     Parameters:
-        arguments (dict): MCP tool arguments. Required keys: `content`, `entry_type`, `author`. Optional keys: `project`, `tags` (list), `metadata` (dict), `dedup_threshold` (number), `dedup_limit` (int).
+        arguments (dict): MCP tool arguments. Required keys: `content`, `entry_type`, `author`. Optional keys: `project`, `tags` (list), `metadata` (dict), `dedup_threshold` (number), `dedup_limit` (int), `include_conflict_prompt` (bool — default False; when True each conflict candidate carries the ~1–2 KB `conflict_prompt` template required to round-trip through `distillery_find_similar(conflict_check=true)`).
         cfg (DistilleryConfig | None): Optional configuration used to derive classification/conflict thresholds; when omitted a default conflict threshold of 0.60 is used.
 
     Returns:
@@ -162,7 +162,12 @@ async def _handle_store(
         May also include:
           - `warnings`: list of similar-entry summaries (id, score, content_preview) when near-duplicates were found,
           - `warning_message`: human-readable summary of warnings,
-          - `conflicts`: list of conflict candidate objects (entry_id, content_preview, similarity_score, conflict_reasoning),
+          - `conflicts`: list of conflict candidate objects. Every item carries
+            ``entry_id``, ``content_preview``, and ``similarity_score``. When
+            ``include_conflict_prompt=True`` each item additionally carries
+            ``conflict_prompt`` (the ~1–2 KB LLM template used by
+            ``distillery_find_similar(conflict_check=true)``). The prompt is
+            omitted by default to keep store responses small; see issue #348.
           - `conflict_message`: guidance message when conflict candidates are returned.
     """
     from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
@@ -180,6 +185,16 @@ async def _handle_store(
         return error_response(
             "INVALID_PARAMS",
             "Field 'output_mode' must be one of: 'full', 'ids', 'review', 'summary'.",
+        )
+
+    # include_conflict_prompt opts the caller into receiving the per-candidate
+    # LLM prompt template (~1–2 KB each). Default False keeps responses small
+    # (see issue #348); callers that actually round-trip via
+    # distillery_find_similar(conflict_check=true) pass True explicitly.
+    include_conflict_prompt = arguments.get("include_conflict_prompt", False)
+    if not isinstance(include_conflict_prompt, bool):
+        return error_response(
+            "INVALID_PARAMS", "Field 'include_conflict_prompt' must be a boolean."
         )
 
     entry_type_str = arguments["entry_type"]
@@ -439,15 +454,19 @@ async def _handle_store(
                     continue
                 lines = result.entry.content.splitlines()
                 preview = lines[0][:120] if lines else result.entry.content[:120]
-                prompt = conflict_checker.build_prompt(entry.content, result.entry.content)
-                conflicts.append(
-                    {
-                        "entry_id": result.entry.id,
-                        "content_preview": preview,
-                        "similarity_score": round(result.score, 4),
-                        "conflict_prompt": prompt,
-                    }
-                )
+                candidate: dict[str, Any] = {
+                    "entry_id": result.entry.id,
+                    "content_preview": preview,
+                    "similarity_score": round(result.score, 4),
+                }
+                # conflict_prompt is opt-in (issue #348); the full template is
+                # only useful to callers who will round-trip it through
+                # distillery_find_similar(conflict_check=true).
+                if include_conflict_prompt:
+                    candidate["conflict_prompt"] = conflict_checker.build_prompt(
+                        entry.content, result.entry.content
+                    )
+                conflicts.append(candidate)
             if conflicts:
                 response_data: dict[str, Any] = {
                     "entry_id": entry_id,

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -368,6 +368,9 @@ class TestMCPStoreConflictDetection:
         """When an existing entry has cosine similarity above conflict_threshold
         but below the dedup skip threshold, distillery_store returns conflicts
         in the response.
+
+        By default (issue #348) ``conflict_prompt`` is NOT included — callers
+        opt in via ``include_conflict_prompt=True``.
         """
         existing_text = "Cats are nocturnal animals that hunt at night"
         new_text = "Cats are diurnal animals that are active during the day"
@@ -403,9 +406,101 @@ class TestMCPStoreConflictDetection:
         assert "entry_id" in conflict
         assert "content_preview" in conflict
         assert "similarity_score" in conflict
-        assert "conflict_prompt" in conflict
+        # Default behaviour: prompt omitted to keep responses small (#348).
+        assert "conflict_prompt" not in conflict
         # conflict_reasoning must NOT be present (it leaked the system prompt — #200)
         assert "conflict_reasoning" not in conflict
+
+    async def test_store_default_omits_conflict_prompt(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        """By default conflict candidates omit ``conflict_prompt`` (issue #348)."""
+        existing_text = "The sky is blue during daylight hours"
+        new_text = "The sky is green during daylight hours"
+        embedding_provider.register(existing_text, _UNIT_A)
+        embedding_provider.register(new_text, _interpolated_vector(_UNIT_A, _UNIT_B, 0.4))
+        await store.store(make_entry(content=existing_text))
+
+        config = _make_config(conflict_threshold=0.60)
+        response = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "inbox",
+                "author": "tester",
+            },
+            config,
+        )
+        data = parse_mcp_response(response)
+
+        assert data.get("conflicts"), "expected at least one conflict candidate"
+        for conflict in data["conflicts"]:
+            assert "conflict_prompt" not in conflict
+            assert set(conflict.keys()) == {
+                "entry_id",
+                "content_preview",
+                "similarity_score",
+            }
+
+    async def test_store_include_conflict_prompt_true_includes_prompt(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        """include_conflict_prompt=True preserves the conflict_prompt field."""
+        existing_text = "Coffee is grown only in South America"
+        new_text = "Coffee is grown only in Antarctica"
+        embedding_provider.register(existing_text, _UNIT_A)
+        embedding_provider.register(new_text, _interpolated_vector(_UNIT_A, _UNIT_B, 0.4))
+        await store.store(make_entry(content=existing_text))
+
+        config = _make_config(conflict_threshold=0.60)
+        response = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "inbox",
+                "author": "tester",
+                "include_conflict_prompt": True,
+            },
+            config,
+        )
+        data = parse_mcp_response(response)
+
+        assert data.get("conflicts"), "expected at least one conflict candidate"
+        for conflict in data["conflicts"]:
+            assert "conflict_prompt" in conflict
+            assert isinstance(conflict["conflict_prompt"], str)
+            assert len(conflict["conflict_prompt"]) > 0
+            assert "entry_id" in conflict
+            assert "content_preview" in conflict
+            assert "similarity_score" in conflict
+
+    async def test_store_invalid_include_conflict_prompt_rejected(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        """Non-bool include_conflict_prompt values return INVALID_PARAMS."""
+        new_text = "Some benign content"
+        embedding_provider.register(new_text, _UNIT_A)
+
+        config = _make_config(conflict_threshold=0.60)
+        response = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "inbox",
+                "author": "tester",
+                "include_conflict_prompt": "yes",  # not a bool
+            },
+            config,
+        )
+        data = parse_mcp_response(response)
+        assert data.get("error") is True
+        assert data.get("code") == "INVALID_PARAMS"
 
     async def test_store_no_conflicts_when_no_similar(
         self,


### PR DESCRIPTION
## Summary

- `distillery_store` used to embed a ~1–2 KB `conflict_prompt` LLM template in every conflict candidate, padding typical responses to 15–25 KB. Most agents never round-trip the prompt through `distillery_find_similar(conflict_check=true)`, so the bytes were wasted context budget on every write (issue #348).
- Add an opt-in `include_conflict_prompt` flag (default `false`). Conflict candidates still carry `entry_id`, `content_preview`, and `similarity_score`; the prompt is only attached when the caller explicitly requests it.
- The existing `output_mode="summary"` on `distillery_store` is kept as-is (bulk-import fast path that skips dedup and conflict entirely). Using a boolean flag instead of repurposing the existing mode avoids breaking that semantic, which issue #348 explicitly allows as a fallback.

## Response size (measured)

Three conflict candidates, controlled 8-dimensional embeddings:

| Mode | Bytes | Reduction |
| ---- | ----- | --------- |
| Before (prompt included, prior default) | 3139 | — |
| After (`include_conflict_prompt=false`, new default) | 910 | **~71% smaller** |
| Opt-in (`include_conflict_prompt=true`) | 3139 | matches prior default |

Each conflict candidate drops ~740 bytes. For the 15–25 KB responses the issue flags (many similar entries, longer content), the savings scale linearly and can approach 80% of the payload.

## Behaviour change

Existing callers that rely on `conflict_prompt` being present in the default response must now pass `include_conflict_prompt=true`. This is noted in the docstring. The only in-repo consumer that would want the prompt is an LLM doing contradiction evaluation; such callers typically use `distillery_find_similar(conflict_check=true)` directly and are unaffected.

## Test plan

- [x] `pytest tests/test_conflict.py` — 27/27 pass, includes three new cases (`test_store_default_omits_conflict_prompt`, `test_store_include_conflict_prompt_true_includes_prompt`, `test_store_invalid_include_conflict_prompt_rejected`)
- [x] `pytest tests/` (full suite, excluding `eval/`) — 2235 passed, 73 skipped
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` on the touched files — clean
- [x] `mypy --strict src/distillery/` — no issues

Closes #348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional parameter to control conflict prompt inclusion in store responses. Conflict prompts are now omitted by default; enable them as needed for improved performance.

* **Tests**
  * Enhanced test coverage for conflict prompt opt-in behavior, including parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->