### PR TITLE
fix(mcp): isolate per-item validation in distillery_store_batch

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -407,8 +407,19 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
               - project (str, optional): Per-entry project override.
           - project (str, optional): Default project applied to entries lacking one.
 
-        RETURNS (success): { entry_ids: list[str], count: int }
+        RETURNS (success): {
+            entry_ids: list[str | None],   # per-item ids; null for failed items
+            count: int,                    # number actually persisted
+            results: list[dict],           # per-item status preserving input order
+        }
+          - Successful items: { entry_id, persisted: true, dedup_action: "stored" }
+          - Failed items:     { entry_id: null, persisted: false, error: { code, message, details? } }
+        Validation failures on individual items no longer abort the batch —
+        valid entries are persisted and failures are reported per item in
+        ``results`` (issue #364).  Iterate ``results`` to discover failures.
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
+          Top-level error is returned only for schema-level problems
+          (``entries`` not a list, budget exhaustion, persistence failure).
 
         RELATED: distillery_store (single entry with dedup/conflict checks),
         distillery_watch (add feed sources with optional history sync)

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -435,13 +435,56 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         # Mirror the attribution/audit pattern used by other mutating wrappers
         # (distillery_store, distillery_update, distillery_correct,
         # distillery_resolve_review) so batch imports are not unaudited.
+        # Drive auditing off the per-item ``results`` list so invalid items
+        # (whose ``entry_id`` is ``None``) are recorded as failures rather
+        # than logged as successes with a null id (issue #364 follow-up).
         rd = json.loads(result[0].text) if result else {}
-        entry_ids = rd.get("entry_ids", []) or []
-        if entry_ids:
-            for entry_id in entry_ids:
-                await _audit(c, user, "distillery_store_batch", entry_id, "store", result)
-        else:
+        if rd.get("error"):
+            # Top-level failure (schema/budget/persistence) — record a single
+            # failure row so the audit trail reflects the aborted call.
             await _audit(c, user, "distillery_store_batch", "", "store", result)
+        else:
+            per_item = rd.get("results") or []
+            if not per_item:
+                # Empty batch — still emit a single audit row for traceability.
+                await _audit(c, user, "distillery_store_batch", "", "store", result)
+            else:
+                for item in per_item:
+                    if item.get("persisted"):
+                        eid = item.get("entry_id") or ""
+                        try:
+                            await c["store"].write_audit_log(
+                                user,
+                                "distillery_store_batch",
+                                eid,
+                                "store",
+                                "success",
+                            )
+                        except Exception:  # noqa: BLE001
+                            logger.debug(
+                                "audit_log write failed for "
+                                "distillery_store_batch (ignored)",
+                                exc_info=True,
+                            )
+                    else:
+                        # Invalid item — surface as "store_failed" so the
+                        # audit trail distinguishes validation rejects from
+                        # persisted rows (matches the "not_found"/"forbidden"
+                        # convention used by ``_own``).
+                        try:
+                            await c["store"].write_audit_log(
+                                user,
+                                "distillery_store_batch",
+                                "",
+                                "store_failed",
+                                "error",
+                            )
+                        except Exception:  # noqa: BLE001
+                            logger.debug(
+                                "audit_log write failed for "
+                                "distillery_store_batch (ignored)",
+                                exc_info=True,
+                            )
         return result
 
     @server.tool

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -640,6 +640,163 @@ async def _handle_store(
 # ---------------------------------------------------------------------------
 
 
+def _build_invalid_entry_type_error(value: Any, *, prefix: str = "") -> dict[str, Any]:
+    """Build the per-item error payload for an invalid *entry_type*.
+
+    Mirrors :func:`_invalid_entry_type_response` but returns just the
+    ``{code, message, details}`` dict so per-item errors in
+    :func:`_handle_store_batch` can surface the same structured suggestion
+    (e.g. ``"note"`` → ``"inbox"``) that callers receive from single-entry
+    validation.
+    """
+    allowed = ", ".join(sorted(_VALID_ENTRY_TYPES))
+    message = f"{prefix}Invalid entry_type {value!r}. Must be one of: {allowed}."
+    details: dict[str, Any] = {
+        "field": "entry_type",
+        "provided": value,
+        "allowed": sorted(_VALID_ENTRY_TYPES),
+    }
+    suggestion = _suggest_entry_type(value)
+    if suggestion is not None:
+        message += f" Did you mean {suggestion!r}?"
+        details["suggestion"] = suggestion
+    return {"code": "INVALID_PARAMS", "message": message, "details": details}
+
+
+def _validate_batch_item(
+    idx: int,
+    item: Any,
+    *,
+    project_default: Any,
+    created_by: str,
+    cfg: DistilleryConfig | None,
+) -> tuple[Any, dict[str, Any] | None]:
+    """Validate a single ``distillery_store_batch`` entry dict.
+
+    Returns a ``(entry, error)`` tuple where exactly one of the two is
+    non-``None``.  When validation succeeds, ``entry`` is a fully constructed
+    :class:`~distillery.models.Entry`; otherwise ``error`` is a
+    ``{code, message, details?}`` dict ready to embed in the per-item
+    ``results`` list.
+    """
+    from distillery.models import Entry, EntrySource, EntryType
+
+    if not isinstance(item, dict):
+        return None, {
+            "code": "INVALID_PARAMS",
+            "message": f"entries[{idx}] must be a dict, got {type(item).__name__}.",
+        }
+    if "content" not in item:
+        return None, {
+            "code": "INVALID_PARAMS",
+            "message": f"entries[{idx}] is missing required 'content'.",
+        }
+    if "author" not in item:
+        return None, {
+            "code": "INVALID_PARAMS",
+            "message": f"entries[{idx}] is missing required 'author'.",
+        }
+
+    entry_type_str = item.get("entry_type", "inbox")
+    if entry_type_str not in _VALID_ENTRY_TYPES:
+        return None, _build_invalid_entry_type_error(entry_type_str, prefix=f"entries[{idx}] has ")
+
+    source_str = str(item.get("source", EntrySource.CLAUDE_CODE.value))
+    if source_str not in _VALID_SOURCES:
+        return None, {
+            "code": "INVALID_PARAMS",
+            "message": (
+                f"entries[{idx}] has invalid source {source_str!r}. "
+                f"Must be one of: {', '.join(sorted(_VALID_SOURCES))}."
+            ),
+        }
+
+    # --- normalize tags (mirror _handle_store logic) ---
+    tags_raw = item.get("tags")
+    if tags_raw is None:
+        tags_normalized: list[Any] = []
+    elif isinstance(tags_raw, str):
+        tags_normalized = [tags_raw]
+    elif isinstance(tags_raw, list):
+        tags_normalized = tags_raw
+    else:
+        return None, {
+            "code": "INVALID_PARAMS",
+            "message": (
+                f"entries[{idx}] has invalid tags: must be a list or string, "
+                f"got {type(tags_raw).__name__}."
+            ),
+        }
+
+    # Validate each tag is a non-empty string
+    final_tags: list[str] = []
+    for tag in tags_normalized:
+        if not isinstance(tag, str):
+            return None, {
+                "code": "INVALID_PARAMS",
+                "message": (
+                    f"entries[{idx}]: each tag must be a string, got {type(tag).__name__}."
+                ),
+            }
+        tag_stripped = tag.strip()
+        if tag_stripped:
+            final_tags.append(tag_stripped)
+
+    # --- reserved prefix enforcement (mirror _handle_store logic) ---
+    _reserved_allowed_sources: set[str] = {EntrySource.IMPORT.value}
+    if (
+        cfg is not None
+        and cfg.tags.reserved_prefixes
+        and source_str not in _reserved_allowed_sources
+    ):
+        for tag in final_tags:
+            top = tag.split("/")[0]
+            if top in cfg.tags.reserved_prefixes:
+                return None, {
+                    "code": "INVALID_PARAMS",
+                    "message": (
+                        f"entries[{idx}]: tag {tag!r} uses reserved prefix {top!r}. "
+                        "Only internal sources may use this namespace."
+                    ),
+                }
+
+    # Validate metadata shape before coercion. ``dict(x)`` accepts
+    # lists-of-pairs and other iterables, so bare coercion would let
+    # malformed payloads slip through (or raise TypeError opaquely).
+    raw_meta = item.get("metadata")
+    if raw_meta is None:
+        metadata: dict[str, Any] = {}
+    elif isinstance(raw_meta, Mapping):
+        metadata = dict(raw_meta)
+    else:
+        return None, {
+            "code": "INVALID_PARAMS",
+            "message": f"entries[{idx}].metadata must be an object",
+        }
+
+    try:
+        entry = Entry(
+            content=item["content"],
+            entry_type=EntryType(entry_type_str),
+            source=EntrySource(source_str),
+            author=item["author"],
+            project=item.get("project", project_default),
+            tags=final_tags,
+            metadata=metadata,
+            created_by=created_by,
+        )
+    except Exception:  # noqa: BLE001
+        # Log the full traceback server-side so operators can diagnose,
+        # but return a generic client-facing message — raw exception text
+        # may include unsanitised payload fragments or internal details.
+        logger.exception("distillery_store_batch: Entry() rejected item %d", idx)
+        return None, {
+            "code": "INVALID_PARAMS",
+            "message": f"entries[{idx}]: failed to construct entry",
+        }
+    return entry, None
+
+
 async def _handle_store_batch(
     store: Any,
     arguments: dict[str, Any],
@@ -647,6 +804,15 @@ async def _handle_store_batch(
     created_by: str = "",
 ) -> list[types.TextContent]:
     """Batch-store multiple entries without dedup or conflict checks.
+
+    Per-item validation isolates failures: invalid items do not block the
+    rest of the batch.  Valid entries are persisted; each invalid entry is
+    reported as ``{entry_id: null, persisted: false, error: {...}}`` in the
+    per-item ``results`` list so callers can iterate failures without
+    retrying the whole page (issue #364).  Top-level ``error`` is still
+    returned for schema-level problems (``entries`` not a list, budget
+    exhaustion, persistence failure) that prevent the batch from running
+    at all.
 
     Args:
         store: An initialised storage backend.
@@ -658,14 +824,17 @@ async def _handle_store_batch(
 
     Returns:
         A structured MCP success or error response.  On success the payload
-        contains ``entry_ids`` (list[str], preserved for backward
-        compatibility), ``count`` (int), and ``results`` — a per-entry list
-        of ``{"entry_id", "persisted", "dedup_action"}`` dicts.  Because the
-        batch path never runs deduplication, every entry is reported as
-        ``persisted=True`` with ``dedup_action="stored"``.
+        contains:
+          - ``entry_ids`` (list[str | None]): per-item ids preserving input
+            order; ``None`` for items that failed validation.
+          - ``count`` (int): number of entries actually persisted.
+          - ``results`` (list[dict]): per-item status.  Successful items
+            carry ``{"entry_id", "persisted": true, "dedup_action":
+            "stored"}``.  Failed items carry ``{"entry_id": null,
+            "persisted": false, "error": {"code", "message", "details"?}}``.
     """
     from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
-    from distillery.models import Entry, EntrySource, EntryType
+    from distillery.models import Entry
 
     entries_raw = arguments.get("entries")
     if not isinstance(entries_raw, list):
@@ -674,109 +843,39 @@ async def _handle_store_batch(
     project_default = arguments.get("project")
 
     # --- validate each entry dict -------------------------------------------
-    built: list[Entry] = []
+    # Per-item validation: invalid items are recorded but do not abort the
+    # batch.  ``valid_entries`` tracks only the items that will be persisted,
+    # along with their original index so the ``results`` list preserves input
+    # ordering.
+    valid_entries: list[tuple[int, Entry]] = []
+    item_errors: dict[int, dict[str, Any]] = {}
     for idx, item in enumerate(entries_raw):
-        if not isinstance(item, dict):
-            return error_response(
-                "INVALID_PARAMS", f"entries[{idx}] must be a dict, got {type(item).__name__}."
-            )
-        if "content" not in item:
-            return error_response(
-                "INVALID_PARAMS", f"entries[{idx}] is missing required 'content'."
-            )
-        if "author" not in item:
-            return error_response("INVALID_PARAMS", f"entries[{idx}] is missing required 'author'.")
-
-        entry_type_str = item.get("entry_type", "inbox")
-        if entry_type_str not in _VALID_ENTRY_TYPES:
-            return _invalid_entry_type_response(entry_type_str, prefix=f"entries[{idx}] has ")
-
-        source_str = str(item.get("source", EntrySource.CLAUDE_CODE.value))
-        if source_str not in _VALID_SOURCES:
-            return error_response(
-                "INVALID_PARAMS",
-                f"entries[{idx}] has invalid source {source_str!r}. "
-                f"Must be one of: {', '.join(sorted(_VALID_SOURCES))}.",
-            )
-
-        # --- normalize tags (mirror _handle_store logic) ---
-        tags_raw = item.get("tags")
-        if tags_raw is None:
-            tags_normalized = []
-        elif isinstance(tags_raw, str):
-            tags_normalized = [tags_raw]
-        elif isinstance(tags_raw, list):
-            tags_normalized = tags_raw
+        entry, err = _validate_batch_item(
+            idx,
+            item,
+            project_default=project_default,
+            created_by=created_by,
+            cfg=cfg,
+        )
+        if err is not None:
+            item_errors[idx] = err
         else:
-            return error_response(
-                "INVALID_PARAMS",
-                f"entries[{idx}] has invalid tags: must be a list or string, got {type(tags_raw).__name__}.",
-            )
+            assert entry is not None  # for mypy
+            valid_entries.append((idx, entry))
 
-        # Validate each tag is a non-empty string
-        final_tags: list[str] = []
-        for tag in tags_normalized:
-            if not isinstance(tag, str):
-                return error_response(
-                    "INVALID_PARAMS",
-                    f"entries[{idx}]: each tag must be a string, got {type(tag).__name__}.",
-                )
-            tag_stripped = tag.strip()
-            if tag_stripped:
-                final_tags.append(tag_stripped)
+    # Empty input or all-invalid input: no persistence required, but still
+    # return the per-item ``results`` (with any validation errors) so callers
+    # get actionable feedback.
+    if not valid_entries:
+        results: list[dict[str, Any]] = []
+        entry_ids_out: list[str | None] = []
+        for idx in range(len(entries_raw)):
+            err = item_errors[idx]
+            results.append({"entry_id": None, "persisted": False, "error": err})
+            entry_ids_out.append(None)
+        return success_response({"entry_ids": entry_ids_out, "results": results, "count": 0})
 
-        # --- reserved prefix enforcement (mirror _handle_store logic) ---
-        _reserved_allowed_sources: set[str] = {EntrySource.IMPORT.value}
-        if (
-            cfg is not None
-            and cfg.tags.reserved_prefixes
-            and source_str not in _reserved_allowed_sources
-        ):
-            for tag in final_tags:
-                top = tag.split("/")[0]
-                if top in cfg.tags.reserved_prefixes:
-                    return error_response(
-                        "INVALID_PARAMS",
-                        f"entries[{idx}]: tag {tag!r} uses reserved prefix {top!r}. "
-                        "Only internal sources may use this namespace.",
-                    )
-
-        # Validate metadata shape before coercion. ``dict(x)`` accepts
-        # lists-of-pairs and other iterables, so bare coercion would let
-        # malformed payloads slip through (or raise TypeError opaquely).
-        raw_meta = item.get("metadata")
-        if raw_meta is None:
-            metadata: dict[str, Any] = {}
-        elif isinstance(raw_meta, Mapping):
-            metadata = dict(raw_meta)
-        else:
-            return error_response(
-                "INVALID_PARAMS",
-                f"entries[{idx}].metadata must be an object",
-            )
-        try:
-            entry = Entry(
-                content=item["content"],
-                entry_type=EntryType(entry_type_str),
-                source=EntrySource(source_str),
-                author=item["author"],
-                project=item.get("project", project_default),
-                tags=final_tags,
-                metadata=metadata,
-                created_by=created_by,
-            )
-        except Exception:  # noqa: BLE001
-            # Log the full traceback server-side so operators can diagnose,
-            # but return a generic client-facing message — raw exception text
-            # may include unsanitised payload fragments or internal details.
-            logger.exception("distillery_store_batch: Entry() rejected item %d", idx)
-            return error_response(
-                "INVALID_PARAMS", f"entries[{idx}]: failed to construct entry"
-            )
-        built.append(entry)
-
-    if not built:
-        return success_response({"entry_ids": [], "results": [], "count": 0})
+    built = [entry for _, entry in valid_entries]
 
     # --- db size check (same guard as _handle_store) -------------------------
     if cfg is not None and cfg.rate_limit.max_db_size_mb > 0:
@@ -795,6 +894,8 @@ async def _handle_store_batch(
                 pass  # can't stat, skip check
 
     # --- embedding budget check (1 embed per entry, no dedup) ---------------
+    # Only the valid subset will be embedded / persisted, so count that
+    # rather than the raw input length.
     if cfg is not None:
         try:
             record_and_check(
@@ -814,7 +915,7 @@ async def _handle_store_batch(
 
     # --- persist ------------------------------------------------------------
     try:
-        entry_ids = await store.store_batch(built)
+        persisted_ids = await store.store_batch(built)
     except EmbeddingProviderError as exc:
         logger.warning(
             "Upstream embedding provider failed during store_batch "
@@ -830,12 +931,30 @@ async def _handle_store_batch(
         logger.exception("Error in store_batch")
         return error_response("INTERNAL", "Failed to batch-store entries")
 
+    # --- assemble per-item results ------------------------------------------
     # Batch-store does not run deduplication; every persisted entry is
     # reported with ``persisted=True`` and ``dedup_action="stored"``.  This
     # keeps the batch response shape aligned with the single-entry
     # ``distillery_store`` response so callers can rely on the same keys.
-    results = [{"entry_id": eid, "persisted": True, "dedup_action": "stored"} for eid in entry_ids]
-    return success_response({"entry_ids": entry_ids, "results": results, "count": len(entry_ids)})
+    # Invalid items (recorded in ``item_errors``) are emitted at their
+    # original position with ``entry_id=null`` so ``results`` length always
+    # matches the input length.
+    id_by_index = {
+        orig_idx: pid for (orig_idx, _), pid in zip(valid_entries, persisted_ids, strict=True)
+    }
+    results = []
+    entry_ids_out = []
+    for idx in range(len(entries_raw)):
+        if idx in item_errors:
+            results.append({"entry_id": None, "persisted": False, "error": item_errors[idx]})
+            entry_ids_out.append(None)
+        else:
+            pid = id_by_index[idx]
+            results.append({"entry_id": pid, "persisted": True, "dedup_action": "stored"})
+            entry_ids_out.append(pid)
+    return success_response(
+        {"entry_ids": entry_ids_out, "results": results, "count": len(persisted_ids)}
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1265,9 +1384,7 @@ async def _handle_list(
     # Validate the type first so truthy non-bool values (e.g. ``1``, ``"true"``)
     # can't slip past the ``is True`` check below and skip the guard entirely.
     if "batch_mode" in arguments and not isinstance(arguments["batch_mode"], bool):
-        return error_response(
-            "INVALID_PARAMS", "Field 'batch_mode' must be a boolean (true/false)"
-        )
+        return error_response("INVALID_PARAMS", "Field 'batch_mode' must be a boolean (true/false)")
     if arguments.get("batch_mode") is True:
         real_filter_keys = {
             "source",

--- a/tests/test_async_sync_pipeline.py
+++ b/tests/test_async_sync_pipeline.py
@@ -688,14 +688,17 @@ class TestHandleStoreBatch:
 
     @pytest.mark.unit
     async def test_batch_store_missing_author(self, store) -> None:  # type: ignore[no-untyped-def]
-        # crud._handle_store_batch requires 'author' for each entry; missing
-        # author returns an INVALID_PARAMS error response immediately.
+        # crud._handle_store_batch validates per-item (issue #364); missing
+        # author surfaces as a per-item error in ``results`` rather than a
+        # top-level failure that aborts the batch.
         entries = [
             {"content": "Valid entry", "entry_type": "reference"},  # missing author
         ]
         result = await _handle_store_batch(store=store, arguments={"entries": entries})
         data = _parse_response(result)
-        assert "error" in data or data.get("error_code")
+        assert data.get("count") == 0
+        assert data["results"][0]["persisted"] is False
+        assert data["results"][0]["error"]["code"] == "INVALID_PARAMS"
 
     @pytest.mark.unit
     async def test_batch_store_empty_list(self, store) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_bulk_ingest.py
+++ b/tests/test_bulk_ingest.py
@@ -82,35 +82,39 @@ async def test_handle_store_batch_per_entry_project_override() -> None:
 
 @pytest.mark.unit
 async def test_handle_store_batch_missing_content() -> None:
-    """Missing content should return INVALID_PARAMS."""
+    """Missing content should surface as a per-item error (issue #364)."""
     store = _make_mock_store()
     result = await _handle_store_batch(
         store=store,
         arguments={"entries": [{"author": "alice"}]},
     )
     data = parse_mcp_response(result)
-    assert data["error"] is True
-    assert data["code"] == "INVALID_PARAMS"
-    assert "content" in data["message"]
+    assert "error" not in data or data["error"] is False
+    assert data["count"] == 0
+    item_err = data["results"][0]["error"]
+    assert item_err["code"] == "INVALID_PARAMS"
+    assert "content" in item_err["message"]
 
 
 @pytest.mark.unit
 async def test_handle_store_batch_missing_author() -> None:
-    """Missing author should return INVALID_PARAMS."""
+    """Missing author should surface as a per-item error (issue #364)."""
     store = _make_mock_store()
     result = await _handle_store_batch(
         store=store,
         arguments={"entries": [{"content": "text"}]},
     )
     data = parse_mcp_response(result)
-    assert data["error"] is True
-    assert data["code"] == "INVALID_PARAMS"
-    assert "author" in data["message"]
+    assert "error" not in data or data["error"] is False
+    assert data["count"] == 0
+    item_err = data["results"][0]["error"]
+    assert item_err["code"] == "INVALID_PARAMS"
+    assert "author" in item_err["message"]
 
 
 @pytest.mark.unit
 async def test_handle_store_batch_invalid_entry_type() -> None:
-    """Invalid entry_type should return INVALID_PARAMS."""
+    """Invalid entry_type for an only-item batch: top-level success, per-item error."""
     store = _make_mock_store()
     result = await _handle_store_batch(
         store=store,
@@ -121,9 +125,17 @@ async def test_handle_store_batch_invalid_entry_type() -> None:
         },
     )
     data = parse_mcp_response(result)
-    assert data["error"] is True
-    assert data["code"] == "INVALID_PARAMS"
-    assert "bogus" in data["message"]
+    # Top-level is success (no ``error: true``) — per-item failures now
+    # surface via the ``results`` array (issue #364).
+    assert "error" not in data or data["error"] is False
+    assert data["count"] == 0
+    assert data["entry_ids"] == [None]
+    assert len(data["results"]) == 1
+    item_err = data["results"][0]["error"]
+    assert item_err["code"] == "INVALID_PARAMS"
+    assert "bogus" in item_err["message"]
+    # store.store_batch is never awaited when no valid entries remain.
+    store.store_batch.assert_not_awaited()
 
 
 @pytest.mark.unit
@@ -139,11 +151,64 @@ async def test_handle_store_batch_entry_type_note_suggests_inbox() -> None:
         },
     )
     data = parse_mcp_response(result)
-    assert data["error"] is True
-    assert data["code"] == "INVALID_PARAMS"
-    assert data["details"]["suggestion"] == "inbox"
+    # Per-item failure, not a top-level error (issue #364).
+    assert "error" not in data or data["error"] is False
+    assert data["count"] == 0
+    item_err = data["results"][0]["error"]
+    assert item_err["code"] == "INVALID_PARAMS"
+    assert item_err["details"]["suggestion"] == "inbox"
     # The prefixed message keeps per-entry context.
-    assert "entries[0]" in data["message"]
+    assert "entries[0]" in item_err["message"]
+
+
+@pytest.mark.unit
+async def test_handle_store_batch_partial_success_invalid_middle_item() -> None:
+    """Issue #364: a batch of 3 with item 2 invalid should persist items 0 and 2.
+
+    Items 0 and 2 are valid; item 1 has an invalid ``entry_type``.  The call
+    should succeed at the top level, persist the two valid entries, and
+    report the invalid item as a per-item failure with ``entry_id=None``.
+    """
+    store = _make_mock_store(["id-0", "id-2"])
+    result = await _handle_store_batch(
+        store=store,
+        arguments={
+            "entries": [
+                {"content": "first", "author": "alice"},
+                {"content": "second (bad)", "author": "bob", "entry_type": "bogus"},
+                {"content": "third", "author": "carol"},
+            ],
+        },
+    )
+    data = parse_mcp_response(result)
+    # Top level is a success response.
+    assert "error" not in data or data["error"] is False
+    assert data["count"] == 2
+    # ``entry_ids`` preserves input order with ``None`` for the failed item.
+    assert data["entry_ids"] == ["id-0", None, "id-2"]
+
+    results = data["results"]
+    assert len(results) == 3
+
+    # Item 0: persisted successfully.
+    assert results[0] == {"entry_id": "id-0", "persisted": True, "dedup_action": "stored"}
+
+    # Item 1: validation failure surfaced per-item, not at the top level.
+    assert results[1]["entry_id"] is None
+    assert results[1]["persisted"] is False
+    assert results[1]["error"]["code"] == "INVALID_PARAMS"
+    assert "entries[1]" in results[1]["error"]["message"]
+    assert "bogus" in results[1]["error"]["message"]
+
+    # Item 2: persisted successfully.
+    assert results[2] == {"entry_id": "id-2", "persisted": True, "dedup_action": "stored"}
+
+    # store_batch was called with only the two valid entries (in input order).
+    store.store_batch.assert_awaited_once()
+    passed = store.store_batch.call_args[0][0]
+    assert len(passed) == 2
+    assert passed[0].content == "first"
+    assert passed[1].content == "third"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- `distillery_store_batch` previously rejected the entire batch on the first invalid item, persisting zero entries. A single malformed entry in a bulk-ingest flow (gh-sync paging, RSS backfill, watch `sync_history`) would tank a whole page of work and force the caller to either hand-validate every record or drop the batch size to 1.
- Switched to per-item validation: each entry is validated independently, valid entries are persisted, and invalid items are reported in the response `results` array as `{entry_id: null, persisted: false, error: {code, message, details?}}`. Input order is preserved in both `results` and `entry_ids` (with `null` for failed items).
- Top-level `error: true` is now reserved for schema-level problems (`entries` not a list, budget exhaustion, persistence failure). Individual validation failures no longer block the batch.

## Notes

- Extracted `_validate_batch_item` and `_build_invalid_entry_type_error` helpers so the per-item errors still carry the same structured `details.suggestion` callers get from single-entry validation (e.g. `"note"` → `"inbox"`).
- Embedding budget check now counts only the valid subset (what will actually be embedded).
- Tool description in `server.py` updated to document the new contract.

## Test plan

- [x] Added `test_handle_store_batch_partial_success_invalid_middle_item`: batch of 3 with item 1 invalid → items 0 and 2 persisted, item 1 reported as a per-item failure with `entry_id=null`.
- [x] Updated the existing `missing_content` / `missing_author` / `invalid_entry_type` / `entry_type_note_suggests_inbox` unit tests to assert the new partial-success contract.
- [x] `pytest tests/test_bulk_ingest.py tests/test_store_batch.py tests/test_store_dedup_response.py` — 24 passed.
- [x] `ruff check src/ tests/` — clean.
- [x] `mypy --strict src/distillery/` — clean.

Fixes #364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch ingest now returns per-item results preserving input order: successful items show persisted info; failed items include per-item error details. Returned entry IDs may be null for failures.

* **Bug Fixes**
  * Batches no longer abort on individual-item validation failures; valid items are persisted and top-level success is returned with count reflecting persisted items.

* **Tests**
  * Tests updated to assert per-item error reporting and partial-success behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->