### PR TITLE
fix(cli): preserve top-level --config/--format across subparsers

### DIFF
--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -44,9 +44,16 @@ def _build_parser() -> argparse.ArgumentParser:
     inherited by each subcommand.  Subcommands define their own copies so
     that they appear in per-subcommand ``--help`` output; the parent
     values act as defaults when the subcommand does not override them.
+
+    To prevent the subparser's default from clobbering a value passed at the
+    top level (argparse populates ``args`` first from the parent, then lets
+    the subparser overwrite every dest it declares), the subparser-side
+    copies use ``default=argparse.SUPPRESS``.  SUPPRESS tells argparse to
+    leave the namespace untouched when the flag is absent, so
+    ``distillery --config X status`` and ``distillery status --config X``
+    both yield ``args.config == 'X'``.
     """
-    # Shared options defined on a parent parser so they appear both at the
-    # top level and inside each subcommand's --help.
+    # Shared options defined on a parent parser so they appear at the top level.
     shared = argparse.ArgumentParser(add_help=False)
     shared.add_argument(
         "--config",
@@ -61,6 +68,27 @@ def _build_parser() -> argparse.ArgumentParser:
         "--format",
         choices=["text", "json"],
         default="text",
+        help="Output format (default: text)",
+    )
+
+    # Subparser-side copy with SUPPRESS defaults.  This makes the flags
+    # visible in per-subcommand ``--help`` output without clobbering the
+    # top-level parent's parsed values when the flag is omitted after the
+    # subcommand.
+    sub_shared = argparse.ArgumentParser(add_help=False)
+    sub_shared.add_argument(
+        "--config",
+        metavar="PATH",
+        default=argparse.SUPPRESS,
+        help=(
+            f"Path to configuration file (overrides {CONFIG_ENV_VAR} env var "
+            "and the default distillery.yaml search)"
+        ),
+    )
+    sub_shared.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default=argparse.SUPPRESS,
         help="Output format (default: text)",
     )
 
@@ -80,19 +108,19 @@ def _build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser(
         "status",
         help="Display database statistics",
-        parents=[shared],
+        parents=[sub_shared],
     )
 
     subparsers.add_parser(
         "health",
         help="Verify database connectivity",
-        parents=[shared],
+        parents=[sub_shared],
     )
 
     poll_parser = subparsers.add_parser(
         "poll",
         help="Poll configured feed sources and store relevant items",
-        parents=[shared],
+        parents=[sub_shared],
     )
     poll_parser.add_argument(
         "--source",
@@ -104,7 +132,7 @@ def _build_parser() -> argparse.ArgumentParser:
     retag_parser = subparsers.add_parser(
         "retag",
         help="Backfill topic tags on existing feed entries",
-        parents=[shared],
+        parents=[sub_shared],
     )
     retag_parser.add_argument(
         "--dry-run",
@@ -122,7 +150,7 @@ def _build_parser() -> argparse.ArgumentParser:
     gh_backfill_parser = subparsers.add_parser(
         "gh-backfill",
         help="Backfill project/tags/author/metadata on existing GitHub entries (#312)",
-        parents=[shared],
+        parents=[sub_shared],
     )
     gh_backfill_parser.add_argument(
         "--dry-run",
@@ -134,7 +162,7 @@ def _build_parser() -> argparse.ArgumentParser:
     export_parser = subparsers.add_parser(
         "export",
         help="Export all entries and feed sources to a JSON file",
-        parents=[shared],
+        parents=[sub_shared],
     )
     export_parser.add_argument(
         "--output",
@@ -146,7 +174,7 @@ def _build_parser() -> argparse.ArgumentParser:
     import_parser = subparsers.add_parser(
         "import",
         help="Import entries and feed sources from a JSON export file",
-        parents=[shared],
+        parents=[sub_shared],
     )
     import_parser.add_argument(
         "--input",
@@ -170,7 +198,7 @@ def _build_parser() -> argparse.ArgumentParser:
     eval_parser = subparsers.add_parser(
         "eval",
         help="Run skill evaluation scenarios against Claude",
-        parents=[shared],
+        parents=[sub_shared],
     )
     eval_parser.add_argument(
         "--skill",
@@ -212,14 +240,14 @@ def _build_parser() -> argparse.ArgumentParser:
     maintenance_parser = subparsers.add_parser(
         "maintenance",
         help="Database maintenance operations",
-        parents=[shared],
+        parents=[sub_shared],
     )
     maintenance_subparsers = maintenance_parser.add_subparsers(dest="maintenance_command")
 
     classify_parser = maintenance_subparsers.add_parser(
         "classify",
         help="Classify pending inbox entries using batch classification",
-        parents=[shared],
+        parents=[sub_shared],
     )
     classify_parser.add_argument(
         "--type",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 
 from distillery import __version__
 from distillery.cli import (
+    _build_parser,
     _check_health,
     _cmd_export,
     _cmd_health,
@@ -272,6 +273,84 @@ class TestConfigFlag:
         with pytest.raises(SystemExit) as exc:
             main(["status", "--config", missing])
         assert exc.value.code == 1
+
+    # --- Regression: #373 — top-level flags must survive the subparser -------
+
+    def test_top_level_config_flag_before_subcommand_reaches_handler(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``distillery --config X status`` must honour the top-level --config.
+
+        Regression test for #373 — argparse used to let the subparser's default
+        clobber the parent-parsed value, silently dropping the user's --config.
+        """
+        cfg_path = write_config(tmp_path, ":memory:")
+        with pytest.raises(SystemExit) as exc:
+            main(["--config", str(cfg_path), "status"])
+        assert exc.value.code == 0
+
+    def test_top_level_format_flag_before_subcommand_reaches_handler(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``distillery --format json status`` must emit JSON (regression for #373)."""
+        cfg_path = write_config(tmp_path, ":memory:")
+        with pytest.raises(SystemExit) as exc:
+            main(["--config", str(cfg_path), "--format", "json", "status"])
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        # JSON output is a parseable object; text output is not.
+        json.loads(captured.out)
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            # Both orderings of --config: before and after the subcommand.
+            ["--config", "/tmp/X.yaml", "status"],
+            ["status", "--config", "/tmp/X.yaml"],
+            # Both orderings of --format.
+            ["--format", "json", "status"],
+            ["status", "--format", "json"],
+            # Combined — all flags before the subcommand.
+            ["--config", "/tmp/X.yaml", "--format", "json", "status"],
+            # Combined — all flags after the subcommand.
+            ["status", "--config", "/tmp/X.yaml", "--format", "json"],
+        ],
+    )
+    def test_flags_yield_same_namespace_regardless_of_position(
+        self,
+        argv: list[str],
+    ) -> None:
+        """The Namespace's ``config`` / ``format`` values must not depend on flag position.
+
+        This is the core invariant #373 violated: argparse's subparser was
+        overwriting parent-parsed values with its own default (None / "text").
+        """
+        parser = _build_parser()
+        ns = parser.parse_args(argv)
+        if "--config" in argv:
+            assert ns.config == "/tmp/X.yaml"
+        else:
+            assert ns.config is None
+        if "--format" in argv:
+            assert ns.format == "json"
+        else:
+            assert ns.format == "text"
+
+    def test_flags_on_nested_subcommand_work_in_every_position(self) -> None:
+        """Regression for #373 extended to nested ``maintenance classify``."""
+        parser = _build_parser()
+        for argv in [
+            ["--config", "X", "maintenance", "classify"],
+            ["maintenance", "--config", "X", "classify"],
+            ["maintenance", "classify", "--config", "X"],
+        ]:
+            ns = parser.parse_args(argv)
+            assert ns.config == "X", f"--config dropped for argv={argv!r}"
+            assert ns.command == "maintenance"
+            assert ns.maintenance_command == "classify"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Top-level `--config` and `--format` flags were silently dropped when placed before the subcommand (e.g. `distillery --config /tmp/cfg.yaml status` hit the default DB). Argparse populated the Namespace from the parent first, then let each subparser overwrite the same dest with its own default.
- Fix: introduce a second shared-parent parser whose `--config` / `--format` use `default=argparse.SUPPRESS`, and attach it to every subparser. SUPPRESS tells argparse to leave the Namespace untouched when the flag is absent, so the parent-parsed value survives.
- The flags still appear in per-subcommand `--help` output, matching the documented behaviour.

## Test plan

- [x] `pytest tests/test_cli*.py -v` — 84 pass (7 new regression tests, including parameterised position-invariance and the nested `maintenance classify` case)
- [x] `ruff check src/ tests/` — all checks pass
- [x] `mypy --strict src/distillery/` — no issues in 61 files
- [x] Manual: `distillery --config X status` and `distillery status --config X` now yield the same `args.config`, same for `--format`

Fixes #373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI argument handling so `--config` and `--format` flags are correctly preserved regardless of their placement relative to subcommands (e.g., `distillery --config X status` now works as expected).

* **Tests**
  * Added regression tests to verify flag handling across different command argument orderings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->