### PR TITLE
feat(mcp): make /poll, /rescore, /maintenance webhooks async

### DIFF
--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -129,6 +129,14 @@ class RateLimitMiddleware:
         loopback_exempt: When ``True`` (default), skip rate limiting for
             requests originating from loopback addresses (``127.0.0.1``,
             ``::1``, ``localhost``).
+        skip_get_path_prefixes: ``GET`` requests whose path starts with any of
+            these prefixes bypass the rate limit.  Use for read-only status
+            endpoints that legitimate callers need to poll (e.g. the
+            ``GET /jobs/{id}`` endpoint in the webhook app — schedulers poll
+            it every few seconds to observe background job completion and
+            would otherwise trivially exceed the mutating-endpoint budget).
+            Non-GET methods are always checked against the limit regardless
+            of path.
     """
 
     _LOOPBACK_ADDRS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
@@ -140,12 +148,14 @@ class RateLimitMiddleware:
         requests_per_hour: int = 600,
         trust_proxy: bool = False,
         loopback_exempt: bool = True,
+        skip_get_path_prefixes: tuple[str, ...] = (),
     ) -> None:
         self.app = app
         self.requests_per_minute = requests_per_minute
         self.requests_per_hour = requests_per_hour
         self.trust_proxy = trust_proxy
         self.loopback_exempt = loopback_exempt
+        self.skip_get_path_prefixes = skip_get_path_prefixes
         # ip -> _IPWindow.  In-memory state; resets on process restart.
         self._windows: dict[str, _IPWindow] = {}
 
@@ -153,6 +163,15 @@ class RateLimitMiddleware:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
+
+        # GET-path exemption for configured read-only endpoints (e.g. job
+        # status polling).  Must be evaluated before IP extraction so it
+        # applies regardless of proxy headers.
+        if self.skip_get_path_prefixes and scope.get("method") == "GET":
+            path = scope.get("path", "")
+            if any(path.startswith(p) for p in self.skip_get_path_prefixes):
+                await self.app(scope, receive, send)
+                return
 
         # Loopback exemption: use the raw ASGI peer address (scope["client"])
         # directly — never trust _client_ip() here, because it may fall back

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -199,12 +199,33 @@ async def _execute_job(
         response = await runner(state, **kwargs)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Webhook %s (job=%s): background runner raised", job.endpoint, job.id)
+        error_message = str(exc) or "unexpected error"
         await _try_rollback(state.get("store"), job)
+
+        # Persist an audit record for the failure too — the happy path
+        # writes one below; skipping it on the except branch left the
+        # most-interesting failure mode invisible in the ``webhook_audit:*``
+        # metadata row.  Manufacture a response shape that matches the
+        # runner's own 500 JSON so ``_record_audit`` sees a consistent
+        # ``{"ok": false, "error": "..."}`` payload.
+        failure_response = JSONResponse(
+            {"ok": False, "error": error_message},
+            status_code=500,
+        )
+        try:
+            await _record_audit(state["store"], job.endpoint, failure_response)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Webhook %s (job=%s): failed to persist audit record on exception path",
+                job.endpoint,
+                job.id,
+            )
+
         # Transition terminal last so callers polling GET /jobs/{id} only see
-        # "failed" once every side effect (store rollback here; audit below
+        # "failed" once every side effect (rollback + audit here; audit below
         # on the success path) has landed.  Otherwise tests that poll until
         # terminal and then exit the TestClient can race a dangling bg write.
-        await _finish_job(job, error=str(exc) or "unexpected error")
+        await _finish_job(job, error=error_message)
         return
 
     try:
@@ -1177,21 +1198,20 @@ def create_webhook_app(
         if isinstance(parsed, JSONResponse):
             return parsed
 
+        # ``root_path`` is set by Starlette's ``Mount`` to the prefix the
+        # webhook app is mounted at (e.g. ``"/api"``).  Using it in
+        # ``status_url`` lets callers poll the job directly without knowing
+        # the mount layout — essential for the scheduler in distill_ops.
+        root_path = request.scope.get("root_path", "")
+
         lock = _endpoint_locks.setdefault(endpoint, asyncio.Lock())
         async with lock:
-            # Cooldown enforcement is preserved — scheduler cooldowns are the
-            # primary debounce against runaway workflow re-triggers.
-            retry_after = await _check_cooldown(store, endpoint)
-            if retry_after is not None:
-                return JSONResponse(
-                    {"ok": False, "error": "too_early", "retry_after": retry_after},
-                    status_code=429,
-                    headers={"Retry-After": str(retry_after)},
-                )
-
-            # Idempotency: if a job is already running for this endpoint,
-            # return 409 with the existing job id so the caller re-attaches
-            # rather than racing two bg tasks.
+            # Idempotency first: if a job is already running for this
+            # endpoint, return 409 with the existing job id so the caller
+            # re-attaches rather than racing a duplicate or backing off on a
+            # cooldown that merely reflects its own in-flight work.  A 429
+            # here would misdirect the scheduler into "try later" when the
+            # correct action is "poll /jobs/{id} for completion".
             existing_job_id = await _active_job_id(endpoint)
             if existing_job_id is not None:
                 return JSONResponse(
@@ -1199,9 +1219,20 @@ def create_webhook_app(
                         "ok": False,
                         "error": "job_in_progress",
                         "job_id": existing_job_id,
-                        "status_url": f"/jobs/{existing_job_id}",
+                        "status_url": f"{root_path}/jobs/{existing_job_id}",
                     },
                     status_code=409,
+                )
+
+            # Cooldown enforcement is preserved — scheduler cooldowns are the
+            # primary debounce against runaway workflow re-triggers from a
+            # caller that is NOT currently mid-job.
+            retry_after = await _check_cooldown(store, endpoint)
+            if retry_after is not None:
+                return JSONResponse(
+                    {"ok": False, "error": "too_early", "retry_after": retry_after},
+                    status_code=429,
+                    headers={"Retry-After": str(retry_after)},
                 )
 
             # Reserve cooldown + allocate a job record before releasing the
@@ -1222,7 +1253,7 @@ def create_webhook_app(
                 "ok": True,
                 "job_id": job.id,
                 "state": "queued",
-                "status_url": f"/jobs/{job.id}",
+                "status_url": f"{root_path}/jobs/{job.id}",
             },
             status_code=202,
         )

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -92,7 +92,7 @@ class _JobStatus:
     task: asyncio.Task[Any] | None = field(default=None, repr=False, compare=False)
 
 
-_jobs: "OrderedDict[str, _JobStatus]" = OrderedDict()
+_jobs: OrderedDict[str, _JobStatus] = OrderedDict()
 _active_job_by_endpoint: dict[str, str] = {}
 _jobs_lock = asyncio.Lock()
 
@@ -183,6 +183,16 @@ async def _execute_job(
     Any exception escaping *runner* is caught and recorded as a failure so it
     surfaces through :func:`jobs_route`.  Audit records are written
     best-effort after completion.
+
+    After the runner finishes — success or failure — this helper calls
+    ``store.rollback()`` (when the store exposes one) to clear any aborted
+    DuckDB transaction state that may have leaked through a code path that
+    bypasses :meth:`DuckDBStore._run_sync`.  Issue #396 documents an
+    aborted-transaction cascade observed during poll runs: without this
+    best-effort rollback, the *next* webhook job on the same process can
+    inherit a poisoned connection and fail every query with
+    ``TransactionContext Error: Current transaction is aborted (please
+    ROLLBACK)``.  Errors from rollback itself are logged and swallowed.
     """
     await _mark_job_running(job)
     try:
