### PR TITLE
release: v0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "distillery",
       "source": "./",
       "description": "Knowledge base skills — capture, search, and synthesize project knowledge",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings"],
       "category": "knowledge-management"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,7 +259,7 @@ Initial public release of the Distillery MVP, covering three specification areas
 - `/classify` skill — classify entries by ID, process full inbox, and manage review queue
 - Config extensions: deduplication thresholds, classification taxonomy, review-queue settings
 
-[Unreleased]: https://github.com/norrietaylor/distillery/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/norrietaylor/distillery/compare/v0.3.2...HEAD
 [v0.2.1]: https://github.com/norrietaylor/distillery/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/norrietaylor/distillery/compare/v0.1.1...v0.2.0
 [v0.1.0]: https://github.com/norrietaylor/distillery/releases/tag/v0.1.0

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.norrietaylor/distillery-mcp",
   "title": "Distillery",
   "description": "Knowledge base for Claude Code with semantic search, feed intelligence, and teams",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "repository": {
     "url": "https://github.com/norrietaylor/distillery",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "transport": {
         "type": "streamable-http",
         "url": "https://distillery-mcp.fly.dev/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -719,7 +719,7 @@ wheels = [
 
 [[package]]
 name = "distillery-mcp"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },
@@ -751,17 +751,17 @@ ragas = [
 [package.metadata]
 requires-dist = [
     { name = "datasets", marker = "extra == 'ragas'", specifier = ">=2.14.0" },
-    { name = "defusedxml", specifier = ">=0.7.0" },
+    { name = "defusedxml", specifier = ">=0.7.0,<1.0" },
     { name = "duckdb", specifier = "~=1.5.0" },
-    { name = "fastmcp", specifier = ">=2.12.0" },
-    { name = "httpx", specifier = ">=0.24.0" },
+    { name = "fastmcp", specifier = ">=2.12.0,<4.0" },
+    { name = "httpx", specifier = ">=0.24.0,<1.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.30.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "ragas", marker = "extra == 'ragas'", specifier = ">=0.2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "types-defusedxml", marker = "extra == 'dev'", specifier = ">=0.7.0" },


### PR DESCRIPTION
## v0.4.0 — Full-Proof

Quality + API hardening release. Closes out the `staging/api-hardening` line of work (PR #250 and the ~30 PRs merged behind it since v0.3.2).

### Version bumps in this PR

| File | From | To |
|------|------|----|
| `.claude-plugin/marketplace.json` | 0.3.3 | 0.4.0 |
| `server.json` (3 sites) | 0.3.2 | 0.4.0 |
| `CHANGELOG.md` footer link | `v0.2.1...HEAD` | `v0.3.2...HEAD` |
| `uv.lock` | — | regenerated |

`pyproject.toml`, `src/distillery/__init__.py`, and `.claude-plugin/plugin.json` were already at 0.4.0 from earlier commits.

### Release theme

**Full-Proof** (undiluted, full-strength) with the deliberate pun on *fool-proof*. Release body and Announcements discussion post lean on this framing.

This release also establishes the **API stability pledge**: going forward, the MCP tool surface (names, parameter shapes, error codes, response envelopes) is treated as a public contract. Breaking changes require a major bump; additive evolution is the default.

### Validation

- `pytest --cov=src/distillery --cov-fail-under=80` — 2371 passed, 73 skipped, 85.91% coverage
- `mypy --strict src/distillery/` — clean
- `ruff check src/ tests/` — clean

### Next steps after merge

1. Tag `v0.4.0` on `main`, push tag
2. `gh release create v0.4.0 --title "v0.4.0 — Full-Proof" --notes-file /tmp/v0.4.0-notes.md` → fires `pypi-publish.yml` + `changelog.yml`
3. Post GitHub Discussion in Announcements category
4. `fly deploy --app distillery-mcp` from `distill_ops` to redeploy hosted server
5. Merge the auto-generated changelog PR

Release plan: `~/.claude/plans/lets-prepare-a-release-warm-mist.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.4.0 across plugin and server configurations.
  * Updated internal version references and changelog tracking to reflect the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->