### PR TITLE
feat(mcp): add output_mode to distillery_store for lightweight inserts

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -276,6 +276,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         dedup_threshold: float | None = None,
         dedup_limit: int | None = None,
         verification: str | None = None,
+        output_mode: str | None = None,
         expires_at: str | None = _UNSET,
     ) -> list[types.TextContent]:
         """Store a new knowledge entry and return its ID with dedup/conflict information.
@@ -285,6 +286,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         documentation, or external. session_id: opaque session identifier for grouping.
         dedup_threshold (0–1) controls near-duplicate warnings.
         verification: unverified, testing, or verified (default: unverified).
+        output_mode: "full" (default) runs dedup and conflict checks and returns any
+        warnings or conflict candidates; "summary" skips both checks and returns only
+        the entry_id, suitable for bulk/trusted sources that do their own dedup.
         expires_at accepts ISO 8601 datetime; entries past expiry appear in stale results.
         """
         c = _lc(ctx)
@@ -302,6 +306,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 dedup_threshold=dedup_threshold,
                 dedup_limit=dedup_limit,
                 verification=verification,
+                output_mode=output_mode,
             ),
         )
         if expires_at is not _UNSET:

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -50,6 +50,15 @@ def _normalize_db_path(raw: str) -> str:
 # CRUD-related constants
 # ---------------------------------------------------------------------------
 