@@ -190,6 +200,7 @@ async def _execute_job(
     except Exception as exc:  # noqa: BLE001
         logger.exception("Webhook %s (job=%s): background runner raised", job.endpoint, job.id)
         await _finish_job(job, error=str(exc) or "unexpected error")
+        await _try_rollback(state.get("store"), job)
         return
 
     try:
@@ -202,11 +213,32 @@ async def _execute_job(
     else:
         await _finish_job(job, error=body.get("error", "unknown error"))
 
+    # Runners catch their own exceptions and return 500 JSON on failure, so
+    # reaching here with ``ok=False`` still means the runner handled an
+    # exception internally — roll back defensively in that case too.
+    if not body.get("ok"):
+        await _try_rollback(state.get("store"), job)
+
     try:
         await _record_audit(state["store"], job.endpoint, response)
     except Exception:  # noqa: BLE001
         logger.exception(
             "Webhook %s (job=%s): failed to persist audit record", job.endpoint, job.id
+        )
+
+
+async def _try_rollback(store: Any, job: _JobStatus) -> None:
+    """Call ``store.rollback()`` best-effort; never raise."""
+    rollback = getattr(store, "rollback", None) if store is not None else None
+    if rollback is None:
+        return
+    try:
+        await rollback()
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "Webhook %s (job=%s): post-failure store.rollback() raised",
+            job.endpoint,
+            job.id,
         )
 
 # ---------------------------------------------------------------------------

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -367,6 +367,25 @@ def _verify_bearer_token(request: Request, secret: str) -> bool:
 # ---------------------------------------------------------------------------
 # Cooldown helpers
 # ---------------------------------------------------------------------------
+#
+# In-memory cache (``_cooldown_ts``) keyed by endpoint name is the
+# authoritative *in-process* source of truth for cooldowns.  DuckDB
+# metadata is still written through so cooldowns survive process restarts
+# (see :func:`test_cooldown_persisted`), but reads prefer the cache.
+#
+# Rationale: the bg task spawned by a successful POST (e.g. audit writes,
+# feed-poll work) shares the single DuckDB connection with the dispatcher
+# handling the *next* request.  DuckDB's Python binding serialises
+# statements on a single connection only when called from the same thread;
+# ``asyncio.to_thread`` dispatches to the default threadpool and can run
+# two store coroutines on different workers concurrently.  In practice
+# that produces flaky ``get_metadata`` reads that miss a just-committed
+# ``set_metadata`` write — which presented as "second POST returned 409
+# (job_in_progress) instead of 429 (too_early)" across Python 3.11-3.14
+# on CI.  The in-memory cache sidesteps the race entirely for the common
+# single-process case; DuckDB retains its persistence role untouched.
+
+_cooldown_ts: dict[str, datetime] = {}
 
 
 async def _check_cooldown(
@@ -374,6 +393,11 @@ async def _check_cooldown(
     endpoint: str,
 ) -> int | None:
     """Check whether *endpoint* is within its cooldown window.
+
+    Consults :data:`_cooldown_ts` first (in-process cache, immune to the
+    DuckDB-across-threadpool race described above).  Falls back to
+    ``store.get_metadata`` on cache miss so a freshly-started process
+    picks up cooldowns persisted by a previous run.
 
     Args:
         store: A :class:`~distillery.store.protocol.DistilleryStore` instance.
@@ -384,15 +408,18 @@ async def _check_cooldown(
         The number of seconds remaining until the cooldown expires, or
         ``None`` if the endpoint is not in cooldown.
     """
-    key = f"webhook_cooldown:{endpoint}"
-    raw = await store.get_metadata(key)
-    if raw is None:
-        return None
-
-    try:
-        last_run = datetime.fromisoformat(raw)
-    except (ValueError, TypeError):
-        return None
+    last_run = _cooldown_ts.get(endpoint)
+    if last_run is None:
+        key = f"webhook_cooldown:{endpoint}"
+        raw = await store.get_metadata(key)
+        if raw is None:
+            return None
+        try:
+            last_run = datetime.fromisoformat(raw)
+        except (ValueError, TypeError):
+            return None
+        # Populate the cache for subsequent checks in this process.
+        _cooldown_ts[endpoint] = last_run
 
     cooldown = _COOLDOWN_SECONDS.get(endpoint, 300)
     now = datetime.now(UTC)
@@ -406,13 +433,18 @@ async def _check_cooldown(
 async def _set_cooldown(store: Any, endpoint: str) -> None:
     """Record the current time as the cooldown timestamp for *endpoint*.
 
+    Writes to :data:`_cooldown_ts` and to DuckDB.  The in-memory write is
+    what subsequent same-process :func:`_check_cooldown` calls read; the
+    DuckDB write is only consulted after a restart.
+
     Args:
         store: A :class:`~distillery.store.protocol.DistilleryStore` instance.
         endpoint: The endpoint name.
     """
+    now = datetime.now(UTC)
+    _cooldown_ts[endpoint] = now
     key = f"webhook_cooldown:{endpoint}"
-    now = datetime.now(UTC).isoformat()
-    await store.set_metadata(key, now)
+    await store.set_metadata(key, now.isoformat())
 
 
 # ---------------------------------------------------------------------------

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -199,19 +199,18 @@ async def _execute_job(
         response = await runner(state, **kwargs)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Webhook %s (job=%s): background runner raised", job.endpoint, job.id)
-        await _finish_job(job, error=str(exc) or "unexpected error")
         await _try_rollback(state.get("store"), job)
+        # Transition terminal last so callers polling GET /jobs/{id} only see
+        # "failed" once every side effect (store rollback here; audit below
+        # on the success path) has landed.  Otherwise tests that poll until
+        # terminal and then exit the TestClient can race a dangling bg write.
+        await _finish_job(job, error=str(exc) or "unexpected error")
         return
 
     try:
         body: dict[str, Any] = json.loads(bytes(response.body).decode())
     except Exception:  # noqa: BLE001
         body = {}
-
-    if body.get("ok"):
-        await _finish_job(job, result=body.get("data", {}))
-    else:
-        await _finish_job(job, error=body.get("error", "unknown error"))
 
     # Runners catch their own exceptions and return 500 JSON on failure, so
     # reaching here with ``ok=False`` still means the runner handled an
@@ -225,6 +224,16 @@ async def _execute_job(
         logger.exception(
             "Webhook %s (job=%s): failed to persist audit record", job.endpoint, job.id
         )
+
+    # Finish last: the job's terminal state is the "all work complete"
+    # signal callers poll for.  Flipping it before the audit / rollback
+    # finishes lets a test's ``_wait_for_job`` return, the TestClient
+    # teardown cancel the task, and a dangling store write race the next
+    # test's fresh store.
+    if body.get("ok"):
+        await _finish_job(job, result=body.get("data", {}))
+    else:
+        await _finish_job(job, error=body.get("error", "unknown error"))
 
 
 async def _try_rollback(store: Any, job: _JobStatus) -> None:

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -1345,6 +1345,11 @@ def create_webhook_app(
                 RateLimitMiddleware,
                 requests_per_minute=10,
                 requests_per_hour=100,
+                # GET /jobs/{id} is a read-only status poll; schedulers poll
+                # it every few seconds while a background job runs and would
+                # trivially exhaust the 10/min mutating-endpoint budget.
+                # The POST routes above keep their normal rate limit.
+                skip_get_path_prefixes=("/jobs/",),
             ),
         ],
     )

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -24,6 +24,10 @@ import hmac
 import json
 import logging
 import os
+import uuid
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
@@ -57,6 +61,153 @@ _endpoint_locks: dict[str, asyncio.Lock] = {}
 # first-hit requests (e.g. workflow_dispatch "all") don't each create a
 # separate DuckDBStore.
 _init_lock = asyncio.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Async job registry (in-process)
+# ---------------------------------------------------------------------------
+#
+# The /poll, /rescore, and /maintenance endpoints return 202 immediately and
+# run the actual work on a background asyncio task.  Callers poll
+# GET /jobs/{id} to observe progress.  Records are kept in a bounded FIFO
+# buffer per process; state is NOT persisted across restarts (scheduler loss
+# is acceptable — cron will re-trigger).
+
+# Maximum number of job records to retain in memory.
+_JOBS_MAX = 100
+
+
+@dataclass
+class _JobStatus:
+    """In-process record of an async webhook job."""
+
+    id: str
+    endpoint: str
+    state: str  # "queued" | "running" | "succeeded" | "failed"
+    submitted_at: datetime
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    result: dict[str, Any] | None = None
+    error: str | None = None
+    task: asyncio.Task[Any] | None = field(default=None, repr=False, compare=False)
+
+
+_jobs: "OrderedDict[str, _JobStatus]" = OrderedDict()
+_active_job_by_endpoint: dict[str, str] = {}
+_jobs_lock = asyncio.Lock()
+
+
+async def _register_job(endpoint: str) -> _JobStatus:
+    """Allocate a new job id and mark it active for *endpoint*.
+
+    Evicts the oldest job record once :data:`_JOBS_MAX` is exceeded.  Callers
+    must have already verified (under the endpoint lock) that no other job is
+    active for *endpoint* — this function does not re-check.
+    """
+    async with _jobs_lock:
+        job = _JobStatus(
+            id=uuid.uuid4().hex[:16],
+            endpoint=endpoint,
+            state="queued",
+            submitted_at=datetime.now(UTC),
+        )
+        _jobs[job.id] = job
+        while len(_jobs) > _JOBS_MAX:
+            _jobs.popitem(last=False)
+        _active_job_by_endpoint[endpoint] = job.id
+        return job
+
+
+async def _active_job_id(endpoint: str) -> str | None:
+    """Return the current active job id for *endpoint*, if any is in flight.
+
+    Stale pointers (job record evicted or already terminal) are cleaned up so
+    subsequent requests aren't blocked by a pointer to a completed job.
+    """
+    async with _jobs_lock:
+        job_id = _active_job_by_endpoint.get(endpoint)
+        if job_id is None:
+            return None
+        job = _jobs.get(job_id)
+        if job is None or job.state in ("succeeded", "failed"):
+            _active_job_by_endpoint.pop(endpoint, None)
+            return None
+        return job_id
+
+
+async def _finish_job(
+    job: _JobStatus,
+    *,
+    result: dict[str, Any] | None = None,
+    error: str | None = None,
+) -> None:
+    """Mark *job* terminal and clear the active-job pointer."""
+    async with _jobs_lock:
+        job.state = "failed" if error is not None else "succeeded"
+        job.finished_at = datetime.now(UTC)
+        job.result = result
+        job.error = error
+        if _active_job_by_endpoint.get(job.endpoint) == job.id:
+            del _active_job_by_endpoint[job.endpoint]
+
+
+async def _mark_job_running(job: _JobStatus) -> None:
+    """Transition *job* from queued to running."""
+    async with _jobs_lock:
+        job.state = "running"
+        job.started_at = datetime.now(UTC)
+
+
+def _job_to_dict(job: _JobStatus) -> dict[str, Any]:
+    """Serialise a :class:`_JobStatus` for the GET /jobs/{id} response."""
+    return {
+        "job_id": job.id,
+        "endpoint": job.endpoint,
+        "state": job.state,
+        "submitted_at": job.submitted_at.isoformat(),
+        "started_at": job.started_at.isoformat() if job.started_at else None,
+        "finished_at": job.finished_at.isoformat() if job.finished_at else None,
+        "result": job.result,
+        "error": job.error,
+    }
+
+
+async def _execute_job(
+    job: _JobStatus,
+    state: dict[str, Any],
+    runner: Callable[..., Awaitable[JSONResponse]],
+    kwargs: dict[str, Any],
+) -> None:
+    """Background driver: run *runner* and store the outcome on *job*.
+
+    Any exception escaping *runner* is caught and recorded as a failure so it
+    surfaces through :func:`jobs_route`.  Audit records are written
+    best-effort after completion.
+    """
+    await _mark_job_running(job)
+    try:
+        response = await runner(state, **kwargs)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Webhook %s (job=%s): background runner raised", job.endpoint, job.id)
+        await _finish_job(job, error=str(exc) or "unexpected error")
+        return
+
+    try:
+        body: dict[str, Any] = json.loads(bytes(response.body).decode())
+    except Exception:  # noqa: BLE001
+        body = {}
+
+    if body.get("ok"):
+        await _finish_job(job, result=body.get("data", {}))
+    else:
+        await _finish_job(job, error=body.get("error", "unknown error"))
+
+    try:
+        await _record_audit(state["store"], job.endpoint, response)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "Webhook %s (job=%s): failed to persist audit record", job.endpoint, job.id
+        )
 
 # ---------------------------------------------------------------------------
 # Store initialisation helper
@@ -331,19 +482,18 @@ async def _run_poll(
     )
 
 
-async def _handle_poll(request: Request, state: dict[str, Any]) -> JSONResponse:
-    """Handler for ``POST /poll``.
+async def _parse_poll_params(
+    request: Request,
+) -> dict[str, Any] | JSONResponse:
+    """Parse ``source_url`` from query string or JSON body.
 
-    Delegates to :func:`_run_poll`.  The optional ``source_url`` parameter
-    may be supplied as a query string parameter (``?source_url=<url>``) or
-    via a JSON request body (``{"source_url": "<url>"}``).
+    Returns a kwargs dict ``{"source_url": str | None}`` on success, or a
+    ``JSONResponse`` with status 400 describing the problem.  Parsing happens
+    synchronously before the request returns 202 so that malformed requests
+    fail fast rather than through the async job status.
 
     Args:
         request: The incoming Starlette request.
-        state: The populated shared-state dict.
-
-    Returns:
-        A :class:`~starlette.responses.JSONResponse` from :func:`_run_poll`.
     """
     source_url: str | None = request.query_params.get("source_url")
     if source_url is None:
@@ -379,7 +529,7 @@ async def _handle_poll(request: Request, state: dict[str, Any]) -> JSONResponse:
                     status_code=400,
                 )
             source_url = val
-    return await _run_poll(state, source_url=source_url)
+    return {"source_url": source_url}
 
 
 async def _run_rescore(
@@ -430,23 +580,17 @@ async def _run_rescore(
     )
 
 
-async def _handle_rescore(request: Request, state: dict[str, Any]) -> JSONResponse:
-    """Handler for ``POST /rescore``.
+async def _parse_rescore_params(
+    request: Request,
+) -> dict[str, Any] | JSONResponse:
+    """Parse ``limit`` from query string or JSON body.
 
-    Delegates to :func:`_run_rescore`.  The optional ``limit`` parameter may
-    be supplied as a query string parameter (``?limit=<N>``) or via a JSON
-    request body (``{"limit": N}``).  Query string takes precedence.
+    Query string takes precedence over the body.  Returns a kwargs dict
+    ``{"limit": int}`` on success, or a ``JSONResponse`` with status 400.
 
     Args:
         request: The incoming Starlette request.
-        state: The populated shared-state dict containing ``"store"`` and
-            ``"config"`` keys.
-
-    Returns:
-        A :class:`~starlette.responses.JSONResponse` from :func:`_run_rescore`,
-        or an error response with status 400 for a malformed body/parameter.
     """
-    # Query string takes precedence over body.
     qs_limit: str | None = request.query_params.get("limit")
     if isinstance(qs_limit, str):
         try:
@@ -491,11 +635,11 @@ async def _handle_rescore(request: Request, state: dict[str, Any]) -> JSONRespon
                     )
                 limit = raw_limit
 
-    return await _run_rescore(state, limit=limit)
+    return {"limit": limit}
 
 
-async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONResponse:
-    """Handler for ``POST /maintenance``.
+async def _run_maintenance(state: dict[str, Any]) -> JSONResponse:
+    """Core maintenance logic invoked by the background job runner.
 
     Sequentially orchestrates three sub-operations:
 
@@ -510,13 +654,17 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
     all three are merged into the combined response under ``poll``,
     ``rescore``, and ``classify_batch`` keys.
 
+    Sub-phase cooldowns are reserved briefly (under the phase endpoint lock)
+    BEFORE the long-running phase work runs, so a direct ``POST /hooks/poll``
+    arriving mid-maintenance sees the cooldown and returns 429 rather than
+    running a duplicate fetch.  The phase work itself runs outside the lock so
+    it doesn't block the fast-path of unrelated webhook requests.
+
     If a sub-operation fails, its result is recorded as
     ``{"ok": false, "error": "<message>"}`` and the remaining sub-operations
     still run — maintenance is best-effort.
 
     Args:
-        request: The incoming Starlette request (unused beyond signature
-            compatibility with the dispatcher).
         state: The populated shared-state dict containing ``"store"``,
             ``"config"``, and ``"embedding_provider"`` keys.
 
@@ -530,7 +678,6 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
     """
     logger.info("Webhook maintenance: starting maintenance cycle (poll → rescore → classify-batch)")
 
-    # Helper to extract the data payload from a JSONResponse produced by _run_* helpers.
     def _extract(response: JSONResponse) -> dict[str, Any]:
         try:
             body: dict[str, Any] = json.loads(bytes(response.body).decode())
@@ -540,14 +687,13 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
 
     store = state["store"]
 
-    # 1. Poll — fetch new feed items (acquire poll lock to serialize with direct /hooks/poll calls).
-    # Reserve the child endpoint cooldown inside the locked section so a direct
-    # POST /hooks/poll that queues behind poll_lock does not run immediately
-    # after this phase finishes, which would cause duplicate fetch work.
+    # 1. Poll — fetch new feed items.  Reserve the poll cooldown before
+    # running the phase so a concurrent direct POST /hooks/poll sees the
+    # reservation and returns 429 rather than duplicating the fetch work.
     poll_lock = _endpoint_locks.setdefault("poll", asyncio.Lock())
     async with poll_lock:
         await _set_cooldown(store, "poll")
-        poll_response = await _run_poll(state)
+    poll_response = await _run_poll(state)
     poll_body = _extract(poll_response)
     poll_result: dict[str, Any] = (
         {"ok": True, **poll_body.get("data", {})}
@@ -555,11 +701,11 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
         else {"ok": False, "error": poll_body.get("error", "poll failed")}
     )
 
-    # 2. Rescore — re-score existing entries (acquire rescore lock to serialize).
+    # 2. Rescore — re-score existing entries.
     rescore_lock = _endpoint_locks.setdefault("rescore", asyncio.Lock())
     async with rescore_lock:
         await _set_cooldown(store, "rescore")
-        rescore_response = await _run_rescore(state)
+    rescore_response = await _run_rescore(state)
     rescore_body = _extract(rescore_response)
     rescore_result: dict[str, Any] = (
         {"ok": True, **rescore_body.get("data", {})}
@@ -567,11 +713,11 @@ async def _handle_maintenance(request: Request, state: dict[str, Any]) -> JSONRe
         else {"ok": False, "error": rescore_body.get("error", "rescore failed")}
     )
 
-    # 3. Classify-batch — classify pending inbox entries (acquire classify-batch lock to serialize).
+    # 3. Classify-batch — classify pending inbox entries.
     classify_lock = _endpoint_locks.setdefault("classify-batch", asyncio.Lock())
     async with classify_lock:
         await _set_cooldown(store, "classify-batch")
-        classify_response = await _run_classify_batch(state)
+    classify_response = await _run_classify_batch(state)
     classify_body = _extract(classify_response)
     classify_result: dict[str, Any] = (
         {"ok": True, **classify_body.get("data", {})}
@@ -846,13 +992,38 @@ async def _handle_classify_batch(request: Request, state: dict[str, Any]) -> JSO
     return await _run_classify_batch(state, entry_type=entry_type, mode=mode, limit=limit)
 
 
-# Mapping of endpoint names to their handler callables.
-# Each handler receives (request, state) where state is the populated
-# shared-state dict containing "store", "config", and "embedding_provider".
-_HANDLERS: dict[str, Any] = {
-    "poll": _handle_poll,
-    "rescore": _handle_rescore,
-    "maintenance": _handle_maintenance,
+# ---------------------------------------------------------------------------
+# Async endpoint dispatch table
+# ---------------------------------------------------------------------------
+#
+# Each async endpoint defines a parser (validates the request synchronously
+# and returns kwargs or a 400 error response) and a runner (the work to do
+# in the background).  The dispatcher in :func:`create_webhook_app`
+# synchronously auths → parses → reserves cooldown → registers the job →
+# returns 202 with a job id.  The runner executes via :func:`_execute_job`
+# on a detached asyncio task.
+
+_AsyncParser = Callable[[Request], Awaitable["dict[str, Any] | JSONResponse"]]
+_AsyncRunner = Callable[..., Awaitable[JSONResponse]]
+
+
+async def _parse_maintenance_params(
+    request: Request,
+) -> dict[str, Any] | JSONResponse:
+    """``/maintenance`` takes no request-level parameters."""
+    return {}
+
+
+_ASYNC_ENDPOINTS: dict[str, tuple[_AsyncParser, _AsyncRunner]] = {
+    "poll": (_parse_poll_params, _run_poll),
+    "rescore": (_parse_rescore_params, _run_rescore),
+    "maintenance": (_parse_maintenance_params, _run_maintenance),
+}
+
+
+# Synchronous dispatch table — retained for ``/hooks/classify-batch`` which
+# remains synchronous (its deprecation path is out of issue #396 scope).
+_SYNC_HANDLERS: dict[str, Callable[[Request, dict[str, Any]], Awaitable[JSONResponse]]] = {
     "classify-batch": _handle_classify_batch,
 }
 
@@ -868,9 +1039,20 @@ def create_webhook_app(
 ) -> Starlette:
     """Build a Starlette application serving the webhook REST endpoints.
 
-    The returned app provides three ``POST`` routes (``/poll``,
-    ``/rescore``, ``/maintenance``) protected by bearer-token
-    authentication and per-endpoint cooldown enforcement.
+    The returned app provides:
+
+    - ``POST /poll``, ``/rescore``, ``/maintenance`` — async endpoints that
+      enqueue a background job and return ``202 Accepted`` with a ``job_id``.
+      Callers poll ``GET /jobs/{job_id}`` to observe progress.
+    - ``POST /hooks/poll``, ``/hooks/rescore`` — deprecated aliases sharing
+      the async contract of their canonical counterparts.
+    - ``POST /hooks/classify-batch`` — deprecated synchronous endpoint.
+    - ``GET /jobs/{job_id}`` — status endpoint for async jobs.
+
+    All endpoints require bearer-token authentication.  Per-endpoint
+    cooldowns are enforced against DuckDB metadata.  A second request while
+    a job is in flight returns ``409 Conflict`` with the existing ``job_id``
+    so the scheduler can re-attach to the existing job rather than racing.
 
     Rate limiting is applied via
     :class:`~distillery.mcp.middleware.RateLimitMiddleware` with tighter
@@ -890,37 +1072,42 @@ def create_webhook_app(
     """
     secret_env = config.server.webhooks.secret_env
 
-    async def _authenticated_endpoint(
-        request: Request,
-        endpoint: str,
-    ) -> JSONResponse:
-        """Dispatch a webhook request after auth and cooldown checks.
-
-        Args:
-            request: The incoming Starlette request.
-            endpoint: The endpoint name (``"poll"``, ``"rescore"``, or
-                ``"maintenance"``).
-
-        Returns:
-            A JSON response from the endpoint handler, or an error
-            response for auth/cooldown failures.
-        """
-        # --- Auth -----------------------------------------------------------
+    async def _authenticate(request: Request) -> JSONResponse | None:
+        """Return a 401 response if auth fails, else ``None``."""
         secret = os.environ.get(secret_env, "")
         if not secret or not _verify_bearer_token(request, secret):
             return JSONResponse(
                 {"ok": False, "error": "unauthorized"},
                 status_code=401,
             )
+        return None
 
-        # --- Store init -----------------------------------------------------
+    async def _dispatch_async(
+        request: Request,
+        endpoint: str,
+    ) -> JSONResponse:
+        """Validate + reserve cooldown + schedule background job.
+
+        Returns ``202`` with ``{"ok": true, "job_id": "...", "state":
+        "queued", "status_url": "/jobs/..."}`` when the job is enqueued.
+        Returns ``429``/``409``/``401``/``400`` for rejected requests.
+        """
+        auth_err = await _authenticate(request)
+        if auth_err is not None:
+            return auth_err
+
         state = await _ensure_store(shared_state, config)
         store = state["store"]
 
-        # --- Per-endpoint lock (serialise cooldown check + handler) ---------
+        parser, runner = _ASYNC_ENDPOINTS[endpoint]
+        parsed = await parser(request)
+        if isinstance(parsed, JSONResponse):
+            return parsed
+
         lock = _endpoint_locks.setdefault(endpoint, asyncio.Lock())
         async with lock:
-            # --- Cooldown ---------------------------------------------------
+            # Cooldown enforcement is preserved — scheduler cooldowns are the
+            # primary debounce against runaway workflow re-triggers.
             retry_after = await _check_cooldown(store, endpoint)
             if retry_after is not None:
                 return JSONResponse(
@@ -929,15 +1116,70 @@ def create_webhook_app(
                     headers={"Retry-After": str(retry_after)},
                 )
 
-            # Reserve the cooldown slot before running the handler so that
-            # a second request arriving during execution sees the reservation.
+            # Idempotency: if a job is already running for this endpoint,
+            # return 409 with the existing job id so the caller re-attaches
+            # rather than racing two bg tasks.
+            existing_job_id = await _active_job_id(endpoint)
+            if existing_job_id is not None:
+                return JSONResponse(
+                    {
+                        "ok": False,
+                        "error": "job_in_progress",
+                        "job_id": existing_job_id,
+                        "status_url": f"/jobs/{existing_job_id}",
+                    },
+                    status_code=409,
+                )
+
+            # Reserve cooldown + allocate a job record before releasing the
+            # endpoint lock so subsequent requests see both signals.
             await _set_cooldown(store, endpoint)
+            job = await _register_job(endpoint)
 
-            # --- Dispatch ---------------------------------------------------
-            handler = _HANDLERS[endpoint]
-            response: JSONResponse = await handler(request, state)
+        # Detach the work.  The returned Task is retained on the job record
+        # to avoid "Task was destroyed while pending" warnings when the event
+        # loop's weak references drop it.
+        job.task = asyncio.create_task(
+            _execute_job(job, state, runner, parsed),
+            name=f"webhook-{endpoint}-{job.id}",
+        )
 
-            # --- Audit record (best-effort) ---------------------------------
+        return JSONResponse(
+            {
+                "ok": True,
+                "job_id": job.id,
+                "state": "queued",
+                "status_url": f"/jobs/{job.id}",
+            },
+            status_code=202,
+        )
+
+    async def _dispatch_sync(
+        request: Request,
+        endpoint: str,
+    ) -> JSONResponse:
+        """Synchronous dispatcher retained for ``/hooks/classify-batch``."""
+        auth_err = await _authenticate(request)
+        if auth_err is not None:
+            return auth_err
+
+        state = await _ensure_store(shared_state, config)
+        store = state["store"]
+
+        lock = _endpoint_locks.setdefault(endpoint, asyncio.Lock())
+        async with lock:
+            retry_after = await _check_cooldown(store, endpoint)
+            if retry_after is not None:
+                return JSONResponse(
+                    {"ok": False, "error": "too_early", "retry_after": retry_after},
+                    status_code=429,
+                    headers={"Retry-After": str(retry_after)},
+                )
+
+            await _set_cooldown(store, endpoint)
+            handler = _SYNC_HANDLERS[endpoint]
+            response = await handler(request, state)
+
             try:
                 await _record_audit(store, endpoint, response)
             except Exception:  # noqa: BLE001
@@ -946,16 +1188,16 @@ def create_webhook_app(
             return response
 
     async def poll_route(request: Request) -> JSONResponse:
-        """Route handler for ``POST /poll``."""
-        return await _authenticated_endpoint(request, "poll")
+        """Route handler for ``POST /poll`` (async)."""
+        return await _dispatch_async(request, "poll")
 
     async def rescore_route(request: Request) -> JSONResponse:
-        """Route handler for ``POST /rescore``."""
-        return await _authenticated_endpoint(request, "rescore")
+        """Route handler for ``POST /rescore`` (async)."""
+        return await _dispatch_async(request, "rescore")
 
     async def maintenance_route(request: Request) -> JSONResponse:
-        """Route handler for ``POST /maintenance``."""
-        return await _authenticated_endpoint(request, "maintenance")
+        """Route handler for ``POST /maintenance`` (async)."""
+        return await _dispatch_async(request, "maintenance")
 
     async def hooks_poll_route(request: Request) -> JSONResponse:
         """Route handler for ``POST /hooks/poll``.
@@ -967,8 +1209,9 @@ def create_webhook_app(
         Canonical path for the poll webhook; shares cooldown with ``/poll``.
         Accepts an optional ``source_url`` query parameter to poll a single
         source (e.g. ``POST /hooks/poll?source_url=https://example.com/feed``).
+        Returns ``202`` with a job id like the canonical ``/poll`` route.
         """
-        response = await _authenticated_endpoint(request, "poll")
+        response = await _dispatch_async(request, "poll")
         if response.status_code != 401:
             logger.warning(
                 "Webhook /hooks/poll is deprecated — migrate to Claude Code routines (see #272)"
@@ -985,8 +1228,9 @@ def create_webhook_app(
         Canonical path for the rescore webhook; shares cooldown with ``/rescore``.
         Accepts an optional ``limit`` query parameter controlling how many
         entries are rescored (e.g. ``POST /hooks/rescore?limit=50``).
+        Returns ``202`` with a job id like the canonical ``/rescore`` route.
         """
-        response = await _authenticated_endpoint(request, "rescore")
+        response = await _dispatch_async(request, "rescore")
         if response.status_code != 401:
             logger.warning(
                 "Webhook /hooks/rescore is deprecated — migrate to Claude Code routines (see #272)"
@@ -1005,14 +1249,47 @@ def create_webhook_app(
 
         - ``entry_type`` (default ``"inbox"``): filter entries by type.
         - ``mode``: ``"llm"`` or ``"heuristic"`` (defaults to config value).
+
+        Unlike the three async endpoints, this one remains synchronous — the
+        issue #396 scope was limited to ``/poll``, ``/rescore``, and
+        ``/maintenance``.
         """
-        response = await _authenticated_endpoint(request, "classify-batch")
+        response = await _dispatch_sync(request, "classify-batch")
         if response.status_code != 401:
             logger.warning(
                 "Webhook /hooks/classify-batch is deprecated"
                 " — migrate to Claude Code routines (see #272)"
             )
         return response
+
+    async def jobs_route(request: Request) -> JSONResponse:
+        """Route handler for ``GET /jobs/{job_id}``.
+
+        Returns the current state of a background job allocated by one of
+        the async endpoints.  Requires the same bearer token as the POST
+        endpoints.  Terminal states (``succeeded``, ``failed``) expose the
+        full result or error so the scheduler can log the outcome without
+        parsing server logs.
+
+        Returns 404 when the job id is unknown (for example because the
+        FIFO buffer has evicted it or the server restarted after the job
+        was submitted).
+        """
+        auth_err = await _authenticate(request)
+        if auth_err is not None:
+            return auth_err
+
+        job_id = request.path_params["job_id"]
+        async with _jobs_lock:
+            job = _jobs.get(job_id)
+            snapshot = _job_to_dict(job) if job is not None else None
+
+        if snapshot is None:
+            return JSONResponse(
+                {"ok": False, "error": "job not found"},
+                status_code=404,
+            )
+        return JSONResponse({"ok": True, "data": snapshot})
 
     routes: list[Route] = [
         Route("/poll", poll_route, methods=["POST"]),
@@ -1021,6 +1298,7 @@ def create_webhook_app(
         Route("/hooks/poll", hooks_poll_route, methods=["POST"]),
         Route("/hooks/rescore", hooks_rescore_route, methods=["POST"]),
         Route("/hooks/classify-batch", hooks_classify_batch_route, methods=["POST"]),
+        Route("/jobs/{job_id}", jobs_route, methods=["GET"]),
     ]
 
     # Apply rate limiting with tighter webhook-specific limits via

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,6 +231,35 @@ from collections.abc import Iterator  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
+def _reset_webhook_module_state() -> Iterator[None]:
+    """Clear module-level webhook state between tests.
+
+    ``distillery.mcp.webhooks`` keeps several module-level dicts (async job
+    registry, in-memory cooldown cache, per-endpoint asyncio locks).  These
+    persist across tests in the same pytest session and cause false 409s
+    (stale active-job pointer) or false 429s (cooldown timestamp from a
+    prior test) when the next test makes its first POST.  Cooldown state
+    stored in the DuckDB ``_meta`` table is isolated by the per-function
+    ``store`` fixture, so no cleanup is needed there.
+
+    Lives in the root conftest so it covers both ``tests/test_webhooks.py``
+    and ``tests/test_webhooks/*`` without duplication; a no-op for tests
+    that don't touch the webhook module.
+    """
+    from distillery.mcp import webhooks as _webhooks
+
+    _webhooks._jobs.clear()
+    _webhooks._active_job_by_endpoint.clear()
+    _webhooks._endpoint_locks.clear()
+    _webhooks._cooldown_ts.clear()
+    yield
+    _webhooks._jobs.clear()
+    _webhooks._active_job_by_endpoint.clear()
+    _webhooks._endpoint_locks.clear()
+    _webhooks._cooldown_ts.clear()
+
+
+@pytest.fixture(autouse=True)
 def _disable_watch_probe(
     request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[None]:

--- a/tests/test_mcp_coverage_gaps.py
+++ b/tests/test_mcp_coverage_gaps.py
@@ -1801,61 +1801,68 @@ class TestTagTreeExactPrefix:
 
 
 class TestWebhookRescoreBodyParsing:
-    """Cover _handle_rescore body parsing (webhooks.py lines 374-391)."""
+    """Cover rescore request parsing + run error paths in the webhook layer.
+
+    After issue #396 the webhook handler was split:
+
+    - ``_parse_rescore_params(request)`` validates the request body/query
+      and returns either a kwargs dict or a 400 ``JSONResponse``.
+    - ``_run_rescore(state, limit=...)`` is the async job runner and
+      returns a 500 ``JSONResponse`` when ``FeedPoller.rescore`` raises.
+
+    These tests cover both halves.
+    """
 
     async def test_rescore_malformed_json_body(self) -> None:
-
-        from distillery.mcp.webhooks import _handle_rescore
+        from distillery.mcp.webhooks import _parse_rescore_params
 
         request = MagicMock()
+        request.query_params = {}
         request.body = AsyncMock(return_value=b"not json")
-        state = {"store": MagicMock(), "config": MagicMock()}
 
-        response = await _handle_rescore(request, state)
+        response = await _parse_rescore_params(request)
         assert response.status_code == 400
 
     async def test_rescore_body_not_dict(self) -> None:
-        from distillery.mcp.webhooks import _handle_rescore
+        from distillery.mcp.webhooks import _parse_rescore_params
 
         request = MagicMock()
+        request.query_params = {}
         request.body = AsyncMock(return_value=b'"just a string"')
-        state = {"store": MagicMock(), "config": MagicMock()}
 
-        response = await _handle_rescore(request, state)
+        response = await _parse_rescore_params(request)
         assert response.status_code == 400
 
     async def test_rescore_body_limit_not_int(self) -> None:
-        from distillery.mcp.webhooks import _handle_rescore
+        from distillery.mcp.webhooks import _parse_rescore_params
 
         request = MagicMock()
+        request.query_params = {}
         request.body = AsyncMock(return_value=b'{"limit": "bad"}')
-        state = {"store": MagicMock(), "config": MagicMock()}
 
-        response = await _handle_rescore(request, state)
+        response = await _parse_rescore_params(request)
         assert response.status_code == 400
 
     async def test_rescore_body_limit_bool(self) -> None:
-        from distillery.mcp.webhooks import _handle_rescore
+        from distillery.mcp.webhooks import _parse_rescore_params
 
         request = MagicMock()
+        request.query_params = {}
         request.body = AsyncMock(return_value=b'{"limit": true}')
-        state = {"store": MagicMock(), "config": MagicMock()}
 
-        response = await _handle_rescore(request, state)
+        response = await _parse_rescore_params(request)
         assert response.status_code == 400
 
     async def test_rescore_handler_error(self) -> None:
-        from distillery.mcp.webhooks import _handle_rescore
+        from distillery.mcp.webhooks import _run_rescore
 
-        request = MagicMock()
-        request.body = AsyncMock(return_value=b"{}")
         state = {"store": MagicMock(), "config": MagicMock()}
 
         with patch(
             "distillery.feeds.poller.FeedPoller.rescore",
             side_effect=RuntimeError("fail"),
         ):
-            response = await _handle_rescore(request, state)
+            response = await _run_rescore(state, limit=200)
             assert response.status_code == 500
 
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -61,17 +61,24 @@ def _wait_for_job(
     *,
     timeout_s: float = 5.0,
     poll_interval_s: float = 0.01,
+    path_prefix: str = "",
 ) -> dict[str, Any]:
-    """Poll ``GET /jobs/{job_id}`` until the job reaches a terminal state.
+    """Poll ``GET {path_prefix}/jobs/{job_id}`` until the job reaches a terminal state.
+
+    ``path_prefix`` supports the parent-mount composition case (e.g.
+    ``"/api"`` when the webhook app is mounted behind Starlette's ``Mount``)
+    — the default empty string works for tests that hit the webhook app
+    directly.
 
     Raises :class:`AssertionError` on timeout so tests fail with a readable
     message rather than flaking.  Returns the serialised job dict.
     """
     deadline = time.monotonic() + timeout_s
+    url = f"{path_prefix}/jobs/{job_id}"
     last: dict[str, Any] | None = None
     while time.monotonic() < deadline:
-        resp = client.get(f"/jobs/{job_id}", headers=_AUTH_HEADER)
-        assert resp.status_code == 200, f"GET /jobs/{job_id} → {resp.status_code}: {resp.text}"
+        resp = client.get(url, headers=_AUTH_HEADER)
+        assert resp.status_code == 200, f"GET {url} → {resp.status_code}: {resp.text}"
         body = resp.json()
         assert body["ok"] is True, body
         last = body["data"]
@@ -901,8 +908,9 @@ async def test_status_url_respects_mount_prefix(
             second_body = second.json()
             assert second_body["status_url"] == f"/api/jobs/{second_body['job_id']}"
 
-        # Let the job finish cleanly.
-        _wait_for_job(client, job_id)
+        # Let the job finish cleanly — mount-aware URL required since the
+        # webhook app is behind /api in this test.
+        _wait_for_job(client, job_id, path_prefix="/api")
 
 
 @pytest.mark.unit

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -43,10 +43,12 @@ def _reset_webhook_module_state() -> Any:
     webhooks_module._jobs.clear()
     webhooks_module._active_job_by_endpoint.clear()
     webhooks_module._endpoint_locks.clear()
+    webhooks_module._cooldown_ts.clear()
     yield
     webhooks_module._jobs.clear()
     webhooks_module._active_job_by_endpoint.clear()
     webhooks_module._endpoint_locks.clear()
+    webhooks_module._cooldown_ts.clear()
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -863,7 +865,9 @@ async def test_second_poll_while_in_flight_returns_409(
 
             # Pin the cooldown to a far-past time so the 429 path does not
             # mask the 409 path.  Any parseable ISO timestamp older than the
-            # cooldown window works.
+            # cooldown window works.  Must clear the in-memory cache too —
+            # _check_cooldown prefers it over the DuckDB row.
+            webhooks_module._cooldown_ts.pop("poll", None)
             await store.set_metadata(
                 "webhook_cooldown:poll", "1970-01-01T00:00:00+00:00"
             )

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -28,27 +28,9 @@ from distillery.mcp import webhooks as webhooks_module
 from distillery.mcp.webhooks import create_webhook_app
 from distillery.store.duckdb import DuckDBStore
 
-
-@pytest.fixture(autouse=True)
-def _reset_webhook_module_state() -> Any:
-    """Clear the module-level async-job registries and endpoint locks.
-
-    Module-level dicts (``_jobs``, ``_active_job_by_endpoint``, and
-    ``_endpoint_locks``) persist across tests in the same pytest session.
-    Without this reset, a stale active-job pointer from a prior test can
-    cause a fresh test's first POST to return 409 (``job_in_progress``)
-    instead of 202.  Cooldown state is keyed in DuckDB and is isolated by
-    the fresh ``store`` fixture, so no cleanup is needed there.
-    """
-    webhooks_module._jobs.clear()
-    webhooks_module._active_job_by_endpoint.clear()
-    webhooks_module._endpoint_locks.clear()
-    webhooks_module._cooldown_ts.clear()
-    yield
-    webhooks_module._jobs.clear()
-    webhooks_module._active_job_by_endpoint.clear()
-    webhooks_module._endpoint_locks.clear()
-    webhooks_module._cooldown_ts.clear()
+# The autouse fixture that clears ``_jobs``, ``_active_job_by_endpoint``,
+# ``_endpoint_locks``, and ``_cooldown_ts`` between tests lives in the root
+# ``tests/conftest.py`` so all webhook test files share it.
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -24,8 +24,29 @@ from starlette.routing import Mount, Route
 from starlette.testclient import TestClient
 
 from distillery.config import DistilleryConfig, ServerConfig, WebhookConfig
+from distillery.mcp import webhooks as webhooks_module
 from distillery.mcp.webhooks import create_webhook_app
 from distillery.store.duckdb import DuckDBStore
+
+
+@pytest.fixture(autouse=True)
+def _reset_webhook_module_state() -> Any:
+    """Clear the module-level async-job registries and endpoint locks.
+
+    Module-level dicts (``_jobs``, ``_active_job_by_endpoint``, and
+    ``_endpoint_locks``) persist across tests in the same pytest session.
+    Without this reset, a stale active-job pointer from a prior test can
+    cause a fresh test's first POST to return 409 (``job_in_progress``)
+    instead of 202.  Cooldown state is keyed in DuckDB and is isolated by
+    the fresh ``store`` fixture, so no cleanup is needed there.
+    """
+    webhooks_module._jobs.clear()
+    webhooks_module._active_job_by_endpoint.clear()
+    webhooks_module._endpoint_locks.clear()
+    yield
+    webhooks_module._jobs.clear()
+    webhooks_module._active_job_by_endpoint.clear()
+    webhooks_module._endpoint_locks.clear()
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,4 +1,4 @@
-"""Unit and integration tests for webhook authentication, cooldowns, and app composition.
+"""Unit and integration tests for webhook authentication, cooldowns, and async jobs.
 
 Covers:
 - Bearer token authentication (missing, wrong, valid)
@@ -6,11 +6,14 @@ Covers:
 - Cooldown persistence via DuckDB get_metadata / set_metadata
 - App composition: parent Starlette app mounts both /api/* and /mcp paths
 - Webhooks-disabled state: no /api routes when disabled or no secret env var
+- Async job contract: POST /poll|/rescore|/maintenance returns 202 + job_id,
+  background task runs the real work, GET /jobs/{id} surfaces the result
 """
 
 from __future__ import annotations
 
 import os
+import time
 from typing import Any
 
 import pytest
@@ -46,6 +49,32 @@ def _make_config(
 def _make_shared_state(store: DuckDBStore) -> dict[str, Any]:
     """Return a minimal shared-state dict using *store*."""
     return {"store": store, "config": _make_config(), "embedding_provider": None}
+
+
+def _wait_for_job(
+    client: TestClient,
+    job_id: str,
+    *,
+    timeout_s: float = 5.0,
+    poll_interval_s: float = 0.01,
+) -> dict[str, Any]:
+    """Poll ``GET /jobs/{job_id}`` until the job reaches a terminal state.
+
+    Raises :class:`AssertionError` on timeout so tests fail with a readable
+    message rather than flaking.  Returns the serialised job dict.
+    """
+    deadline = time.monotonic() + timeout_s
+    last: dict[str, Any] | None = None
+    while time.monotonic() < deadline:
+        resp = client.get(f"/jobs/{job_id}", headers=_AUTH_HEADER)
+        assert resp.status_code == 200, f"GET /jobs/{job_id} → {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert body["ok"] is True, body
+        last = body["data"]
+        if last["state"] in ("succeeded", "failed"):
+            return last
+        time.sleep(poll_interval_s)
+    raise AssertionError(f"job {job_id} did not terminate within {timeout_s}s; last={last!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -84,19 +113,29 @@ async def test_auth_wrong_token(store: DuckDBStore, monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.unit
-async def test_auth_valid_token(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch) -> None:
-    """POST with correct bearer token returns 200 accepted."""
+async def test_auth_valid_token_returns_202(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST with correct bearer token returns 202 and a job id."""
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     config = _make_config()
     shared = _make_shared_state(store)
     app = create_webhook_app(shared, config)
 
-    client = TestClient(app, raise_server_exceptions=False)
-    resp = client.post("/poll", headers=_AUTH_HEADER)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/poll", headers=_AUTH_HEADER)
 
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["ok"] is True
+        assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert body["ok"] is True
+        assert isinstance(body["job_id"], str) and body["job_id"]
+        assert body["state"] == "queued"
+        assert body["status_url"] == f"/jobs/{body['job_id']}"
+
+        # The background task must complete; the real FeedPoller runs against
+        # the empty fixture store and returns an all-zeros poll summary.
+        final = _wait_for_job(client, body["job_id"])
+        assert final["state"] == "succeeded"
 
 
 # ---------------------------------------------------------------------------
@@ -106,32 +145,37 @@ async def test_auth_valid_token(store: DuckDBStore, monkeypatch: pytest.MonkeyPa
 
 @pytest.mark.unit
 async def test_cooldown_enforced(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch) -> None:
-    """First authenticated request succeeds; immediate second returns 429 with Retry-After."""
+    """First authenticated request returns 202; immediate second returns 429 with Retry-After."""
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     config = _make_config()
     shared = _make_shared_state(store)
     app = create_webhook_app(shared, config)
 
-    client = TestClient(app, raise_server_exceptions=False)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        # First request: enqueues job, returns 202.  Cooldown is reserved
+        # synchronously before 202 returns, so the second call sees it.
+        first = client.post("/poll", headers=_AUTH_HEADER)
+        assert first.status_code == 202, f"Expected 202 on first request, got {first.status_code}"
 
-    # First request: should succeed
-    first = client.post("/poll", headers=_AUTH_HEADER)
-    assert first.status_code == 200, f"Expected 200 on first request, got {first.status_code}"
+        # Immediate second request: must be rejected with 429.
+        second = client.post("/poll", headers=_AUTH_HEADER)
+        assert second.status_code == 429, (
+            f"Expected 429 on second request, got {second.status_code}"
+        )
 
-    # Immediate second request: must be rejected with 429
-    second = client.post("/poll", headers=_AUTH_HEADER)
-    assert second.status_code == 429, f"Expected 429 on second request, got {second.status_code}"
+        body = second.json()
+        assert body["ok"] is False
+        assert body["error"] == "too_early"
+        assert "retry_after" in body
+        assert isinstance(body["retry_after"], int)
+        assert body["retry_after"] > 0
 
-    body = second.json()
-    assert body["ok"] is False
-    assert body["error"] == "too_early"
-    assert "retry_after" in body
-    assert isinstance(body["retry_after"], int)
-    assert body["retry_after"] > 0
+        # Retry-After header must also be present.
+        assert "retry-after" in second.headers
+        assert int(second.headers["retry-after"]) > 0
 
-    # Retry-After header must also be present
-    assert "retry-after" in second.headers
-    assert int(second.headers["retry-after"]) > 0
+        # Let the first job finish so the test exits cleanly.
+        _wait_for_job(client, first.json()["job_id"])
 
 
 @pytest.mark.integration
@@ -147,11 +191,11 @@ async def test_cooldown_persisted(store: DuckDBStore, monkeypatch: pytest.Monkey
     shared1 = _make_shared_state(store)
     app1 = create_webhook_app(shared1, config)
 
-    client1 = TestClient(app1, raise_server_exceptions=False)
-
-    # First request triggers cooldown recording in DuckDB.
-    resp = client1.post("/poll", headers=_AUTH_HEADER)
-    assert resp.status_code == 200
+    with TestClient(app1, raise_server_exceptions=False) as client1:
+        # First request triggers cooldown recording in DuckDB.
+        resp = client1.post("/poll", headers=_AUTH_HEADER)
+        assert resp.status_code == 202
+        _wait_for_job(client1, resp.json()["job_id"])
 
     # Verify the cooldown was actually written to DuckDB.
     cooldown_val = await store.get_metadata("webhook_cooldown:poll")
@@ -161,14 +205,13 @@ async def test_cooldown_persisted(store: DuckDBStore, monkeypatch: pytest.Monkey
     # but pointing at the same underlying store.
     shared2 = _make_shared_state(store)
     app2 = create_webhook_app(shared2, config)
-    client2 = TestClient(app2, raise_server_exceptions=False)
-
-    # The new app should see the cooldown from DuckDB.
-    resp2 = client2.post("/poll", headers=_AUTH_HEADER)
-    assert resp2.status_code == 429, (
-        "New webhook app instance did not see DuckDB-persisted cooldown"
-    )
-    assert resp2.json()["error"] == "too_early"
+    with TestClient(app2, raise_server_exceptions=False) as client2:
+        # The new app should see the cooldown from DuckDB.
+        resp2 = client2.post("/poll", headers=_AUTH_HEADER)
+        assert resp2.status_code == 429, (
+            "New webhook app instance did not see DuckDB-persisted cooldown"
+        )
+        assert resp2.json()["error"] == "too_early"
 
 
 # ---------------------------------------------------------------------------
@@ -200,22 +243,30 @@ async def test_app_composition(store: DuckDBStore, monkeypatch: pytest.MonkeyPat
         ]
     )
 
-    client = TestClient(parent, raise_server_exceptions=False)
+    with TestClient(parent, raise_server_exceptions=False) as client:
+        # /mcp path should be accessible.
+        mcp_resp = client.get("/mcp")
+        assert mcp_resp.status_code == 200
+        assert mcp_resp.json() == {"mcp": True}
 
-    # /mcp path should be accessible.
-    mcp_resp = client.get("/mcp")
-    assert mcp_resp.status_code == 200
-    assert mcp_resp.json() == {"mcp": True}
+        # /api/poll without auth should return 401.
+        api_resp = client.post("/api/poll")
+        assert api_resp.status_code == 401
+        assert api_resp.json()["error"] == "unauthorized"
 
-    # /api/poll without auth should return 401 (i.e. the route exists and
-    # the webhook app is handling it).
-    api_resp = client.post("/api/poll")
-    assert api_resp.status_code == 401
-    assert api_resp.json()["error"] == "unauthorized"
+        # /api/poll with correct auth should return 202 + job id.
+        api_auth_resp = client.post("/api/poll", headers=_AUTH_HEADER)
+        assert api_auth_resp.status_code == 202
+        job_id = api_auth_resp.json()["job_id"]
 
-    # /api/poll with correct auth should return 200.
-    api_auth_resp = client.post("/api/poll", headers=_AUTH_HEADER)
-    assert api_auth_resp.status_code == 200
+        # Let the bg task complete to avoid a pending task at teardown.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            resp = client.get(f"/api/jobs/{job_id}", headers=_AUTH_HEADER)
+            assert resp.status_code == 200
+            if resp.json()["data"]["state"] in ("succeeded", "failed"):
+                break
+            time.sleep(0.01)
 
 
 # ---------------------------------------------------------------------------
@@ -294,14 +345,14 @@ async def test_webhooks_disabled(store: DuckDBStore, monkeypatch: pytest.MonkeyP
 
 
 # ---------------------------------------------------------------------------
-# Handler tests — poll, rescore, maintenance
+# Handler tests — poll, rescore, maintenance (async contract)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 async def test_poll_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch) -> None:
-    """POST /poll returns {ok: true, data: {sources_polled, items_fetched, items_stored, errors}}
-    with values from FeedPoller.poll() summary."""
+    """POST /poll returns 202 immediately; the background job runs FeedPoller.poll()
+    and the GET /jobs/{id} result reflects the summary."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from distillery.feeds.poller import PollerSummary, PollResult
@@ -310,7 +361,6 @@ async def test_poll_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch)
     config = _make_config()
     shared = _make_shared_state(store)
 
-    # Build a deterministic summary with one source, no errors.
     result = PollResult(
         source_url="https://example.com/feed", source_type="rss", items_fetched=10, items_stored=7
     )
@@ -319,17 +369,15 @@ async def test_poll_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch)
     mock_poller = MagicMock()
     mock_poller.poll = AsyncMock(return_value=summary)
 
-    # Patch FeedPoller where it is looked up (module-level import in webhooks).
-    # Each test receives a fresh in-memory store (no pre-existing cooldowns).
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller) as mock_cls:
         app = create_webhook_app(shared, config)
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/poll", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/poll", headers=_AUTH_HEADER)
+            assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+            final = _wait_for_job(client, resp.json()["job_id"])
 
-    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
-    body = resp.json()
-    assert body["ok"] is True
-    data = body["data"]
+    assert final["state"] == "succeeded", final
+    data = final["result"]
     assert data["sources_polled"] == 1
     assert data["items_fetched"] == 10
     assert data["items_stored"] == 7
@@ -340,8 +388,8 @@ async def test_poll_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch)
 
 @pytest.mark.unit
 async def test_rescore_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch) -> None:
-    """POST /rescore with body {limit: 50} passes limit to FeedPoller.rescore()
-    and returns {ok: true, data: {rescored, upgraded, downgraded}}."""
+    """POST /rescore with body {limit: 50} returns 202; the background job
+    forwards limit=50 to FeedPoller.rescore() and the job result carries the stats."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
@@ -353,17 +401,15 @@ async def test_rescore_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPat
     mock_poller = MagicMock()
     mock_poller.rescore = AsyncMock(return_value=rescore_stats)
 
-    # Patch FeedPoller where it is looked up (module-level import in webhooks).
-    # Each test receives a fresh in-memory store (no pre-existing cooldowns).
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, config)
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/rescore", headers=_AUTH_HEADER, json={"limit": 50})
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/rescore", headers=_AUTH_HEADER, json={"limit": 50})
+            assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+            final = _wait_for_job(client, resp.json()["job_id"])
 
-    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
-    body = resp.json()
-    assert body["ok"] is True
-    data = body["data"]
+    assert final["state"] == "succeeded", final
+    data = final["result"]
     assert data["rescored"] == 50
     assert data["upgraded"] == 12
     assert data["downgraded"] == 5
@@ -373,8 +419,9 @@ async def test_rescore_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPat
 
 @pytest.mark.unit
 async def test_maintenance_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch) -> None:
-    """POST /maintenance orchestrates poll → rescore → classify-batch and returns a
-    combined response with poll, rescore, and classify_batch keys."""
+    """POST /maintenance returns 202; the background job orchestrates
+    poll → rescore → classify-batch and the GET /jobs/{id} result contains
+    combined poll, rescore, and classify_batch keys."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from distillery.feeds.poller import PollerSummary, PollResult
@@ -401,13 +448,13 @@ async def test_maintenance_handler(store: DuckDBStore, monkeypatch: pytest.Monke
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, config)
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/maintenance", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/maintenance", headers=_AUTH_HEADER)
+            assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+            final = _wait_for_job(client, resp.json()["job_id"])
 
-    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
-    body = resp.json()
-    assert body["ok"] is True
-    data = body["data"]
+    assert final["state"] == "succeeded", final
+    data = final["result"]
 
     # Response must contain all three sub-operation keys.
     assert "poll" in data
@@ -429,11 +476,12 @@ async def test_maintenance_handler(store: DuckDBStore, monkeypatch: pytest.Monke
 
 
 @pytest.mark.unit
-async def test_handler_error_returns_500(
+async def test_handler_error_surfaces_in_job(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When FeedPoller.poll() raises an exception the endpoint returns
-    {ok: false, error: '<message>'} with HTTP status 500."""
+    """When FeedPoller.poll() raises an exception the endpoint still returns 202,
+    but the background job terminates in the 'failed' state with a descriptive
+    error payload."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
@@ -443,29 +491,28 @@ async def test_handler_error_returns_500(
     mock_poller = MagicMock()
     mock_poller.poll = AsyncMock(side_effect=RuntimeError("feed source unavailable"))
 
-    # Patch FeedPoller where it is looked up (module-level import in webhooks).
-    # Each test receives a fresh in-memory store (no pre-existing cooldowns).
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, config)
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/poll", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/poll", headers=_AUTH_HEADER)
+            assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+            final = _wait_for_job(client, resp.json()["job_id"])
 
-    assert resp.status_code == 500, f"Expected 500, got {resp.status_code}: {resp.text}"
-    body = resp.json()
-    assert body["ok"] is False
+    assert final["state"] == "failed", final
     # The webhook returns a stable, generic error message to clients and keeps
     # the exception details (e.g. "feed source unavailable") in server logs.
-    assert body["error"] == "poll cycle failed"
+    assert final["error"] == "poll cycle failed"
 
 
 # ---------------------------------------------------------------------------
-# /hooks/poll and /hooks/rescore endpoint tests
+# /hooks/poll and /hooks/rescore endpoint tests (deprecated async aliases)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 async def test_hooks_poll_route_exists(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch) -> None:
-    """POST /hooks/poll is a valid route that returns 200 with a valid bearer token."""
+    """POST /hooks/poll is a valid route that returns 202 + job id with a valid
+    bearer token, and the background job succeeds."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from distillery.feeds.poller import PollerSummary, PollResult
@@ -484,13 +531,15 @@ async def test_hooks_poll_route_exists(store: DuckDBStore, monkeypatch: pytest.M
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, config)
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/hooks/poll", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/hooks/poll", headers=_AUTH_HEADER)
+            assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            assert body["ok"] is True
+            assert "job_id" in body
+            final = _wait_for_job(client, body["job_id"])
 
-    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
-    body = resp.json()
-    assert body["ok"] is True
-    assert "data" in body
+    assert final["state"] == "succeeded"
 
 
 @pytest.mark.unit
@@ -514,7 +563,8 @@ async def test_hooks_poll_rejects_unauthenticated(
 async def test_hooks_poll_source_url_query_param(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """POST /hooks/poll?source_url=<url> passes source_url to FeedPoller.poll()."""
+    """POST /hooks/poll?source_url=<url> forwards source_url to FeedPoller.poll()
+    on the background task."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from distillery.feeds.poller import PollerSummary, PollResult
@@ -532,15 +582,14 @@ async def test_hooks_poll_source_url_query_param(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, config)
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post(
-            f"/hooks/poll?source_url={target_url}",
-            headers=_AUTH_HEADER,
-        )
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post(
+                f"/hooks/poll?source_url={target_url}",
+                headers=_AUTH_HEADER,
+            )
+            assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+            _wait_for_job(client, resp.json()["job_id"])
 
-    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
-    body = resp.json()
-    assert body["ok"] is True
     # Verify poll was called with the specific source_url.
     mock_poller.poll.assert_awaited_once_with(source_url=target_url)
 
@@ -549,7 +598,8 @@ async def test_hooks_poll_source_url_query_param(
 async def test_hooks_rescore_route_exists(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """POST /hooks/rescore is a valid route that returns 200 with a valid bearer token."""
+    """POST /hooks/rescore is a valid route that returns 202 + job id with a valid
+    bearer token, and the background job succeeds."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
@@ -562,13 +612,15 @@ async def test_hooks_rescore_route_exists(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, config)
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/hooks/rescore", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/hooks/rescore", headers=_AUTH_HEADER)
+            assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            assert body["ok"] is True
+            assert "job_id" in body
+            final = _wait_for_job(client, body["job_id"])
 
-    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
-    body = resp.json()
-    assert body["ok"] is True
-    assert "data" in body
+    assert final["state"] == "succeeded"
 
 
 @pytest.mark.unit
@@ -592,7 +644,7 @@ async def test_hooks_rescore_rejects_unauthenticated(
 async def test_hooks_rescore_limit_query_param(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """POST /hooks/rescore?limit=50 passes limit=50 to FeedPoller.rescore()."""
+    """POST /hooks/rescore?limit=50 forwards limit=50 to FeedPoller.rescore()."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
@@ -605,13 +657,11 @@ async def test_hooks_rescore_limit_query_param(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, config)
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/hooks/rescore?limit=50", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/hooks/rescore?limit=50", headers=_AUTH_HEADER)
+            assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+            _wait_for_job(client, resp.json()["job_id"])
 
-    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
-    body = resp.json()
-    assert body["ok"] is True
-    # Verify rescore was called with limit=50.
     mock_poller.rescore.assert_awaited_once_with(limit=50)
 
 
@@ -619,7 +669,7 @@ async def test_hooks_rescore_limit_query_param(
 async def test_hooks_rescore_invalid_limit_query_param(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """POST /hooks/rescore?limit=abc returns 400 bad request."""
+    """POST /hooks/rescore?limit=abc returns 400 bad request (parsed before 202)."""
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     config = _make_config()
     shared = _make_shared_state(store)
@@ -641,9 +691,9 @@ async def test_hooks_rescore_non_positive_limit_query_param(
 ) -> None:
     """POST /hooks/rescore?limit=0 and ?limit=-1 return 400 bad request.
 
-    Guards the ``limit <= 0`` branch in :func:`_handle_rescore` against
-    regression — a purely typed check would let zero/negative values slip
-    through.  Each bad limit runs in its own parametrised invocation so the
+    Guards the ``limit <= 0`` branch in the rescore parser against regression
+    — a purely typed check would let zero/negative values slip through.
+    Each bad limit runs in its own parametrised invocation so the
     fresh in-memory ``store`` fixture provides a clean cooldown slate.
     """
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
@@ -662,3 +712,103 @@ async def test_hooks_rescore_non_positive_limit_query_param(
     assert "positive" in body["error"], (
         f"error should mention 'positive' for limit={bad_limit!r}; got {body['error']!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Async job semantics — idempotency, status endpoint, unknown job id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_jobs_endpoint_requires_auth(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /jobs/{id} without a bearer token returns 401 unauthorized."""
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+    app = create_webhook_app(shared, config)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/jobs/does-not-matter")
+    assert resp.status_code == 401
+    assert resp.json()["error"] == "unauthorized"
+
+
+@pytest.mark.unit
+async def test_jobs_endpoint_unknown_id_returns_404(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /jobs/<unknown> returns 404 with a descriptive error."""
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+    app = create_webhook_app(shared, config)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/jobs/no-such-id", headers=_AUTH_HEADER)
+    assert resp.status_code == 404
+    assert resp.json() == {"ok": False, "error": "job not found"}
+
+
+@pytest.mark.unit
+async def test_second_poll_while_in_flight_returns_409(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """While a poll job is running, a second POST /poll returns 409 with the
+    existing job_id so the caller re-attaches rather than racing.
+
+    This guards the idempotency contract independently of the cooldown —
+    we overwrite the cooldown key with a far-past timestamp between the
+    two requests so the only reason the second call can fail is the
+    in-flight lock.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from distillery.feeds.poller import PollerSummary, PollResult
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+
+    # Slow poll: keep the bg task alive long enough that the second request
+    # sees the job mid-flight.  We use asyncio.sleep (not a cross-loop Event)
+    # because the bg task and the second dispatch run in the TestClient's
+    # portal loop — but the test function itself runs in pytest-asyncio's
+    # loop, and asyncio.Event is loop-bound.
+    result = PollResult(source_url="https://x/feed", source_type="rss")
+    summary = PollerSummary(results=[result])
+
+    async def _slow_poll(*args: Any, **kwargs: Any) -> PollerSummary:
+        await asyncio.sleep(0.5)
+        return summary
+
+    mock_poller = MagicMock()
+    mock_poller.poll = AsyncMock(side_effect=_slow_poll)
+
+    with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
+        app = create_webhook_app(shared, config)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            first = client.post("/poll", headers=_AUTH_HEADER)
+            assert first.status_code == 202
+            first_job_id = first.json()["job_id"]
+
+            # Pin the cooldown to a far-past time so the 429 path does not
+            # mask the 409 path.  Any parseable ISO timestamp older than the
+            # cooldown window works.
+            await store.set_metadata(
+                "webhook_cooldown:poll", "1970-01-01T00:00:00+00:00"
+            )
+
+            second = client.post("/poll", headers=_AUTH_HEADER)
+            assert second.status_code == 409, (
+                f"Expected 409 while first job in-flight, got {second.status_code}: {second.text}"
+            )
+            body = second.json()
+            assert body["ok"] is False
+            assert body["error"] == "job_in_progress"
+            assert body["job_id"] == first_job_id
+
+            # Wait for the first job to finish cleanly.
+            _wait_for_job(client, first_job_id, timeout_s=3.0)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -24,7 +24,6 @@ from starlette.routing import Mount, Route
 from starlette.testclient import TestClient
 
 from distillery.config import DistilleryConfig, ServerConfig, WebhookConfig
-from distillery.mcp import webhooks as webhooks_module
 from distillery.mcp.webhooks import create_webhook_app
 from distillery.store.duckdb import DuckDBStore
 
@@ -158,11 +157,19 @@ async def test_cooldown_enforced(store: DuckDBStore, monkeypatch: pytest.MonkeyP
 
     with TestClient(app, raise_server_exceptions=False) as client:
         # First request: enqueues job, returns 202.  Cooldown is reserved
-        # synchronously before 202 returns, so the second call sees it.
+        # synchronously before 202 returns.
         first = client.post("/poll", headers=_AUTH_HEADER)
         assert first.status_code == 202, f"Expected 202 on first request, got {first.status_code}"
 
-        # Immediate second request: must be rejected with 429.
+        # Wait for the first job to terminate before the second POST.  The
+        # dispatcher checks idempotency (409) before cooldown (429); while
+        # the first job is in flight the second call correctly returns 409.
+        # To test cooldown enforcement in isolation we need the first job
+        # out of the active-job registry first.
+        _wait_for_job(client, first.json()["job_id"])
+
+        # Second request after the first finished: now it hits the cooldown
+        # path and must be rejected with 429.
         second = client.post("/poll", headers=_AUTH_HEADER)
         assert second.status_code == 429, (
             f"Expected 429 on second request, got {second.status_code}"
@@ -178,9 +185,6 @@ async def test_cooldown_enforced(store: DuckDBStore, monkeypatch: pytest.MonkeyP
         # Retry-After header must also be present.
         assert "retry-after" in second.headers
         assert int(second.headers["retry-after"]) > 0
-
-        # Let the first job finish so the test exits cleanly.
-        _wait_for_job(client, first.json()["job_id"])
 
 
 @pytest.mark.integration
@@ -807,12 +811,12 @@ async def test_second_poll_while_in_flight_returns_409(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """While a poll job is running, a second POST /poll returns 409 with the
-    existing job_id so the caller re-attaches rather than racing.
+    existing job_id (including a mount-aware ``status_url``) so the caller
+    re-attaches rather than racing a duplicate.
 
-    This guards the idempotency contract independently of the cooldown —
-    we overwrite the cooldown key with a far-past timestamp between the
-    two requests so the only reason the second call can fail is the
-    in-flight lock.
+    The dispatcher checks idempotency BEFORE cooldown, so the 409 is the
+    authoritative signal even though the first POST also reserved a
+    cooldown.  This test therefore needs no cooldown manipulation.
     """
     import asyncio
     from unittest.mock import AsyncMock, MagicMock, patch
@@ -824,10 +828,9 @@ async def test_second_poll_while_in_flight_returns_409(
     shared = _make_shared_state(store)
 
     # Slow poll: keep the bg task alive long enough that the second request
-    # sees the job mid-flight.  We use asyncio.sleep (not a cross-loop Event)
-    # because the bg task and the second dispatch run in the TestClient's
-    # portal loop — but the test function itself runs in pytest-asyncio's
-    # loop, and asyncio.Event is loop-bound.
+    # sees the job mid-flight.  asyncio.sleep is safe across portal loops
+    # (unlike asyncio.Event which is loop-bound) because the bg task and
+    # the second dispatch run in the same TestClient portal.
     result = PollResult(source_url="https://x/feed", source_type="rss")
     summary = PollerSummary(results=[result])
 
@@ -845,15 +848,6 @@ async def test_second_poll_while_in_flight_returns_409(
             assert first.status_code == 202
             first_job_id = first.json()["job_id"]
 
-            # Pin the cooldown to a far-past time so the 429 path does not
-            # mask the 409 path.  Any parseable ISO timestamp older than the
-            # cooldown window works.  Must clear the in-memory cache too —
-            # _check_cooldown prefers it over the DuckDB row.
-            webhooks_module._cooldown_ts.pop("poll", None)
-            await store.set_metadata(
-                "webhook_cooldown:poll", "1970-01-01T00:00:00+00:00"
-            )
-
             second = client.post("/poll", headers=_AUTH_HEADER)
             assert second.status_code == 409, (
                 f"Expected 409 while first job in-flight, got {second.status_code}: {second.text}"
@@ -862,6 +856,143 @@ async def test_second_poll_while_in_flight_returns_409(
             assert body["ok"] is False
             assert body["error"] == "job_in_progress"
             assert body["job_id"] == first_job_id
+            # Unmounted app: status_url has no prefix.
+            assert body["status_url"] == f"/jobs/{first_job_id}"
 
             # Wait for the first job to finish cleanly.
             _wait_for_job(client, first_job_id, timeout_s=3.0)
+
+
+@pytest.mark.unit
+async def test_status_url_respects_mount_prefix(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the webhook app is mounted at ``/api``, the ``status_url`` in
+    both the 202 and 409 responses must include the mount prefix so the
+    scheduler can GET it directly without knowing the mount layout.
+    """
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+    webhook_app = create_webhook_app(shared, config)
+
+    parent = Starlette(routes=[Mount("/api", app=webhook_app)])
+
+    with TestClient(parent, raise_server_exceptions=False) as client:
+        first = client.post("/api/poll", headers=_AUTH_HEADER)
+        assert first.status_code == 202, f"Expected 202, got {first.status_code}"
+        first_body = first.json()
+        job_id = first_body["job_id"]
+
+        # 202 response: status_url must include /api prefix.
+        assert first_body["status_url"] == f"/api/jobs/{job_id}", (
+            f"status_url should be mount-aware; got {first_body['status_url']!r}"
+        )
+
+        # GET /api/jobs/{id} must actually work (sanity that the URL is usable).
+        status_resp = client.get(first_body["status_url"], headers=_AUTH_HEADER)
+        assert status_resp.status_code == 200, (
+            f"Reported status_url must be GETtable; got {status_resp.status_code}"
+        )
+
+        # 409 response (while in flight): same mount-aware shape.
+        second = client.post("/api/poll", headers=_AUTH_HEADER)
+        if second.status_code == 409:
+            second_body = second.json()
+            assert second_body["status_url"] == f"/api/jobs/{second_body['job_id']}"
+
+        # Let the job finish cleanly.
+        _wait_for_job(client, job_id)
+
+
+@pytest.mark.unit
+async def test_failed_job_records_audit(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the bg runner raises, _execute_job must still write
+    ``webhook_audit:{endpoint}`` with the error so the failure mode isn't
+    invisible to operators inspecting the DB.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+
+    mock_poller = MagicMock()
+    mock_poller.poll = AsyncMock(side_effect=RuntimeError("feed blew up"))
+
+    with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
+        app = create_webhook_app(shared, config)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/poll", headers=_AUTH_HEADER)
+            assert resp.status_code == 202
+            final = _wait_for_job(client, resp.json()["job_id"])
+
+    assert final["state"] == "failed"
+
+    # Audit record must exist for the failure — previously the except
+    # branch exited without writing one, leaving the DB silent on the
+    # most-interesting path.
+    audit_raw = await store.get_metadata("webhook_audit:poll")
+    assert audit_raw is not None, (
+        "webhook_audit:poll must be written even when the runner raises"
+    )
+    import json as _json
+
+    record = _json.loads(audit_raw)
+    assert record["ok"] is False
+    assert record["status"] == 500
+    assert "feed blew up" in record.get("error", "") or record.get("error")
+
+
+@pytest.mark.unit
+async def test_409_preferred_over_429_when_both_apply(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When a job is in flight AND the cooldown would fire, the dispatcher
+    must return 409 (job_in_progress), not 429 (too_early).
+
+    Guards the ordering requested by CodeRabbit review on PR #397:
+    schedulers that retry on 429 would back off on a cooldown that merely
+    reflects their own in-flight work; the correct action is to poll
+    ``/jobs/{id}`` for completion, which 409 signals with ``job_id`` and
+    ``status_url``.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from distillery.feeds.poller import PollerSummary, PollResult
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+
+    result = PollResult(source_url="https://x/feed", source_type="rss")
+    summary = PollerSummary(results=[result])
+
+    async def _slow_poll(*args: Any, **kwargs: Any) -> PollerSummary:
+        await asyncio.sleep(0.5)
+        return summary
+
+    mock_poller = MagicMock()
+    mock_poller.poll = AsyncMock(side_effect=_slow_poll)
+
+    with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
+        app = create_webhook_app(shared, config)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            # First POST sets cooldown AND starts a slow bg job.  When the
+            # second POST arrives the cooldown is live (set synchronously
+            # before 202 returns) and the job is in flight.  Both gates
+            # would fire — we must see 409, not 429.
+            first = client.post("/poll", headers=_AUTH_HEADER)
+            assert first.status_code == 202
+
+            second = client.post("/poll", headers=_AUTH_HEADER)
+            assert second.status_code == 409, (
+                f"Expected 409 (job_in_progress wins over cooldown), "
+                f"got {second.status_code}: {second.text}"
+            )
+            assert second.json()["error"] == "job_in_progress"
+
+            _wait_for_job(client, first.json()["job_id"], timeout_s=3.0)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -504,6 +504,52 @@ async def test_handler_error_surfaces_in_job(
     assert final["error"] == "poll cycle failed"
 
 
+@pytest.mark.unit
+async def test_failed_job_triggers_store_rollback(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the bg runner fails, _execute_job calls store.rollback() so any
+    aborted DuckDB transaction state cannot leak into the next webhook job.
+
+    This is the defensive safety-net described in issue #396: a prior
+    rollback regression let a poisoned connection cascade every subsequent
+    find_similar/store call in the same poll run.  Rollback at the webhook
+    boundary is redundant with ``DuckDBStore._run_sync`` on the happy path
+    but catches regressions in paths that bypass it.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+
+    # Wrap the real store with a spy on rollback() to observe calls without
+    # disturbing the rest of the interface.
+    rollback_spy = AsyncMock(wraps=store.rollback)
+    spy_store = MagicMock(wraps=store)
+    spy_store.rollback = rollback_spy
+    shared: dict[str, Any] = {
+        "store": spy_store,
+        "config": _make_config(),
+        "embedding_provider": None,
+    }
+
+    mock_poller = MagicMock()
+    mock_poller.poll = AsyncMock(side_effect=RuntimeError("feed source unavailable"))
+
+    with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
+        app = create_webhook_app(shared, config)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/poll", headers=_AUTH_HEADER)
+            assert resp.status_code == 202
+            final = _wait_for_job(client, resp.json()["job_id"])
+
+    assert final["state"] == "failed", final
+    assert rollback_spy.await_count >= 1, (
+        "store.rollback() must be called when the bg runner fails "
+        "(defensive guard against issue #396 cascade)"
+    )
+
+
 # ---------------------------------------------------------------------------
 # /hooks/poll and /hooks/rescore endpoint tests (deprecated async aliases)
 # ---------------------------------------------------------------------------

--- a/tests/test_webhooks/test_maintenance.py
+++ b/tests/test_webhooks/test_maintenance.py
@@ -21,8 +21,26 @@ from starlette.testclient import TestClient
 
 from distillery.config import DistilleryConfig, ServerConfig, WebhookConfig
 from distillery.feeds.poller import PollerSummary, PollResult
+from distillery.mcp import webhooks as webhooks_module
 from distillery.mcp.webhooks import create_webhook_app
 from distillery.store.duckdb import DuckDBStore
+
+
+@pytest.fixture(autouse=True)
+def _reset_webhook_module_state() -> Any:
+    """Clear module-level async-job registries between tests.
+
+    See the matching fixture in ``tests/test_webhooks.py`` for rationale:
+    the ``_jobs`` + ``_active_job_by_endpoint`` dicts leak across tests and
+    cause a fresh POST to return 409 (stale active pointer) instead of 202.
+    """
+    webhooks_module._jobs.clear()
+    webhooks_module._active_job_by_endpoint.clear()
+    webhooks_module._endpoint_locks.clear()
+    yield
+    webhooks_module._jobs.clear()
+    webhooks_module._active_job_by_endpoint.clear()
+    webhooks_module._endpoint_locks.clear()
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_webhooks/test_maintenance.py
+++ b/tests/test_webhooks/test_maintenance.py
@@ -1,15 +1,18 @@
-"""Tests for POST /maintenance webhook endpoint (rewired orchestrator).
+"""Tests for POST /maintenance webhook endpoint (rewired as async orchestrator).
 
 Covers:
 - Auth requirement (401 without bearer token)
-- Orchestrator calls poll → rescore → classify-batch in sequence
-- Combined response format: {poll: {...}, rescore: {...}, classify_batch: {...}}
-- Error in one sub-operation is reported but does not block the others
+- POST returns 202 + job_id; orchestrator runs poll → rescore → classify-batch
+  on a background task and reports completion via GET /jobs/{id}
+- Combined result format: {poll: {...}, rescore: {...}, classify_batch: {...}}
+- Error in one sub-operation is reported in the job result but does not
+  block the other sub-operations
 - Cooldown enforcement (429 on second immediate request)
 """
 
 from __future__ import annotations
 
+import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -91,6 +94,37 @@ def _make_poller_mock(
     return mock
 
 
+def _wait_for_job(
+    client: TestClient,
+    job_id: str,
+    *,
+    timeout_s: float = 5.0,
+    poll_interval_s: float = 0.01,
+) -> dict[str, Any]:
+    """Poll ``GET /jobs/{job_id}`` until the job is terminal; return the dict."""
+    deadline = time.monotonic() + timeout_s
+    last: dict[str, Any] | None = None
+    while time.monotonic() < deadline:
+        resp = client.get(f"/jobs/{job_id}", headers=_AUTH_HEADER)
+        assert resp.status_code == 200, f"GET /jobs/{job_id} → {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert body["ok"] is True, body
+        last = body["data"]
+        if last["state"] in ("succeeded", "failed"):
+            return last
+        time.sleep(poll_interval_s)
+    raise AssertionError(f"job {job_id} did not terminate within {timeout_s}s; last={last!r}")
+
+
+def _submit_and_await(
+    client: TestClient,
+) -> dict[str, Any]:
+    """POST /maintenance, assert 202, wait for completion, return job snapshot."""
+    resp = client.post("/maintenance", headers=_AUTH_HEADER)
+    assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+    return _wait_for_job(client, resp.json()["job_id"])
+
+
 # ---------------------------------------------------------------------------
 # Auth tests
 # ---------------------------------------------------------------------------
@@ -129,16 +163,17 @@ async def test_maintenance_rejects_wrong_token(
 
 
 # ---------------------------------------------------------------------------
-# Combined response format
+# Combined result format
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-async def test_maintenance_combined_response_format(
+async def test_maintenance_combined_result_format(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """POST /maintenance returns {ok: true, data: {poll: {...}, rescore: {...},
-    classify_batch: {...}}} — all three sub-operation keys are present."""
+    """POST /maintenance returns 202 + job id; the job result contains
+    {poll: {...}, rescore: {...}, classify_batch: {...}} — all three
+    sub-operation keys are present."""
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     shared = _make_shared_state(store)
 
@@ -148,18 +183,14 @@ async def test_maintenance_combined_response_format(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/maintenance", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            final = _submit_and_await(client)
 
-    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
-    body = resp.json()
-    assert body["ok"] is True
-    data = body["data"]
-
-    # All three sub-operation keys must be present.
-    assert "poll" in data, "Missing 'poll' key in maintenance response"
-    assert "rescore" in data, "Missing 'rescore' key in maintenance response"
-    assert "classify_batch" in data, "Missing 'classify_batch' key in maintenance response"
+    assert final["state"] == "succeeded", final
+    data = final["result"]
+    assert "poll" in data, "Missing 'poll' key in maintenance result"
+    assert "rescore" in data, "Missing 'rescore' key in maintenance result"
+    assert "classify_batch" in data, "Missing 'classify_batch' key in maintenance result"
 
 
 @pytest.mark.unit
@@ -174,10 +205,10 @@ async def test_maintenance_poll_sub_operation_values(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/maintenance", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            final = _submit_and_await(client)
 
-    data = resp.json()["data"]
+    data = final["result"]
     poll = data["poll"]
     assert poll["sources_polled"] == 3
     assert poll["items_fetched"] == 12
@@ -197,10 +228,10 @@ async def test_maintenance_rescore_sub_operation_values(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/maintenance", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            final = _submit_and_await(client)
 
-    data = resp.json()["data"]
+    data = final["result"]
     rescore = data["rescore"]
     assert rescore["rescored"] == 25
     assert rescore["upgraded"] == 7
@@ -220,16 +251,15 @@ async def test_maintenance_classify_batch_sub_operation_present(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/maintenance", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            final = _submit_and_await(client)
 
-    data = resp.json()["data"]
+    data = final["result"]
     classify = data["classify_batch"]
     assert "classified" in classify
     assert "pending_review" in classify
     assert "errors" in classify
     assert "by_type" in classify
-    # Fresh store has no pending entries.
     assert classify["classified"] == 0
     assert classify["pending_review"] == 0
     assert classify["errors"] == 0
@@ -244,26 +274,25 @@ async def test_maintenance_classify_batch_sub_operation_present(
 async def test_maintenance_calls_poll_then_rescore(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Both FeedPoller.poll() and FeedPoller.rescore() are called during maintenance."""
+    """Both FeedPoller.poll() and FeedPoller.rescore() are called during maintenance,
+    and poll is invoked before rescore."""
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     shared = _make_shared_state(store)
 
     mock_poller = _make_poller_mock()
 
-    with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller) as mock_cls:
+    with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/maintenance", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            final = _submit_and_await(client)
 
-    assert resp.status_code == 200
-    # Both methods must be awaited, and poll must precede rescore.
+    assert final["state"] == "succeeded"
     mock_poller.poll.assert_awaited()
     mock_poller.rescore.assert_awaited()
     call_names = [c[0] for c in mock_poller.mock_calls]
     assert call_names.index("poll") < call_names.index("rescore"), (
         "poll() must be called before rescore() in the maintenance pipeline"
     )
-    _ = mock_cls  # referenced to suppress unused-variable lint
 
 
 # ---------------------------------------------------------------------------
@@ -277,7 +306,8 @@ async def test_maintenance_poll_failure_does_not_block_rescore_or_classify(
 ) -> None:
     """When poll sub-operation fails, rescore and classify-batch still run.
 
-    The top-level ok is still true; poll reports its error inline."""
+    The overall job still terminates as ``succeeded`` because maintenance is
+    best-effort; the poll error is captured in the poll sub-result."""
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     shared = _make_shared_state(store)
 
@@ -285,15 +315,13 @@ async def test_maintenance_poll_failure_does_not_block_rescore_or_classify(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/maintenance", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            final = _submit_and_await(client)
 
-    assert resp.status_code == 200, (
-        f"Maintenance should return 200 even when poll fails; got {resp.status_code}"
+    assert final["state"] == "succeeded", (
+        f"Maintenance should still succeed as a whole when poll fails; got {final!r}"
     )
-    body = resp.json()
-    assert body["ok"] is True
-    data = body["data"]
+    data = final["result"]
 
     # poll sub-result reports failure.
     assert data["poll"].get("ok") is False or "error" in data["poll"], (
@@ -311,7 +339,8 @@ async def test_maintenance_rescore_failure_does_not_block_classify(
 ) -> None:
     """When rescore sub-operation fails, classify-batch still runs.
 
-    The top-level ok is still true; rescore reports its error inline."""
+    The overall job still terminates as ``succeeded``; rescore reports its
+    error inline."""
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     shared = _make_shared_state(store)
 
@@ -319,22 +348,17 @@ async def test_maintenance_rescore_failure_does_not_block_classify(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/maintenance", headers=_AUTH_HEADER)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            final = _submit_and_await(client)
 
-    assert resp.status_code == 200, (
-        f"Maintenance should return 200 even when rescore fails; got {resp.status_code}"
+    assert final["state"] == "succeeded", (
+        f"Maintenance should still succeed as a whole when rescore fails; got {final!r}"
     )
-    body = resp.json()
-    assert body["ok"] is True
-    data = body["data"]
+    data = final["result"]
 
-    # rescore sub-result reports failure.
     assert data["rescore"].get("ok") is False or "error" in data["rescore"], (
         "rescore failure should be reflected in the rescore sub-result"
     )
-
-    # classify_batch is still present.
     assert "classify_batch" in data
 
 
@@ -347,7 +371,11 @@ async def test_maintenance_rescore_failure_does_not_block_classify(
 async def test_maintenance_cooldown_enforced(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """First POST /maintenance succeeds; immediate second returns 429 with Retry-After."""
+    """First POST /maintenance returns 202; immediate second returns 429 with Retry-After.
+
+    Cooldown is reserved synchronously inside the dispatcher before the 202
+    is returned, so the second POST sees the cooldown regardless of whether
+    the first job has completed."""
     monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
     shared = _make_shared_state(store)
 
@@ -355,19 +383,22 @@ async def test_maintenance_cooldown_enforced(
 
     with patch("distillery.mcp.webhooks.FeedPoller", return_value=mock_poller):
         app = create_webhook_app(shared, _make_config())
-        client = TestClient(app, raise_server_exceptions=False)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            first = client.post("/maintenance", headers=_AUTH_HEADER)
+            assert first.status_code == 202, (
+                f"First request should be accepted, got {first.status_code}"
+            )
 
-        first = client.post("/maintenance", headers=_AUTH_HEADER)
-        assert first.status_code == 200, f"First request should succeed, got {first.status_code}"
+            second = client.post("/maintenance", headers=_AUTH_HEADER)
+            assert second.status_code == 429, (
+                f"Second immediate request should be rate-limited, got {second.status_code}"
+            )
+            body = second.json()
+            assert body["ok"] is False
+            assert body["error"] == "too_early"
+            assert isinstance(body.get("retry_after"), int)
+            assert body["retry_after"] > 0
+            assert "retry-after" in second.headers
 
-        second = client.post("/maintenance", headers=_AUTH_HEADER)
-
-    assert second.status_code == 429, (
-        f"Second immediate request should be rate-limited, got {second.status_code}"
-    )
-    body = second.json()
-    assert body["ok"] is False
-    assert body["error"] == "too_early"
-    assert isinstance(body.get("retry_after"), int)
-    assert body["retry_after"] > 0
-    assert "retry-after" in second.headers
+            # Let the first job finish cleanly.
+            _wait_for_job(client, first.json()["job_id"])

--- a/tests/test_webhooks/test_maintenance.py
+++ b/tests/test_webhooks/test_maintenance.py
@@ -21,28 +21,12 @@ from starlette.testclient import TestClient
 
 from distillery.config import DistilleryConfig, ServerConfig, WebhookConfig
 from distillery.feeds.poller import PollerSummary, PollResult
-from distillery.mcp import webhooks as webhooks_module
 from distillery.mcp.webhooks import create_webhook_app
 from distillery.store.duckdb import DuckDBStore
 
-
-@pytest.fixture(autouse=True)
-def _reset_webhook_module_state() -> Any:
-    """Clear module-level async-job registries between tests.
-
-    See the matching fixture in ``tests/test_webhooks.py`` for rationale:
-    the ``_jobs`` + ``_active_job_by_endpoint`` dicts leak across tests and
-    cause a fresh POST to return 409 (stale active pointer) instead of 202.
-    """
-    webhooks_module._jobs.clear()
-    webhooks_module._active_job_by_endpoint.clear()
-    webhooks_module._endpoint_locks.clear()
-    webhooks_module._cooldown_ts.clear()
-    yield
-    webhooks_module._jobs.clear()
-    webhooks_module._active_job_by_endpoint.clear()
-    webhooks_module._endpoint_locks.clear()
-    webhooks_module._cooldown_ts.clear()
+# The autouse fixture that clears ``_jobs``, ``_active_job_by_endpoint``,
+# ``_endpoint_locks``, and ``_cooldown_ts`` between tests lives in the root
+# ``tests/conftest.py`` so all webhook test files share it.
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_webhooks/test_maintenance.py
+++ b/tests/test_webhooks/test_maintenance.py
@@ -393,9 +393,16 @@ async def test_maintenance_cooldown_enforced(
                 f"First request should be accepted, got {first.status_code}"
             )
 
+            # Wait for the first job to finish — the dispatcher's idempotency
+            # check (409) runs BEFORE the cooldown check (429).  A second
+            # POST while the first job is in flight correctly returns 409,
+            # which would mask the 429 behavior this test exists to cover.
+            _wait_for_job(client, first.json()["job_id"])
+
             second = client.post("/maintenance", headers=_AUTH_HEADER)
             assert second.status_code == 429, (
-                f"Second immediate request should be rate-limited, got {second.status_code}"
+                f"Second request after first finished should be rate-limited, "
+                f"got {second.status_code}"
             )
             body = second.json()
             assert body["ok"] is False
@@ -403,6 +410,3 @@ async def test_maintenance_cooldown_enforced(
             assert isinstance(body.get("retry_after"), int)
             assert body["retry_after"] > 0
             assert "retry-after" in second.headers
-
-            # Let the first job finish cleanly.
-            _wait_for_job(client, first.json()["job_id"])

--- a/tests/test_webhooks/test_maintenance.py
+++ b/tests/test_webhooks/test_maintenance.py
@@ -37,10 +37,12 @@ def _reset_webhook_module_state() -> Any:
     webhooks_module._jobs.clear()
     webhooks_module._active_job_by_endpoint.clear()
     webhooks_module._endpoint_locks.clear()
+    webhooks_module._cooldown_ts.clear()
     yield
     webhooks_module._jobs.clear()
     webhooks_module._active_job_by_endpoint.clear()
     webhooks_module._endpoint_locks.clear()
+    webhooks_module._cooldown_ts.clear()
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

- `/poll`, `/rescore`, `/maintenance` (and their `/hooks/*` siblings) now return `202 Accepted` with a `job_id` and schedule the real work on an in-process `asyncio.create_task`. No more tying up a uvicorn worker for the duration of a poll cycle.
- New `GET /jobs/{job_id}` endpoint exposes the job state (`queued` / `running` / `succeeded` / `failed`), timestamps, and the terminal result or error. Same bearer auth as the POST endpoints. Records are held in a bounded in-process FIFO (100 slots) — scheduler loss across restarts is acceptable, cron will re-trigger.
- A second POST while a job is already in flight returns `409 Conflict` with the existing `job_id` + `status_url` (issue \"idempotency lock\" requirement) so the caller re-attaches rather than racing a duplicate fetch.
- Preserved: bearer auth (constant-time compare), per-endpoint DuckDB cooldowns (`429` + `Retry-After`), audit records.
- Parameter validation still happens synchronously before 202 is returned, so malformed `source_url` / `limit` still fail fast with `400`.
- `/hooks/classify-batch` stays synchronous — issue #396 scope was limited to the three endpoints above.

Closes #396

## Why this shape

- The issue calls out the Fly cold-start 502 ('request arrives before backend ready' — 2–5 min for Firecracker + Python + DuckDB + hybrid index). The warmup workaround in \`distill_ops\` masks that, but the synchronous handler is still a ticking time bomb under the 512MB/1-CPU shared VM with \`hard_limit = 10\`. Returning 202 unblocks the uvicorn worker the moment validation finishes.
- In-process queue (not Redis/external) matches the single-replica Fly deployment. If Horizon ever grows to multi-replica, the same contract can swap in a durable backend.
- 409 over 'return the existing job_id as a 202' because the issue asks us to pick one and document it; 409 surfaces the re-attach case more clearly in the scheduler logs.
- The registry cap (100) is deliberate — the scheduler only polls for the job it just submitted.

## Follow-up in \`distill_ops\`

This PR changes the contract on the MCP server side. The scheduler workflow in [distill_ops/.github/workflows/scheduler.yml](https://github.com/norrietaylor/distill_ops) still treats a 200 from \`/api/poll\` as completion — it'll happily accept 202 (the \`--fail\` flag only trips on 4xx/5xx) but will report \"success\" before the job actually finishes. A small follow-up in that repo should:

1. Capture \`job_id\` from the 202 body.
2. Poll \`GET /api/jobs/{job_id}\` until \`state\` is \`succeeded\` or \`failed\`.
3. Fail the job when the terminal state is \`failed\`.

That's a separate PR in the ops repo.

## Test plan

- [x] Auth: missing / wrong bearer → 401 (unchanged).
- [x] POST /poll with valid token → 202 + \`job_id\`; \`GET /jobs/{id}\` shows terminal \`succeeded\` with the expected poll summary.
- [x] FeedPoller.poll raising → bg job transitions to \`failed\` with \`error: \"poll cycle failed\"\` (generic message preserved, traceback stays in logs).
- [x] Cooldown still enforced across restarts (cooldown_persisted integration test).
- [x] 429 + \`Retry-After\` on immediate second POST.
- [x] 409 when a second POST arrives while the first job is in flight (cooldown is pinned to epoch to isolate the 409 path from the 429 path).
- [x] \`/hooks/poll?source_url=…\` forwards the URL to the bg \`poll()\` call.
- [x] \`/hooks/rescore?limit=N\` forwards limit to the bg \`rescore()\` call.
- [x] Bad \`limit\` / missing \`source_url\` still fail with 400 before 202.
- [x] Maintenance still orchestrates poll → rescore → classify-batch, surfaces sub-operation errors without aborting the others, and the whole thing lands in the job result dict.
- [x] \`GET /jobs/{id}\` requires auth; unknown id returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Poll/rescore/maintenance endpoints now enqueue background jobs, returning 202 with job_id/state/status_url; deprecated hook aliases follow same async contract. Added authenticated GET /jobs/{job_id} for status/results. Rate-limit middleware can exempt GET path prefixes.

* **Bug Fixes**
  * Idempotency returns 409 for in‑flight jobs, improved cooldown enforcement, and best-effort rollback/audit on background failures.

* **Tests**
  * Tests reset webhook state, await job completion, and validate idempotency, cooldown, mount-aware status URLs, and rollback/audit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->