### PR TITLE
fix(feeds): pin verify=True on remaining AsyncClient sites

### DIFF
--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -733,7 +733,7 @@ class GitHubSyncAdapter:
 
         should_close = client is None
         if client is None:
-            client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, follow_redirects=True)
+            client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, follow_redirects=True, verify=True)
         try:
             response = await self._request_with_retry(client, api_url, params)
             batch: list[dict[str, Any]] = response.json()
@@ -851,7 +851,7 @@ class GitHubSyncAdapter:
 
         should_close = client is None
         if client is None:
-            client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, follow_redirects=True)
+            client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, follow_redirects=True, verify=True)
 
         try:
             page = 1

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -5,10 +5,13 @@ Uses mock HTTP responses to avoid hitting the real GitHub API.
 
 from __future__ import annotations
 
+import ast
 import re
+from pathlib import Path
 
 import pytest
 
+import distillery.feeds.github_sync as github_sync_module
 from distillery.feeds.github_sync import (
     _MAX_RETRIES,
     GitHubSyncAdapter,
@@ -794,3 +797,49 @@ class TestBackfillGithubMetadataIntegration:
         second = await backfill_github_metadata(store)
         assert first == 1
         assert second == 0
+
+
+# ---------------------------------------------------------------------------
+# Static audit — defense-in-depth per PR #112: every httpx.AsyncClient site
+# must pin verify=True explicitly so a future default change cannot silently
+# disable TLS verification (regression guard for #368).
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncClientVerifyPinned:
+    """AST audit: every httpx.AsyncClient(...) in github_sync.py has verify=True."""
+
+    @pytest.mark.unit
+    def test_every_async_client_pins_verify_true(self) -> None:
+        source_path = Path(github_sync_module.__file__)
+        tree = ast.parse(source_path.read_text())
+
+        offending: list[int] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            # Match both ``httpx.AsyncClient(...)`` and a bare ``AsyncClient(...)``.
+            is_async_client = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "AsyncClient"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "httpx"
+            ) or (isinstance(func, ast.Name) and func.id == "AsyncClient")
+            if not is_async_client:
+                continue
+
+            verify_kw = next((kw for kw in node.keywords if kw.arg == "verify"), None)
+            if (
+                verify_kw is None
+                or not isinstance(verify_kw.value, ast.Constant)
+                or verify_kw.value.value is not True
+            ):
+                offending.append(node.lineno)
+
+        assert not offending, (
+            "httpx.AsyncClient constructions missing explicit verify=True at "
+            f"{source_path.name} lines {offending}. Every AsyncClient site must "
+            "pin verify=True per PR #112 (defense-in-depth against a future "
+            "httpx default flip)."
+        )


### PR DESCRIPTION
## Summary

- Adds explicit `verify=True` to the two `httpx.AsyncClient(...)` constructions in `src/distillery/feeds/github_sync.py` (lines 736 and 854) that were missed by the PR #112 TLS-audit sweep.
- Adds a static AST audit in `tests/test_github_sync.py` that walks the module and asserts every `httpx.AsyncClient(...)` site carries a literal `verify=True` keyword, guarding against future regressions.

## Why

httpx currently defaults to `verify=True`, so TLS verification is already enforced in production. But the PR #112 audit chose to pin it explicitly at every call site as defense-in-depth against a future default flip or local code change silently lowering trust. These two sites slipped through that sweep.

## Test plan

- [x] `pytest tests/test_github_sync.py -v` — 58 passed (includes new `test_every_async_client_pins_verify_true`)
- [x] `ruff check src/ tests/` — All checks passed
- [x] `mypy --strict src/distillery/` — Success: no issues found in 61 source files
- [x] Reproduction from issue now returns zero offending lines: `grep -n "httpx.AsyncClient" src/distillery/feeds/github_sync.py | grep -v "verify="` yields only type annotations, no constructor calls.

Fixes #368

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API client configurations to explicitly set verification settings in GitHub sync operations.

* **Tests**
  * Added test suite to validate that API client instantiations include required configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->