### PR TITLE
docs: correct stale tool counts to 16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ DuckDB (local persistent storage)
 | Layer | Description | Key types |
 |-------|-------------|-----------|
 | **Skills** | `/distill`, `/recall`, `/pour`, `/bookmark`, `/minutes`, `/classify`, `/watch`, `/radar`, `/tune` — SKILL.md files that orchestrate MCP tool calls | — |
-| **MCP Server** | FastMCP server exposing 19 tools over stdio/HTTP transport | `mcp/server.py` |
+| **MCP Server** | FastMCP server exposing 16 tools over stdio/HTTP transport | `mcp/server.py` |
 | **Core protocols** | `DistilleryStore`, `EmbeddingProvider`, `ClassificationEngine` — typed `Protocol` interfaces | `store/protocol.py`, `embedding/protocol.py`, `classification/engine.py` |
 | **DuckDB backend** | `DuckDBStore` implements `DistilleryStore`; vector similarity search via VSS extension | `store/duckdb.py` |
 

--- a/docs/presentation.html
+++ b/docs/presentation.html
@@ -1100,7 +1100,7 @@ $ distillery-mcp --transport http --port 8000
     <div class="card">
       <h3>Core Platform</h3>
       <ul>
-        <li style="color: var(--green);">10 skills, 22 MCP tools</li>
+        <li style="color: var(--green);">14 skills, 16 MCP tools</li>
         <li style="color: var(--green);">DuckDB + HNSW vector search</li>
         <li style="color: var(--green);">LLM classification + semantic dedup</li>
         <li style="color: var(--green);">Retrieval quality metrics + stale detection</li>

--- a/docs/presentation.html
+++ b/docs/presentation.html
@@ -727,7 +727,7 @@
 <!-- SLIDE 5: The 6 Skills -->
 <!-- ============================================================ -->
 <div class="slide" id="s5">
-  <h2 class="fade-in">10 conversational commands</h2>
+  <h2 class="fade-in">14 conversational commands</h2>
   <div style="height: 16px;"></div>
   <table class="skill-table fade-in">
     <tr><th>Skill</th><th>Purpose</th><th>Example</th></tr>
@@ -1045,11 +1045,11 @@ $ distillery-mcp --transport http --port 8000
   <div style="height: 24px;"></div>
   <div style="display: flex; gap: 64px; justify-content: center;" class="fade-in">
     <div class="stat">
-      <div class="number">10</div>
+      <div class="number">14</div>
       <div class="label">Claude Code skills</div>
     </div>
     <div class="stat">
-      <div class="number">22</div>
+      <div class="number">16</div>
       <div class="label">MCP server tools</div>
     </div>
     <div class="stat">


### PR DESCRIPTION
## Summary

- Authoritative tool count from `len(asyncio.run(mcp.list_tools()))` is **16**.
- Sweep two residual user-facing locations that still advertised stale counts after the spec-16 API consolidation:
  - `CONTRIBUTING.md` MCP Server layer row: `19 tools` -> `16 tools`
  - `docs/presentation.html` "What's shipped" slide: `10 skills, 22 MCP tools` -> `14 skills, 16 MCP tools`
- The five files enumerated in #366 (`plugin-install.md`, `building-a-second-brain-for-claude-code.md`, `roadmap.md`, `architecture.svg`, `presentation.html` line 952) already reflect 16 on `main`; this PR finishes the sweep for the remaining user-facing mentions.
- Historical references (CHANGELOG entries, spec docs under `docs/specs/05-*` and `docs/specs/07-*`, `roadmap.md` consolidation-history line) and at-the-time-accurate test docstrings were intentionally left alone.

## Test plan

- [x] `python -c "import asyncio; from distillery.mcp.server import mcp; print(len(asyncio.run(mcp.list_tools())))"` -> `16`
- [x] `grep -n "19 tools\|22 MCP tools" CONTRIBUTING.md docs/presentation.html` returns no matches after the change
- [ ] CI (lint/type/tests) green — no Python files touched

Fixes #366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines to reflect current tool counts.
  * Updated presentation slides and summaries to show 14 conversational skills and 16 MCP tools across materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->