### PR TITLE
feat(config): add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Always create a pull request for changes — never push directly to `main`. Crea
 
 - Fixtures in `tests/conftest.py`: `make_entry()`, `mock_embedding_provider`, `deterministic_embedding_provider`, `store` (async in-memory DuckDB)
 - The `deterministic_embedding_provider` uses an 8-dimensional registry for controlled similarity testing
-- CI matrix: Python 3.11, 3.12, 3.13
+- CI matrix: Python 3.11, 3.12, 3.13, 3.14
 
 ## Skills
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 


### PR DESCRIPTION
## Summary
- Adds `3.14` to the CI matrix in `.github/workflows/ci.yml`
- Adds `Programming Language :: Python :: 3.14` classifier to `pyproject.toml`
- Updates `CLAUDE.md` matrix reference

Closes #394

## Dependency wheel check (PyPI, latest versions)
- `duckdb 1.5.2` — cp314 wheels published
- `fastmcp 3.2.4` — py3-none-any (pure Python)
- `pyyaml 6.0.3` — cp314 wheels published
- `httpx 0.28.1` — py3-none-any (pure Python)
- `defusedxml 0.7.1` — py2.py3-none-any (pure Python)

No lower-bound bumps needed; `requires-python = ">=3.11"` still covers the floor.

## Local verification (Python 3.13.7)
- `ruff check src/ tests/` — All checks passed
- `mypy --strict src/` — Success: no issues found in 61 source files
- `pytest --cov=src/distillery --cov-fail-under=80` — 2371 passed, 73 skipped, coverage 85.91%

3.14 itself is exercised by the CI matrix on this PR.

## Test plan
- [ ] CI matrix job `ci (3.14)` passes
- [ ] CI matrix jobs `ci (3.11/3.12/3.13)` remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation to reflect Python 3.14 support

* **Chores**
  * Added Python 3.14 to supported versions
  * Updated CI testing matrix for Python 3.14
  * Updated project metadata for Python 3.14 compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->