### PR TITLE
fix(cross-post): set User-Agent so dev.to stops 403'ing the runner

### DIFF
--- a/scripts/cross_post_blog.py
+++ b/scripts/cross_post_blog.py
@@ -23,6 +23,7 @@ import yaml
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
 DEVTO_TAG_LIMIT = 4
 HTTP_TIMEOUT_SECONDS = 30
+USER_AGENT = "distillery-cross-post/1.0 (+https://github.com/norrietaylor/distillery)"
 
 
 def parse(path: str) -> tuple[dict, str]:
@@ -56,7 +57,9 @@ def _normalize_tags(raw: object) -> list[str]:
 
 def _get_json(url: str, headers: dict, allow_statuses: tuple[int, ...] = ()) -> dict | None:
     """GET url and return parsed JSON; return None for statuses in allow_statuses; exit otherwise."""
-    req = urllib.request.Request(url, headers=headers, method="GET")
+    req = urllib.request.Request(
+        url, headers={"user-agent": USER_AGENT, **headers}, method="GET"
+    )
     try:
         with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as r:
             return json.loads(r.read())
@@ -136,7 +139,7 @@ def _post_json(url: str, payload: dict, headers: dict) -> dict:
     req = urllib.request.Request(
         url,
         data=json.dumps(payload).encode(),
-        headers={"content-type": "application/json", **headers},
+        headers={"content-type": "application/json", "user-agent": USER_AGENT, **headers},
         method="POST",
     )
     try:


### PR DESCRIPTION
## Summary

Second failure on the merged workflow: \`https://dev.to/api/articles -> HTTP 403\`. The key works locally (curl GET /me → 200, curl POST → 201), so the problem is not scope but request fingerprint.

## Root cause

dev.to is behind Cloudflare and rejects the default \`Python-urllib/3.12\` User-Agent with an empty-body 403. Verified from the same Mac with the same key:

| User-Agent          | Status |
|---------------------|--------|
| (default urllib)    | 403    |
| \`curl/8.4.0\`        | 200    |
| \`distillery-cross-post/1.0\` | 200 |

## Fix

Set an explicit User-Agent on every request from \`cross_post_blog.py\`.

## Test plan

- [ ] Merge, re-run workflow_dispatch on \`docs/blog/distillery-0-4-0-full-proof.md\`
- [ ] Expect: dev.to dedup attempt succeeds (key now has read access visible), POST succeeds, Hashnode dedup + POST succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated outgoing HTTP requests to include a user-agent header for improved request identification and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->