### PR TITLE
fix(config): friendly error for malformed YAML config

### DIFF
--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -1119,8 +1119,8 @@ def load_config(config_path: str | None = None) -> DistilleryConfig:
     Raises:
         FileNotFoundError: If *config_path* is given explicitly but the file
             does not exist.
-        ValueError: If the configuration contains invalid values.
-        yaml.YAMLError: If the YAML file cannot be parsed.
+        ValueError: If the configuration contains invalid values or the YAML
+            file cannot be parsed.
     """
     # If caller supplied an explicit path, it MUST exist.
     if config_path is not None:
@@ -1138,7 +1138,12 @@ def load_config(config_path: str | None = None) -> DistilleryConfig:
         return config
 
     with open(resolved, encoding="utf-8") as fh:
-        raw = yaml.safe_load(fh)
+        try:
+            raw = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            raise ValueError(
+                f"Invalid YAML syntax in configuration file {resolved}: {exc}"
+            ) from exc
 
     if raw is None:
         raw = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,6 +247,26 @@ class TestStatusCommand:
             main(["status", "--config", missing])
         assert exc.value.code == 1
 
+    def test_status_malformed_yaml_prints_friendly_error(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Malformed YAML should surface as a one-line error, not a traceback."""
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("storage:\n  database_path: [unterminated\n")
+        with pytest.raises(SystemExit) as exc:
+            main(["status", "--config", str(bad)])
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        err = captured.err
+        assert "Error loading configuration" in err
+        assert "Invalid YAML syntax" in err
+        # No Python traceback lines should leak to stderr.
+        assert "Traceback" not in err
+        assert "yaml.parser" not in err
+        assert "yaml.scanner" not in err
+
 
 # ---------------------------------------------------------------------------
 # --config flag

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -379,6 +379,13 @@ class TestValidationErrors:
         with pytest.raises(ValueError, match="mapping"):
             load_config(str(p))
 
+    def test_malformed_yaml_raises_value_error(self, tmp_path: Path) -> None:
+        """Malformed YAML surfaces as ValueError (not a raw yaml.YAMLError)."""
+        p = tmp_path / "distillery.yaml"
+        p.write_text("storage:\n  database_path: [unterminated\n")
+        with pytest.raises(ValueError, match="Invalid YAML syntax"):
+            load_config(str(p))
+
 
 # ---------------------------------------------------------------------------
 # Config path override via environment variable


### PR DESCRIPTION
## Summary

- Wrap `yaml.safe_load` in `load_config()` with a `yaml.YAMLError` handler that re-raises as `ValueError("Invalid YAML syntax in configuration file {path}: ...")`.
- Every CLI subcommand already catches `(FileNotFoundError, ValueError)` around `load_config()`, so this single patch covers all call sites (`status`, `health`, `export`, `import`, `retag`, `maintenance classify`, etc.) — no more raw `yaml.parser.ParserError`/`ScannerError` traceback leaking to stderr.
- Mirrors the existing missing-file UX: one-line friendly message to stderr, exit code 1.

Before:
```
$ distillery status --config /tmp/bad.yaml
Traceback (most recent call last):
  ...
yaml.parser.ParserError: while parsing a flow sequence ...
```

After:
```
$ distillery status --config /tmp/bad.yaml
Error loading configuration: Invalid YAML syntax in configuration file /tmp/bad.yaml: ...
$ echo $?
1
```

## Test plan

- [x] `pytest tests/test_config.py tests/test_cli.py -v` — 158 passed (+2 new tests)
- [x] `ruff check src/ tests/` — clean
- [x] `mypy --strict src/distillery/` — clean
- [x] Manual reproduction with `printf 'storage:\n  database_path: [unterminated\n' > /tmp/bad.yaml && distillery status --config /tmp/bad.yaml` now prints a friendly one-liner and exits 1.

Fixes #374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading configuration files with invalid YAML syntax — users now receive clear, friendly error messages instead of technical exceptions and tracebacks.

* **Tests**
  * Added regression tests to verify proper error handling and user-friendly messaging for malformed configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->