+# Valid output_mode values for distillery_store.
+#
+# "full" (default) runs the dedup and conflict checks after persisting the
+# entry (three embeddings per call).  "summary" skips both checks and
+# returns just the ``entry_id`` (one embedding per call), for callers that
+# have already deduplicated their input — for example ``/gh-sync``, which
+# does its own ``external_id`` dedup map and does not need conflict prompts.
+_VALID_STORE_OUTPUT_MODES = frozenset({"full", "summary"})
+
 # Valid entry_type values (mirrors EntryType enum).
 _VALID_ENTRY_TYPES = {
     "session",
@@ -128,15 +137,17 @@ async def _handle_store(
     Create and persist a new Entry from the provided arguments, run deduplication and a non-fatal conflict check, and return the stored entry id along with any warnings or conflict candidates.
 
     Parameters:
-        arguments (dict): MCP tool arguments. Required keys: `content`, `entry_type`, `author`. Optional keys: `project`, `tags` (list), `metadata` (dict), `dedup_threshold` (number), `dedup_limit` (int).
+        arguments (dict): MCP tool arguments. Required keys: `content`, `entry_type`, `author`. Optional keys: `project`, `tags` (list), `metadata` (dict), `dedup_threshold` (number), `dedup_limit` (int), `output_mode` (``"full"`` or ``"summary"``).
         cfg (DistilleryConfig | None): Optional configuration used to derive classification/conflict thresholds; when omitted a default conflict threshold of 0.60 is used.
 
     Returns:
-        list[types.TextContent]: MCP content list containing a JSON-serializable object with at least `entry_id`. May also include:
+        list[types.TextContent]: MCP content list containing a JSON-serializable object with at least `entry_id`. In the default ``output_mode="full"`` it may also include:
           - `warnings`: list of similar-entry summaries (id, score, content_preview) when near-duplicates were found,
           - `warning_message`: human-readable summary of warnings,
           - `conflicts`: list of conflict candidate objects (entry_id, content_preview, similarity_score, conflict_reasoning),
           - `conflict_message`: guidance message when conflict candidates are returned.
+
+        With ``output_mode="summary"`` the dedup and conflict checks are skipped and only ``entry_id`` is returned.
     """
     from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
     from distillery.models import Entry, EntrySource, EntryType, VerificationStatus
@@ -165,6 +176,17 @@ async def _handle_store(
     session_id_err = validate_type(arguments, "session_id", str, "string")
     if session_id_err:
         return error_response("INVALID_PARAMS", session_id_err)
+
+    output_mode_err = validate_type(arguments, "output_mode", str, "string")
+    if output_mode_err:
+        return error_response("INVALID_PARAMS", output_mode_err)
+    output_mode = arguments.get("output_mode") or "full"
+    if output_mode not in _VALID_STORE_OUTPUT_MODES:
+        return error_response(
+            "INVALID_PARAMS",
+            "Field 'output_mode' must be one of: " + ", ".join(sorted(_VALID_STORE_OUTPUT_MODES)),
+        )
+    skip_analysis = output_mode == "summary"
 
     from distillery.config import DefaultsConfig
 
@@ -215,10 +237,15 @@ async def _handle_store(
             except OSError:
                 pass  # can't stat, skip check
 
-    # --- embedding budget check (store + dedup + conflict = 3 embeds) ------
+    # --- embedding budget check --------------------------------------------
+    # Full mode: store + dedup + conflict = 3 embeds.
+    # Summary mode: store only = 1 embed (dedup and conflict are skipped).
     if cfg is not None:
+        embed_count = 1 if skip_analysis else 3
         try:
-            record_and_check(store.connection, cfg.rate_limit.embedding_budget_daily, count=3)
+            record_and_check(
+                store.connection, cfg.rate_limit.embedding_budget_daily, count=embed_count
+            )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
 
@@ -278,6 +305,10 @@ async def _handle_store(
     except Exception as exc:  # noqa: BLE001
         logger.exception("Error storing entry")
         return error_response("STORE_ERROR", f"Failed to store entry: {exc}")
+
+    # Summary mode: skip dedup + conflict analysis and return just the id.
+    if skip_analysis:
+        return success_response({"entry_id": entry_id})
 
     # --- deduplication check ------------------------------------------------
     warnings: list[dict[str, Any]] = []
@@ -923,6 +954,7 @@ __all__ = [
     "_VALID_SOURCES",
     "_IMMUTABLE_FIELDS",
     "_VALID_OUTPUT_MODES",
+    "_VALID_STORE_OUTPUT_MODES",
     "_entry_to_summary_dict",
     "_entry_to_id_dict",
     "_is_remote_db_path",

--- a/tests/test_store_output_mode.py
+++ b/tests/test_store_output_mode.py
@@ -1,0 +1,295 @@
+"""Tests for the ``output_mode`` argument on ``distillery_store``.
+
+``output_mode="summary"`` is the lightweight path: the entry is persisted and
+the handler returns immediately with just ``entry_id``. The dedup warning
+block and conflict check block are skipped, which also drops the per-call
+embedding-budget cost from three embeds to one. Callers that already have
+their own dedup mechanism (for example the ``/gh-sync`` skill, which tracks
+``metadata.external_id``) use this mode to avoid the extra embeddings.
+
+The tests below exercise that behaviour end-to-end via ``_handle_store``:
+
+* summary mode does not surface ``warnings`` / ``conflicts`` even when
+  similar entries are present,
+* summary mode does not call ``store.find_similar`` at all,
+* summary mode requests a single embedding from the budget, not three,
+* the default (no ``output_mode`` argument) preserves the existing
+  behaviour,
+* invalid values are rejected with ``INVALID_PARAMS``.
+
+See issue #238.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from distillery.config import (
+    ClassificationConfig,
+    DistilleryConfig,
+    EmbeddingConfig,
+    StorageConfig,
+)
+from distillery.mcp.server import _handle_store
+from distillery.store.duckdb import DuckDBStore
+from tests.conftest import ControlledEmbeddingProvider, make_entry, parse_mcp_response
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_UNIT_A = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def _make_config(conflict_threshold: float = 0.60) -> DistilleryConfig:
+    """Build a config with a low conflict threshold so similar entries surface."""
+    return DistilleryConfig(
+        storage=StorageConfig(database_path=":memory:"),
+        embedding=EmbeddingConfig(model="controlled-test-8d"),
+        classification=ClassificationConfig(
+            confidence_threshold=0.6,
+            conflict_threshold=conflict_threshold,
+        ),
+    )
+
+
+def _make_budget_mock_connection() -> MagicMock:
+    """Return a connection mock that satisfies ``record_and_check``'s call pattern."""
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = None  # no prior usage recorded
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test_conflict.py so the store uses the controlled provider)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def embedding_provider(
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> ControlledEmbeddingProvider:
+    return controlled_embedding_provider
+
+
+@pytest.fixture
+async def store(embedding_provider: ControlledEmbeddingProvider) -> DuckDBStore:  # type: ignore[return]
+    s = DuckDBStore(db_path=":memory:", embedding_provider=embedding_provider)
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+# ---------------------------------------------------------------------------
+# Behaviour: summary mode skips dedup warnings and conflict checks
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryModeSkipsAnalysis:
+    async def test_summary_mode_returns_only_entry_id_when_similar_exists(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        """With a near-duplicate already in the store, summary mode returns
+        just ``entry_id`` — no ``warnings`` and no ``conflicts``."""
+        existing_text = "Cats are nocturnal hunters"
+        new_text = "Cats are nocturnal animals"
+        # Identical vectors → similarity 1.0, well above dedup + conflict thresholds.
+        embedding_provider.register(existing_text, _UNIT_A)
+        embedding_provider.register(new_text, _UNIT_A)
+        await store.store(make_entry(content=existing_text))
+
+        config = _make_config(conflict_threshold=0.60)
+        response = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "inbox",
+                "author": "tester",
+                "output_mode": "summary",
+            },
+            config,
+        )
+        data = parse_mcp_response(response)
+
+        assert data.get("error") is None
+        assert "entry_id" in data
+        assert "warnings" not in data
+        assert "warning_message" not in data
+        assert "conflicts" not in data
+        assert "conflict_message" not in data
+
+    async def test_summary_mode_does_not_call_find_similar(self) -> None:
+        """Summary mode must not invoke ``store.find_similar`` at all."""
+        mock_store = AsyncMock()
+        mock_store.store.return_value = "stored-id"
+        mock_store.find_similar.side_effect = AssertionError(
+            "find_similar must not be called in summary mode"
+        )
+        mock_store.connection = _make_budget_mock_connection()
+
+        response = await _handle_store(
+            mock_store,
+            {
+                "content": "trusted content that already deduplicated upstream",
+                "entry_type": "github",
+                "author": "tester",
+                "output_mode": "summary",
+            },
+            _make_config(),
+        )
+        data = parse_mcp_response(response)
+
+        assert data.get("error") is None
+        assert data["entry_id"] == "stored-id"
+        mock_store.find_similar.assert_not_called()
+
+    async def test_summary_mode_requests_one_embedding_budget_unit(self) -> None:
+        """Summary mode requests count=1 from ``record_and_check``; full is count=3."""
+        mock_store = AsyncMock()
+        mock_store.store.return_value = "stored-id"
+        mock_store.find_similar.return_value = []  # unused in summary
+        conn = _make_budget_mock_connection()
+        mock_store.connection = conn
+
+        # Patch the budget helper to observe the count argument.
+        from distillery.mcp import budget as budget_module
+
+        seen_counts: list[int] = []
+
+        def _fake_record_and_check(_conn: object, _limit: int, count: int = 1) -> None:
+            seen_counts.append(count)
+
+        original = budget_module.record_and_check
+        budget_module.record_and_check = _fake_record_and_check  # type: ignore[assignment]
+        try:
+            await _handle_store(
+                mock_store,
+                {
+                    "content": "batch ingest payload",
+                    "entry_type": "feed",
+                    "author": "tester",
+                    "output_mode": "summary",
+                },
+                _make_config(),
+            )
+        finally:
+            budget_module.record_and_check = original  # type: ignore[assignment]
+
+        assert seen_counts == [1]
+
+
+# ---------------------------------------------------------------------------
+# Behaviour: default remains the "full" analysis path
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultModeIsFull:
+    async def test_default_mode_runs_conflict_check(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        """Omitting ``output_mode`` keeps the existing conflict-check behaviour."""
+        existing_text = "Dogs are pack animals"
+        new_text = "Dogs are solitary animals"
+        embedding_provider.register(existing_text, _UNIT_A)
+        embedding_provider.register(new_text, _UNIT_A)
+        await store.store(make_entry(content=existing_text))
+
+        config = _make_config(conflict_threshold=0.60)
+        response = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "inbox",
+                "author": "tester",
+            },
+            config,
+        )
+        data = parse_mcp_response(response)
+
+        assert data.get("error") is None
+        assert "entry_id" in data
+        assert "conflicts" in data
+        assert len(data["conflicts"]) >= 1
+
+    async def test_explicit_full_mode_runs_conflict_check(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        existing_text = "Birds migrate in winter"
+        new_text = "Birds do not migrate in winter"
+        embedding_provider.register(existing_text, _UNIT_A)
+        embedding_provider.register(new_text, _UNIT_A)
+        await store.store(make_entry(content=existing_text))
+
+        response = await _handle_store(
+            store,
+            {
+                "content": new_text,
+                "entry_type": "inbox",
+                "author": "tester",
+                "output_mode": "full",
+            },
+            _make_config(conflict_threshold=0.60),
+        )
+        data = parse_mcp_response(response)
+
+        assert data.get("error") is None
+        assert "conflicts" in data
+
+
+# ---------------------------------------------------------------------------
+# Validation: invalid output_mode
+# ---------------------------------------------------------------------------
+
+
+class TestOutputModeValidation:
+    async def test_invalid_output_mode_returns_invalid_params(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        embedding_provider.register("anything", _UNIT_A)
+        response = await _handle_store(
+            store,
+            {
+                "content": "anything",
+                "entry_type": "inbox",
+                "author": "tester",
+                "output_mode": "ids",  # valid for list but not for store
+            },
+            _make_config(),
+        )
+        data = parse_mcp_response(response)
+        assert data.get("error") is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert "output_mode" in data["message"]
+
+    async def test_non_string_output_mode_returns_invalid_params(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        embedding_provider.register("anything", _UNIT_A)
+        response = await _handle_store(
+            store,
+            {
+                "content": "anything",
+                "entry_type": "inbox",
+                "author": "tester",
+                "output_mode": 123,
+            },
+            _make_config(),
+        )
+        data = parse_mcp_response(response)
+        assert data.get("error") is True
+        assert data["code"] == "INVALID_PARAMS"


### PR DESCRIPTION
Adds an optional `output_mode` argument to `distillery_store` with two values. `"full"` is the existing behaviour: persist the entry, run the dedup check and the conflict check, and return any warnings or conflict candidates alongside the entry id. `"summary"` persists the entry and returns just `entry_id`, skipping both post-persist analysis blocks. The default stays `"full"`, so nothing changes for interactive `/distill` or `/bookmark` flows.

The motivating caller is bulk ingest from sources that already deduplicate upstream — `/gh-sync` builds an `external_id` map keyed on `{owner}/{repo}#{type}-{number}` to route new-vs-update, so the embedding similarity analysis is redundant work there. In summary mode the per-call embedding cost also drops from three to one, so callers hit the daily budget roughly three times later.

I left the `/gh-sync` skill alone in this PR to keep it narrowly focused on the server addition; adopting `output_mode="summary"` from the skill side is a follow-up and pairs naturally with the #234 project-tag work.

Closes #238.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `output_mode` parameter to the `distillery_store` tool with "full" (default) and "summary" modes, allowing customizable store operation behavior and response structure.

* **Tests**
  * Added comprehensive integration test suite covering the new `output_mode` parameter functionality and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->