### PR TITLE
chore(security): suppress two new non-exploitable glibc CVEs

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -29,6 +29,12 @@ ignore:
   - vulnerability: CVE-2026-4046
     reason: "glibc 2.43 (Wolfi) — no upstream fix available"
 
+  - vulnerability: CVE-2026-5358
+    reason: "glibc 2.43 (Wolfi) — CVSS 9.1 (Critical); buffer overflow in nis_local_principal. Not exploitable in our deployment: NIS/YP support has been obsolete since glibc 2.26 and Distillery performs no NIS lookups — identity is handled via GitHub OAuth over HTTPS. Sourceware bug 34067; no upstream fix released yet. Reviewed: 2026-04-23"
+
+  - vulnerability: CVE-2026-5928
+    reason: "glibc 2.43 (Wolfi) — CVSS 7.5 (High); ungetwc wide-character pushback reads before allocated buffer. Not exploitable in our deployment: the bug requires calling ungetwc() with a non-Unicode multibyte charset that has single-byte/multi-byte encoding overlaps. Distillery is Unicode/UTF-8 end-to-end (JSON HTTP, DuckDB, Python source) and makes no ungetwc calls anywhere in its code paths. Sourceware bug 33998; no upstream fix released yet. Reviewed: 2026-04-23"
+
   # --- Go stdlib CVEs from Wolfi base image ---
   # Distillery is a pure Python application. Go stdlib is present in the
   # base image's tooling but no Go code is compiled or executed by Distillery.


### PR DESCRIPTION
## Summary

Unblocks the \`Scan (distillery)\` check on every open PR by suppressing two glibc CVEs that appeared since .grype.yaml was last updated. Both are non-exploitable in Distillery's deployment, both have no Wolfi fix available yet, and both match the existing suppression pattern in the file.

| CVE | Sev | Package | Not exploitable because |
|---|---|---|---|
| CVE-2026-5358 | Critical (9.1) | glibc 2.43 | \`nis_local_principal\` buffer overflow. NIS/YP has been obsolete in glibc since 2.26. Distillery does no NIS lookups — identity is GitHub OAuth over HTTPS. |
| CVE-2026-5928 | High (7.5) | glibc 2.43 | \`ungetwc\` wide-char pushback read-before-buffer. Requires a non-Unicode multibyte charset with single/multi-byte encoding overlaps. Distillery is UTF-8 end-to-end and makes no \`ungetwc\` calls anywhere. |

Both upstream bugs (sourceware 33998, 34067) have no released fix — Wolfi's latest \`glibc\` is still 2.43-r6. Will revisit when a fix lands.

## Context

Audited the Grype JSON report from the PR #397 build (\`grype-report-distillery.json\` artifact). The two CVEs above were the only Critical/High entries **not** already in the \`ignore\` list — every other High+ on the image was already suppressed with a documented reason.

## Test plan

- [ ] Supply-chain scan on this PR turns green (same Grype config runs against the built image).
- [ ] Re-run Scan on PR #397 / #391 / #389 after merge to confirm it unblocks them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security vulnerability suppression configuration to reflect deployment-specific security assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->