### PR TITLE
fix(cli): emit JSON envelope on eval error paths

### DIFF
--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -33,6 +33,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from distillery import __version__
 from distillery.config import CONFIG_ENV_VAR, load_config
 
@@ -1421,7 +1423,7 @@ def _cmd_eval(
 
     try:
         scenarios = load_scenarios_from_dir(resolved_dir)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, yaml.YAMLError, KeyError) as exc:
         _emit_eval_error(
             fmt,
             message=f"failed to load scenarios from {resolved_dir}: {exc}",

--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -1352,6 +1352,26 @@ def _format_retrieval_metrics_text(result: Any) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+def _emit_eval_error(
+    fmt: str,
+    message: str,
+    code: str,
+    **extra: Any,
+) -> None:
+    """Emit an eval error in the requested format.
+
+    When ``fmt == "json"``, print a JSON envelope on stdout so consumers
+    piping to ``jq`` always receive valid JSON. Otherwise, print a plain
+    ``Error:`` line on stderr to match the pre-existing text behaviour.
+    """
+    if fmt == "json":
+        payload: dict[str, Any] = {"status": "error", "message": message, "code": code}
+        payload.update(extra)
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"Error: {message}", file=sys.stderr)
+
+
 def _cmd_eval(
     scenarios_dir: str | None,
     skill_filter: str | None,
@@ -1373,9 +1393,13 @@ def _cmd_eval(
         from distillery.eval.runner import ClaudeEvalRunner
         from distillery.eval.scenarios import load_scenarios_from_dir
     except ImportError as exc:
-        print(
-            f"Error: eval dependencies not installed. Run: pip install 'distillery-mcp[eval]'\n{exc}",
-            file=sys.stderr,
+        _emit_eval_error(
+            fmt,
+            message=(
+                f"eval dependencies not installed. Run: "
+                f"pip install 'distillery-mcp[eval]'. {exc}"
+            ),
+            code="eval_dependencies_missing",
         )
         return 1
 
@@ -1387,15 +1411,36 @@ def _cmd_eval(
         resolved_dir = Path(scenarios_dir)
 
     if not resolved_dir.exists():
-        print(f"Error: scenarios directory not found: {resolved_dir}", file=sys.stderr)
+        _emit_eval_error(
+            fmt,
+            message=f"scenarios directory not found: {resolved_dir}",
+            code="scenarios_dir_not_found",
+            scenarios_dir=str(resolved_dir),
+        )
         return 1
 
-    scenarios = load_scenarios_from_dir(resolved_dir)
+    try:
+        scenarios = load_scenarios_from_dir(resolved_dir)
+    except (OSError, ValueError) as exc:
+        _emit_eval_error(
+            fmt,
+            message=f"failed to load scenarios from {resolved_dir}: {exc}",
+            code="scenarios_load_failed",
+            scenarios_dir=str(resolved_dir),
+        )
+        return 1
+
     if skill_filter:
         scenarios = [s for s in scenarios if s.skill == skill_filter]
 
     if not scenarios:
-        print(f"No scenarios found (skill filter: {skill_filter!r})", file=sys.stderr)
+        _emit_eval_error(
+            fmt,
+            message=f"no scenarios found (skill filter: {skill_filter!r})",
+            code="no_scenarios_found",
+            skill_filter=skill_filter,
+            scenarios_dir=str(resolved_dir),
+        )
         return 1
 
     # Override model on all scenarios.
@@ -1405,7 +1450,11 @@ def _cmd_eval(
     try:
         runner = ClaudeEvalRunner()
     except (ImportError, ValueError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+        _emit_eval_error(
+            fmt,
+            message=str(exc),
+            code="eval_runner_init_failed",
+        )
         return 1
 
     async def _run_all() -> list[Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,7 +247,6 @@ class TestStatusCommand:
             main(["status", "--config", missing])
         assert exc.value.code == 1
 
-
 # ---------------------------------------------------------------------------
 # --config flag
 # ---------------------------------------------------------------------------
@@ -1090,3 +1089,77 @@ class TestMaintenanceClassifyCommand:
         assert "usage" in captured.out.lower()
         assert "--type" in captured.out
         assert "--mode" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# eval subcommand — JSON error-path contract (issue #376)
+# ---------------------------------------------------------------------------
+
+
+class TestEvalJsonErrorPaths:
+    """``distillery eval --format json`` must emit valid JSON on every exit path.
+
+    Consumers pipe the output to ``jq``; a plain-text error breaks the pipeline.
+    """
+
+    def test_eval_json_missing_scenarios_dir(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A nonexistent --scenarios-dir emits a JSON envelope on stdout."""
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(SystemExit) as exc:
+            main(["eval", "--format", "json", "--scenarios-dir", str(missing)])
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        # stdout must be valid JSON — json.loads should not raise.
+        data = json.loads(captured.out)
+        assert data["status"] == "error"
+        assert data["code"] == "scenarios_dir_not_found"
+        assert str(missing) in data["message"]
+        assert data["scenarios_dir"] == str(missing)
+
+    def test_eval_json_unknown_skill_filter(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """An unknown --skill filter yields an empty selection and JSON error envelope."""
+        # Create an empty scenarios directory so the dir-exists check passes
+        # but the skill filter produces zero matches.
+        scenarios_dir = tmp_path / "scenarios"
+        scenarios_dir.mkdir()
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    "eval",
+                    "--format",
+                    "json",
+                    "--scenarios-dir",
+                    str(scenarios_dir),
+                    "--skill",
+                    "totally-not-a-skill",
+                ]
+            )
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["status"] == "error"
+        assert data["code"] == "no_scenarios_found"
+        assert data["skill_filter"] == "totally-not-a-skill"
+
+    def test_eval_text_missing_scenarios_dir_unchanged(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Text format retains the existing ``Error:`` stderr message."""
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(SystemExit) as exc:
+            main(["eval", "--format", "text", "--scenarios-dir", str(missing)])
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        # Text path writes to stderr, not stdout.
+        assert captured.out == ""
+        assert "scenarios directory not found" in captured.err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1126,10 +1126,15 @@ class TestEvalJsonErrorPaths:
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """An unknown --skill filter yields an empty selection and JSON error envelope."""
-        # Create an empty scenarios directory so the dir-exists check passes
-        # but the skill filter produces zero matches.
+        # Create a scenarios directory with one scenario for a *different* known
+        # skill so the skill filter produces zero matches — rather than relying
+        # on the empty-dir short-circuit to trigger no_scenarios_found.
         scenarios_dir = tmp_path / "scenarios"
         scenarios_dir.mkdir()
+        (scenarios_dir / "sample.yaml").write_text(
+            "name: sample\nskill: recall\nprompt: test\n",
+            encoding="utf-8",
+        )
         with pytest.raises(SystemExit) as exc:
             main(
                 [


### PR DESCRIPTION
## Summary

- `distillery eval --format json` silently emitted plain text on early-exit paths (missing scenarios dir, empty skill filter, import errors, runner init failures), breaking `jq` pipelines.
- Wrap each error path in a consistent JSON envelope — `{status: "error", message, code, ...extra}` — via a small `_emit_eval_error()` helper, only when `fmt == "json"`. Text format keeps the original `Error:` stderr message.
- Added JSON-loadability assertions for two error paths (missing scenarios dir, unknown skill filter) plus a text-path regression guard.

## Error codes surfaced

- `eval_dependencies_missing`
- `scenarios_dir_not_found`
- `scenarios_load_failed`
- `no_scenarios_found`
- `eval_runner_init_failed`

## Test plan

- [x] `pytest tests/test_eval*.py tests/test_cli*.py` — 177 passed, 73 skipped
- [x] `ruff check src/ tests/` — clean
- [x] `mypy --strict src/distillery/` — clean
- [x] New tests assert `json.loads(stdout)` succeeds on ≥2 error paths

Fixes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized eval command error handling with consistent JSON error envelopes (status, code, message, contextual fields) while keeping human-readable text on stderr for non-JSON runs.
  * Distinct error codes and added contextual details for missing dependencies, missing or unreadable scenarios, no scenarios found (including skill filters), and runner initialization failures.

* **Tests**
  * Added tests validating eval error outputs for both JSON and text formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->