### PR TITLE
fix(gh-sync): unblock re-sync — output_mode, entry_type docs, label sanitiser

### DIFF
--- a/skills/gh-sync/SKILL.md
+++ b/skills/gh-sync/SKILL.md
@@ -81,7 +81,7 @@ Before processing, retrieve the list of already-synced entries for this reposito
 distillery_list(
     entry_type="github",
     limit=500,
-    output_mode="metadata",
+    output_mode="summary",
     # scope to the target repo
 )
 ```

--- a/skills/gh-sync/SKILL.md
+++ b/skills/gh-sync/SKILL.md
@@ -225,7 +225,7 @@ Synced 8 issues, 4 PRs from norrietaylor/distillery. 5 new, 7 updated. 6 cross-r
 - Use `entry_type="github"` for all synced entries
 - `metadata.external_id` format: `{owner}/{repo}#issue-{number}` or `{owner}/{repo}#pr-{number}`
 - Required metadata fields: `repo`, `ref_type`, `ref_number`, `title`, `url`, `state`
-- Labels are converted to tags: lowercase, hyphens replacing spaces, invalid characters stripped
+- Labels are converted to tags by the shared sanitiser (`distillery.feeds.github_tag.sanitize_label`): lowercase, spaces and underscores become hyphens, consecutive hyphens collapse, leading/trailing hyphens are stripped, and labels that still do not match the tag grammar `[a-z0-9][a-z0-9-]*` are dropped rather than failing the whole entry. Example: `github_actions` → `github-actions`, `!!! urgent` → dropped.
 - Entry content: `# {title}\n\n{body}\n\n**{commenter}**: {comment}` (top 10 comments max)
 - Cross-reference relation creation is non-fatal — continue on failure, report in summary
 - Self-references (an issue referencing its own number) are skipped

