### PR TITLE
fix(mcp): validate enum params before DB lookup in classify and resolve_review

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -35,6 +35,8 @@ from distillery.mcp.tools.analytics import (
 from distillery.mcp.tools.classify import (
     _handle_classify,
     _handle_resolve_review,
+    validate_classify_schema,
+    validate_resolve_review_schema,
 )
 from distillery.mcp.tools.configure import _handle_configure
 from distillery.mcp.tools.crud import (
@@ -462,8 +464,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                             )
                         except Exception:  # noqa: BLE001
                             logger.debug(
-                                "audit_log write failed for "
-                                "distillery_store_batch (ignored)",
+                                "audit_log write failed for distillery_store_batch (ignored)",
                                 exc_info=True,
                             )
                     else:
@@ -481,8 +482,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                             )
                         except Exception:  # noqa: BLE001
                             logger.debug(
-                                "audit_log write failed for "
-                                "distillery_store_batch (ignored)",
+                                "audit_log write failed for distillery_store_batch (ignored)",
                                 exc_info=True,
                             )
         return result
@@ -894,9 +894,6 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         """
         c = _lc(ctx)
         user = _get_authenticated_user()
-        err = await _own(c, user, entry_id, "distillery_classify")
-        if err:
-            return err
         args: dict[str, Any] = dict(
             entry_id=entry_id,
             entry_type=entry_type,
@@ -907,6 +904,16 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 suggested_project=suggested_project,
             ),
         )
+        # Validate schema-level params (entry_type, confidence range) BEFORE
+        # the ownership pre-check so a single round-trip surfaces all bad
+        # params — otherwise ``_own``'s NOT_FOUND short-circuits invalid
+        # enum values (issue #372).
+        schema_err = validate_classify_schema(args)
+        if schema_err:
+            return schema_err
+        err = await _own(c, user, entry_id, "distillery_classify")
+        if err:
+            return err
         return await _handle_classify(store=c["store"], config=c["config"], arguments=args)
 
     @server.tool
@@ -942,9 +949,6 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         """
         c = _lc(ctx)
         user = _get_authenticated_user()
-        err = await _own(c, user, entry_id, "distillery_resolve_review")
-        if err:
-            return err
         args: dict[str, Any] = dict(
             entry_id=entry_id, action=action, **_omit_none(new_entry_type=new_entry_type)
         )
@@ -955,6 +959,16 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             args["actor"] = user
         if reviewer is not None:
             args["reviewer"] = reviewer
+        # Validate schema-level params (action enum, new_entry_type) BEFORE
+        # the ownership pre-check so a single round-trip surfaces all bad
+        # params — otherwise ``_own``'s NOT_FOUND short-circuits invalid
+        # actions (issue #372).
+        schema_err = validate_resolve_review_schema(args)
+        if schema_err:
+            return schema_err
+        err = await _own(c, user, entry_id, "distillery_resolve_review")
+        if err:
+            return err
         result = await _handle_resolve_review(store=c["store"], arguments=args)
         await _audit(c, user, "distillery_resolve_review", entry_id, action, result)
         return result

--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -31,6 +31,97 @@ _VALID_REVIEW_ACTIONS = {"approve", "reclassify", "archive"}
 
 
 # ---------------------------------------------------------------------------
