### PR TITLE
chore(docker): bump Dockerfile base to python-3.14 (#398)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 ARG BUILD_SHA=unknown
 ENV DISTILLERY_BUILD_SHA=${BUILD_SHA}
 
-# Install Python 3.13
-RUN apk add --no-cache python-3.13
+# Install Python 3.14
+RUN apk add --no-cache python-3.14
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /usr/local/bin/uv


### PR DESCRIPTION
Closes #398.

CI already exercises Python 3.14 via the matrix in `.github/workflows/ci.yml` (landed in #395) and the PyPI classifiers in `pyproject.toml` list it, but the runtime Dockerfile was still pinned to `python-3.13`. This bumps the Wolfi base package to `python-3.14`. I confirmed the package is published in the Wolfi feed by fetching the APKINDEX from `packages.wolfi.dev/os/x86_64` — `python-3.10` through `python-3.14` are all present, so the fallback-to-tagged-Python-image path called out in the issue is not needed.

I left the existing `.grype.yaml` CPython 3.13 CVE suppressions in place. They become unused but harmless under 3.14 (the scanner will simply not see a 3.13 interpreter to match against); pruning them should wait until a clean supply-chain scan confirms 3.14 does not surface new CPython CVEs that need the same treatment.

The install path (`uv pip install --system --no-cache .`) is unchanged and already exercised against 3.14 in CI, and the `INSTALL vss` step inherits the same DuckDB version via transitive deps.