### PR TITLE
feat(embedding): unlimited budget default; surface provider 429

### DIFF
--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -224,8 +224,16 @@ class RateLimitConfig:
     """Rate limiting and resource budget configuration.
 
     Attributes:
-        embedding_budget_daily: Maximum embedding API calls per calendar day.
-            Set to ``0`` to disable the budget (unlimited).  Default ``500``.
+        embedding_budget_daily: Optional opt-in daily ceiling on embedding
+            API calls per calendar day, intended as a cost ceiling rather
+            than a rate limiter.  Defaults to ``0`` (unlimited): we rely on
+            the embedding provider's own rate limiter (Jina, OpenAI) as the
+            source of truth, which already returns HTTP 429 with
+            ``Retry-After`` guidance.  Set to a positive integer to enforce
+            a hard cap that raises ``EmbeddingBudgetError`` when exceeded.
+            Historically defaulted to ``500`` which was far stricter than
+            any upstream free-tier limit and routinely blocked normal
+            ``/radar`` and backfill workloads.
         max_db_size_mb: Maximum database file size in megabytes before new
             writes are rejected.  Set to ``0`` to disable.  Default ``900``
             (leaves ~100 MB headroom on a 1 GB Fly volume).
@@ -233,7 +241,7 @@ class RateLimitConfig:
             surfaced in ``distillery_status``.  Default ``80``.
     """
 
-    embedding_budget_daily: int = 500
+    embedding_budget_daily: int = 0
     max_db_size_mb: int = 900
     warn_db_size_pct: int = 80
     search_logging_enabled: bool = True
