### PR TITLE
fix(store): roll back aborted transactions; surface query failures in status

### DIFF
--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -357,6 +357,19 @@ async def _handle_store(
             )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
+        except Exception:  # noqa: BLE001
+            # Any non-budget failure here (e.g. TransactionContext aborted on a
+            # shared connection — see issue #363) would otherwise propagate as
+            # a raw DuckDB message.  Roll back the connection and return a
+            # sanitised INTERNAL response so clients see a stable contract.
+            logger.exception("Embedding budget check failed")
+            rollback = getattr(store, "rollback", None)
+            if callable(rollback):
+                try:
+                    await rollback()
+                except Exception:  # noqa: BLE001
+                    logger.debug("post-budget rollback skipped", exc_info=True)
+            return error_response("INTERNAL", "Failed to check embedding budget")
 
     # --- parse verification ---------------------------------------------------
     verification_val = VerificationStatus.UNVERIFIED
@@ -771,6 +784,15 @@ async def _handle_store_batch(
             )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
+        except Exception:  # noqa: BLE001
+            logger.exception("Embedding budget check failed (store_batch)")
+            rollback = getattr(store, "rollback", None)
+            if callable(rollback):
+                try:
+                    await rollback()
+                except Exception:  # noqa: BLE001
+                    logger.debug("post-budget rollback skipped", exc_info=True)
+            return error_response("INTERNAL", "Failed to check embedding budget")
 
     # --- persist ------------------------------------------------------------
     try:
