### PR TITLE
chore(ci): slim container image using uv multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,6 @@ CHANGELOG.md
 CONTRIBUTING.md
 CLAUDE.md
 LICENSE
-uv.lock
 Makefile
 .gitignore
 .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,93 @@
-FROM cgr.dev/chainguard/wolfi-base:latest
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage build for the Distillery MCP server.
+#
+# Stage 1 (builder): Wolfi base + Python 3.13 + the `uv` static binary
+# (copied from the official Astral image). Resolves dependencies from
+# `uv.lock` and produces a self-contained `/app/.venv`.
+#
+# Stage 2 (runtime): the same Wolfi + Python 3.13 base — but only the
+# prebuilt virtualenv is copied in. No `uv` (~48 MB), no compilers, no
+# pip cache, and no source tree shipped to production.
+
+ARG WOLFI_TAG=latest
+ARG UV_VERSION=0.11.3
+
+# Pinned `uv` binary. Pulled in via a separate stage so we can parameterise
+# the version via the UV_VERSION build arg in the `COPY --from=` below.
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
+# ─────────────────────────────────────────────────────────────────────
+# Stage 1: builder — resolve and install dependencies with uv
+# ─────────────────────────────────────────────────────────────────────
+FROM cgr.dev/chainguard/wolfi-base:${WOLFI_TAG} AS builder
+
+# Python 3.13 + uv. Wolfi's `python-3.13` package ships the interpreter
+# only; we layer `uv` on top from the pinned Astral image.
+RUN apk add --no-cache python-3.13
+COPY --from=uv /uv /usr/local/bin/uv
+
+# Speed/size knobs for uv:
+#   - copy link mode avoids hardlink fallbacks across mounted layers
+#   - bytecode compile up front so the runtime image has no first-call cost
+#   - never download a different Python: use the one provided by the base
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_PYTHON=/usr/bin/python3.13 \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
 
 WORKDIR /app
 
-ARG BUILD_SHA=unknown
-ENV DISTILLERY_BUILD_SHA=${BUILD_SHA}
+# 1. Install dependencies first using only lockfile + project metadata.
+#    This layer is cached unless dependencies change.
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
 
-# Install Python 3.13
+# 2. Install the project itself in non-editable mode.
+COPY src ./src
+COPY README.md ./README.md
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-editable --no-dev
+
+# ─────────────────────────────────────────────────────────────────────
+# Stage 2: runtime — Wolfi base + Python only, venv copied from builder
+# ─────────────────────────────────────────────────────────────────────
+FROM cgr.dev/chainguard/wolfi-base:${WOLFI_TAG} AS runtime
+
+ARG BUILD_SHA=unknown
+ENV DISTILLERY_BUILD_SHA=${BUILD_SHA} \
+    PATH="/app/.venv/bin:${PATH}" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    VIRTUAL_ENV=/app/.venv
+
+# OCI labels (preserve provenance and discoverability).
+LABEL org.opencontainers.image.source="https://github.com/norrietaylor/distillery" \
+      org.opencontainers.image.description="Distillery MCP server — persistent shared memory for Claude Code" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# Install only the runtime Python; no compilers, no `uv`, no build tools.
 RUN apk add --no-cache python-3.13
 
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /usr/local/bin/uv
+# Create a non-root user with a writable home so DuckDB can install its
+# VSS extension under ~/.duckdb at build time.
+RUN adduser --disabled-password --uid 10001 --home /app appuser \
+    && chown -R appuser:appuser /app
 
-# Create non-root user
-RUN adduser --disabled-password --uid 10001 appuser
+WORKDIR /app
 
-# Copy the full repo (build context is repo root)
-COPY . .
-
-# Install the package (production only, no dev deps)
-RUN uv pip install --system --no-cache .
-
-# Pre-install the DuckDB VSS extension so HNSW indexing is available at runtime
-# without a network download. Run as appuser so it lands in ~/.duckdb/extensions/.
-RUN su -s /bin/sh appuser -c "python -c \"import duckdb; duckdb.connect(':memory:').execute('INSTALL vss')\""
-
-RUN chown -R appuser:appuser /app
+# Copy the prebuilt virtualenv from the builder. Owned by appuser so it
+# remains writable for runtime cache files (e.g. DuckDB extension dir).
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
 
 USER appuser
+
+# Pre-install the DuckDB VSS extension so HNSW indexing is available at
+# runtime without a network download. Lands in /app/.duckdb/extensions/.
+RUN python -c "import duckdb; duckdb.connect(':memory:').execute('INSTALL vss')"
+
 EXPOSE 8000
 
 # Default: HTTP transport on port 8000.

--- a/docs/team/deployment.md
+++ b/docs/team/deployment.md
@@ -170,6 +170,14 @@ docker build -t distillery .
 docker run -p 8000:8000 -e JINA_API_KEY=... distillery
 ```
 
+The Dockerfile is a multi-stage build: a `builder` stage that uses [`uv`](https://docs.astral.sh/uv/) to resolve dependencies from `uv.lock` into a self-contained virtualenv, and a slim runtime stage based on `cgr.dev/chainguard/wolfi-base` with only Python 3.13 and the prebuilt `.venv`. No `uv` binary, compilers, or build cache are shipped to production.
+
+Pin a specific `uv` version via the `UV_VERSION` build arg if you need reproducibility:
+
+```bash
+docker build --build-arg UV_VERSION=0.11.3 -t distillery .
+```
+
 ## Database Migrations
 
 Distillery uses a forward-only schema migration system. Migrations run automatically on startup — no manual steps are needed for additive changes (new columns, new tables).

--- a/docs/team/deployment.md
+++ b/docs/team/deployment.md
@@ -170,7 +170,7 @@ docker build -t distillery .
 docker run -p 8000:8000 -e JINA_API_KEY=... distillery
 ```
 