--- a/src/distillery/eval/mcp_bridge.py
+++ b/src/distillery/eval/mcp_bridge.py
@@ -72,8 +72,8 @@ DISTILLERY_TOOL_SCHEMAS: list[dict[str, Any]] = [
                 "entry_type": {
                     "type": "string",
                     "description": (
-                        "One of: session, bookmark, minutes, meeting, "
-                        "reference, idea, inbox, person, project, digest, github."
+                        "One of: session, bookmark, minutes, meeting, reference, "
+                        "idea, inbox, person, project, digest, github, feed."
                     ),
                 },
                 "author": {"type": "string", "description": "Author identifier."},

--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import httpx
 
+from distillery.feeds.github_tag import sanitize_label
 from distillery.models import Entry, EntrySource, EntryStatus, EntryType
 from distillery.store.protocol import DistilleryStore
 
@@ -354,13 +355,9 @@ class GitHubSyncAdapter:
         external_id = _make_external_id(self._owner, self._repo, ref_type, number)
         content = _build_content(title, body, comments)
 
-        # Build tags from labels (lowercase, sanitised).
-        tags: list[str] = []
-        for label in labels:
-            sanitised = label.lower().replace(" ", "-")
-            # Only include if it matches tag format.
-            if re.fullmatch(r"[a-z0-9][a-z0-9\-]*", sanitised):
-                tags.append(sanitised)
+        # Build tags from labels using the shared sanitiser so the feeds path
+        # and the /gh-sync skill agree on the coercion rule (see issue #241).
+        tags: list[str] = [t for label in labels if (t := sanitize_label(label)) is not None]
 
         metadata: dict[str, Any] = {
             "repo": f"{self._owner}/{self._repo}",

--- a/src/distillery/feeds/github_tag.py
+++ b/src/distillery/feeds/github_tag.py
@@ -1,0 +1,55 @@
+"""Shared GitHub label → Distillery tag sanitiser.
+
+Both the server-side feeds adapter (:mod:`distillery.feeds.github_sync`) and
+the ``/gh-sync`` skill convert GitHub label names into Distillery tag
+segments. They must agree on the rule so the two import paths produce the
+same tag set on the same labels; see issue #241.
+
+The sanitiser is intentionally lenient:
+
+* ``github_actions`` (a default label on any repo using GitHub Actions) is
+  coerced to ``github-actions`` rather than dropped, preserving the topical
+  signal that underscore-variant labels carry.
+* Labels that still fail Distillery's tag grammar after coercion return
+  ``None`` so callers skip just that label rather than failing the whole
+  entry.
+"""
+
+from __future__ import annotations
+
+import re
+
+from distillery.models import is_valid_tag_segment
+
+_COLLAPSE_HYPHENS_RE = re.compile(r"-+")
+
+
+def sanitize_label(label: str) -> str | None:
+    """Return a Distillery-safe tag segment derived from *label*, or ``None``.
+
+    The coercion is: lowercase, replace spaces and underscores with hyphens,
+    collapse runs of hyphens, strip leading and trailing hyphens, then accept
+    the result only if it matches Distillery's tag segment grammar
+    (``[a-z0-9][a-z0-9-]*``).
+
+    Examples::
+
+        sanitize_label("bug")              == "bug"
+        sanitize_label("github_actions")   == "github-actions"
+        sanitize_label("High Priority")    == "high-priority"
+        sanitize_label("CLA Signed")       == "cla-signed"
+        sanitize_label("!!! urgent")       is None   # "!" is uncoercible
+        sanitize_label("")                 is None
+
+    Args:
+        label: Raw label name as returned by the GitHub REST API.
+
+    Returns:
+        The sanitised tag segment, or ``None`` if no valid segment can be
+        derived from *label*.
+    """
+    candidate = label.lower().replace(" ", "-").replace("_", "-")
+    candidate = _COLLAPSE_HYPHENS_RE.sub("-", candidate).strip("-")
+    if not candidate:
+        return None
+    return candidate if is_valid_tag_segment(candidate) else None

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -281,8 +281,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         """Store a new knowledge entry and return its ID with dedup/conflict information.
 
         entry_type must be one of: session, bookmark, minutes, meeting, reference,
-        idea, inbox. source: claude-code (default), manual, import, inference,
-        documentation, or external. session_id: opaque session identifier for grouping.
+        idea, inbox, person, project, digest, github, feed.
+        source: claude-code (default), manual, import, inference, documentation,
+        or external. session_id: opaque session identifier for grouping.
         dedup_threshold (0–1) controls near-duplicate warnings.
         verification: unverified, testing, or verified (default: unverified).
         expires_at accepts ISO 8601 datetime; entries past expiry appear in stale results.
@@ -340,7 +341,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
 
         At least one field must be provided. status: active, pending_review, or
         archived. entry_type: session, bookmark, minutes, meeting, reference,
-        idea, or inbox. verification: unverified, testing, or verified.
+        idea, inbox, person, project, digest, github, or feed.
+        verification: unverified, testing, or verified.
         session_id: opaque session identifier for grouping.
         expires_at accepts ISO 8601 datetime; pass null to clear.
         """
@@ -578,7 +580,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     ) -> list[types.TextContent]:
         """Apply a pre-computed classification to an existing entry.
 
-        entry_type: session, bookmark, minutes, meeting, reference, idea, or inbox.
+        entry_type: session, bookmark, minutes, meeting, reference, idea, inbox,
+        person, project, digest, github, or feed.
         confidence (0–1) determines the updated entry status.
         """
         c = _lc(ctx)

--- a/src/distillery/models.py
+++ b/src/distillery/models.py
@@ -112,6 +112,17 @@ def _new_uuid() -> str:
 _TAG_SEGMENT_RE = re.compile(r"^[a-z0-9][a-z0-9\-]*$")
 
 
+def is_valid_tag_segment(segment: str) -> bool:
+    """Return ``True`` if *segment* is a valid single-level tag segment.
+
+    A segment is the portion between forward slashes in a hierarchical tag
+    (see :func:`validate_tag`). This is a non-raising probe used by
+    sanitisers that need to decide whether a derived string is usable as a
+    tag without paying for exception overhead.
+    """
+    return bool(_TAG_SEGMENT_RE.match(segment))
+
+
 def validate_tag(tag: str) -> None:
     """Validate a single tag string.
 

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -338,13 +338,25 @@ class TestGitHubSyncAdapterSync:
 
     @pytest.mark.integration
     async def test_sync_handles_labels_as_tags(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]
-        """Issue labels should become entry tags (lowercase, sanitised)."""
+        """Issue labels become entry tags via the shared sanitiser.
+
+        Covers the coercion classes the shared helper promises (see
+        :mod:`distillery.feeds.github_tag`): already-valid, spaces,
+        underscores (issue #241 regression), mixed case, and uncoercible
+        labels that must be dropped without failing the whole entry.
+        """
         httpx_mock.add_response(
             url=re.compile(r".*/repos/test/repo/issues\?.*"),
             json=[
                 _mock_issue(
                     number=1,
-                    labels=[{"name": "bug"}, {"name": "high-priority"}],
+                    labels=[
+                        {"name": "bug"},
+                        {"name": "high-priority"},
+                        {"name": "github_actions"},
+                        {"name": "CLA Signed"},
+                        {"name": "!!! urgent"},
+                    ],
                 )
             ],
         )
@@ -357,8 +369,7 @@ class TestGitHubSyncAdapterSync:
         await adapter.sync()
 
         entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
-        assert "bug" in entries[0].tags
-        assert "high-priority" in entries[0].tags
+        assert set(entries[0].tags) == {"bug", "high-priority", "github-actions", "cla-signed"}
 
     @pytest.mark.integration
     async def test_sync_skips_self_references(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_github_tag.py
+++ b/tests/test_github_tag.py
@@ -1,0 +1,72 @@
+"""Unit tests for the shared GitHub label → Distillery tag sanitiser.
+
+Covers :func:`distillery.feeds.github_tag.sanitize_label`. The sanitiser
+is the single source of truth used by both the server-side feeds adapter
+and the ``/gh-sync`` skill; see issue #241.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.feeds.github_tag import sanitize_label
+
+pytestmark = pytest.mark.unit
+
+
+class TestSanitizeLabel:
+    """Exercise the coercion rule and its boundary conditions."""
+
+    def test_already_valid_label_is_returned_unchanged(self) -> None:
+        assert sanitize_label("bug") == "bug"
+        assert sanitize_label("high-priority") == "high-priority"
+
+    def test_uppercase_is_lowercased(self) -> None:
+        assert sanitize_label("Bug") == "bug"
+        assert sanitize_label("CLA Signed") == "cla-signed"
+
+    def test_spaces_become_hyphens(self) -> None:
+        assert sanitize_label("high priority") == "high-priority"
+
+    def test_underscores_become_hyphens(self) -> None:
+        # Regression for issue #241: github_actions is a default label on
+        # any repo using GitHub Actions and must survive sanitisation rather
+        # than failing the whole entry.
+        assert sanitize_label("github_actions") == "github-actions"
+
+    def test_underscores_and_spaces_mixed(self) -> None:
+        assert sanitize_label("High_Priority Bug") == "high-priority-bug"
+
+    def test_consecutive_separators_collapse(self) -> None:
+        assert sanitize_label("a  b") == "a-b"
+        assert sanitize_label("a__b") == "a-b"
+        assert sanitize_label("a -_ b") == "a-b"
+
+    def test_leading_and_trailing_separators_are_stripped(self) -> None:
+        assert sanitize_label("-leading") == "leading"
+        assert sanitize_label("trailing-") == "trailing"
+        assert sanitize_label("_wrapped_") == "wrapped"
+
+    def test_digit_prefix_is_allowed(self) -> None:
+        assert sanitize_label("9 lives") == "9-lives"
+
+    def test_empty_input_returns_none(self) -> None:
+        assert sanitize_label("") is None
+
+    def test_separator_only_input_returns_none(self) -> None:
+        assert sanitize_label("   ") is None
+        assert sanitize_label("_") is None
+        assert sanitize_label("---") is None
+
+    def test_uncoercible_characters_return_none(self) -> None:
+        # Punctuation not in the coercion map stays in the candidate and
+        # fails the segment grammar, so the label is dropped entirely.
+        assert sanitize_label("!!! urgent") is None
+        assert sanitize_label("needs/review") is None  # forward slash is not a segment char
+        assert sanitize_label("v1.0") is None  # dot is not a segment char
+
+    def test_unicode_letters_are_dropped(self) -> None:
+        # Distillery's tag grammar is ASCII-only; non-ASCII labels currently
+        # have no well-defined coercion, so they are skipped rather than
+        # silently normalised to something the caller did not choose.
+        assert sanitize_label("café") is None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -684,3 +684,31 @@ class TestCreateServer:
             "distillery_relations",
         }
         assert expected == tool_names, f"Missing tools: {expected - tool_names}"
+
+    async def test_entry_type_docstrings_cover_all_enum_values(self) -> None:
+        """Tools that accept entry_type must document every EntryType value.
+
+        Guards against the drift class found in issue #232: the docstring
+        enumeration diverges from the server's validator (``_VALID_ENTRY_TYPES``
+        in :mod:`distillery.mcp.tools.crud`) whenever a new member is added to
+        :class:`EntryType` without also updating the prose.
+        """
+        config = DistilleryConfig(
+            storage=StorageConfig(database_path=":memory:"),
+            embedding=EmbeddingConfig(provider="", model="stub", dimensions=4),
+        )
+        server = create_server(config)
+        tools = {t.name: t for t in await server.list_tools()}
+
+        entry_type_documenting_tools = (
+            "distillery_store",
+            "distillery_update",
+            "distillery_classify",
+        )
+        for tool_name in entry_type_documenting_tools:
+            description = tools[tool_name].description or ""
+            missing = [et.value for et in EntryType if et.value not in description]
+            assert not missing, (
+                f"{tool_name} docstring omits EntryType values {missing}; "
+                "update the description to list every enum member."
+            )


### PR DESCRIPTION
This bundle fixes three small but blocking bugs in the /gh-sync path that
I hit on a single sync run against Oddly/elasticstack. The three issues
share a surface so I have kept them in one PR with one commit each, but
they are independent — feel free to take them in any order.

The first commit closes #240. The /gh-sync skill was asking distillery_list
for output_mode="metadata", which was renamed to "summary" in #78 and
never caught in the skill. Every re-run against a project with prior
github entries failed the dedup step with INVALID_PARAMS. One-word fix.

The second closes #232. The distillery_store, distillery_update, and
distillery_classify tool descriptions listed only the original seven
entry types. The server's validator (_VALID_ENTRY_TYPES in crud.py) has
accepted twelve for a while, but person, project, digest, github, and
feed were never propagated into the docstrings. The same drift was also
present in the distillery_store JSON schema used by the eval harness,
missing only "feed". I updated all four surfaces together and added a
test that introspects the live FastMCP tool registrations and asserts
every EntryType.value appears in the description of each entry-type-
accepting tool, so the next enum addition fails CI instead of shipping
as stale prose.

The third closes #241. Distillery had two GitHub label sanitisers that
disagreed. The server-side adapter lowercased, replaced spaces with
hyphens, and skipped labels that still did not match [a-z0-9][a-z0-9-]*.
The skill's prose rule did not describe the real regex and left
underscores untouched, so the LLM handed github_actions — a default
label on any repo using GitHub Actions — straight to distillery_store,
which rejected the whole entry. I pulled the rule into a shared helper
in src/distillery/feeds/github_tag.py, extended it to coerce underscores
alongside spaces and to collapse and strip hyphens, and rewrote the
skill rule to name and describe the helper. models.py gains a small
public is_valid_tag_segment primitive so the new module does not have
to import the private regex. Unit tests cover the boundary conditions
I could think of, and the existing feeds-adapter integration test is
extended to exercise the same classes end-to-end.

Nothing here changes the shape of any existing tool or response, and
all three commits land green on ruff, ruff format, mypy --strict (no
new errors introduced; the two pre-existing errors in
eval/retrieval_scorer.py:241 are untouched), and pytest (one unrelated
pre-existing failure in tests/test_cli_export_import.py::test_roundtrip_fidelity
appears to be a timezone quirk on my machine).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `feed` entry type in Distillery storage.
  * Improved GitHub issue and pull request label-to-tag conversion with more robust sanitization and normalization rules.

* **Documentation**
  * Updated tool documentation to reflect all supported entry types: `session`, `bookmark`, `minutes`, `meeting`, `reference`, `idea`, `inbox`, `person`, `project`, `digest`, `github`, and `feed`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->