@@ -1627,6 +1649,15 @@ async def _handle_correct(
             record_and_check(store.connection, cfg.rate_limit.embedding_budget_daily, count=1)
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
+        except Exception:  # noqa: BLE001
+            logger.exception("Embedding budget check failed (correct)")
+            rollback = getattr(store, "rollback", None)
+            if callable(rollback):
+                try:
+                    await rollback()
+                except Exception:  # noqa: BLE001
+                    logger.debug("post-budget rollback skipped", exc_info=True)
+            return error_response("INTERNAL", "Failed to check embedding budget")
 
     # --- atomically persist entry, relation, and archive original -----------
     try:

--- a/src/distillery/mcp/tools/meta.py
+++ b/src/distillery/mcp/tools/meta.py
@@ -84,17 +84,19 @@ async def _handle_status(
     # Use the async protocol contract rather than poking at the DuckDB-specific
     # ``store.connection`` — keeps this handler backend-agnostic and prevents
     # synchronous DB I/O on the async request path.
+    #
+    # Client-visible error strings are stable generic codes (not raw exception
+    # text) so a durable unqueryable-DB state surfaces as ``degraded`` without
+    # leaking DuckDB internals / filesystem paths / query fragments to the
+    # caller.  The full exception is logged server-side for operators.
     entry_count: int | None = None
     count_error: str | None = None
     try:
         entry_count = await store.count_entries(filters=None)
-    except Exception as exc:  # noqa: BLE001
-        # Surface the failure: a durable unqueryable-DB state (see issue #363
-        # follow-up) otherwise shows up as a silent ``null`` entry_count,
-        # masking the outage behind an ``"ok"`` status.
-        count_error = f"{type(exc).__name__}: {exc}"
-        degraded_reasons.append(f"count_entries: {count_error}")
-        logger.warning("distillery_status: count_entries failed: %s", count_error)
+    except Exception:  # noqa: BLE001
+        count_error = "entry_count_unavailable"
+        degraded_reasons.append(count_error)
+        logger.exception("distillery_status: count_entries failed")
 
     db_size = _db_size_bytes(config)
     store_info: dict[str, Any] = {
@@ -116,11 +118,11 @@ async def _handle_status(
     try:
         sources = await store.list_feed_sources()
         feed_summary["source_count"] = len(sources)
-    except Exception as exc:  # noqa: BLE001
-        feed_error = f"{type(exc).__name__}: {exc}"
+    except Exception:  # noqa: BLE001
+        feed_error = "feed_sources_unavailable"
         feed_summary["error"] = feed_error
-        degraded_reasons.append(f"list_feed_sources: {feed_error}")
-        logger.warning("distillery_status: list_feed_sources failed: %s", feed_error)
+        degraded_reasons.append(feed_error)
+        logger.exception("distillery_status: list_feed_sources failed")
 
     with contextlib.suppress(Exception):
         raw_audit = await store.get_metadata("webhook_audit:poll")
@@ -139,15 +141,23 @@ async def _handle_status(
     # ``"ok"`` status with silently-null counts.
     probe_fn = getattr(store, "probe_readiness", None)
     if callable(probe_fn):
+        raw_ready_error: str | None = None
         try:
-            ready, ready_error = await probe_fn()
+            ready, raw_ready_error = await probe_fn()
         except Exception as exc:  # noqa: BLE001
-            ready, ready_error = False, f"{type(exc).__name__}: {exc}"
+            ready = False
+            raw_ready_error = f"{type(exc).__name__}: {exc}"
         payload["store_ready"] = ready
         if not ready:
-            payload["store_ready_error"] = ready_error
-            if ready_error:
-                degraded_reasons.append(f"readiness_probe: {ready_error}")
+            # Log the raw probe error server-side; expose only the stable
+            # generic code to clients.
+            if raw_ready_error:
+                logger.warning(
+                    "distillery_status: readiness probe failed: %s", raw_ready_error
+                )
+            stable_code = "readiness_probe_failed"
+            payload["store_ready_error"] = stable_code
+            degraded_reasons.append(stable_code)
 
     if degraded_reasons:
         payload["status"] = "degraded"

--- a/src/distillery/mcp/tools/meta.py
+++ b/src/distillery/mcp/tools/meta.py
@@ -70,6 +70,8 @@ async def _handle_status(
     """
     from distillery import __build_sha__, __version__
 
+    degraded_reasons: list[str] = []
+
     payload: dict[str, Any] = {
         "status": "ok",
         "version": __version__,
@@ -83,16 +85,24 @@ async def _handle_status(
     # ``store.connection`` — keeps this handler backend-agnostic and prevents
     # synchronous DB I/O on the async request path.
     entry_count: int | None = None
+    count_error: str | None = None
     try:
         entry_count = await store.count_entries(filters=None)
-    except Exception:  # noqa: BLE001
-        logger.debug("distillery_status: count_entries failed", exc_info=True)
+    except Exception as exc:  # noqa: BLE001
+        # Surface the failure: a durable unqueryable-DB state (see issue #363
+        # follow-up) otherwise shows up as a silent ``null`` entry_count,
+        # masking the outage behind an ``"ok"`` status.
+        count_error = f"{type(exc).__name__}: {exc}"
+        degraded_reasons.append(f"count_entries: {count_error}")
+        logger.warning("distillery_status: count_entries failed: %s", count_error)
 
     db_size = _db_size_bytes(config)
     store_info: dict[str, Any] = {
         "entry_count": entry_count,
         "db_size_bytes": db_size,
     }
+    if count_error is not None:
+        store_info["entry_count_error"] = count_error
     payload["store"] = store_info
 
     # --- embedding provider --------------------------------------------------
@@ -102,11 +112,15 @@ async def _handle_status(
 
     # --- feed poll summary (optional, best-effort) ---------------------------
     feed_summary: dict[str, Any] = {"source_count": 0, "last_poll_at": None}
+    feed_error: str | None = None
     try:
         sources = await store.list_feed_sources()
         feed_summary["source_count"] = len(sources)
-    except Exception:  # noqa: BLE001
-        logger.debug("distillery_status: list_feed_sources failed", exc_info=True)
+    except Exception as exc:  # noqa: BLE001
+        feed_error = f"{type(exc).__name__}: {exc}"
+        feed_summary["error"] = feed_error
+        degraded_reasons.append(f"list_feed_sources: {feed_error}")
+        logger.warning("distillery_status: list_feed_sources failed: %s", feed_error)
 
     with contextlib.suppress(Exception):
         raw_audit = await store.get_metadata("webhook_audit:poll")
@@ -118,6 +132,26 @@ async def _handle_status(
             except (TypeError, ValueError):
                 pass
     payload["last_feed_poll"] = feed_summary
+
+    # --- readiness probe (issue #363 follow-up) -----------------------------
+    # Actively probe that the store can answer a trivial query so operators
+    # see durable "DB file mounts but queries fail" states instead of an
+    # ``"ok"`` status with silently-null counts.
+    probe_fn = getattr(store, "probe_readiness", None)
+    if callable(probe_fn):
+        try:
+            ready, ready_error = await probe_fn()
+        except Exception as exc:  # noqa: BLE001
+            ready, ready_error = False, f"{type(exc).__name__}: {exc}"
+        payload["store_ready"] = ready
+        if not ready:
+            payload["store_ready_error"] = ready_error
+            if ready_error:
+                degraded_reasons.append(f"readiness_probe: {ready_error}")
+
+    if degraded_reasons:
+        payload["status"] = "degraded"
+        payload["degraded_reasons"] = degraded_reasons
 
     # --- uptime --------------------------------------------------------------
     if started_at is not None:

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -22,10 +22,10 @@ import logging
 import os
 import re
 import uuid
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 from urllib.parse import unquote, urlparse
 
 import duckdb
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
     from distillery.store.protocol import SearchResult
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 
 def _sql_escape(value: str) -> str:
@@ -831,6 +833,96 @@ class DuckDBStore:
         return self._embedding_provider
 
     # ------------------------------------------------------------------
+    # Transaction safety (issue #363)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _rollback_quietly(conn: duckdb.DuckDBPyConnection) -> None:
+        """Best-effort ``ROLLBACK`` to clear an aborted transaction.
+
+        DuckDB leaves a connection in an aborted-transaction state when a
+        statement raises inside an implicit or explicit transaction — every
+        subsequent call on the same connection fails with
+        ``TransactionContext Error: Current transaction is aborted (please
+        ROLLBACK)``.  Issuing a ``ROLLBACK`` clears the aborted state and
+        restores the connection to a usable baseline.
+
+        Errors from ``ROLLBACK`` itself are logged at debug level and
+        swallowed — if rollback fails we are no worse off than if we had
+        never tried.  Callers must still propagate the original exception.
+        """
+        try:
+            conn.rollback()
+        except duckdb.Error as rollback_exc:
+            logger.debug("Post-error ROLLBACK skipped: %s", rollback_exc)
+
+    async def _run_sync(
+        self,
+        fn: Callable[..., _T],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        """Run *fn* via :func:`asyncio.to_thread` with rollback on error.
+
+        Wraps every sync store operation so that any exception raised by
+        *fn* triggers a best-effort ``ROLLBACK`` on the shared DuckDB
+        connection **before** the exception propagates.  Without this,
+        a single failed write would leave the shared connection in an
+        aborted-transaction state and all subsequent reads and writes
+        would fail until the connection was recycled (issue #363).
+
+        Read-only operations (e.g. :meth:`_sync_get`) can also reach this
+        path when a prior uncaught exception poisoned the connection;
+        running ``ROLLBACK`` after the failed read restores the connection
+        so the next call succeeds rather than cascading the same error.
+        """
+        try:
+            return await asyncio.to_thread(fn, *args, **kwargs)
+        except BaseException:
+            conn = self._conn
+            if conn is not None:
+                await asyncio.to_thread(self._rollback_quietly, conn)
+            raise
+
+    async def rollback(self) -> None:
+        """Public rollback hook for non-store code paths that touch the connection.
+
+        The MCP tool layer occasionally issues raw ``conn.execute`` calls
+        (e.g. the per-request embedding-budget counter in
+        :mod:`distillery.mcp.budget`) that bypass :meth:`_run_sync`.  Those
+        call sites can invoke ``await store.rollback()`` in their exception
+        handlers to clear an aborted transaction before the next request.
+        """
+        if self._conn is None:
+            return
+        await asyncio.to_thread(self._rollback_quietly, self._conn)
+
+    async def probe_readiness(self) -> tuple[bool, str | None]:
+        """Return ``(True, None)`` when the connection can answer a trivial query.
+
+        Exercised by the MCP status handler (``distillery_status``) and by
+        :meth:`initialize` immediately after schema setup so that a database
+        file which mounts but is not queryable (e.g. after a partial WAL
+        replay / volume snapshot inconsistency — see issue #363 follow-up)
+        surfaces as an explicit error instead of a silent null in the
+        status payload.
+
+        The probe runs ``SELECT COUNT(*) FROM entries`` via the normal
+        async path so transient aborted-transaction state is rolled back
+        by :meth:`_run_sync` before a second probe is attempted.
+        """
+        if self._conn is None:
+            return False, "store not initialized"
+        try:
+            await self._run_sync(
+                lambda: self._conn.execute("SELECT COUNT(*) FROM entries").fetchone()  # type: ignore[union-attr]
+            )
+        except Exception as exc:  # noqa: BLE001
+            return False, f"{type(exc).__name__}: {exc}"
+        return True, None
+
+    # ------------------------------------------------------------------
     # CRUD protocol methods (T02.3)
     # ------------------------------------------------------------------
 
@@ -907,7 +999,7 @@ class DuckDBStore:
         Returns:
             The UUID string of the stored entry.
         """
-        return await asyncio.to_thread(self._sync_store, entry)
+        return await self._run_sync(self._sync_store, entry)
 
     def _sync_store_batch(self, entries: Sequence[Entry]) -> list[str]:
         """Synchronous batch-store implementation; called via asyncio.to_thread."""
@@ -980,7 +1072,7 @@ class DuckDBStore:
         Returns:
             List of UUID strings for the stored entries.
         """
-        return await asyncio.to_thread(self._sync_store_batch, entries)
+        return await self._run_sync(self._sync_store_batch, entries)
 
     def _sync_get(self, entry_id: str) -> Entry | None:
         """
@@ -1018,7 +1110,7 @@ class DuckDBStore:
         Returns:
             The matching ``Entry``, or ``None`` if the ID does not exist.
         """
-        return await asyncio.to_thread(self._sync_get, entry_id)
+        return await self._run_sync(self._sync_get, entry_id)
 
     def _sync_update(self, entry_id: str, updates: dict[str, Any]) -> Entry:
         """
@@ -1152,7 +1244,7 @@ class DuckDBStore:
         Returns:
             The updated ``Entry``.
         """
-        return await asyncio.to_thread(self._sync_update, entry_id, updates)
+        return await self._run_sync(self._sync_update, entry_id, updates)
 
     def _sync_delete(self, entry_id: str) -> bool:
         """Synchronous implementation of delete(); called via asyncio.to_thread."""
@@ -1184,7 +1276,7 @@ class DuckDBStore:
         Returns:
             ``True`` if the entry was found and archived, ``False`` otherwise.
         """
-        return await asyncio.to_thread(self._sync_delete, entry_id)
+        return await self._run_sync(self._sync_delete, entry_id)
 
     # ------------------------------------------------------------------
     # Filter helpers (shared by search, find_similar, list_entries)
@@ -1556,7 +1648,7 @@ class DuckDBStore:
             self._touch_accessed(conn, returned_ids)
             return results
 
-        return await asyncio.to_thread(_sync)
+        return await self._run_sync(_sync)
 
     @staticmethod
     def _touch_accessed(conn: duckdb.DuckDBPyConnection, entry_ids: list[str]) -> None:
@@ -1617,7 +1709,7 @@ class DuckDBStore:
                 results.append(SearchResult(entry=entry, score=score))
             return results
 
-        return await asyncio.to_thread(_sync)
+        return await self._run_sync(_sync)
 
     @overload
     async def list_entries(
@@ -1719,7 +1811,7 @@ class DuckDBStore:
             rows = result.fetchall()
             return [self._row_to_entry(row, col_names) for row in rows]
 
-        return await asyncio.to_thread(_sync)
+        return await self._run_sync(_sync)
 
     async def _get_entry_stats(
         self,
@@ -1792,7 +1884,7 @@ class DuckDBStore:
                 "storage_bytes": storage_bytes,
             }
 
-        return await asyncio.to_thread(_sync)
+        return await self._run_sync(_sync)
 
     async def count_entries(
         self,
@@ -1823,7 +1915,7 @@ class DuckDBStore:
             row = conn.execute(sql, params).fetchone()
             return int(row[0]) if row else 0
 
-        return await asyncio.to_thread(_sync)
+        return await self._run_sync(_sync)
 
     async def aggregate_entries(
         self,
@@ -1940,7 +2032,7 @@ class DuckDBStore:
                 "total_entries": total_entries,
             }
 
-        return await asyncio.to_thread(_sync)
+        return await self._run_sync(_sync)
 
     # ------------------------------------------------------------------
     # Audit logging
@@ -1969,7 +2061,7 @@ class DuckDBStore:
             )
 
         try:
-            await asyncio.to_thread(_sync)
+            await self._run_sync(_sync)
         except Exception:  # noqa: BLE001
             logger.debug("audit_log write failed (ignored)", exc_info=True)
 
@@ -2083,7 +2175,7 @@ class DuckDBStore:
             ``user_id``, ``tool``, ``entry_id``, ``action``, ``outcome``.
             Ordered by descending timestamp.
         """
-        return await asyncio.to_thread(self._sync_query_audit_log, filters, limit)
+        return await self._run_sync(self._sync_query_audit_log, filters, limit)
 
     # ------------------------------------------------------------------
     # Feedback logging (T01.2)
@@ -2140,7 +2232,7 @@ class DuckDBStore:
         Returns:
             search_id (str): UUID string of the newly created `search_log` row.
         """
-        return await asyncio.to_thread(
+        return await self._run_sync(
             self._sync_log_search, query, result_entry_ids, result_scores, session_id
         )
 
@@ -2188,7 +2280,7 @@ class DuckDBStore:
         Returns:
             str: UUID string of the created `feedback_log` row.
         """
-        return await asyncio.to_thread(self._sync_log_feedback, search_id, entry_id, signal)
+        return await self._run_sync(self._sync_log_feedback, search_id, entry_id, signal)
 
     # ------------------------------------------------------------------
     # Search log queries for implicit feedback
@@ -2218,7 +2310,7 @@ class DuckDBStore:
         Returns:
             list[str]: Search IDs (UUIDs) of matching ``search_log`` rows.
         """
-        return await asyncio.to_thread(self._sync_get_searches_for_entry, entry_id, since)
+        return await self._run_sync(self._sync_get_searches_for_entry, entry_id, since)
 
     # ------------------------------------------------------------------
     # Feed source persistence
@@ -2358,7 +2450,7 @@ class DuckDBStore:
 
     async def list_feed_sources(self) -> list[dict[str, Any]]:
         """Return all persisted feed sources as dicts."""
-        return await asyncio.to_thread(self._sync_list_feed_sources)
+        return await self._run_sync(self._sync_list_feed_sources)
 
     async def add_feed_source(
         self,
@@ -2369,13 +2461,13 @@ class DuckDBStore:
         trust_weight: float = 1.0,
     ) -> dict[str, Any]:
         """Add a feed source. Raises ValueError if URL already exists."""
-        return await asyncio.to_thread(
+        return await self._run_sync(
             self._sync_add_feed_source, url, source_type, label, poll_interval_minutes, trust_weight
         )
 
     async def remove_feed_source(self, url: str) -> bool:
         """Remove a feed source by URL. Returns True if it existed."""
-        return await asyncio.to_thread(self._sync_remove_feed_source, url)
+        return await self._run_sync(self._sync_remove_feed_source, url)
 
     async def record_poll_status(
         self,
@@ -2398,7 +2490,7 @@ class DuckDBStore:
             ``True`` if a matching row was updated, ``False`` if no source
             with *url* exists.
         """
-        return await asyncio.to_thread(
+        return await self._run_sync(
             self._sync_record_poll_status,
             url,
             polled_at=polled_at,
@@ -2428,11 +2520,11 @@ class DuckDBStore:
 
     async def get_metadata(self, key: str) -> str | None:
         """Read a value from the ``_meta`` key-value table."""
-        return await asyncio.to_thread(self._sync_get_metadata, key)
+        return await self._run_sync(self._sync_get_metadata, key)
 
     async def set_metadata(self, key: str, value: str) -> None:
         """Write a value to the ``_meta`` key-value table (upsert)."""
-        await asyncio.to_thread(self._sync_set_metadata, key, value)
+        await self._run_sync(self._sync_set_metadata, key, value)
 
     def _sync_prune_search_log(self, retention_days: int) -> int:
         """Delete ``search_log`` rows older than *retention_days*.
@@ -2465,7 +2557,7 @@ class DuckDBStore:
 
     async def prune_search_log(self, retention_days: int) -> int:
         """Delete ``search_log`` rows older than *retention_days* (async wrapper)."""
-        return await asyncio.to_thread(self._sync_prune_search_log, retention_days)
+        return await self._run_sync(self._sync_prune_search_log, retention_days)
 
     # ------------------------------------------------------------------
     # Tag vocabulary
@@ -2502,7 +2594,7 @@ class DuckDBStore:
         Returns:
             Dict mapping each matching tag string to its occurrence count.
         """
-        return await asyncio.to_thread(self._sync_get_tag_vocabulary, prefix)
+        return await self._run_sync(self._sync_get_tag_vocabulary, prefix)
 
     # ------------------------------------------------------------------
     # Entry relations
@@ -2571,7 +2663,7 @@ class DuckDBStore:
             ValueError: If either ``from_id`` or ``to_id`` does not exist in
                 the store.
         """
-        return await asyncio.to_thread(self._sync_add_relation, from_id, to_id, relation_type)
+        return await self._run_sync(self._sync_add_relation, from_id, to_id, relation_type)
 
     def _sync_apply_correction(
         self,
@@ -2669,7 +2761,7 @@ class DuckDBStore:
 
         See :meth:`_sync_apply_correction` for details.
         """
-        return await asyncio.to_thread(self._sync_apply_correction, new_entry, wrong_entry_id)
+        return await self._run_sync(self._sync_apply_correction, new_entry, wrong_entry_id)
 
     def _sync_get_related(
         self,
@@ -2736,7 +2828,7 @@ class DuckDBStore:
             List of dicts with keys: ``id``, ``from_id``, ``to_id``,
             ``relation_type``, ``created_at`` (ISO 8601 str).
         """
-        return await asyncio.to_thread(self._sync_get_related, entry_id, direction, relation_type)
+        return await self._run_sync(self._sync_get_related, entry_id, direction, relation_type)
 
     def _sync_remove_relation(self, relation_id: str) -> bool:
         """Synchronous implementation of remove_relation(); called via asyncio.to_thread."""
@@ -2759,4 +2851,4 @@ class DuckDBStore:
         Returns:
             ``True`` if the row existed and was deleted, ``False`` otherwise.
         """
-        return await asyncio.to_thread(self._sync_remove_relation, relation_id)
+        return await self._run_sync(self._sync_remove_relation, relation_id)

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -879,7 +879,17 @@ class DuckDBStore:
         """
         try:
             return await asyncio.to_thread(fn, *args, **kwargs)
-        except BaseException:
+        except Exception:
+            # Catching ``Exception`` — not ``BaseException`` — so that
+            # ``asyncio.CancelledError`` does not trigger rollback.  When a
+            # task is cancelled while awaiting ``asyncio.to_thread(fn, …)``
+            # the worker thread executing *fn* keeps running (Python has no
+            # safe way to forcibly stop a thread), so issuing
+            # ``conn.rollback()`` from a second worker thread would race
+            # against the still-live first one on the shared DuckDB
+            # connection — which is not thread-safe for concurrent use.
+            # On cancellation we simply re-raise; on ordinary exceptions
+            # *fn* has already returned control so the rollback is safe.
             conn = self._conn
             if conn is not None:
                 await asyncio.to_thread(self._rollback_quietly, conn)

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -47,6 +47,28 @@ class DistilleryStore(Protocol):
         result = await store.get(entry_id)
     """
 
+    async def rollback(self) -> None:
+        """Roll back any aborted transaction on the shared connection.
+
+        Safe to call at any time.  Intended for MCP tool handlers that
+        touch the underlying connection directly (e.g. the per-request
+        embedding-budget counter) so they can clear an aborted-transaction
+        state before subsequent requests hit the same connection.  See
+        issue #363.
+        """
+        ...
+
+    async def probe_readiness(self) -> tuple[bool, str | None]:
+        """Return ``(True, None)`` when the store can answer a trivial query.
+
+        Returns ``(False, message)`` when the underlying database is
+        present but unqueryable (e.g. partial WAL replay, half-applied
+        migration, corrupt segment) so health probes can surface the
+        durable failure instead of silently falling back to null in the
+        ``distillery_status`` payload.  See issue #363 follow-up.
+        """
+        ...
+
     async def store(self, entry: Entry) -> str:
         """Persist a new entry and return its ID.
 

--- a/tests/test_store_rollback_on_error.py
+++ b/tests/test_store_rollback_on_error.py
@@ -137,30 +137,53 @@ class TestStatusDegraded:
     """``distillery_status`` must surface query failures (issue #363 follow-up)."""
 
     async def test_status_marks_degraded_when_count_entries_raises(
-        self, store: DuckDBStore, mock_embedding_provider: object
+        self,
+        store: DuckDBStore,
+        mock_embedding_provider: object,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """When ``count_entries`` raises, status must report ``degraded`` with the error."""
+        """When ``count_entries`` raises, status must report ``degraded`` with a stable code.
+
+        The client-facing payload must NOT contain raw exception text
+        (e.g. ``DuckDB``/``RuntimeError``/paths) — only a stable generic
+        code that callers can branch on.  The full exception is logged
+        server-side.
+        """
+        import logging
+
         from distillery.config import DistilleryConfig
         from distillery.mcp.tools.meta import _handle_status
 
         from .conftest import parse_mcp_response
 
         async def broken_count_entries(filters: object = None, **kwargs: object) -> int:
-            raise RuntimeError("DB unreadable")
+            raise RuntimeError("DB unreadable at /private/path.db")
 
         store.count_entries = broken_count_entries  # type: ignore[method-assign]
 
-        result = await _handle_status(
-            store=store,
-            config=DistilleryConfig(),
-            embedding_provider=mock_embedding_provider,
-            tool_count=16,
-            transport="http",
-            started_at=None,
-        )
+        with caplog.at_level(logging.WARNING, logger="distillery.mcp.tools.meta"):
+            result = await _handle_status(
+                store=store,
+                config=DistilleryConfig(),
+                embedding_provider=mock_embedding_provider,
+                tool_count=16,
+                transport="http",
+                started_at=None,
+            )
         payload = parse_mcp_response(result)
 
         assert payload["status"] == "degraded"
         assert payload["store"]["entry_count"] is None
-        assert "DB unreadable" in payload["store"]["entry_count_error"]
-        assert any("count_entries" in r for r in payload["degraded_reasons"])
+        assert payload["store"]["entry_count_error"] == "entry_count_unavailable"
+        assert "entry_count_unavailable" in payload["degraded_reasons"]
+        # The raw exception text must stay server-side (in logs) and never
+        # reach the client-visible payload.
+        serialised = result[0].text
+        assert "DB unreadable" not in serialised
+        assert "/private/path.db" not in serialised
+        assert "RuntimeError" not in serialised
+        # But it must still appear in the server-side log for operators —
+        # ``logger.exception`` attaches the traceback to the record's
+        # ``exc_info``; ``caplog.text`` renders it so the raw message is
+        # searchable there.
+        assert "DB unreadable" in caplog.text

--- a/tests/test_store_rollback_on_error.py
+++ b/tests/test_store_rollback_on_error.py
@@ -1,0 +1,166 @@
+"""Regression tests for issue #363.
+
+A single server-side DuckDB error previously left the shared connection
+in an aborted-transaction state.  Every subsequent call — reads as well
+as writes — failed with::
+
+    TransactionContext Error: Current transaction is aborted (please ROLLBACK)
+
+The fix wraps every async store operation in :meth:`DuckDBStore._run_sync`,
+which issues a best-effort ``ROLLBACK`` when the wrapped sync function
+raises.  Read-only operations reach the same wrapper so a connection
+poisoned by a prior failure is cleared before the next call.
+
+These tests exercise the rollback contract directly against an in-memory
+store so they catch regressions without depending on server-side
+behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.store.duckdb import DuckDBStore
+
+from .conftest import make_entry
+
+pytestmark = pytest.mark.unit
+
+
+class TestRunSyncRollback:
+    """Exercise the ``_run_sync`` rollback-on-exception contract."""
+
+    async def test_rolls_back_on_raise(self, store: DuckDBStore) -> None:
+        """A failing sync fn must trigger ROLLBACK before the exception propagates."""
+        rollback_calls: list[str] = []
+
+        original_rollback = store._rollback_quietly  # type: ignore[attr-defined]
+
+        def tracking_rollback(conn: object) -> None:
+            rollback_calls.append("called")
+            original_rollback(conn)
+
+        store._rollback_quietly = tracking_rollback  # type: ignore[attr-defined,method-assign]
+
+        def exploding() -> None:
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await store._run_sync(exploding)  # type: ignore[attr-defined]
+
+        assert rollback_calls == ["called"]
+
+    async def test_no_rollback_on_success(self, store: DuckDBStore) -> None:
+        """A successful sync fn must not call ROLLBACK — no spurious WAL churn."""
+        rollback_calls: list[str] = []
+        store._rollback_quietly = lambda conn: rollback_calls.append("called")  # type: ignore[attr-defined,method-assign]
+
+        result = await store._run_sync(lambda: 42)  # type: ignore[attr-defined]
+
+        assert result == 42
+        assert rollback_calls == []
+
+    async def test_rollback_quietly_swallows_errors(self, store: DuckDBStore) -> None:
+        """A ROLLBACK that itself fails must not mask the caller's original error."""
+        import duckdb
+
+        class DummyConn:
+            def rollback(self) -> None:
+                raise duckdb.Error("nothing to roll back")
+
+        # Should not raise.
+        DuckDBStore._rollback_quietly(DummyConn())  # type: ignore[arg-type]
+
+
+class TestReadAfterWriteFailure:
+    """The key scenario from issue #363: a failed write must not brick reads."""
+
+    async def test_read_succeeds_after_store_failure(self, store: DuckDBStore) -> None:
+        """After a store() raises, a follow-up list_entries() must succeed."""
+        good_entry = make_entry(content="healthy entry")
+        await store.store(good_entry)
+
+        # Force _sync_store to raise so the connection has an opportunity to
+        # enter an aborted state.  _run_sync should roll back before the
+        # exception escapes, restoring the connection for subsequent reads.
+        original_sync_store = store._sync_store  # type: ignore[attr-defined]
+
+        def failing_sync_store(entry: object) -> str:
+            original_sync_store(entry)  # do the write, then raise
+            raise RuntimeError("simulated post-write failure")
+
+        store._sync_store = failing_sync_store  # type: ignore[attr-defined,method-assign]
+        with pytest.raises(RuntimeError, match="simulated post-write failure"):
+            await store.store(make_entry(content="will-fail"))
+
+        # Restore the real method so subsequent operations behave normally.
+        store._sync_store = original_sync_store  # type: ignore[attr-defined,method-assign]
+
+        # The canonical poison scenario: a list after a failed write used to
+        # raise ``TransactionContext Error: Current transaction is aborted``.
+        # With the rollback wrapper it returns the stored entries.
+        entries = await store.list_entries(filters=None, limit=100, offset=0)
+        assert any(e.content == "healthy entry" for e in entries)
+
+    async def test_probe_readiness_returns_true_on_healthy_store(self, store: DuckDBStore) -> None:
+        """A freshly-initialised store must report itself ready."""
+        ready, err = await store.probe_readiness()
+        assert ready is True
+        assert err is None
+
+    async def test_probe_readiness_reports_failure_when_uninitialised(
+        self, mock_embedding_provider: object
+    ) -> None:
+        """A store that has never been initialised must report not-ready with a reason."""
+        uninitialised = DuckDBStore(
+            db_path=":memory:",
+            embedding_provider=mock_embedding_provider,  # type: ignore[arg-type]
+        )
+        ready, err = await uninitialised.probe_readiness()
+        assert ready is False
+        assert err is not None
+        assert "not initialized" in err
+
+    async def test_rollback_public_method_noop_on_uninitialised(
+        self, mock_embedding_provider: object
+    ) -> None:
+        """``await store.rollback()`` must be safe when _conn is None."""
+        uninitialised = DuckDBStore(
+            db_path=":memory:",
+            embedding_provider=mock_embedding_provider,  # type: ignore[arg-type]
+        )
+        # Should not raise.
+        await uninitialised.rollback()
+
+
+class TestStatusDegraded:
+    """``distillery_status`` must surface query failures (issue #363 follow-up)."""
+
+    async def test_status_marks_degraded_when_count_entries_raises(
+        self, store: DuckDBStore, mock_embedding_provider: object
+    ) -> None:
+        """When ``count_entries`` raises, status must report ``degraded`` with the error."""
+        from distillery.config import DistilleryConfig
+        from distillery.mcp.tools.meta import _handle_status
+
+        from .conftest import parse_mcp_response
+
+        async def broken_count_entries(filters: object = None, **kwargs: object) -> int:
+            raise RuntimeError("DB unreadable")
+
+        store.count_entries = broken_count_entries  # type: ignore[method-assign]
+
+        result = await _handle_status(
+            store=store,
+            config=DistilleryConfig(),
+            embedding_provider=mock_embedding_provider,
+            tool_count=16,
+            transport="http",
+            started_at=None,
+        )
+        payload = parse_mcp_response(result)
+
+        assert payload["status"] == "degraded"
+        assert payload["store"]["entry_count"] is None
+        assert "DB unreadable" in payload["store"]["entry_count_error"]
+        assert any("count_entries" in r for r in payload["degraded_reasons"])


### PR DESCRIPTION
Fixes #363.

## Summary

- Wrap every async store operation in `DuckDBStore._run_sync`, which issues a best-effort `ROLLBACK` on the shared DuckDB connection when the wrapped sync function raises. A single failed `distillery_store` no longer cascades into `TransactionContext Error: Current transaction is aborted` across every subsequent read and write.
- Wrap the MCP layer's direct `store.connection.execute` calls (the per-request embedding-budget counter in `crud.py`) with a non-budget exception path that calls the new public `store.rollback()` and returns a sanitised `INTERNAL` response instead of leaking raw DuckDB text to clients.
- Surface query failures in `distillery_status`: when `count_entries`, `list_feed_sources`, or the new `probe_readiness()` check fails, the payload now reports `status: "degraded"`, `degraded_reasons`, and a per-field error string. Addresses the follow-up observation that a durable unqueryable-DB state was masked behind an `ok` status.

## Scope note

The follow-up comment on the issue showed that the stuck state **persists across process restart** — the 440MB DB file mounts, `distillery_status` still returns `ok`, but every query fails. That durable state is **not** resolved by this PR; it needs server-side log investigation (candidates: partial WAL replay, HNSW/FTS state, volume snapshot inconsistency). What this PR guarantees is that the durable state now **surfaces explicitly** (as `status: "degraded"` with the raw exception) instead of hiding behind `ok` + null counts, so operators can see the outage the moment it appears.

## Test plan

- [x] New `tests/test_store_rollback_on_error.py` (8 tests): rollback-on-raise, no-rollback-on-success, rollback swallows errors, read-succeeds-after-write-failure (the canonical issue-363 scenario), `probe_readiness` healthy/unhealthy, `rollback()` no-op when uninitialised, `distillery_status` goes `degraded` when `count_entries` raises.
- [x] Full `pytest` run: 2304 passed, 73 skipped (4 pre-existing `TestWalFtsReplayHardening` failures on main, unrelated).
- [x] `mypy --strict src/distillery/`: clean.
- [x] `ruff check` / `ruff format --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health endpoint now reports "degraded" with explicit degraded_reasons and stable error codes.
  * Added a readiness probe for store connectivity.

* **Bug Fixes**
  * Prevents raw database errors from being exposed to clients; returns stable internal error responses.
  * Ensures failed operations trigger safe rollback/recovery so the system remains usable after errors.

* **Tests**
  * Added regression tests for rollback, readiness, and degraded-status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->