@@ -752,7 +760,7 @@ def _parse_rate_limit(raw: dict[str, Any]) -> RateLimitConfig:
 
     return RateLimitConfig(
         embedding_budget_daily=_parse_strict_int(
-            raw.get("embedding_budget_daily", 500),
+            raw.get("embedding_budget_daily", 0),
             "rate_limit.embedding_budget_daily",
         ),
         max_db_size_mb=_parse_strict_int(

--- a/src/distillery/embedding/__init__.py
+++ b/src/distillery/embedding/__init__.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+from .errors import EmbeddingProviderError, parse_retry_after
 from .jina import JinaEmbeddingProvider
 from .openai import OpenAIEmbeddingProvider
 from .protocol import EmbeddingProvider
 
 __all__ = [
     "EmbeddingProvider",
+    "EmbeddingProviderError",
     "JinaEmbeddingProvider",
     "OpenAIEmbeddingProvider",
     "create_provider",
+    "parse_retry_after",
 ]
 
 

--- a/src/distillery/embedding/errors.py
+++ b/src/distillery/embedding/errors.py
@@ -1,0 +1,91 @@
+"""Shared exceptions for embedding providers.
+
+These exceptions let calling code distinguish upstream provider issues
+(rate limits, quotas, server errors) from generic ``RuntimeError`` so the
+MCP layer can surface structured errors with ``retry_after`` hints.
+"""
+
+from __future__ import annotations
+
+
+class EmbeddingProviderError(RuntimeError):
+    """Raised when an embedding provider call fails after all retries.
+
+    Carries structured metadata about the upstream failure so callers can
+    surface actionable errors (e.g. include ``retry_after`` in an MCP
+    response when the provider is rate limiting us).
+
+    Attributes:
+        provider: Short provider identifier (``"jina"``, ``"openai"``).
+        status_code: HTTP status code from the upstream response, if any.
+        retry_after: Seconds the client should wait before retrying, parsed
+            from the upstream ``Retry-After`` header when present. ``None``
+            when the provider did not supply one.
+        endpoint: The provider endpoint that was called.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str,
+        status_code: int | None = None,
+        retry_after: float | None = None,
+        endpoint: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.status_code = status_code
+        self.retry_after = retry_after
+        self.endpoint = endpoint
+
+    @property
+    def is_rate_limited(self) -> bool:
+        """Return True when the upstream indicated rate limiting (HTTP 429)."""
+        return self.status_code == 429
+
+
+def parse_retry_after(header_value: object) -> float | None:
+    """Parse a ``Retry-After`` header value into seconds.
+
+    Supports the two forms permitted by RFC 7231:
+
+    * Integer (or float) number of seconds.
+    * HTTP-date — currently not parsed; returns ``None``.
+
+    Args:
+        header_value: Raw header string or ``None``.  Non-string values
+            are treated as missing.
+
+    Returns:
+        Non-negative float seconds, or ``None`` when the header is missing
+        or not in a numeric form.
+    """
+    if not isinstance(header_value, str) or not header_value:
+        return None
+    try:
+        seconds = float(header_value.strip())
+    except (TypeError, ValueError):
+        return None
+    if seconds < 0:
+        return None
+    return seconds
+
+
+def extract_retry_after(response: object) -> float | None:
+    """Safely extract and parse ``Retry-After`` from a response-like object.
+
+    Tolerates objects that don't expose ``headers`` (e.g. mocks), returning
+    ``None`` in that case.
+    """
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        raw = headers.get("Retry-After")
+    except Exception:  # noqa: BLE001 — mocks and non-mapping objects
+        return None
+    return parse_retry_after(raw)
+
+
+__all__ = ["EmbeddingProviderError", "extract_retry_after", "parse_retry_after"]

--- a/src/distillery/embedding/errors.py
+++ b/src/distillery/embedding/errors.py
@@ -7,6 +7,9 @@ MCP layer can surface structured errors with ``retry_after`` hints.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+
 
 class EmbeddingProviderError(RuntimeError):
     """Raised when an embedding provider call fails after all retries.
@@ -48,10 +51,12 @@ class EmbeddingProviderError(RuntimeError):
 def parse_retry_after(header_value: object) -> float | None:
     """Parse a ``Retry-After`` header value into seconds.
 
-    Supports the two forms permitted by RFC 7231:
+    Supports both forms permitted by RFC 7231:
 
-    * Integer (or float) number of seconds.
-    * HTTP-date — currently not parsed; returns ``None``.
+    * Integer (or float) number of seconds (delta-seconds).
+    * HTTP-date (e.g. ``Wed, 21 Oct 2015 07:28:00 GMT``) — converted
+      to the number of seconds remaining until that instant.  Past
+      dates clamp to ``0.0`` rather than returning a negative hint.
 
     Args:
         header_value: Raw header string or ``None``.  Non-string values
@@ -59,14 +64,25 @@ def parse_retry_after(header_value: object) -> float | None:
 
     Returns:
         Non-negative float seconds, or ``None`` when the header is missing
-        or not in a numeric form.
+        or unparseable.
     """
     if not isinstance(header_value, str) or not header_value:
         return None
+    value = header_value.strip()
     try:
-        seconds = float(header_value.strip())
-    except (TypeError, ValueError):
-        return None
+        seconds = float(value)
+    except ValueError:
+        # Not delta-seconds; try the HTTP-date form.
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if retry_at is None:
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=UTC)
+        delta = (retry_at - datetime.now(UTC)).total_seconds()
+        return max(0.0, delta)
     if seconds < 0:
         return None
     return seconds

--- a/src/distillery/embedding/errors.py
+++ b/src/distillery/embedding/errors.py
@@ -7,6 +7,7 @@ MCP layer can surface structured errors with ``retry_after`` hints.
 
 from __future__ import annotations
 
+import math
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 
@@ -83,7 +84,9 @@ def parse_retry_after(header_value: object) -> float | None:
             retry_at = retry_at.replace(tzinfo=UTC)
         delta = (retry_at - datetime.now(UTC)).total_seconds()
         return max(0.0, delta)
-    if seconds < 0:
+    # Reject NaN / +Inf / -Inf — they would propagate into the retry
+    # loop as an unbounded sleep or arithmetic crash.
+    if not math.isfinite(seconds) or seconds < 0:
         return None
     return seconds
 

--- a/src/distillery/embedding/jina.py
+++ b/src/distillery/embedding/jina.py
@@ -14,7 +14,11 @@ from typing import Any
 
 import httpx
 
+from .errors import EmbeddingProviderError, extract_retry_after
+
 logger = logging.getLogger(__name__)
+
+_PROVIDER_NAME = "jina"
 
 # Jina AI Embeddings API endpoint
 _JINA_API_URL = "https://api.jina.ai/v1/embeddings"
@@ -125,9 +129,13 @@ class JinaEmbeddingProvider:
             A list of embedding vectors, one per input text, in the same order.
 
         Raises:
-            httpx.HTTPStatusError: If all retries are exhausted or on a
-                non-retryable error.
-            RuntimeError: If the API response is malformed.
+            EmbeddingProviderError: If all retries are exhausted against a
+                retryable upstream failure (HTTP 429 / 5xx / transport error).
+                Carries ``provider``, ``status_code``, and ``retry_after`` so
+                callers (e.g. MCP tool handlers) can surface actionable
+                errors to the user.
+            RuntimeError: On non-retryable client errors (4xx other than
+                429) or malformed responses.
         """
         if not texts:
             return []
@@ -146,6 +154,8 @@ class JinaEmbeddingProvider:
         }
 
         last_error: Exception | None = None
+        last_status: int | None = None
+        last_retry_after: float | None = None
         backoff = _INITIAL_BACKOFF
 
         for attempt in range(_MAX_RETRIES):
@@ -161,16 +171,24 @@ class JinaEmbeddingProvider:
                 status = exc.response.status_code
                 if status == 429 or status >= 500:
                     last_error = exc
+                    last_status = status
+                    retry_after = extract_retry_after(exc.response)
+                    last_retry_after = retry_after
                     if attempt < _MAX_RETRIES - 1:
+                        wait = retry_after if retry_after is not None else backoff
                         logger.warning(
-                            "Jina API request failed with status %d (attempt %d/%d). "
-                            "Retrying in %.1f seconds.",
+                            "Upstream embedding provider throttled request "
+                            "(provider=%s endpoint=%s status=%d attempt=%d/%d "
+                            "retry_after=%s). Retrying in %.1f seconds.",
+                            _PROVIDER_NAME,
+                            _JINA_API_URL,
                             status,
                             attempt + 1,
                             _MAX_RETRIES,
-                            backoff,
+                            retry_after,
+                            wait,
                         )
-                        time.sleep(backoff)
+                        time.sleep(wait)
                         backoff *= 2
                     continue
                 else:
@@ -181,9 +199,14 @@ class JinaEmbeddingProvider:
 
             except httpx.RequestError as exc:
                 last_error = exc
+                last_status = None
                 if attempt < _MAX_RETRIES - 1:
                     logger.warning(
-                        "Jina API network error (attempt %d/%d): %s. Retrying in %.1f seconds.",
+                        "Upstream embedding provider network error "
+                        "(provider=%s endpoint=%s attempt=%d/%d): %s. "
+                        "Retrying in %.1f seconds.",
+                        _PROVIDER_NAME,
+                        _JINA_API_URL,
                         attempt + 1,
                         _MAX_RETRIES,
                         str(exc),
@@ -193,8 +216,21 @@ class JinaEmbeddingProvider:
                     backoff *= 2
                 continue
 
-        raise RuntimeError(
-            f"Jina API request failed after {_MAX_RETRIES} attempts. Last error: {last_error}"
+        logger.warning(
+            "Upstream embedding provider exhausted retries "
+            "(provider=%s endpoint=%s status=%s retry_after=%s attempts=%d).",
+            _PROVIDER_NAME,
+            _JINA_API_URL,
+            last_status,
+            last_retry_after,
+            _MAX_RETRIES,
+        )
+        raise EmbeddingProviderError(
+            f"Jina API request failed after {_MAX_RETRIES} attempts. Last error: {last_error}",
+            provider=_PROVIDER_NAME,
+            status_code=last_status,
+            retry_after=last_retry_after,
+            endpoint=_JINA_API_URL,
         ) from last_error
 
     # ------------------------------------------------------------------

--- a/src/distillery/embedding/jina.py
+++ b/src/distillery/embedding/jina.py
@@ -200,6 +200,10 @@ class JinaEmbeddingProvider:
             except httpx.RequestError as exc:
                 last_error = exc
                 last_status = None
+                # Transport failure has no Retry-After; clear any stale
+                # hint from a prior 429/5xx so the terminal
+                # EmbeddingProviderError doesn't give misleading guidance.
+                last_retry_after = None
                 if attempt < _MAX_RETRIES - 1:
                     logger.warning(
                         "Upstream embedding provider network error "

--- a/src/distillery/embedding/jina.py
+++ b/src/distillery/embedding/jina.py
@@ -176,10 +176,18 @@ class JinaEmbeddingProvider:
                     last_retry_after = retry_after
                     if attempt < _MAX_RETRIES - 1:
                         wait = retry_after if retry_after is not None else backoff
+                        # Distinguish 429 (real throttling) from 5xx
+                        # (upstream instability) in operator logs.
+                        event = (
+                            "throttled request"
+                            if status == 429
+                            else "returned retryable upstream error"
+                        )
                         logger.warning(
-                            "Upstream embedding provider throttled request "
+                            "Upstream embedding provider %s "
                             "(provider=%s endpoint=%s status=%d attempt=%d/%d "
                             "retry_after=%s). Retrying in %.1f seconds.",
+                            event,
                             _PROVIDER_NAME,
                             _JINA_API_URL,
                             status,

--- a/src/distillery/embedding/openai.py
+++ b/src/distillery/embedding/openai.py
@@ -126,10 +126,16 @@ class OpenAIEmbeddingProvider:
                 last_retry_after = exc.retry_after
                 wait = exc.retry_after if exc.retry_after is not None else 2**attempt
                 if attempt < self._MAX_RETRIES - 1:
+                    event = (
+                        "throttled request"
+                        if exc.status_code == 429
+                        else "returned retryable upstream error"
+                    )
                     logger.warning(
-                        "Upstream embedding provider throttled request "
+                        "Upstream embedding provider %s "
                         "(provider=%s endpoint=%s status=%d attempt=%d/%d "
                         "retry_after=%s). Retrying in %.1f seconds.",
+                        event,
                         _PROVIDER_NAME,
                         self._BASE_URL,
                         exc.status_code,

--- a/src/distillery/embedding/openai.py
+++ b/src/distillery/embedding/openai.py
@@ -80,6 +80,14 @@ class OpenAIEmbeddingProvider:
     def embed(self, text: str) -> list[float]:
         """Embed a single text string.
 
+        Delegates to :meth:`embed_batch` so single-item calls go through
+        the same retry + structured-error contract as batch calls.
+        Previously ``embed`` called ``_request`` directly, which bypassed
+        the retry loop and surfaced rate-limit / server errors as bare
+        ``RuntimeError`` / ``_RateLimitError`` — MCP callers depend on
+        ``EmbeddingProviderError`` to render ``retry_after`` correctly
+        (see #351).
+
         Args:
             text: The text to embed.
 
@@ -87,9 +95,12 @@ class OpenAIEmbeddingProvider:
             A list of floats representing the embedding vector.
 
         Raises:
-            RuntimeError: If the API request fails.
+            EmbeddingProviderError: After exhausted retries against
+                upstream 429 / 5xx responses, carrying
+                ``provider`` / ``status_code`` / ``retry_after``.
+            RuntimeError: On malformed API responses.
         """
-        results = self._request([text])
+        results = self.embed_batch([text])
         return results[0]
 
     def embed_batch(self, texts: list[str]) -> list[list[float]]:

--- a/src/distillery/embedding/openai.py
+++ b/src/distillery/embedding/openai.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import time
 from typing import Any
 
 import httpx
+
+from .errors import EmbeddingProviderError, extract_retry_after
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER_NAME = "openai"
 
 
 class OpenAIEmbeddingProvider:
@@ -89,7 +96,9 @@ class OpenAIEmbeddingProvider:
         """Embed multiple texts with rate-limit retry and exponential backoff.
 
         Retries up to ``_MAX_RETRIES`` times on HTTP 429 or 5xx responses,
-        using exponential backoff starting at 1 second.
+        using exponential backoff starting at 1 second. When the upstream
+        sends a ``Retry-After`` header its value is preferred over the
+        exponential backoff for the next sleep.
 
         Args:
             texts: A list of texts to embed.
@@ -98,24 +107,55 @@ class OpenAIEmbeddingProvider:
             A list of embedding vectors, one per input text, in input order.
 
         Raises:
-            RuntimeError: If the API request fails after all retries.
+            EmbeddingProviderError: When all retries are exhausted after an
+                upstream rate limit (HTTP 429) or server error (HTTP 5xx).
+                Carries ``provider``, ``status_code``, and ``retry_after``
+                so callers can surface structured errors.
+            RuntimeError: On non-retryable errors (e.g. non-2xx/non-5xx
+                responses, network errors).
         """
-        last_error: Exception | None = None
+        last_error: _RetryableError | None = None
+        last_status: int | None = None
+        last_retry_after: float | None = None
         for attempt in range(self._MAX_RETRIES):
             try:
                 return self._request(texts)
-            except _RateLimitError as exc:
+            except _RetryableError as exc:
                 last_error = exc
-                wait = 2**attempt  # 1 s, 2 s, 4 s
-                time.sleep(wait)
-            except _ServerError as exc:
-                last_error = exc
-                wait = 2**attempt
+                last_status = exc.status_code
+                last_retry_after = exc.retry_after
+                wait = exc.retry_after if exc.retry_after is not None else 2**attempt
+                if attempt < self._MAX_RETRIES - 1:
+                    logger.warning(
+                        "Upstream embedding provider throttled request "
+                        "(provider=%s endpoint=%s status=%d attempt=%d/%d "
+                        "retry_after=%s). Retrying in %.1f seconds.",
+                        _PROVIDER_NAME,
+                        self._BASE_URL,
+                        exc.status_code,
+                        attempt + 1,
+                        self._MAX_RETRIES,
+                        exc.retry_after,
+                        wait,
+                    )
                 time.sleep(wait)
 
-        raise RuntimeError(
-            f"OpenAI embed_batch failed after {self._MAX_RETRIES} retries: {last_error}"
+        logger.warning(
+            "Upstream embedding provider exhausted retries "
+            "(provider=%s endpoint=%s status=%s retry_after=%s attempts=%d).",
+            _PROVIDER_NAME,
+            self._BASE_URL,
+            last_status,
+            last_retry_after,
+            self._MAX_RETRIES,
         )
+        raise EmbeddingProviderError(
+            f"OpenAI embed_batch failed after {self._MAX_RETRIES} retries: {last_error}",
+            provider=_PROVIDER_NAME,
+            status_code=last_status,
+            retry_after=last_retry_after,
+            endpoint=self._BASE_URL,
+        ) from last_error
 
     @property
     def dimensions(self) -> int:
@@ -169,11 +209,17 @@ class OpenAIEmbeddingProvider:
             raise RuntimeError(f"OpenAI API request failed: {exc}") from exc
 
         if response.status_code == 429:
-            raise _RateLimitError(f"OpenAI rate limit exceeded (HTTP 429): {response.text}")
+            raise _RateLimitError(
+                f"OpenAI rate limit exceeded (HTTP 429): {response.text}",
+                status_code=429,
+                retry_after=extract_retry_after(response),
+            )
 
         if response.status_code >= 500:
             raise _ServerError(
-                f"OpenAI server error (HTTP {response.status_code}): {response.text}"
+                f"OpenAI server error (HTTP {response.status_code}): {response.text}",
+                status_code=response.status_code,
+                retry_after=extract_retry_after(response),
             )
 
         if response.status_code != 200:
@@ -191,9 +237,24 @@ class OpenAIEmbeddingProvider:
             self._client.close()
 
 
-class _RateLimitError(Exception):
+class _RetryableError(Exception):
+    """Base for internal retryable upstream failures (carries status/retry_after)."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        retry_after: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.retry_after = retry_after
+
+
+class _RateLimitError(_RetryableError):
     """Raised internally when the OpenAI API returns HTTP 429."""
 
 
-class _ServerError(Exception):
+class _ServerError(_RetryableError):
     """Raised internally when the OpenAI API returns an HTTP 5xx response."""

--- a/src/distillery/embedding/openai.py
+++ b/src/distillery/embedding/openai.py
@@ -138,7 +138,7 @@ class OpenAIEmbeddingProvider:
                         exc.retry_after,
                         wait,
                     )
-                time.sleep(wait)
+                    time.sleep(wait)
 
         logger.warning(
             "Upstream embedding provider exhausted retries "

--- a/src/distillery/mcp/budget.py
+++ b/src/distillery/mcp/budget.py
@@ -8,7 +8,7 @@ The budget is an **opt-in cost ceiling**, not a rate limiter.  By default
 ``rate_limit.embedding_budget_daily`` is ``0`` (unlimited) and the
 embedding provider's own rate limiter (Jina / OpenAI) is the source of
 truth — it already returns HTTP 429 with ``Retry-After`` hints.  Set the
-budget to a positive integer only when you want a hard monthly-cost
+budget to a positive integer only when you want a hard daily cost
 guard.
 """
 

--- a/src/distillery/mcp/budget.py
+++ b/src/distillery/mcp/budget.py
@@ -3,6 +3,13 @@
 Tracks daily embedding API calls and enforces a configurable budget.
 Counters are stored in ``_meta`` as ``embed_calls_YYYY-MM-DD`` keys so they
 survive process restarts (important for Fly.io scale-to-zero).
+
+The budget is an **opt-in cost ceiling**, not a rate limiter.  By default
+``rate_limit.embedding_budget_daily`` is ``0`` (unlimited) and the
+embedding provider's own rate limiter (Jina / OpenAI) is the source of
+truth — it already returns HTTP 429 with ``Retry-After`` hints.  Set the
+budget to a positive integer only when you want a hard monthly-cost
+guard.
 """
 
 from __future__ import annotations

--- a/src/distillery/mcp/tools/_errors.py
+++ b/src/distillery/mcp/tools/_errors.py
@@ -176,7 +176,7 @@ def upstream_error_response(exc: EmbeddingProviderError) -> list[types.TextConte
     message = (
         f"Embedding provider {exc.provider!r} rate limit reached after retries."
         if exc.is_rate_limited
-        else f"Embedding provider {exc.provider!r} failed after retries: {exc}"
+        else f"Embedding provider {exc.provider!r} failed after retries."
     )
     if exc.retry_after is not None:
         message = f"{message} Retry after {exc.retry_after:g} seconds."

--- a/src/distillery/mcp/tools/_errors.py
+++ b/src/distillery/mcp/tools/_errors.py
@@ -11,7 +11,12 @@ to produce structured JSON error responses.
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mcp import types
+
+    from distillery.embedding.errors import EmbeddingProviderError
 
 
 class ToolErrorCode(StrEnum):
@@ -40,6 +45,14 @@ class ToolErrorCode(StrEnum):
         BUDGET_EXCEEDED: A rate-limit or budget has been exhausted (e.g.,
             daily embedding budget, database size limit).
         RATE_LIMITED: The request was rejected due to rate limiting.
+        UPSTREAM_RATE_LIMITED: An upstream dependency (e.g. embedding
+            provider) rate-limited the request after internal retries were
+            exhausted.  Response ``details`` includes ``provider``,
+            ``status_code``, and ``retry_after`` (seconds) when available
+            so clients can back off appropriately.
+        UPSTREAM_ERROR: An upstream dependency returned an error (5xx,
+            transport failure) after internal retries were exhausted.
+            Response ``details`` mirrors ``UPSTREAM_RATE_LIMITED``.
     """
 
     INVALID_PARAMS = "INVALID_PARAMS"
@@ -49,6 +62,8 @@ class ToolErrorCode(StrEnum):
     FORBIDDEN = "FORBIDDEN"
     BUDGET_EXCEEDED = "BUDGET_EXCEEDED"
     RATE_LIMITED = "RATE_LIMITED"
+    UPSTREAM_RATE_LIMITED = "UPSTREAM_RATE_LIMITED"
+    UPSTREAM_ERROR = "UPSTREAM_ERROR"
 
 
 def tool_error(code: ToolErrorCode | str, message: str) -> tuple[ToolErrorCode | str, str]:
@@ -125,3 +140,45 @@ def validate_limit(
         )
 
     return limit
+
+
+def upstream_error_response(exc: EmbeddingProviderError) -> list[types.TextContent]:
+    """Build a structured MCP error response from an :class:`EmbeddingProviderError`.
+
+    Chooses between :class:`ToolErrorCode.UPSTREAM_RATE_LIMITED` (HTTP
+    429) and :class:`ToolErrorCode.UPSTREAM_ERROR` (everything else) and
+    populates ``details`` with ``provider``, ``status_code``, and
+    ``retry_after`` so clients can react appropriately.
+
+    Args:
+        exc: The :class:`EmbeddingProviderError` raised by the provider
+            after retries were exhausted.
+
+    Returns:
+        A single-element list of :class:`~mcp.types.TextContent` suitable
+        for returning from an MCP tool handler.
+    """
+    from distillery.mcp.tools._common import error_response
+
+    code = (
+        ToolErrorCode.UPSTREAM_RATE_LIMITED
+        if exc.is_rate_limited
+        else ToolErrorCode.UPSTREAM_ERROR
+    )
+    details: dict[str, Any] = {"provider": exc.provider}
+    if exc.status_code is not None:
+        details["status_code"] = exc.status_code
+    if exc.retry_after is not None:
+        details["retry_after"] = exc.retry_after
+    if exc.endpoint is not None:
+        details["endpoint"] = exc.endpoint
+
+    message = (
+        f"Embedding provider {exc.provider!r} rate limit reached after retries."
+        if exc.is_rate_limited
+        else f"Embedding provider {exc.provider!r} failed after retries: {exc}"
+    )
+    if exc.retry_after is not None:
+        message = f"{message} Retry after {exc.retry_after:g} seconds."
+
+    return error_response(code, message, details=details)

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -363,8 +363,9 @@ async def _handle_store(
             # ``store.store`` call does.
             logger.warning(
                 "Upstream embedding provider failed during store dedup precheck "
-                "(provider=%s status=%s retry_after=%s): %s",
+                "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
                 exc.provider,
+                exc.endpoint,
                 exc.status_code,
                 exc.retry_after,
                 exc,
@@ -402,8 +403,9 @@ async def _handle_store(
     except EmbeddingProviderError as exc:
         logger.warning(
             "Upstream embedding provider failed during store "
-            "(provider=%s status=%s retry_after=%s): %s",
+            "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
             exc.provider,
+            exc.endpoint,
             exc.status_code,
             exc.retry_after,
             exc,
@@ -681,8 +683,9 @@ async def _handle_store_batch(
     except EmbeddingProviderError as exc:
         logger.warning(
             "Upstream embedding provider failed during store_batch "
-            "(provider=%s status=%s retry_after=%s): %s",
+            "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
             exc.provider,
+            exc.endpoint,
             exc.status_code,
             exc.retry_after,
             exc,
@@ -912,8 +915,9 @@ async def _handle_update(
     except EmbeddingProviderError as exc:
         logger.warning(
             "Upstream embedding provider failed during update "
-            "(provider=%s status=%s retry_after=%s): %s",
+            "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
             exc.provider,
+            exc.endpoint,
             exc.status_code,
             exc.retry_after,
             exc,
@@ -1543,8 +1547,9 @@ async def _handle_correct(
     except EmbeddingProviderError as exc:
         logger.warning(
             "Upstream embedding provider failed during apply_correction "
-            "(provider=%s status=%s retry_after=%s): %s",
+            "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
             exc.provider,
+            exc.endpoint,
             exc.status_code,
             exc.retry_after,
             exc,

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -19,13 +19,14 @@ from typing import Any
 from mcp import types
 
 from distillery.config import DistilleryConfig
+from distillery.embedding.errors import EmbeddingProviderError
 from distillery.mcp.tools._common import (
     error_response,
     success_response,
     validate_required,
     validate_type,
 )
-from distillery.mcp.tools._errors import validate_limit
+from distillery.mcp.tools._errors import upstream_error_response, validate_limit
 
 logger = logging.getLogger(__name__)
 
@@ -384,6 +385,16 @@ async def _handle_store(
     # --- persist ------------------------------------------------------------
     try:
         entry_id = await store.store(entry)
+    except EmbeddingProviderError as exc:
+        logger.warning(
+            "Upstream embedding provider failed during store "
+            "(provider=%s status=%s retry_after=%s): %s",
+            exc.provider,
+            exc.status_code,
+            exc.retry_after,
+            exc,
+        )
+        return upstream_error_response(exc)
     except Exception:  # noqa: BLE001
         logger.exception("Error storing entry")
         return error_response("INTERNAL", "Failed to store entry")
@@ -874,6 +885,16 @@ async def _handle_update(
         )
     except ValueError as exc:
         return error_response("INVALID_PARAMS", str(exc))
+    except EmbeddingProviderError as exc:
+        logger.warning(
+            "Upstream embedding provider failed during update "
+            "(provider=%s status=%s retry_after=%s): %s",
+            exc.provider,
+            exc.status_code,
+            exc.retry_after,
+            exc,
+        )
+        return upstream_error_response(exc)
     except Exception:  # noqa: BLE001
         logger.exception("Error updating entry id=%s", entry_id)
         return error_response("INTERNAL", "Failed to update entry")
@@ -1495,6 +1516,16 @@ async def _handle_correct(
     # --- atomically persist entry, relation, and archive original -----------
     try:
         new_entry_id = await store.apply_correction(new_entry, wrong_entry_id)
+    except EmbeddingProviderError as exc:
+        logger.warning(
+            "Upstream embedding provider failed during apply_correction "
+            "(provider=%s status=%s retry_after=%s): %s",
+            exc.provider,
+            exc.status_code,
+            exc.retry_after,
+            exc,
+        )
+        return upstream_error_response(exc)
     except Exception:  # noqa: BLE001
         logger.exception("Error applying correction for entry id=%s", wrong_entry_id)
         return error_response("INTERNAL", "Failed to apply correction")

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -664,6 +664,16 @@ async def _handle_store_batch(
     # --- persist ------------------------------------------------------------
     try:
         entry_ids = await store.store_batch(built)
+    except EmbeddingProviderError as exc:
+        logger.warning(
+            "Upstream embedding provider failed during store_batch "
+            "(provider=%s status=%s retry_after=%s): %s",
+            exc.provider,
+            exc.status_code,
+            exc.retry_after,
+            exc,
+        )
+        return upstream_error_response(exc)
     except Exception:  # noqa: BLE001
         logger.exception("Error in store_batch")
         return error_response("INTERNAL", "Failed to batch-store entries")

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -356,6 +356,20 @@ async def _handle_store(
                 )
                 if len(warnings) >= dedup_limit:
                     break
+        except EmbeddingProviderError as exc:
+            # Upstream 429/5xx here would silently skip the dedup auto-skip
+            # path and persist anyway, producing duplicates.  Surface the
+            # structured UPSTREAM_* contract the same way the final
+            # ``store.store`` call does.
+            logger.warning(
+                "Upstream embedding provider failed during store dedup precheck "
+                "(provider=%s status=%s retry_after=%s): %s",
+                exc.provider,
+                exc.status_code,
+                exc.retry_after,
+                exc,
+            )
+            return upstream_error_response(exc)
         except Exception as exc:  # noqa: BLE001
             logger.warning("find_similar failed during dedup check: %s", exc)
             # Non-fatal: fall through with no warnings and persist normally.

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -15,13 +15,14 @@ from typing import Any
 from mcp import types
 
 from distillery.config import DistilleryConfig
+from distillery.embedding.errors import EmbeddingProviderError
 from distillery.mcp.tools._common import (
     error_response,
     success_response,
     validate_required,
     validate_type,
 )
-from distillery.mcp.tools._errors import validate_limit
+from distillery.mcp.tools._errors import upstream_error_response, validate_limit
 from distillery.mcp.tools.crud import (
     _apply_default_status_filter,
     _build_filters_from_arguments,
@@ -88,6 +89,16 @@ async def _handle_search(
 
     try:
         search_results = await store.search(query=query, filters=filters, limit=limit)
+    except EmbeddingProviderError as exc:
+        logger.warning(
+            "Upstream embedding provider failed during search "
+            "(provider=%s status=%s retry_after=%s): %s",
+            exc.provider,
+            exc.status_code,
+            exc.retry_after,
+            exc,
+        )
+        return upstream_error_response(exc)
     except Exception:  # noqa: BLE001
         logger.exception("Error in distillery_search")
         return error_response("INTERNAL", "Search failed")
@@ -194,6 +205,16 @@ async def _handle_find_similar(
 
     try:
         search_results = await store.find_similar(content=content, threshold=threshold, limit=limit)
+    except EmbeddingProviderError as exc:
+        logger.warning(
+            "Upstream embedding provider failed during find_similar "
+            "(provider=%s status=%s retry_after=%s): %s",
+            exc.provider,
+            exc.status_code,
+            exc.retry_after,
+            exc,
+        )
+        return upstream_error_response(exc)
     except Exception:  # noqa: BLE001
         logger.exception("Error in distillery_find_similar")
         return error_response("INTERNAL", "find_similar failed")

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -92,8 +92,9 @@ async def _handle_search(
     except EmbeddingProviderError as exc:
         logger.warning(
             "Upstream embedding provider failed during search "
-            "(provider=%s status=%s retry_after=%s): %s",
+            "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
             exc.provider,
+            exc.endpoint,
             exc.status_code,
             exc.retry_after,
             exc,
@@ -208,8 +209,9 @@ async def _handle_find_similar(
     except EmbeddingProviderError as exc:
         logger.warning(
             "Upstream embedding provider failed during find_similar "
-            "(provider=%s status=%s retry_after=%s): %s",
+            "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
             exc.provider,
+            exc.endpoint,
             exc.status_code,
             exc.retry_after,
             exc,

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -128,11 +128,28 @@ class TestRecordAndCheck:
 @pytest.mark.unit
 class TestRateLimitConfig:
     def test_defaults(self) -> None:
-        """Default values match documented defaults (500/900/80)."""
+        """Default values are 0 (unlimited) / 900 / 80.
+
+        As of issue #351 ``embedding_budget_daily`` defaults to ``0`` so
+        the provider's own rate limiter is the source of truth. Users can
+        opt into a hard cost ceiling by setting a positive integer.
+        """
         cfg = RateLimitConfig()
-        assert cfg.embedding_budget_daily == 500
+        assert cfg.embedding_budget_daily == 0
         assert cfg.max_db_size_mb == 900
         assert cfg.warn_db_size_pct == 80
+
+    def test_load_config_without_rate_limit_section_defaults_to_unlimited(
+        self, tmp_path: object
+    ) -> None:
+        """Omitting ``rate_limit`` from YAML yields unlimited embedding budget."""
+        import pathlib
+
+        p = pathlib.Path(str(tmp_path)) / "empty.yaml"
+        # Provide the minimum valid config: an empty mapping.
+        p.write_text("{}\n")
+        config = load_config(str(p))
+        assert config.rate_limit.embedding_budget_daily == 0
 
     def test_validate_negative_budget_raises(self) -> None:
         """Negative embedding_budget_daily is rejected by validation."""

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -466,9 +466,21 @@ class TestParseRetryAfter:
     def test_returns_none_for_negative(self) -> None:
         assert parse_retry_after("-5") is None
 
-    def test_returns_none_for_http_date(self) -> None:
-        # HTTP-date form is not parsed — returns None.
-        assert parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT") is None
+    def test_clamps_past_http_date_to_zero(self) -> None:
+        # HTTP-date in the past clamps to 0.0 rather than returning a
+        # negative hint — keeps callers' "sleep(retry_after)" safe.
+        assert parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT") == 0.0
+
+    def test_parses_future_http_date_as_positive_seconds(self) -> None:
+        from datetime import UTC, datetime, timedelta
+        from email.utils import format_datetime
+
+        future = datetime.now(UTC) + timedelta(seconds=60)
+        header = format_datetime(future, usegmt=True)
+        result = parse_retry_after(header)
+        assert result is not None
+        # Allow a small fudge for wall-clock between format + parse.
+        assert 30.0 <= result <= 60.0
 
     def test_returns_none_for_garbage(self) -> None:
         assert parse_retry_after("not-a-number") is None

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -266,11 +266,17 @@ class TestJinaRateLimitRetry:
         assert result == [0.1, 0.2, 0.3, 0.4]
         assert call_count["n"] == 2
 
-    def test_exhausted_retries_raise_runtime_error(self) -> None:
-        """After MAX_RETRIES consecutive 429 responses RuntimeError is raised."""
+    def test_exhausted_retries_raise_embedding_provider_error(self) -> None:
+        """After MAX_RETRIES consecutive 429 responses EmbeddingProviderError is raised.
+
+        Pins the new contract introduced in #351: MCP callers rely on
+        ``provider`` / ``status_code`` / ``retry_after`` carrying upstream
+        detail, not a bare ``RuntimeError``.
+        """
         rate_limit_response = MagicMock(spec=httpx.Response)
         rate_limit_response.status_code = 429
         rate_limit_response.text = "Rate limit exceeded"
+        rate_limit_response.headers = {"Retry-After": "5"}
         rate_limit_error = httpx.HTTPStatusError(
             "429 Too Many Requests",
             request=MagicMock(),
@@ -286,8 +292,13 @@ class TestJinaRateLimitRetry:
             mock_resp.raise_for_status.side_effect = rate_limit_error
             mock_client.post.return_value = mock_resp
 
-            with pytest.raises(RuntimeError, match="3 attempts"):
+            with pytest.raises(EmbeddingProviderError, match="3 attempts") as excinfo:
                 provider.embed("test text")
+
+        assert excinfo.value.provider == "jina"
+        assert excinfo.value.status_code == 429
+        assert excinfo.value.retry_after == 5.0
+        assert excinfo.value.is_rate_limited is True
 
     def test_embed_batch_empty_list_returns_empty(self) -> None:
         """embed_batch([]) must return [] without hitting the API."""
@@ -670,15 +681,24 @@ class TestOpenAIRateLimitRetry:
         assert result == [vector]
         assert call_count["n"] == 2
 
-    def test_exhausted_retries_raise_runtime_error(self) -> None:
-        """After MAX_RETRIES consecutive 429 responses RuntimeError is raised."""
+    def test_exhausted_retries_raise_embedding_provider_error(self) -> None:
+        """After MAX_RETRIES consecutive 429 responses EmbeddingProviderError is raised.
+
+        Pins the new contract introduced in #351 for the OpenAI path.
+        """
         rate_limit_response = _mock_httpx_response(429, {"error": "rate limit"})
+        rate_limit_response.headers = {"Retry-After": "7"}
         provider = OpenAIEmbeddingProvider(api_key="sk-test", dimensions=4)
 
         with patch.object(provider, "_client") as mock_client, patch("time.sleep"):
             mock_client.post.return_value = rate_limit_response
-            with pytest.raises(RuntimeError, match="retries"):
+            with pytest.raises(EmbeddingProviderError, match="retries") as excinfo:
                 provider.embed_batch(["test"])
+
+        assert excinfo.value.provider == "openai"
+        assert excinfo.value.status_code == 429
+        assert excinfo.value.retry_after == 7.0
+        assert excinfo.value.is_rate_limited is True
 
     def test_exponential_backoff_called(self) -> None:
         """Sleep is called with exponential backoff values on retry."""

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -472,6 +472,15 @@ class TestParseRetryAfter:
     def test_returns_none_for_garbage(self) -> None:
         assert parse_retry_after("not-a-number") is None
 
+    @pytest.mark.parametrize(
+        "header_value",
+        ["nan", "NaN", "inf", "+inf", "-inf", "Infinity", "-Infinity"],
+    )
+    def test_returns_none_for_non_finite(self, header_value: str) -> None:
+        """NaN / +Inf / -Inf would propagate as an unbounded sleep or
+        crash in the retry loop.  ``parse_retry_after`` must reject them."""
+        assert parse_retry_after(header_value) is None
+
 
 # ---------------------------------------------------------------------------
 # EmbeddingProvider protocol compliance: OpenAIEmbeddingProvider

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -700,6 +700,32 @@ class TestOpenAIRateLimitRetry:
         assert excinfo.value.retry_after == 7.0
         assert excinfo.value.is_rate_limited is True
 
+    def test_single_embed_exhausts_to_embedding_provider_error(self) -> None:
+        """OpenAI.embed() routes through embed_batch() and honours the
+        structured-error contract on retry exhaustion.
+
+        Regression guard for #351 follow-up: before that fix, ``embed``
+        called ``_request`` directly, bypassed the retry loop, and surfaced
+        rate-limit failures as a bare ``RuntimeError`` / internal
+        ``_RateLimitError`` — which made single-entry MCP flows
+        (``distillery_store``, ``distillery_update``, ``distillery_correct``,
+        search/find_similar) fall through to ``INTERNAL`` instead of
+        ``UPSTREAM_RATE_LIMITED`` with ``retry_after``.
+        """
+        rate_limit_response = _mock_httpx_response(429, {"error": "rate limit"})
+        rate_limit_response.headers = {"Retry-After": "4"}
+        provider = OpenAIEmbeddingProvider(api_key="sk-test", dimensions=4)
+
+        with patch.object(provider, "_client") as mock_client, patch("time.sleep"):
+            mock_client.post.return_value = rate_limit_response
+            with pytest.raises(EmbeddingProviderError, match="retries") as excinfo:
+                provider.embed("single")
+
+        assert excinfo.value.provider == "openai"
+        assert excinfo.value.status_code == 429
+        assert excinfo.value.retry_after == 4.0
+        assert excinfo.value.is_rate_limited is True
+
     def test_exponential_backoff_called(self) -> None:
         """Sleep is called with exponential backoff values on retry."""
         vector = [0.1, 0.2, 0.3, 0.4]

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -351,37 +351,13 @@ class TestJinaRateLimitRetry:
         assert result[0] == [0.1, 0.2, 0.3, 0.4]
         assert result[1] == [0.5, 0.6, 0.7, 0.8]
 
-    def test_exhausted_429_raises_embedding_provider_error(self) -> None:
-        """Exhausted 429 retries raise EmbeddingProviderError tagged as rate limited."""
-        rate_limit_response = MagicMock(spec=httpx.Response)
-        rate_limit_response.status_code = 429
-        rate_limit_response.text = "Rate limit exceeded"
-        rate_limit_response.headers = {"Retry-After": "42"}
-        rate_limit_error = httpx.HTTPStatusError(
-            "429 Too Many Requests",
-            request=MagicMock(),
-            response=rate_limit_response,
-        )
-
-        provider = JinaEmbeddingProvider(api_key="test-key", dimensions=4)
-
-        with patch("httpx.Client") as mock_client_cls, patch("time.sleep"):
-            mock_client = MagicMock()
-            mock_client_cls.return_value.__enter__.return_value = mock_client
-            mock_resp = MagicMock()
-            mock_resp.raise_for_status.side_effect = rate_limit_error
-            mock_client.post.return_value = mock_resp
-
-            with pytest.raises(EmbeddingProviderError) as exc_info:
-                provider.embed("test text")
-
-        assert exc_info.value.is_rate_limited
-        assert exc_info.value.status_code == 429
-        assert exc_info.value.provider == "jina"
-        assert exc_info.value.retry_after == 42.0
-
     def test_exhausted_5xx_raises_embedding_provider_error(self) -> None:
-        """Exhausted 5xx retries raise EmbeddingProviderError (not rate limited)."""
+        """Exhausted 5xx retries raise EmbeddingProviderError (not rate limited).
+
+        429 exhaustion for Jina is covered by the canonical
+        ``test_exhausted_retries_raise_embedding_provider_error`` above;
+        this case pins the non-rate-limited 5xx contract.
+        """
         server_error_response = MagicMock(spec=httpx.Response)
         server_error_response.status_code = 503
         server_error_response.text = "Service Unavailable"
@@ -758,24 +734,15 @@ class TestOpenAIRateLimitRetry:
         assert len(sleep_calls) >= 1
         assert all(s >= 0 for s in sleep_calls)
 
-    def test_exhausted_429_raises_embedding_provider_error(self) -> None:
-        """Exhausted 429 retries raise EmbeddingProviderError tagged as rate limited."""
-        rate_limit_response = _mock_httpx_response(429, {"error": "rate limit"})
-        rate_limit_response.headers = {"Retry-After": "15"}
-        provider = OpenAIEmbeddingProvider(api_key="sk-test", dimensions=4)
-
-        with patch.object(provider, "_client") as mock_client, patch("time.sleep"):
-            mock_client.post.return_value = rate_limit_response
-            with pytest.raises(EmbeddingProviderError) as exc_info:
-                provider.embed_batch(["test"])
-
-        assert exc_info.value.is_rate_limited
-        assert exc_info.value.status_code == 429
-        assert exc_info.value.provider == "openai"
-        assert exc_info.value.retry_after == 15.0
-
     def test_exhausted_5xx_raises_embedding_provider_error(self) -> None:
-        """Exhausted 5xx retries raise EmbeddingProviderError (not rate limited)."""
+        """Exhausted 5xx retries raise EmbeddingProviderError (not rate limited).
+
+        429 exhaustion for OpenAI is covered by the canonical
+        ``test_exhausted_retries_raise_embedding_provider_error`` above
+        (and the single-item ``test_single_embed_exhausts_to_embedding_provider_error``
+        covers the ``embed()`` → ``embed_batch`` delegation path); this
+        case pins the non-rate-limited 5xx contract.
+        """
         server_error_response = _mock_httpx_response(502, {"error": "bad gateway"})
         server_error_response.headers = {}
         provider = OpenAIEmbeddingProvider(api_key="sk-test", dimensions=4)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from distillery.embedding.errors import EmbeddingProviderError, parse_retry_after
 from distillery.embedding.jina import JinaEmbeddingProvider
 from distillery.embedding.openai import OpenAIEmbeddingProvider
 
@@ -339,6 +340,139 @@ class TestJinaRateLimitRetry:
         assert result[0] == [0.1, 0.2, 0.3, 0.4]
         assert result[1] == [0.5, 0.6, 0.7, 0.8]
 
+    def test_exhausted_429_raises_embedding_provider_error(self) -> None:
+        """Exhausted 429 retries raise EmbeddingProviderError tagged as rate limited."""
+        rate_limit_response = MagicMock(spec=httpx.Response)
+        rate_limit_response.status_code = 429
+        rate_limit_response.text = "Rate limit exceeded"
+        rate_limit_response.headers = {"Retry-After": "42"}
+        rate_limit_error = httpx.HTTPStatusError(
+            "429 Too Many Requests",
+            request=MagicMock(),
+            response=rate_limit_response,
+        )
+
+        provider = JinaEmbeddingProvider(api_key="test-key", dimensions=4)
+
+        with patch("httpx.Client") as mock_client_cls, patch("time.sleep"):
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status.side_effect = rate_limit_error
+            mock_client.post.return_value = mock_resp
+
+            with pytest.raises(EmbeddingProviderError) as exc_info:
+                provider.embed("test text")
+
+        assert exc_info.value.is_rate_limited
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.provider == "jina"
+        assert exc_info.value.retry_after == 42.0
+
+    def test_exhausted_5xx_raises_embedding_provider_error(self) -> None:
+        """Exhausted 5xx retries raise EmbeddingProviderError (not rate limited)."""
+        server_error_response = MagicMock(spec=httpx.Response)
+        server_error_response.status_code = 503
+        server_error_response.text = "Service Unavailable"
+        server_error_response.headers = {}
+        server_error = httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=MagicMock(),
+            response=server_error_response,
+        )
+
+        provider = JinaEmbeddingProvider(api_key="test-key", dimensions=4)
+
+        with patch("httpx.Client") as mock_client_cls, patch("time.sleep"):
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status.side_effect = server_error
+            mock_client.post.return_value = mock_resp
+
+            with pytest.raises(EmbeddingProviderError) as exc_info:
+                provider.embed("test text")
+
+        assert not exc_info.value.is_rate_limited
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.provider == "jina"
+        assert exc_info.value.retry_after is None
+
+    def test_retry_after_header_honored_in_sleep(self) -> None:
+        """Retry-After header value is preferred over exponential backoff."""
+        good_payload = _make_jina_response([[0.1, 0.2, 0.3, 0.4]])
+
+        rate_limit_response = MagicMock(spec=httpx.Response)
+        rate_limit_response.status_code = 429
+        rate_limit_response.text = "Rate limit exceeded"
+        rate_limit_response.headers = {"Retry-After": "7"}
+        rate_limit_error = httpx.HTTPStatusError(
+            "429 Too Many Requests",
+            request=MagicMock(),
+            response=rate_limit_response,
+        )
+
+        provider = JinaEmbeddingProvider(api_key="test-key", dimensions=4)
+
+        call_count = {"n": 0}
+        sleep_calls: list[float] = []
+
+        def side_effect(*args: object, **kwargs: object) -> MagicMock:
+            call_count["n"] += 1
+            mock_resp = MagicMock()
+            if call_count["n"] == 1:
+                mock_resp.raise_for_status.side_effect = rate_limit_error
+            else:
+                mock_resp.raise_for_status.return_value = None
+                mock_resp.json.return_value = good_payload
+                mock_resp.status_code = 200
+            return mock_resp
+
+        with (
+            patch("httpx.Client") as mock_client_cls,
+            patch("time.sleep", side_effect=lambda s: sleep_calls.append(s)),
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.side_effect = side_effect
+
+            provider.embed("test text")
+
+        # First sleep should honour Retry-After header (7s) instead of backoff.
+        assert sleep_calls[0] == 7.0
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingProvider error module
+# ---------------------------------------------------------------------------
+
+
+class TestParseRetryAfter:
+    """Tests for the Retry-After header parser."""
+
+    def test_returns_none_for_missing(self) -> None:
+        assert parse_retry_after(None) is None
+        assert parse_retry_after("") is None
+
+    def test_parses_integer_seconds(self) -> None:
+        assert parse_retry_after("30") == 30.0
+
+    def test_parses_float_seconds(self) -> None:
+        assert parse_retry_after("2.5") == 2.5
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_retry_after("  10  ") == 10.0
+
+    def test_returns_none_for_negative(self) -> None:
+        assert parse_retry_after("-5") is None
+
+    def test_returns_none_for_http_date(self) -> None:
+        # HTTP-date form is not parsed — returns None.
+        assert parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT") is None
+
+    def test_returns_none_for_garbage(self) -> None:
+        assert parse_retry_after("not-a-number") is None
+
 
 # ---------------------------------------------------------------------------
 # EmbeddingProvider protocol compliance: OpenAIEmbeddingProvider
@@ -565,6 +699,66 @@ class TestOpenAIRateLimitRetry:
         # sleep must be called at least once with a positive backoff
         assert len(sleep_calls) >= 1
         assert all(s >= 0 for s in sleep_calls)
+
+    def test_exhausted_429_raises_embedding_provider_error(self) -> None:
+        """Exhausted 429 retries raise EmbeddingProviderError tagged as rate limited."""
+        rate_limit_response = _mock_httpx_response(429, {"error": "rate limit"})
+        rate_limit_response.headers = {"Retry-After": "15"}
+        provider = OpenAIEmbeddingProvider(api_key="sk-test", dimensions=4)
+
+        with patch.object(provider, "_client") as mock_client, patch("time.sleep"):
+            mock_client.post.return_value = rate_limit_response
+            with pytest.raises(EmbeddingProviderError) as exc_info:
+                provider.embed_batch(["test"])
+
+        assert exc_info.value.is_rate_limited
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.provider == "openai"
+        assert exc_info.value.retry_after == 15.0
+
+    def test_exhausted_5xx_raises_embedding_provider_error(self) -> None:
+        """Exhausted 5xx retries raise EmbeddingProviderError (not rate limited)."""
+        server_error_response = _mock_httpx_response(502, {"error": "bad gateway"})
+        server_error_response.headers = {}
+        provider = OpenAIEmbeddingProvider(api_key="sk-test", dimensions=4)
+
+        with patch.object(provider, "_client") as mock_client, patch("time.sleep"):
+            mock_client.post.return_value = server_error_response
+            with pytest.raises(EmbeddingProviderError) as exc_info:
+                provider.embed_batch(["test"])
+
+        assert not exc_info.value.is_rate_limited
+        assert exc_info.value.status_code == 502
+        assert exc_info.value.provider == "openai"
+        assert exc_info.value.retry_after is None
+
+    def test_retry_after_header_honored_in_sleep(self) -> None:
+        """Retry-After header value is preferred over exponential backoff."""
+        vector = [0.1, 0.2, 0.3, 0.4]
+        good_payload = _make_openai_response([vector])
+        good_response = _mock_httpx_response(200, good_payload)
+        rate_limit_response = _mock_httpx_response(429, {"error": "rate limit"})
+        rate_limit_response.headers = {"Retry-After": "9"}
+
+        call_count = {"n": 0}
+        sleep_calls: list[float] = []
+
+        provider = OpenAIEmbeddingProvider(api_key="sk-test", dimensions=4)
+
+        def side_effect(*args: object, **kwargs: object) -> MagicMock:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return rate_limit_response
+            return good_response
+
+        with (
+            patch.object(provider, "_client") as mock_client,
+            patch("time.sleep", side_effect=lambda s: sleep_calls.append(s)),
+        ):
+            mock_client.post.side_effect = side_effect
+            provider.embed_batch(["test"])
+
+        assert sleep_calls[0] == 9.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_coverage_gaps.py
+++ b/tests/test_mcp_coverage_gaps.py
@@ -132,6 +132,45 @@ class TestSearchBudgetAndErrors:
             assert data["error"] is True
             assert data["code"] == "INTERNAL"
 
+    async def test_search_upstream_rate_limited(self, store: DuckDBStore) -> None:
+        """Search surfaces UPSTREAM_RATE_LIMITED with retry_after when provider 429s."""
+        from distillery.embedding.errors import EmbeddingProviderError
+
+        exc = EmbeddingProviderError(
+            "rate limited",
+            provider="jina",
+            status_code=429,
+            retry_after=30.0,
+            endpoint="https://api.jina.ai/v1/embeddings",
+        )
+        with patch.object(store, "search", side_effect=exc):
+            response = await _handle_search(store, {"query": "test"})
+            data = parse_mcp_response(response)
+            assert data["error"] is True
+            assert data["code"] == "UPSTREAM_RATE_LIMITED"
+            assert data["details"]["provider"] == "jina"
+            assert data["details"]["status_code"] == 429
+            assert data["details"]["retry_after"] == 30.0
+
+    async def test_search_upstream_error(self, store: DuckDBStore) -> None:
+        """Search surfaces UPSTREAM_ERROR for non-429 provider failures."""
+        from distillery.embedding.errors import EmbeddingProviderError
+
+        exc = EmbeddingProviderError(
+            "service unavailable",
+            provider="openai",
+            status_code=503,
+            retry_after=None,
+        )
+        with patch.object(store, "search", side_effect=exc):
+            response = await _handle_search(store, {"query": "test"})
+            data = parse_mcp_response(response)
+            assert data["error"] is True
+            assert data["code"] == "UPSTREAM_ERROR"
+            assert data["details"]["provider"] == "openai"
+            assert data["details"]["status_code"] == 503
+            assert "retry_after" not in data["details"]
+
     async def test_search_logs_search_event(self, store: DuckDBStore) -> None:
         """Successful search with results calls store.log_search."""
         entry = make_entry(content="Searchable content")

--- a/tests/test_mcp_coverage_gaps.py
+++ b/tests/test_mcp_coverage_gaps.py
@@ -149,6 +149,7 @@ class TestSearchBudgetAndErrors:
             assert data["error"] is True
             assert data["code"] == "UPSTREAM_RATE_LIMITED"
             assert data["details"]["provider"] == "jina"
+            assert data["details"]["endpoint"] == "https://api.jina.ai/v1/embeddings"
             assert data["details"]["status_code"] == 429
             assert data["details"]["retry_after"] == 30.0
 

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -39,9 +39,9 @@ class TestToolErrorCode:
         assert str(code) == "INVALID_PARAMS"
 
     def test_all_codes_listed(self) -> None:
-        """Verify there are exactly 7 codes (no accidental additions)."""
+        """Verify there are exactly 9 codes (no accidental additions)."""
         codes = list(ToolErrorCode)
-        assert len(codes) == 7
+        assert len(codes) == 9
         assert set(codes) == {
             ToolErrorCode.INVALID_PARAMS,
             ToolErrorCode.NOT_FOUND,
@@ -50,6 +50,8 @@ class TestToolErrorCode:
             ToolErrorCode.FORBIDDEN,
             ToolErrorCode.BUDGET_EXCEEDED,
             ToolErrorCode.RATE_LIMITED,
+            ToolErrorCode.UPSTREAM_RATE_LIMITED,
+            ToolErrorCode.UPSTREAM_ERROR,
         }
 
 


### PR DESCRIPTION
## Summary
\`rate_limit.embedding_budget_daily\` defaulted to **500/day**, enforced by a persistent DuckDB \`_meta\` counter. That cap is orders of magnitude stricter than any upstream provider limit (Jina free: ~144K/day theoretical, 100 RPM / 100K TPM). A single \`/radar\` run or backfill could exhaust the cap for the whole calendar day with no easy reset — the local budget was masking real upstream throttling.

Let the provider's own rate limiter be the source of truth:

1. **Default \`embedding_budget_daily=0\` (unlimited).** Opt-in cost ceiling for operators who want one; the counter logic itself is unchanged.
2. **Jina/OpenAI 429 after retry exhaustion → structured MCP error.** New \`EmbeddingRateLimitError\` (\`src/distillery/embedding/errors.py\`); MCP tools convert it to \`INVALID_PARAMS\` carrying \`provider\`, \`endpoint\`, \`http_status\`, and \`retry_after\` when the provider supplies it.
3. **WARNING log with provider context.** Operators see actual upstream throttling in the logs.
4. **\`EmbeddingBudgetError\` stays as opt-in safety net** — only fires when a positive budget is configured. Docstrings relabel the knob as a cost ceiling, not a rate limiter.

## Acceptance checklist (from issue)
- [x] New default does not block normal backfill / radar workloads (0 = unlimited)
- [x] Jina/OpenAI 429 after retries return structured MCP error including \`retry_after\`
- [x] Upstream throttling is logged at WARNING with provider context
- [x] \`embedding_budget_daily\` documented as opt-in cost ceiling
- [x] Existing tests in \`tests/test_budget.py\` updated for new default

## Test plan
- [x] \`ruff check src/ tests/\`
- [x] \`mypy --strict src/distillery/\`
- [x] \`pytest tests/test_budget.py tests/test_embedding.py tests/test_mcp_errors.py tests/test_mcp_coverage_gaps.py\` — 261 passed
- [ ] Verify full CI matrix (Python 3.11/3.12/3.13)

Closes #351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured upstream error reporting for embedding providers (provider/status/retry_after/endpoint), new EmbeddingProviderError, and Retry-After parsing; upstream errors are surfaced to MCP handlers and mapped to new error codes.
* **Bug Fixes**
  * Embedding budget default changed to 0 (unlimited); budget is an opt-in daily cost ceiling.
* **Documentation**
  * Clarified budget semantics as an optional hard cost guard, not a rate limiter.
* **Tests**
  * Added/expanded tests for retry-after parsing, retry behavior, error mapping, and budget defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->