+# Schema-only validators (run before any DB lookup)
+# ---------------------------------------------------------------------------
+#
+# These helpers exist so the MCP tool wrappers in ``server.py`` can surface
+# enum/action failures *before* the ownership pre-check (``_own``) issues a
+# ``store.get(entry_id)`` and short-circuits with NOT_FOUND.  Without this,
+# a single call carrying both a bad ``entry_id`` and a bad ``entry_type`` /
+# ``action`` would only surface NOT_FOUND, forcing the caller to retry once
+# per invalid parameter (issue #372).
+#
+# The handlers (``_handle_classify`` / ``_handle_resolve_review``) re-run the
+# same checks defensively, keeping them safe to call directly from tests or
+# webhook entrypoints that bypass the server wrappers.
+
+
+def validate_classify_schema(arguments: dict[str, Any]) -> list[types.TextContent] | None:
+    """Validate ``distillery_classify`` schema-level params before any DB lookup.
+
+    Surfaces ``INVALID_PARAMS`` for missing required fields, an unknown
+    ``entry_type`` (with alias suggestion when applicable), a non-numeric
+    ``confidence``, an out-of-range ``confidence``, or a malformed
+    ``suggested_tags`` list.
+
+    Args:
+        arguments: Raw MCP tool arguments dict.
+
+    Returns:
+        An MCP error response if any schema-level validation fails, else
+        ``None`` so the caller can proceed to DB lookup / handler dispatch.
+    """
+    err = validate_required(arguments, "entry_id", "entry_type", "confidence")
+    if err:
+        return error_response("INVALID_PARAMS", err)
+
+    entry_type_str = arguments["entry_type"]
+    if entry_type_str not in _VALID_ENTRY_TYPES:
+        return _invalid_entry_type_response(entry_type_str)
+
+    confidence_raw = arguments["confidence"]
+    if isinstance(confidence_raw, bool) or not isinstance(confidence_raw, (int, float)):
+        return error_response("INVALID_PARAMS", "Field 'confidence' must be a number")
+    if not (0.0 <= float(confidence_raw) <= 1.0):
+        return error_response("INVALID_PARAMS", "Field 'confidence' must be in [0.0, 1.0]")
+
+    tags_err = validate_type(arguments, "suggested_tags", list, "list of strings")
+    if tags_err:
+        return error_response("INVALID_PARAMS", tags_err)
+
+    return None
+
+
+def validate_resolve_review_schema(arguments: dict[str, Any]) -> list[types.TextContent] | None:
+    """Validate ``distillery_resolve_review`` schema-level params before DB lookup.
+
+    Surfaces ``INVALID_PARAMS`` for missing required fields, an unknown
+    ``action``, a missing ``new_entry_type`` when ``action="reclassify"``,
+    or an unknown ``new_entry_type``.
+
+    Args:
+        arguments: Raw MCP tool arguments dict.
+
+    Returns:
+        An MCP error response if any schema-level validation fails, else
+        ``None`` so the caller can proceed to DB lookup / handler dispatch.
+    """
+    err = validate_required(arguments, "entry_id", "action")
+    if err:
+        return error_response("INVALID_PARAMS", err)
+
+    action = arguments["action"]
+    if action not in _VALID_REVIEW_ACTIONS:
+        return error_response(
+            "INVALID_PARAMS",
+            f"Invalid action {action!r}. Must be one of: "
+            f"{', '.join(sorted(_VALID_REVIEW_ACTIONS))}.",
+        )
+
+    if action == "reclassify":
+        new_type_str = arguments.get("new_entry_type")
+        if not new_type_str:
+            return error_response(
+                "INVALID_PARAMS",
+                "Field 'new_entry_type' is required when action='reclassify'.",
+            )
+        if new_type_str not in _VALID_ENTRY_TYPES:
+            return _invalid_entry_type_response(new_type_str, field="new_entry_type")
+
+    return None
+
+
+# ---------------------------------------------------------------------------
 # _handle_classify
 # ---------------------------------------------------------------------------
 