-The Dockerfile is a multi-stage build: a `builder` stage that uses [`uv`](https://docs.astral.sh/uv/) to resolve dependencies from `uv.lock` into a self-contained virtualenv, and a slim runtime stage based on `cgr.dev/chainguard/wolfi-base` with only Python 3.13 and the prebuilt `.venv`. No `uv` binary, compilers, or build cache are shipped to production.
+The Dockerfile is a multi-stage build: a `builder` stage that uses [`uv`](https://docs.astral.sh/uv/) to resolve dependencies from `uv.lock` into a self-contained virtualenv, and a slim runtime stage based on `cgr.dev/chainguard/wolfi-base` with only Python 3.14 and the prebuilt `.venv`. No `uv` binary, compilers, or build cache are shipped to production.
 
 Pin a specific `uv` version via the `UV_VERSION` build arg if you need reproducibility:
 


### PR DESCRIPTION
## Summary

Refactor the Dockerfile from a single-stage Wolfi + `uv pip install` build to a **two-stage** build that uses `uv sync --frozen` against `uv.lock` for reproducible installs, then copies only the prebuilt `.venv` into a slim runtime stage.

Key wins:

- The `uv` binary (~48 MB) is no longer shipped to runtime — it lives only in the builder stage.
- No compilers, no build cache, no source tree, no test files, no `pyproject.toml`/`uv.lock` are baked into the final image.
- Builds are reproducible from the locked dependency graph (`uv.lock`) rather than the floating range in `pyproject.toml`.
- BuildKit cache mounts (`--mount=type=cache,target=/root/.cache/uv`) speed up rebuilds without persisting to layers.
- Dependencies install in their own layer (cached unless lockfile changes); the project installs in a separate layer that invalidates only when `src/` changes.
- The base image stays Wolfi (already slim), so no new CVE suppressions are introduced.

## Image size comparison

Local `linux/arm64` builds against the same source tree:

| Build         | Base image                              | Size      |
|---------------|-----------------------------------------|-----------|
| Before        | Wolfi + `uv pip install --system`       | **361 MB** |
| After         | Wolfi (multi-stage, venv-only runtime)  | **329 MB** |
| **Delta**     |                                         | **-32 MB / -8.9 %** |

Layer breakdown of the new image (`docker history distillery:after`):

```
153 MB  COPY --chown=appuser:appuser /app/.venv /app/.venv
 52.9 MB  apk add --no-cache python-3.13
 28.3 MB  RUN python -c "...INSTALL vss"      # DuckDB extension
   ...    Wolfi base layers
```

Most of the venv weight (~125 MB) is DuckDB itself, which only ships `manylinux` wheels — switching to Alpine/musl would force a source build (much larger). Wolfi remains the right base.

## Smoke tests run locally

```bash
# CLI entrypoints
docker run --rm distillery:after distillery --help          # OK
docker run --rm distillery:after distillery-mcp --help      # OK
docker run --rm distillery:after distillery health          # exit 1 (expected: no DB configured; matches old image)

# Imports + DuckDB VSS extension preloaded
docker run --rm distillery:after python -c \
  "import duckdb; con = duckdb.connect(':memory:'); con.execute('LOAD vss')"
# -> [..., ('vss',)]

# HTTP transport starts
docker run --rm -p 8000:8000 distillery:after
# -> "Uvicorn running on http://0.0.0.0:8000"
```

## Implementation notes

- `uv` binary version is parameterised via `ARG UV_VERSION=0.11.3`. Pulled in via a dedicated `FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv` stage so BuildKit can interpolate the arg in the subsequent `COPY --from=uv` instruction.
- `.dockerignore` no longer excludes `uv.lock` (the builder needs it).
- `UV_PYTHON=/usr/bin/python3.13` and `UV_PYTHON_DOWNLOADS=never` ensure the venv uses Wolfi's Python rather than a downloaded interpreter.
- `UV_COMPILE_BYTECODE=1` precompiles `.pyc` files at build time, so the runtime container has no first-call compile cost.
- Non-root user (`appuser`, UID 10001), `EXPOSE 8000`, OCI labels, `CMD ["distillery-mcp", "--transport", "http"]` are all preserved.

## Test plan

- [x] `docker build -t distillery:after .` succeeds locally (Apple Silicon, Docker 29.4 / OrbStack).
- [x] All four smoke tests above pass on the local image.
- [ ] CI `Supply Chain Security / Scan (distillery)` build is green.
- [ ] Grype scan stays at ≤ existing suppression count (no new CVEs).
- [ ] CI `ci.yml` test matrix is green (no test references the Dockerfile).

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Docker builds with a multi-stage build that produces smaller runtime images and prepackages a self-contained virtual environment.
  * Ensured the dependency lock is included in the build context and added a build argument to pin the build tool version for reproducible builds.
* **Documentation**
  * Updated deployment guide with concrete Docker build instructions and reproducible-build examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->