### PR TITLE
fix(store): eliminate FTS WAL replay failure on cold start

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -26,7 +26,7 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import duckdb
 
@@ -508,17 +508,24 @@ class DuckDBStore:
             exists on disk.
         """
         exc_msg = str(exc)
-        if "fts_main_entries" not in exc_msg and "WAL" not in exc_msg:
+        # Match only the specific replay-failure signature.  A broader
+        # substring match on "WAL" would also trigger on unrelated WAL
+        # open errors, silently moving user data aside.
+        is_fts_replay_failure = "Failure while replaying WAL file" in exc_msg and (
+            "fts_main_entries" in exc_msg or "Cannot drop entry" in exc_msg
+        )
+        if not is_fts_replay_failure:
             raise exc
 
-        # Only attempt WAL recovery for local file paths.  Skip in-memory
-        # databases, S3, MotherDuck, and other URI schemes.
-        parsed = urlparse(self._db_path)
-        is_local_file = self._db_path != ":memory:" and parsed.scheme in ("", "file")
-        if not is_local_file:
+        # Resolve _db_path to a real filesystem path.  urlparse treats
+        # Windows drive letters (``C:\...``) as URI schemes, and file://
+        # URIs need unquoting + path extraction rather than a raw
+        # ``Path(self._db_path + ".wal")`` concat.
+        db_file = self._resolve_local_db_path()
+        if db_file is None:
             raise exc
 
-        wal_path = Path(self._db_path + ".wal")
+        wal_path = Path(str(db_file) + ".wal")
         if not wal_path.exists():
             raise exc
 
@@ -526,18 +533,22 @@ class DuckDBStore:
         # recover uncommitted data if needed.  Silently deleting the WAL
         # (the previous behaviour) is unrecoverable and unfriendly.
         timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
-        backup_path: Path | None = wal_path.with_suffix(f".wal.corrupt.{timestamp}")
+        backup_path = wal_path.with_suffix(f".wal.corrupt.{timestamp}")
         try:
-            assert backup_path is not None
             wal_path.rename(backup_path)
-        except OSError:
-            # Fall back to unlink if rename fails (e.g. cross-device).
-            logger.warning(
-                "Could not rename WAL to %s; deleting instead. Uncommitted data will be lost.",
+        except OSError as rename_exc:
+            # Leave the WAL in place and propagate the failure.  The
+            # previous behaviour unlinked the WAL as a fallback, which
+            # reintroduced the exact data-loss path this recovery is
+            # meant to eliminate.
+            logger.error(
+                "Could not preserve WAL as %s; leaving the original WAL file "
+                "in place for manual recovery.  Original replay failure: %s",
                 backup_path,
+                exc,
+                exc_info=rename_exc,
             )
-            wal_path.unlink()
-            backup_path = None
+            raise exc from rename_exc
 
         logger.warning(
             "Database WAL appears corrupt (FTS-related): %s. "
@@ -545,9 +556,49 @@ class DuckDBStore:
             "been preserved for manual recovery but will NOT be replayed. "
             "The FTS index will be rebuilt from scratch during init.",
             exc,
-            backup_path if backup_path is not None else "(deleted)",
+            backup_path,
         )
         return self._open_connection()
+
+    def _resolve_local_db_path(self) -> Path | None:
+        """Return the filesystem path for ``self._db_path`` if it's local.
+
+        Handles four shapes:
+
+        * ``":memory:"`` — not local.
+        * S3 / MotherDuck URIs — not local.
+        * ``file://`` URIs — local; unquote the path component.
+        * Windows drive-letter paths (``C:\\...``) — local; ``urlparse``
+          would otherwise mistake ``C`` for a URI scheme.
+        * Plain POSIX or relative paths — local.
+
+        Returns ``None`` for non-local paths so the caller can skip
+        recovery rather than acting on a URI that has no meaningful
+        ``.wal`` sidecar on the local filesystem.
+        """
+        raw = self._db_path
+        if raw == ":memory:":
+            return None
+        if self._is_s3_path(raw) or self._is_motherduck_path(raw):
+            return None
+
+        parsed = urlparse(raw)
+        scheme = parsed.scheme.lower()
+
+        # Windows drive letter: scheme is a single ASCII letter and the
+        # "netloc" is empty; treat the raw string as a local path.
+        if len(scheme) == 1 and scheme.isalpha():
+            return Path(raw)
+
+        if scheme == "file":
+            # file:// URI: the path component carries the filesystem
+            # path; unquote %-encoded bytes.
+            return Path(unquote(parsed.path))
+
+        if scheme == "":
+            return Path(raw)
+
+        return None
 
     def _sync_initialize(self) -> None:
         """Initialize the DuckDB connection and run pending schema migrations.

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -591,9 +591,30 @@ class DuckDBStore:
             return Path(raw)
 
         if scheme == "file":