@@ -58,26 +149,16 @@ async def _handle_classify(
     from distillery.models import EntryStatus, EntryType, validate_tag
 
     # --- input validation ---------------------------------------------------
-    err = validate_required(arguments, "entry_id", "entry_type", "confidence")
-    if err:
-        return error_response("INVALID_PARAMS", err)
+    # Schema-only checks (enum membership, ranges, types) run first so a
+    # response surfaces param errors *before* a DB round-trip — see
+    # ``validate_classify_schema`` for rationale (issue #372).
+    schema_err = validate_classify_schema(arguments)
+    if schema_err:
+        return schema_err
 
     entry_id: str = arguments["entry_id"]
     entry_type_str: str = arguments["entry_type"]
-    confidence_raw = arguments["confidence"]
-
-    if entry_type_str not in _VALID_ENTRY_TYPES:
-        return _invalid_entry_type_response(entry_type_str)
-
-    if not isinstance(confidence_raw, (int, float)):
-        return error_response("INVALID_PARAMS", "Field 'confidence' must be a number")
-    confidence = float(confidence_raw)
-    if not (0.0 <= confidence <= 1.0):
-        return error_response("INVALID_PARAMS", "Field 'confidence' must be in [0.0, 1.0]")
-
-    tags_err = validate_type(arguments, "suggested_tags", list, "list of strings")
-    if tags_err:
-        return error_response("INVALID_PARAMS", tags_err)
+    confidence = float(arguments["confidence"])
 
     # --- retrieve existing entry --------------------------------------------
     try:
@@ -201,18 +282,15 @@ async def _handle_resolve_review(
     from distillery.models import EntryStatus, EntryType
 
     # --- input validation ---------------------------------------------------
-    err = validate_required(arguments, "entry_id", "action")
-    if err:
-        return error_response("INVALID_PARAMS", err)
+    # Schema-only checks (action enum, new_entry_type when reclassifying) run
+    # first so a response surfaces param errors *before* a DB round-trip —
+    # see ``validate_resolve_review_schema`` for rationale (issue #372).
+    schema_err = validate_resolve_review_schema(arguments)
+    if schema_err:
+        return schema_err
 
     entry_id: str = arguments["entry_id"]
     action: str = arguments["action"]
-
-    if action not in _VALID_REVIEW_ACTIONS:
-        return error_response(
-            "INVALID_PARAMS",
-            f"Invalid action {action!r}. Must be one of: {', '.join(sorted(_VALID_REVIEW_ACTIONS))}.",
-        )
 
     # --- retrieve existing entry --------------------------------------------
     try:
@@ -301,14 +379,9 @@ async def _handle_resolve_review(
         updates["metadata"] = new_metadata
 
     elif action == "reclassify":
-        new_type_str: str | None = arguments.get("new_entry_type")
-        if not new_type_str:
-            return error_response(
-                "INVALID_PARAMS",
-                "Field 'new_entry_type' is required when action='reclassify'.",
-            )
-        if new_type_str not in _VALID_ENTRY_TYPES:
-            return _invalid_entry_type_response(new_type_str, field="new_entry_type")
+        # ``new_entry_type`` presence + enum are validated by
+        # ``validate_resolve_review_schema`` at the top of the handler.
+        new_type_str: str = arguments["new_entry_type"]
         _clear_stale_delegation_keys(new_metadata)
         new_metadata["reclassified_from"] = entry.entry_type.value
         new_metadata["reviewed_at"] = now
@@ -364,4 +437,6 @@ __all__ = [
     "_handle_classify",
     "_handle_resolve_review",
     "_VALID_REVIEW_ACTIONS",
+    "validate_classify_schema",
+    "validate_resolve_review_schema",
 ]

--- a/tests/test_mcp_validation_order.py
+++ b/tests/test_mcp_validation_order.py
@@ -1,0 +1,268 @@
+"""Tests for issue #372: schema-level validation must run before DB lookup.
+
+When a ``distillery_classify`` or ``distillery_resolve_review`` call carries
+both a bad ``entry_id`` and an invalid enum / action, the response should
+surface the schema-level failure (``INVALID_PARAMS``) rather than
+short-circuiting on the ownership pre-check / handler ``store.get`` and
+returning ``NOT_FOUND``.
+
+The fix lives in two places:
+  * ``server.py`` — the tool wrappers call ``validate_classify_schema`` /
+    ``validate_resolve_review_schema`` *before* the ownership pre-check
+    (``_own``), so HTTP/OAuth callers get the enum failure on the first
+    round-trip.
+  * ``tools/classify.py`` — the handlers themselves run the same validators
+    first thing so direct handler calls (tests, webhook entrypoints) get
+    the same ordering guarantee.
+
+Both layers are exercised below.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.config import (
+    ClassificationConfig,
+    DistilleryConfig,
+    EmbeddingConfig,
+    StorageConfig,
+)
+from distillery.mcp.tools.classify import (
+    _handle_classify,
+    _handle_resolve_review,
+    validate_classify_schema,
+    validate_resolve_review_schema,
+)
+from distillery.store.duckdb import DuckDBStore
+from tests.conftest import parse_mcp_response
+
+pytestmark = pytest.mark.unit
+
+
+_BOGUS_ID = "00000000-0000-0000-0000-000000000000"
+
+
+# ---------------------------------------------------------------------------
+# Pure-schema validators (no store needed)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateClassifySchema:
+    """``validate_classify_schema`` is the pure-schema gatekeeper."""
+
+    def test_returns_invalid_params_for_unknown_entry_type(self) -> None:
+        """Unknown entry_type surfaces INVALID_PARAMS even when entry_id is also bogus."""
+        result = validate_classify_schema(
+            {
+                "entry_id": _BOGUS_ID,
+                "entry_type": "invalid_type_xyz",
+                "confidence": 0.5,
+            }
+        )
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert data["details"]["field"] == "entry_type"
+        assert data["details"]["provided"] == "invalid_type_xyz"
+        assert "session" in data["details"]["allowed"]
+
+    def test_alias_surfaces_suggestion(self) -> None:
+        """Aliases like 'note' surface a canonical suggestion in details."""
+        result = validate_classify_schema(
+            {"entry_id": _BOGUS_ID, "entry_type": "note", "confidence": 0.5}
+        )
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["details"]["suggestion"] == "inbox"
+
+    def test_returns_invalid_params_for_confidence_out_of_range(self) -> None:
+        result = validate_classify_schema(
+            {"entry_id": _BOGUS_ID, "entry_type": "session", "confidence": 1.5}
+        )
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["code"] == "INVALID_PARAMS"
+        assert "confidence" in data["message"]
+
+    def test_returns_invalid_params_for_non_numeric_confidence(self) -> None:
+        result = validate_classify_schema(
+            {"entry_id": _BOGUS_ID, "entry_type": "session", "confidence": "high"}
+        )
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["code"] == "INVALID_PARAMS"
+
+    def test_rejects_bool_confidence(self) -> None:
+        """``bool`` is a subclass of ``int`` in Python; reject it explicitly."""
+        result = validate_classify_schema(
+            {"entry_id": _BOGUS_ID, "entry_type": "session", "confidence": True}
+        )
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["code"] == "INVALID_PARAMS"
+
+    def test_returns_none_when_all_valid(self) -> None:
+        assert (
+            validate_classify_schema(
+                {"entry_id": _BOGUS_ID, "entry_type": "session", "confidence": 0.5}
+            )
+            is None
+        )
+
+    def test_missing_required_field(self) -> None:
+        result = validate_classify_schema({"entry_id": _BOGUS_ID})
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["code"] == "INVALID_PARAMS"
+        assert "Missing required" in data["message"]
+
+
+class TestValidateResolveReviewSchema:
+    """``validate_resolve_review_schema`` is the pure-schema gatekeeper."""
+
+    def test_returns_invalid_params_for_unknown_action(self) -> None:
+        """Unknown action surfaces INVALID_PARAMS even when entry_id is also bogus."""
+        result = validate_resolve_review_schema(
+            {"entry_id": _BOGUS_ID, "action": "nuke_from_orbit"}
+        )
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert "nuke_from_orbit" in data["message"]
+        assert "approve" in data["message"]
+
+    def test_reclassify_requires_new_entry_type(self) -> None:
+        result = validate_resolve_review_schema({"entry_id": _BOGUS_ID, "action": "reclassify"})
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["code"] == "INVALID_PARAMS"
+        assert "new_entry_type" in data["message"]
+
+    def test_reclassify_with_invalid_new_entry_type(self) -> None:
+        result = validate_resolve_review_schema(
+            {
+                "entry_id": _BOGUS_ID,
+                "action": "reclassify",
+                "new_entry_type": "bogus_type",
+            }
+        )
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["code"] == "INVALID_PARAMS"
+        assert data["details"]["field"] == "new_entry_type"
+
+    def test_returns_none_when_action_valid(self) -> None:
+        assert validate_resolve_review_schema({"entry_id": _BOGUS_ID, "action": "approve"}) is None
+
+    def test_missing_required_field(self) -> None:
+        result = validate_resolve_review_schema({"entry_id": _BOGUS_ID})
+        assert result is not None
+        data = parse_mcp_response(result)
+        assert data["code"] == "INVALID_PARAMS"
+
+
+# ---------------------------------------------------------------------------
+# Handler-level checks (verify validation order survives a bogus DB lookup)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def store(deterministic_embedding_provider):  # type: ignore[no-untyped-def]
+    s = DuckDBStore(db_path=":memory:", embedding_provider=deterministic_embedding_provider)
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+@pytest.fixture
+def config() -> DistilleryConfig:
+    return DistilleryConfig(
+        storage=StorageConfig(database_path=":memory:"),
+        embedding=EmbeddingConfig(provider="", model="stub", dimensions=4),
+        classification=ClassificationConfig(confidence_threshold=0.6),
+    )
+
+
+class TestClassifyValidationOrder:
+    """Issue #372: bad entry_id + bad entry_type surfaces INVALID_PARAMS, not NOT_FOUND."""
+
+    async def test_bad_id_and_bad_entry_type_returns_invalid_params(
+        self, store: DuckDBStore, config: DistilleryConfig
+    ) -> None:
+        """Reproduces the exact case from issue #372."""
+        response = await _handle_classify(
+            store,
+            config,
+            {
+                "entry_id": _BOGUS_ID,
+                "entry_type": "invalid_type_xyz",
+                "confidence": 0.5,
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        # The schema check must surface the bad entry_type, not the missing entry.
+        assert data["details"]["field"] == "entry_type"
+        assert "NOT_FOUND" not in data["code"]
+
+    async def test_bad_id_with_valid_entry_type_still_returns_not_found(
+        self, store: DuckDBStore, config: DistilleryConfig
+    ) -> None:
+        """Sanity: if schema is valid, NOT_FOUND still surfaces (no regression)."""
+        response = await _handle_classify(
+            store,
+            config,
+            {
+                "entry_id": _BOGUS_ID,
+                "entry_type": "session",
+                "confidence": 0.8,
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["code"] == "NOT_FOUND"
+
+
+class TestResolveReviewValidationOrder:
+    """Issue #372: bad entry_id + bad action surfaces INVALID_PARAMS, not NOT_FOUND."""
+
+    async def test_bad_id_and_bad_action_returns_invalid_params(self, store: DuckDBStore) -> None:
+        """Reproduces the exact case from issue #372."""
+        response = await _handle_resolve_review(
+            store,
+            {"entry_id": _BOGUS_ID, "action": "nuke_from_orbit"},
+        )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert "nuke_from_orbit" in data["message"]
+
+    async def test_bad_id_and_reclassify_with_bad_new_type_returns_invalid_params(
+        self, store: DuckDBStore
+    ) -> None:
+        """Reclassify with a bogus new_entry_type also surfaces INVALID_PARAMS."""
+        response = await _handle_resolve_review(
+            store,
+            {
+                "entry_id": _BOGUS_ID,
+                "action": "reclassify",
+                "new_entry_type": "bogus_type",
+            },
+        )
+        data = parse_mcp_response(response)
+        assert data["code"] == "INVALID_PARAMS"
+        assert data["details"]["field"] == "new_entry_type"
+
+    async def test_bad_id_with_valid_action_still_returns_not_found(
+        self, store: DuckDBStore
+    ) -> None:
+        """Sanity: if schema is valid, NOT_FOUND still surfaces (no regression)."""
+        response = await _handle_resolve_review(
+            store,
+            {"entry_id": _BOGUS_ID, "action": "approve"},
+        )
+        data = parse_mcp_response(response)
+        assert data["code"] == "NOT_FOUND"


### PR DESCRIPTION
## Summary

- Move schema-only validation (entry_type / action / new_entry_type / confidence range) **before** the ownership pre-check (`_own`) in the `distillery_classify` and `distillery_resolve_review` tool wrappers, so a single round-trip surfaces all bad params instead of short-circuiting on `NOT_FOUND`.
- Extract the validation into reusable `validate_classify_schema` / `validate_resolve_review_schema` helpers so both the tool wrappers and the handlers themselves run them first.
- This makes the two tools consistent with `distillery_store`, which already validates `entry_type` before persistence.

## Test plan

- [x] New unit suite `tests/test_mcp_validation_order.py` (17 tests) covering:
  - validators directly: bad enum / bad action / bad new_entry_type / out-of-range confidence / non-numeric confidence / `bool` confidence rejection / missing required fields / alias suggestion
  - handler seam: bad-id-AND-bad-enum returns `INVALID_PARAMS`, bad-id-only still returns `NOT_FOUND` (no regression)
  - reclassify with bogus `new_entry_type` surfaces `INVALID_PARAMS`
- [x] `pytest -m unit` (1666 passed)
- [x] `ruff check src/ tests/`
- [x] `ruff format --check` on changed files
- [x] `mypy --strict src/distillery/`

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting by validating input parameters before database lookups, ensuring users receive clear validation errors immediately rather than generic not-found messages.

* **Tests**
  * Added comprehensive validation tests for classify and review-resolution operations to verify correct error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->