### PR TITLE
feat(skills): default plugin install to local stdio MCP (#381)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -30,8 +30,8 @@
   },
   "mcpServers": {
     "distillery": {
-      "type": "http",
-      "url": "https://distillery-mcp.fly.dev/mcp"
+      "command": "uvx",
+      "args": ["distillery-mcp"]
     }
   },
   "hooks": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Changed
+
+- **BREAKING (default behavior):** `claude plugin install distillery` now configures a **local stdio** MCP server (`uvx distillery-mcp`) instead of the hosted demo at `distillery-mcp.fly.dev`. The hosted demo becomes explicit opt-in. (#381) *(skills)*
+
+### Migration
+
+Existing users who relied on the hosted demo and want to keep using it after `claude plugin update` should register it explicitly at user scope (this shadows the plugin's local default):
+
+```bash
+claude mcp add distillery --scope user --transport http --url https://distillery-mcp.fly.dev/mcp
+```
+
+The hosted demo is intended for evaluation only — do not store sensitive data on it.
+
 ## [0.4.0] - 2026-04-19
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ export JINA_API_KEY=jina_...
 
 Restart Claude Code and run the onboarding wizard:
 
-```
+```text
 /setup
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,40 +74,32 @@ claude plugin marketplace add norrietaylor/distillery
 claude plugin install distillery
 ```
 
-This installs all 14 skills. The plugin defaults to a hosted demo server — you can start using Distillery immediately.
+This installs all 14 skills and configures the MCP server to run **locally** via `uvx distillery-mcp` — a private, self-contained knowledge base on your machine. Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/) (install: `curl -LsSf https://astral.sh/uv/install.sh | sh`).
 
-> **Demo Server:** `distillery-mcp.fly.dev` is for evaluation only. Do not store sensitive or confidential data.
-
-### Step 2: Switch to Local with uvx (Recommended)
-
-For a private knowledge base, run the MCP server locally with `uvx` — no persistent install needed:
+### Step 2: Set Your Embedding API Key (Optional but Recommended)
 
 ```bash
-# Get a free API key from jina.ai, then:
+# Get a free API key from jina.ai
 export JINA_API_KEY=jina_...
 ```
 
-Add to `~/.claude/settings.json` (overrides the plugin's demo server):
-
-```json
-{
-  "mcpServers": {
-    "distillery": {
-      "command": "uvx",
-      "args": ["distillery-mcp"],
-      "env": {
-        "JINA_API_KEY": "${JINA_API_KEY}"
-      }
-    }
-  }
-}
-```
+`uvx` inherits this from your shell environment. Without a key, Distillery falls back to a stub embedding provider (search quality degraded).
 
 Restart Claude Code and run the onboarding wizard:
 
 ```
 /setup
 ```
+
+### Try the Hosted Demo (Opt-In)
+
+Want to evaluate without installing anything locally? Override the plugin default with the hosted demo at `distillery-mcp.fly.dev`:
+
+```bash
+claude mcp add distillery --scope user --transport http --url https://distillery-mcp.fly.dev/mcp
+```
+
+> **Demo Server:** `distillery-mcp.fly.dev` is for evaluation only. Do not store sensitive or confidential data.
 
 See the [Local Setup Guide](https://norrietaylor.github.io/distillery/getting-started/local-setup/) for full configuration options, or [deploy your own instance](https://norrietaylor.github.io/distillery/team/deployment/) for team use.
 

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -89,7 +89,7 @@ export DISTILLERY_CONFIG=/path/to/distillery.yaml
 
 Without a `JINA_API_KEY`, Distillery falls back to the stub embedding provider (search quality degraded). See [Local Setup](local-setup.md) for full configuration (embedding providers, cloud storage, etc.).
 
-If you prefer to manage the configuration yourself in `~/.claude/settings.json` (for example to set `env` explicitly), you can shadow the plugin registration with the same stdio block:
+If you prefer to manage the configuration yourself in `~/.claude.json` (for example to set `env` explicitly), you can shadow the plugin registration with the same stdio block:
 
 ```json
 {
@@ -119,7 +119,7 @@ Register the demo at user scope (shadows the plugin's local default):
 claude mcp add distillery --scope user --transport http --url https://distillery-mcp.fly.dev/mcp
 ```
 
-Or add the equivalent block to `~/.claude/settings.json`:
+Or add the equivalent block to `~/.claude.json`:
 
 ```json
 {

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -89,18 +89,14 @@ export DISTILLERY_CONFIG=/path/to/distillery.yaml
 
 Without a `JINA_API_KEY`, Distillery falls back to the stub embedding provider (search quality degraded). See [Local Setup](local-setup.md) for full configuration (embedding providers, cloud storage, etc.).
 
-If you prefer to manage the configuration yourself in `~/.claude.json` (for example to set `env` explicitly), you can shadow the plugin registration with the same stdio block:
+If you prefer to manage the configuration yourself in `~/.claude.json`, you can shadow the plugin registration with the same stdio block. `uvx` inherits the Claude Code process environment, so set `JINA_API_KEY` (and any other Distillery config vars) in your shell before launching Claude Code rather than relying on `${VAR}` interpolation here:
 
 ```json
 {
   "mcpServers": {
     "distillery": {
       "command": "uvx",
-      "args": ["distillery-mcp"],
-      "env": {
-        "JINA_API_KEY": "${JINA_API_KEY}",
-        "DISTILLERY_CONFIG": "${DISTILLERY_CONFIG}"
-      }
+      "args": ["distillery-mcp"]
     }
   }
 }
@@ -145,6 +141,9 @@ claude mcp add distillery --scope user --transport http --url https://your-insta
 ## Remote Auto-Poll Setup
 
 Enable remote auto-polling so feed sources are polled automatically even when Claude Code is not running. This uses Claude Code's scheduled remote agents (triggers).
+
+!!! note "HTTP transport required"
+    Remote auto-poll requires an HTTP-reachable MCP endpoint (Hosted Demo or Self-hosted HTTP). The default local stdio transport (`uvx distillery-mcp`) only runs on your machine and is not reachable by remote triggers.
 
 ### Step 1 — Register the MCP Connector
 

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -12,7 +12,10 @@ claude plugin marketplace add norrietaylor/distillery
 claude plugin install distillery
 ```
 
-This installs the skill definitions globally and configures the MCP server connection to the hosted Distillery instance.
+This installs the skill definitions globally and configures the MCP server to run **locally** via `uvx distillery-mcp` — a private, self-contained knowledge base on your machine. Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/) on your `PATH`.
+
+!!! tip "Install uv"
+    `curl -LsSf https://astral.sh/uv/install.sh | sh` — or use `pip install distillery-mcp` and override the plugin's default `command` to `distillery-mcp` (see [Troubleshooting](mcp-setup.md#troubleshooting)).
 
 After installation, restart Claude Code and run the onboarding wizard:
 
@@ -22,8 +25,8 @@ After installation, restart Claude Code and run the onboarding wizard:
 
 This verifies MCP connectivity, detects your transport, and configures auto-poll for ambient intelligence.
 
-!!! warning "Demo Server"
-    The plugin defaults to the hosted instance at `distillery-mcp.fly.dev`, which is a **demo server** for evaluation only. Do not store sensitive or confidential data. For production use, [deploy your own instance](../team/deployment.md) or use [local setup](local-setup.md).
+!!! note "Hosted demo (opt-in)"
+    Want a zero-install evaluation? You can opt into the hosted demo at `distillery-mcp.fly.dev` instead — see [MCP Configuration](#mcp-configuration) below. The demo server is for **evaluation only**; do not store sensitive or confidential data.
 
 !!! note "Claude Desktop"
     The Claude Desktop app does not support Claude Code skills or the plugin install system. Desktop users can connect the MCP server directly (all 16 tools are available) but slash commands like `/distill` and `/recall` are CLI-only features.
@@ -59,21 +62,34 @@ ln -s ~/.claude/distillery/skills/setup     ~/.claude/skills/setup
 
 ## MCP Configuration
 
-The skills require the Distillery MCP server. The recommended approach is to run it locally via `uvx` for a private knowledge base. The plugin also bundles a demo server connection for quick evaluation.
+The skills require the Distillery MCP server. The plugin's **default** is local stdio via `uvx distillery-mcp`. Hosted demo and self-hosted HTTP are opt-in alternatives.
 
-### Recommended — Local stdio with uvx
+### Default — Local stdio with uvx
 
-Run the MCP server locally for a private, self-contained knowledge base. Requires Python 3.11+.
+`claude plugin install distillery` registers this configuration automatically. The plugin manifest declares:
 
-```bash
-# No install needed
-uvx distillery-mcp
-
-# Or install persistently
-pip install distillery-mcp
+```json
+{
+  "mcpServers": {
+    "distillery": {
+      "command": "uvx",
+      "args": ["distillery-mcp"]
+    }
+  }
+}
 ```
 
-Add to `~/.claude/settings.json`:
+`uvx` inherits the Claude Code process environment, so set `JINA_API_KEY` (and any other Distillery config vars) in your shell before launching Claude Code:
+
+```bash
+export JINA_API_KEY=jina_...   # free at jina.ai
+# Optional:
+export DISTILLERY_CONFIG=/path/to/distillery.yaml
+```
+
+Without a `JINA_API_KEY`, Distillery falls back to the stub embedding provider (search quality degraded). See [Local Setup](local-setup.md) for full configuration (embedding providers, cloud storage, etc.).
+
+If you prefer to manage the configuration yourself in `~/.claude/settings.json` (for example to set `env` explicitly), you can shadow the plugin registration with the same stdio block:
 
 ```json
 {
@@ -90,16 +106,20 @@ Add to `~/.claude/settings.json`:
 }
 ```
 
-This overrides the plugin's default demo server connection. See [Local Setup](local-setup.md) for full configuration (embedding providers, cloud storage, etc.).
+### Opt-in — Hosted demo
 
-### Alternative — Demo server (no setup)
-
-The plugin manifest configures a connection to the hosted demo at `https://distillery-mcp.fly.dev/mcp` with GitHub OAuth authentication. On first use, Claude Code opens a browser for GitHub OAuth login.
+Distillery operates a hosted demo at `https://distillery-mcp.fly.dev/mcp` for zero-install evaluation. Authentication is via GitHub OAuth (Claude Code opens a browser on first use).
 
 !!! warning "Demo Server"
-    The demo server is for **evaluation only**. Do not store sensitive or confidential data. For production use, run locally with `uvx` (above) or deploy your own instance.
+    The demo server is for **evaluation only**. Do not store sensitive or confidential data. For production use, stick with the default local stdio setup or deploy your own instance.
 
-To configure manually, add to `~/.claude/settings.json`:
+Register the demo at user scope (shadows the plugin's local default):
+
+```bash
+claude mcp add distillery --scope user --transport http --url https://distillery-mcp.fly.dev/mcp
+```
+
+Or add the equivalent block to `~/.claude/settings.json`:
 
 ```json
 {
@@ -112,11 +132,11 @@ To configure manually, add to `~/.claude/settings.json`:
 }
 ```
 
-### Alternative — Self-hosted HTTP
+### Opt-in — Self-hosted HTTP
 
 Deploy your own Distillery server with GitHub OAuth. See [Operator Deployment](../team/deployment.md) for setup and the [distill_ops](https://github.com/norrietaylor/distill_ops) repo for platform-specific guides (Fly.io, Prefect Horizon).
 
-To override the plugin's default demo URL, register your own MCP server at user scope. This shadows the plugin registration:
+To shadow the plugin default with your own instance, register at user scope:
 
 ```bash
 claude mcp add distillery --scope user --transport http --url https://your-instance.example.com/mcp

--- a/docs/home.md
+++ b/docs/home.md
@@ -46,36 +46,31 @@ claude plugin marketplace add norrietaylor/distillery
 claude plugin install distillery
 ```
 
-This installs all 14 skills. The plugin defaults to a hosted demo server — you can start using Distillery immediately.
+This installs all 14 skills and configures the MCP server to run **locally** via `uvx distillery-mcp` — a private, self-contained knowledge base on your machine. Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/).
 
-!!! warning "Demo Server"
-    The plugin defaults to `distillery-mcp.fly.dev`, which is a **demo server** for evaluation only. Do not store sensitive or confidential data.
+!!! tip "Install uv"
+    `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
-### Step 2: Switch to Local with uvx (Recommended)
-
-For a private knowledge base, run the MCP server locally — no persistent install needed:
+### Step 2: Set Your Embedding API Key (Optional but Recommended)
 
 ```bash
 export JINA_API_KEY=jina_...   # free at jina.ai
 ```
 
-Add to `~/.claude/settings.json` (overrides the plugin's demo server):
-
-```json
-{
-  "mcpServers": {
-    "distillery": {
-      "command": "uvx",
-      "args": ["distillery-mcp"],
-      "env": {
-        "JINA_API_KEY": "${JINA_API_KEY}"
-      }
-    }
-  }
-}
-```
+`uvx` inherits this from your shell environment. Without a key, Distillery falls back to a stub embedding provider (search quality degraded).
 
 Restart Claude Code and run `/setup` to complete onboarding.
+
+### Try the Hosted Demo (Opt-In)
+
+Want to evaluate without installing locally? Override the plugin default with the hosted demo at `distillery-mcp.fly.dev`:
+
+```bash
+claude mcp add distillery --scope user --transport http --url https://distillery-mcp.fly.dev/mcp
+```
+
+!!! warning "Demo Server"
+    `distillery-mcp.fly.dev` is a **demo server** for evaluation only. Do not store sensitive or confidential data.
 
 See [Local Setup](getting-started/local-setup.md) for full configuration (embedding providers, cloud storage, etc.) or [deploy your own instance](team/deployment.md) for team use.
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -83,7 +83,7 @@ Quickest setup — install the plugin (configures local stdio by default):
   claude plugin marketplace add norrietaylor/distillery
   claude plugin install distillery
 
-Or add manually to ~/.claude/settings.json:
+Or add manually to ~/.claude.json:
 
   {
     "mcpServers": {

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -78,7 +78,12 @@ Distillery MCP Server Not Available
 
 The Distillery MCP server is not configured or not running.
 
-Quickest setup — add to ~/.claude/settings.json:
+Quickest setup — install the plugin (configures local stdio by default):
+
+  claude plugin marketplace add norrietaylor/distillery
+  claude plugin install distillery
+
+Or add manually to ~/.claude/settings.json:
 
   {
     "mcpServers": {
@@ -94,6 +99,10 @@ Quickest setup — add to ~/.claude/settings.json:
 
 Get a free Jina API key at https://jina.ai
 Then restart Claude Code and run /setup again.
+
+Prefer the hosted demo (evaluation only, no sensitive data)?
+  claude mcp add distillery --scope user --transport http \
+    --url https://distillery-mcp.fly.dev/mcp
 
 Full guide: https://norrietaylor.github.io/distillery/getting-started/local-setup/
 ```

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -221,27 +221,30 @@ class TestPluginMCPServers:
         manifest = load_plugin_manifest()
         assert "distillery" in manifest["mcpServers"]
 
-    def test_distillery_server_has_type_http(self) -> None:
-        """The distillery server must use HTTP transport."""
+    def test_distillery_server_uses_stdio_transport(self) -> None:
+        """The distillery server must use stdio transport (command, no url)."""
         manifest = load_plugin_manifest()
         server = manifest["mcpServers"]["distillery"]
-        assert server.get("type") == "http"
+        assert "command" in server, "stdio transport requires a 'command' field"
+        assert "url" not in server, "stdio transport must not include a 'url' field"
 
-    def test_distillery_server_has_url(self) -> None:
-        """The distillery server must have a 'url' field."""
+    def test_distillery_server_command_is_uvx(self) -> None:
+        """The distillery server must launch via 'uvx distillery-mcp'."""
         manifest = load_plugin_manifest()
         server = manifest["mcpServers"]["distillery"]
-        assert "url" in server
+        assert server["command"] == "uvx"
+        assert "distillery-mcp" in server.get("args", [])
 
-    def test_distillery_server_url_is_hardcoded_fly_url(self) -> None:
-        """The distillery server URL must be the hardcoded Fly.io hosted URL.
+    def test_distillery_server_no_url_field(self) -> None:
+        """The distillery server must not declare a hosted URL.
 
-        Note: ${user_config.<key>} interpolation is NOT supported in mcpServers.url.
-        Self-hosters should override via: claude mcp add distillery --scope user
+        The plugin default is local stdio. Hosted demo is opt-in via:
+        claude mcp add distillery --scope user --transport http \
+            --url https://distillery-mcp.fly.dev/mcp
         """
         manifest = load_plugin_manifest()
         server = manifest["mcpServers"]["distillery"]
-        assert server["url"] == "https://distillery-mcp.fly.dev/mcp"
+        assert "url" not in server
 
     def test_distillery_server_no_unsupported_fields(self) -> None:
         """The distillery server must not contain fields unsupported by the plugin schema."""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -423,7 +423,7 @@ class TestPluginDocumentationContent:
         assert "distillery-mcp.fly.dev" in content
 
     def test_mcp_servers_settings_json_snippet_present(self) -> None:
-        """Plugin doc must show a mcpServers settings.json configuration snippet."""
+        """Plugin doc must show a manual mcpServers configuration snippet for ~/.claude.json."""
         content = load_plugin_doc()
         assert "mcpServers" in content
-        assert "settings.json" in content
+        assert "~/.claude.json" in content


### PR DESCRIPTION
## Summary

- Flip the plugin's default MCP transport from the hosted demo (`https://distillery-mcp.fly.dev/mcp`, labeled "evaluation only") to local stdio (`uvx distillery-mcp`). The hosted demo becomes explicit opt-in.
- Update tests, README, `docs/home.md`, `docs/getting-started/plugin-install.md`, and `skills/setup/SKILL.md` so local stdio reads as the default and the hosted demo is presented as a zero-install evaluation alternative.
- Add a `CHANGELOG.md` entry with the one-line migration command for users who want to keep using the hosted demo: `claude mcp add distillery --scope user --transport http --url https://distillery-mcp.fly.dev/mcp`.

The `env` block is intentionally omitted from the plugin manifest because `${user_config.<key>}` interpolation has been unreliable in this codebase (see #235), and `uvx` already inherits the Claude Code process environment so `JINA_API_KEY` propagates from the user's shell. Without a key, Distillery falls back to the stub embedding provider.

## Test plan

- [x] `pytest tests/test_plugin.py -v` — 51 passed (rewritten `TestPluginMCPServers` assertions cover stdio defaults)
- [x] `pytest -m unit` — 1649 passed, 2 skipped
- [x] `ruff check src/ tests/` — clean
- [x] `mypy --strict src/distillery/` — no issues
- [x] `mkdocs build --strict` — no broken anchors
- [ ] Manual smoke: `claude plugin install distillery` → `/setup` reports **Local**
- [ ] Manual smoke: `claude mcp add ... distillery-mcp.fly.dev` override → `/setup` reports **Hosted**

Closes #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Distillery plugin now defaults to running a local MCP instance instead of the hosted demo; hosted demo remains opt-in.

* **Documentation**
  * Updated Quick Start and install docs to guide local setup, prerequisites, and environment-variable configuration.
  * Added opt-in instructions for switching back to the hosted demo and warnings about evaluation-only use.

* **Tests**
  * Updated tests and examples to reflect the new local-default configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->