-            # file:// URI: the path component carries the filesystem
-            # path; unquote %-encoded bytes.
-            return Path(unquote(parsed.path))
+            # file:// URI: combine authority (UNC host) + path.  Two
+            # edge cases matter:
+            #   * file://server/share/path → UNC; re-attach "//server"
+            #     in front of the path so the resulting Path points at
+            #     \\server\share\path on Windows (and stays harmless on
+            #     POSIX, where UNC is not a thing).
+            #   * file:///C:/path → parsed.path is "/C:/path".  Strip
+            #     the leading slash so Path("C:/path") resolves to the
+            #     Windows drive-letter form instead of a relative
+            #     "/C:/..." that no filesystem understands.
+            path_part = unquote(parsed.path)
+            netloc = parsed.netloc
+            if netloc:
+                return Path("//" + netloc + path_part)
+            # Strip the synthetic leading slash in front of a Windows
+            # drive letter (e.g. "/C:/foo" → "C:/foo").
+            if (
+                len(path_part) >= 3
+                and path_part[0] == "/"
+                and path_part[1].isalpha()
+                and path_part[2] == ":"
+            ):
+                path_part = path_part[1:]
+            return Path(path_part)
 
         if scheme == "":
             return Path(raw)

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -276,24 +276,48 @@ class DuckDBStore:
     def _rebuild_fts_index(self, conn: duckdb.DuckDBPyConnection) -> None:
         """Rebuild the full-text search index on ``entries.content``.
 
-        Explicitly drops the ``fts_main_entries`` schema with ``CASCADE``
-        before recreating via the FTS PRAGMA.  The drop+create is wrapped in
-        a single transaction so an interrupted rebuild cannot leave a partial
-        schema in the WAL.
+        Uses ``PRAGMA create_fts_index(..., overwrite=1)`` which atomically
+        drops and recreates the ``fts_main_entries`` schema inside the FTS
+        extension's own routine.  A ``CHECKPOINT`` is issued immediately
+        afterwards so the FTS DDL is flushed to the main database file rather
+        than lingering in the WAL.
+
+        This matters because DuckDB's WAL replay cannot always re-order FTS
+        schema drop/create DDL when the process is killed abruptly
+        (SIGKILL, OOM, Fly.io scale-to-zero hard-stop) before a checkpoint
+        runs.  Replay has been observed to fail with:
+
+            Cannot drop entry "fts_main_entries" because there are entries
+            that depend on it.
+
+        Checkpointing after each rebuild means the WAL never carries FTS
+        DDL across process boundaries, eliminating the replay hazard.  See
+        GitHub issue #349 for background.
         """
         if not self._fts_available:
             return
         try:
-            conn.execute("BEGIN TRANSACTION")
-            conn.execute("DROP SCHEMA IF EXISTS fts_main_entries CASCADE")
-            conn.execute("PRAGMA create_fts_index('entries', 'id', 'content')")
-            conn.execute("COMMIT")
+            # ``overwrite=1`` makes the PRAGMA idempotent — the FTS extension
+            # handles dropping any existing ``fts_main_entries`` schema
+            # internally, so we don't emit a separate DROP SCHEMA into the
+            # WAL.  Run outside an explicit BEGIN so the PRAGMA commits
+            # cleanly on its own; the immediate CHECKPOINT below flushes
+            # the resulting DDL out of the WAL.
+            conn.execute("PRAGMA create_fts_index('entries', 'id', 'content', overwrite=1)")
             logger.debug("FTS index rebuilt on entries.content")
         except duckdb.Error as exc:
-            with contextlib.suppress(duckdb.Error):
-                conn.execute("ROLLBACK")
             logger.warning("FTS index rebuild failed: %s", exc)
             self._fts_available = False
+            return
+
+        # Force a CHECKPOINT so the FTS schema DDL is persisted to the
+        # main database file.  If the process is killed before the next
+        # checkpoint, WAL replay will not have to re-apply FTS DDL —
+        # which is where we have seen ordering-related replay failures.
+        try:
+            conn.execute("CHECKPOINT")
+        except duckdb.Error as exc:  # pragma: no cover — best-effort
+            logger.debug("Post-FTS-rebuild CHECKPOINT skipped: %s", exc)
 
     def _setup_httpfs(self, conn: duckdb.DuckDBPyConnection) -> None:
         """Install and load the httpfs extension, then configure S3 credentials.
@@ -459,6 +483,72 @@ class DuckDBStore:
                 f"incompatible embeddings."
             )
 
+    def _recover_from_wal_replay_failure(self, exc: duckdb.Error) -> duckdb.DuckDBPyConnection:
+        """Recover from a WAL replay failure caused by FTS schema DDL.
+
+        Replay is known to fail for FTS-related DDL when the process was
+        killed between an FTS index rebuild and the subsequent checkpoint
+        (see issue #349).  Recovery moves the WAL file aside to a
+        timestamped backup so any uncommitted data is preserved for manual
+        inspection, then retries the connection.
+
+        Only local file paths are eligible for recovery; in-memory,
+        S3, and MotherDuck URIs re-raise the original error.
+
+        Returns
+        -------
+        duckdb.DuckDBPyConnection
+            A fresh connection to the database (now opened without WAL).
+
+        Raises
+        ------
+        duckdb.Error
+            Re-raised when the error is not WAL/FTS-related, when the path
+            is not a recoverable local file, or when no ``.wal`` sidecar
+            exists on disk.
+        """
+        exc_msg = str(exc)
+        if "fts_main_entries" not in exc_msg and "WAL" not in exc_msg:
+            raise exc
+
+        # Only attempt WAL recovery for local file paths.  Skip in-memory
+        # databases, S3, MotherDuck, and other URI schemes.
+        parsed = urlparse(self._db_path)
+        is_local_file = self._db_path != ":memory:" and parsed.scheme in ("", "file")
+        if not is_local_file:
+            raise exc
+
+        wal_path = Path(self._db_path + ".wal")
+        if not wal_path.exists():
+            raise exc
+
+        # Move the WAL aside with a timestamped suffix so operators can
+        # recover uncommitted data if needed.  Silently deleting the WAL
+        # (the previous behaviour) is unrecoverable and unfriendly.
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+        backup_path: Path | None = wal_path.with_suffix(f".wal.corrupt.{timestamp}")
+        try:
+            assert backup_path is not None
+            wal_path.rename(backup_path)
+        except OSError:
+            # Fall back to unlink if rename fails (e.g. cross-device).
+            logger.warning(
+                "Could not rename WAL to %s; deleting instead. Uncommitted data will be lost.",
+                backup_path,
+            )
+            wal_path.unlink()
+            backup_path = None
+
+        logger.warning(
+            "Database WAL appears corrupt (FTS-related): %s. "
+            "Moved WAL aside to %s and retrying — uncommitted data has "
+            "been preserved for manual recovery but will NOT be replayed. "
+            "The FTS index will be rebuilt from scratch during init.",
+            exc,
+            backup_path if backup_path is not None else "(deleted)",
+        )
+        return self._open_connection()
+
     def _sync_initialize(self) -> None:
         """Initialize the DuckDB connection and run pending schema migrations.
 
@@ -472,39 +562,19 @@ class DuckDBStore:
         initialization write path in a retry loop.
 
         If the database cannot be opened due to a corrupt WAL (e.g. from an
-        interrupted FTS index rebuild), the WAL file is deleted and the
-        connection is retried.  This is a last-resort recovery path —
-        uncommitted data in the WAL will be lost.
+        interrupted FTS index rebuild), the WAL is moved aside to a
+        timestamped backup file and the connection is retried.  The backup
+        preserves any uncommitted data for manual recovery — it is NOT
+        automatically replayed.  :meth:`_rebuild_fts_index` aggressively
+        checkpoints after each rebuild to minimise how often this path is
+        exercised (see issue #349).
         """
         import time
 
         try:
             conn = self._open_connection()
         except duckdb.Error as exc:
-            exc_msg = str(exc)
-            if "fts_main_entries" in exc_msg or "WAL" in exc_msg:
-                # Only attempt WAL recovery for local file paths.
-                # Skip in-memory databases, S3, MotherDuck, and other URI schemes.
-                parsed = urlparse(self._db_path)
-                is_local_file = self._db_path != ":memory:" and parsed.scheme in ("", "file")
-                if is_local_file:
-                    wal_path = Path(self._db_path + ".wal")
-                    if wal_path.exists():
-                        logger.warning(
-                            "Database WAL appears corrupt (FTS-related): %s. "
-                            "Deleting WAL file %s and retrying — "
-                            "uncommitted data may be lost.",
-                            exc,
-                            wal_path,
-                        )
-                        wal_path.unlink()
-                        conn = self._open_connection()
-                    else:
-                        raise
-                else:
-                    raise
-            else:
-                raise
+            conn = self._recover_from_wal_replay_failure(exc)
 
         # httpfs must be loaded before vss when using S3 storage.
         if self._is_s3_path(self._db_path):

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -762,6 +762,348 @@ class TestFeedSourceLiveness:
 
 
 # ---------------------------------------------------------------------------
+# WAL / FTS replay hardening (issue #349)
+# ---------------------------------------------------------------------------
+
+
+class TestWalFtsReplayHardening:
+    """Regression coverage for the FTS WAL-replay failure described in #349.
+
+    DuckDB's WAL replay has been observed to fail with
+    ``Cannot drop entry "fts_main_entries"`` when a process is killed
+    between an FTS index rebuild and the next checkpoint (e.g. Fly.io
+    scale-to-zero with SIGKILL).  The mitigations exercised here are:
+
+    1. ``_rebuild_fts_index`` issues a ``CHECKPOINT`` after each rebuild
+       so FTS DDL never lingers in the WAL across process boundaries.
+    2. The WAL recovery path preserves (rather than deletes) the WAL so
+       operators can manually inspect uncommitted data.
+    3. The rebuild PRAGMA uses ``overwrite=1`` — the FTS extension's own
+       atomic drop/create — instead of emitting a separate DROP SCHEMA.
+    """
+
+    async def test_wal_checkpointed_after_store(
+        self, deterministic_embedding_provider: object
+    ) -> None:
+        """After a write + FTS rebuild, the WAL file should be empty/absent.
+
+        The fix forces a ``CHECKPOINT`` after every FTS rebuild so the
+        rebuild's DDL is persisted to the main DB file rather than the WAL.
+        If the process is hard-killed between writes, there is no FTS DDL
+        in the WAL to mis-replay.
+        """
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "wal_check.db")
+            store = DuckDBStore(
+                db_path=db_path,
+                embedding_provider=deterministic_embedding_provider,
+                hybrid_search=True,
+            )
+            await store.initialize()
+            assert store._fts_available is True  # noqa: SLF001
+            await store.store(make_entry(content="hello world from distillery"))
+
+            wal_path = Path(db_path + ".wal")
+            # DuckDB may or may not delete the sidecar after CHECKPOINT,
+            # but it must not still contain unflushed FTS DDL.  An empty
+            # file or absent file satisfies the invariant.
+            if wal_path.exists():
+                assert wal_path.stat().st_size == 0, (
+                    f"WAL still has {wal_path.stat().st_size} bytes after "
+                    "CHECKPOINT; FTS DDL may linger across process death."
+                )
+            await store.close()
+
+    async def test_rebuild_fts_uses_overwrite_pragma(self, hybrid_store: DuckDBStore) -> None:
+        """The rebuild should use the FTS extension's atomic overwrite path.
+
+        Instead of emitting a manual ``DROP SCHEMA ... CASCADE`` +
+        ``PRAGMA create_fts_index`` (which puts ordering-sensitive DDL into
+        the WAL), the rebuild delegates the drop to the FTS extension via
+        ``overwrite=1``.  Verified here by passing a fake connection to
+        ``_rebuild_fts_index`` and capturing the SQL statements it emits.
+        """
+
+        class RecordingConn:
+            def __init__(self) -> None:
+                self.queries: list[str] = []
+
+            def execute(self, query: str, *args: object, **kwargs: object) -> object:
+                self.queries.append(query)
+                return self
+
+            def fetchone(self) -> tuple[object, ...] | None:
+                return None
+
+        spy_conn = RecordingConn()
+        hybrid_store._rebuild_fts_index(spy_conn)  # type: ignore[arg-type]  # noqa: SLF001
+        joined = "\n".join(spy_conn.queries)
+
+        assert "DROP SCHEMA" not in joined, (
+            "_rebuild_fts_index must not execute a manual DROP SCHEMA — #349."
+        )
+        assert "overwrite=1" in joined, (
+            "PRAGMA create_fts_index must use overwrite=1 so the drop/create "
+            "is handled atomically inside the FTS extension"
+        )
+        assert "CHECKPOINT" in joined, (
+            "_rebuild_fts_index must CHECKPOINT to flush FTS DDL out of the WAL"
+        )
+
+    async def test_recovery_preserves_wal_as_backup(
+        self, deterministic_embedding_provider: object
+    ) -> None:
+        """On FTS WAL replay failure, the WAL must be preserved (not deleted).
+
+        Simulates the failure by constructing a fake WAL file, then calls
+        the recovery helper directly with a synthetic FTS-related error.
+        The recovery must rename the WAL to a ``.corrupt.<ts>`` sidecar so
+        operators can inspect uncommitted data.
+        """
+        import tempfile
+        from pathlib import Path
+
+        import duckdb
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "recover.db")
+            # Create a live DB file so _open_connection can succeed after
+            # the WAL is moved aside.
+            conn = duckdb.connect(db_path)
+            conn.close()
+
+            # Plant a fake WAL file (content does not matter — the recovery
+            # helper only moves the file aside).
+            wal_path = Path(db_path + ".wal")
+            wal_path.write_bytes(b"pretend-wal-data")
+            assert wal_path.exists()
+
+            store = DuckDBStore(
+                db_path=db_path,
+                embedding_provider=deterministic_embedding_provider,
+                hybrid_search=False,  # FTS not required for recovery path itself
+            )
+            fake_error = duckdb.Error(
+                "Dependency Error: Failure while replaying WAL file: Cannot drop "
+                'entry "fts_main_entries" because there are entries that depend on it.'
+            )
+            recovered = store._recover_from_wal_replay_failure(fake_error)  # noqa: SLF001
+            try:
+                # Original WAL should no longer exist.
+                assert not wal_path.exists(), "WAL should have been moved aside"
+                # Exactly one backup sibling should exist.
+                backups = list(wal_path.parent.glob("*.wal.corrupt.*"))
+                assert len(backups) == 1, f"expected 1 backup, got {backups}"
+                # And the backup should contain the original WAL bytes.
+                assert backups[0].read_bytes() == b"pretend-wal-data"
+            finally:
+                recovered.close()
+
+    async def test_recovery_ignores_unrelated_errors(
+        self, deterministic_embedding_provider: object
+    ) -> None:
+        """Non-WAL/FTS errors should re-raise, not silently move WAL aside."""
+        import tempfile
+        from pathlib import Path
+
+        import duckdb
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "unrelated.db")
+            store = DuckDBStore(
+                db_path=db_path,
+                embedding_provider=deterministic_embedding_provider,
+            )
+            unrelated = duckdb.Error("some totally unrelated failure")
+            with pytest.raises(duckdb.Error, match="unrelated"):
+                store._recover_from_wal_replay_failure(unrelated)  # noqa: SLF001
+
+    async def test_reopen_after_many_writes_survives(
+        self, deterministic_embedding_provider: object
+    ) -> None:
+        """Reopening a file-backed DB after many FTS rebuilds must succeed.
+
+        Writes trigger ``_rebuild_fts_index`` on every call.  Before the
+        fix this left a trail of FTS DDL in the WAL; a subsequent open
+        could fail replay.  With the post-rebuild CHECKPOINT the WAL
+        stays clean and reopen is a simple read of the main file.
+        """
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "reopen.db")
+
+            # Session 1 — write a handful of entries, close cleanly.
+            s1 = DuckDBStore(
+                db_path=db_path,
+                embedding_provider=deterministic_embedding_provider,
+                hybrid_search=True,
+            )
+            await s1.initialize()
+            for i in range(5):
+                await s1.store(make_entry(content=f"entry number {i} talks about duckdb"))
+            await s1.close()
+
+            # Session 2 — same file, must open without WAL replay issues
+            # and find the previously-stored rows.
+            s2 = DuckDBStore(
+                db_path=db_path,
+                embedding_provider=deterministic_embedding_provider,
+                hybrid_search=True,
+            )
+            await s2.initialize()
+            try:
+                count = s2.connection.execute("SELECT COUNT(*) FROM entries").fetchone()
+                assert count is not None
+                assert count[0] == 5
+                # And FTS must still function after reopen.
+                results = s2._bm25_search("duckdb", limit=10)  # noqa: SLF001
+                assert len(results) >= 1
+            finally:
+                await s2.close()
+
+    def test_ungraceful_shutdown_survives_fts_replay(self) -> None:
+        """SIGKILL mid-write must NOT leave the DB unopenable.
+
+        This is the exact Fly.io scale-to-zero scenario from issue #349:
+        a producer process writes entries and is killed hard before any
+        close-time CHECKPOINT runs.  A subsequent open must succeed
+        without the ``Cannot drop entry "fts_main_entries"`` replay
+        error.
+
+        Implemented via subprocess so the hard-kill (``os.kill(..., SIGKILL)``)
+        does not affect the test runner.  Runs synchronously — subprocess
+        APIs are blocking — but the subprocess itself drives asyncio.
+        """
+        import os
+        import signal
+        import subprocess
+        import sys
+        import tempfile
+        import textwrap
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "sigkill.db")
+
+            # Writer subprocess: init store, write one entry, then SIGKILL
+            # itself before the normal close()/CHECKPOINT can run.
+            writer = textwrap.dedent(
+                f"""
+                import asyncio, os, signal, sys
+                from distillery.store.duckdb import DuckDBStore
+
+                class DetEmb:
+                    model_name = "test"
+                    dimensions = 4
+                    def embed(self, text):
+                        return [0.1, 0.2, 0.3, 0.4]
+                    def embed_batch(self, texts):
+                        return [self.embed(t) for t in texts]
+
+                async def main():
+                    store = DuckDBStore(
+                        db_path={db_path!r},
+                        embedding_provider=DetEmb(),
+                        hybrid_search=True,
+                    )
+                    await store.initialize()
+                    from distillery.models import (
+                        Entry, EntrySource, EntryStatus, EntryType,
+                    )
+                    import uuid
+                    from datetime import datetime, UTC
+                    entry = Entry(
+                        id=str(uuid.uuid4()),
+                        content="sigkill survivor entry",
+                        entry_type=EntryType.REFERENCE,
+                        source=EntrySource.CLAUDE_CODE,
+                        author="test",
+                        project=None,
+                        tags=[],
+                        status=EntryStatus.ACTIVE,
+                        metadata={{}},
+                        created_at=datetime.now(tz=UTC),
+                        updated_at=datetime.now(tz=UTC),
+                        version=1,
+                    )
+                    await store.store(entry)
+                    # DO NOT close.  SIGKILL ourselves — Fly.io scale-to-zero
+                    # hard-stop simulation.
+                    os.kill(os.getpid(), signal.SIGKILL)
+
+                asyncio.run(main())
+                """
+            )
+            # Use PYTHONPATH so the subprocess uses the same source tree.
+            env = os.environ.copy()
+            src_root = str(Path(__file__).resolve().parent.parent / "src")
+            env["PYTHONPATH"] = src_root + os.pathsep + env.get("PYTHONPATH", "")
+
+            proc = subprocess.run(
+                [sys.executable, "-c", writer],
+                env=env,
+                capture_output=True,
+                timeout=60,
+            )
+            # The writer should have been terminated by SIGKILL (exit code -9).
+            assert proc.returncode == -signal.SIGKILL or proc.returncode < 0, (
+                f"writer did not SIGKILL itself (rc={proc.returncode}); "
+                f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+            )
+
+            # Reader subprocess: open the same file; must not raise.
+            reader = textwrap.dedent(
+                f"""
+                import asyncio
+                from distillery.store.duckdb import DuckDBStore
+
+                class DetEmb:
+                    model_name = "test"
+                    dimensions = 4
+                    def embed(self, text):
+                        return [0.1, 0.2, 0.3, 0.4]
+                    def embed_batch(self, texts):
+                        return [self.embed(t) for t in texts]
+
+                async def main():
+                    store = DuckDBStore(
+                        db_path={db_path!r},
+                        embedding_provider=DetEmb(),
+                        hybrid_search=True,
+                    )
+                    await store.initialize()
+                    row = store.connection.execute(
+                        "SELECT COUNT(*) FROM entries"
+                    ).fetchone()
+                    print("COUNT=" + str(row[0]))
+                    await store.close()
+
+                asyncio.run(main())
+                """
+            )
+            r_proc = subprocess.run(
+                [sys.executable, "-c", reader],
+                env=env,
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+            assert r_proc.returncode == 0, (
+                f"reader failed to open DB after SIGKILL: rc={r_proc.returncode} "
+                f"stdout={r_proc.stdout!r} stderr={r_proc.stderr!r}"
+            )
+            # Count may be 0 (if write wasn't checkpointed) or 1 (if it was).
+            # Either outcome is acceptable; what matters is that the DB is
+            # openable at all — before the fix, it was not.
+            assert b"COUNT=" in r_proc.stdout
+
+
+# ---------------------------------------------------------------------------
 # Hybrid search (BM25 + vector RRF fusion with recency decay)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Every Fly.io cold start on `distillery-mcp-dev` triggered a WAL replay failure (`Cannot drop entry "fts_main_entries"`) because `_rebuild_fts_index` emitted manual `DROP SCHEMA ... CASCADE` + `PRAGMA create_fts_index` inside a transaction on every write, accumulating DDL in the WAL.
- Structural fix (three layers):
  1. `_rebuild_fts_index` now uses `PRAGMA create_fts_index(..., overwrite=1)` so the FTS extension owns the drop/create atomically — no manual DDL in the WAL.
  2. `CHECKPOINT` immediately after every FTS rebuild, so FTS DDL is flushed to the main DB file and never lingers across process boundaries.
  3. Recovery path moves the WAL aside to `.wal.corrupt.<ts>` rather than deleting it, so operators can inspect uncommitted data.

## Test plan
- [x] `ruff check src/ tests/`
- [x] `mypy --strict src/distillery/`
- [x] `pytest tests/test_duckdb_store.py` — 109 passed (includes new `TestWalFtsReplayHardening` with subprocess-based SIGKILL reproduction of the Fly.io cold-start sequence)
- [ ] Monitor staging cold-start logs after merge for absence of the FTS WAL warning

Fixes #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from abnormal database shutdowns and WAL/FTS replay failures.
  * Corrupted WAL sidecars are preserved by renaming to timestamped backups instead of being deleted.
  * Added a checkpoint immediately after index rebuilds to ensure FTS changes are flushed and improve reopen reliability.

* **Tests**
  * Added integration tests covering FTS rebuilds, WAL replay hardening, reopen-after-crash, and SIGKILL scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->