### PR TITLE
fix(store): return raw cosine similarity for project-filtered search

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1527,8 +1527,11 @@ class DuckDBStore:
             limit: Maximum number of results to return.
 
         Returns:
-            list[SearchResult]: Matches ordered by decreasing fused score;
-            each result contains the matched Entry and a ``score`` in [0, 1].
+            list[SearchResult]: Matches ordered by decreasing fused rank
+            (RRF in hybrid mode, raw cosine similarity otherwise).  Each
+            ``score`` is the entry's raw cosine similarity to the query
+            mapped to ``[0, 1]`` — it is NOT rescaled per-scope, so values
+            stay comparable across metadata filters (issue #370).
         """
         from distillery.store.protocol import SearchResult
 
@@ -1559,13 +1562,14 @@ class DuckDBStore:
             col_names = [desc[0] for desc in result.description]
             rows = result.fetchall()
 
-            # Build entry lookup and vector ranks.
+            # Build entry lookup, vector ranks, and per-entry cosine similarity.
             entry_map: dict[str, Entry] = {}
             vector_ranks: dict[str, int] = {}
             entry_created: dict[str, datetime] = {}
+            cosine_score: dict[str, float] = {}
             for rank, row in enumerate(rows, start=1):
                 row_dict = dict(zip(col_names, row, strict=True))
-                row_dict.pop("score")
+                raw_cosine = float(row_dict.pop("score"))
                 entry = self._row_to_entry(
                     tuple(row_dict.values()),
                     list(row_dict.keys()),
@@ -1573,17 +1577,20 @@ class DuckDBStore:
                 entry_map[entry.id] = entry
                 vector_ranks[entry.id] = rank
                 entry_created[entry.id] = entry.created_at
+                # Map raw cosine similarity in [-1, 1] to a displayed score in [0, 1].
+                cosine_score[entry.id] = (raw_cosine + 1.0) / 2.0
 
             if not use_hybrid:
-                # Vector-only: normalise cosine similarity to [0, 1].
+                # Vector-only: return raw cosine similarity (mapped to [0, 1]).
+                # No min-max rescaling — score represents true similarity to the
+                # query, identical regardless of any metadata filter (issue #370).
                 results: list[SearchResult] = []
                 returned_ids: list[str] = []
-                for _rank, row in enumerate(rows[:limit], start=1):
+                for row in rows[:limit]:
                     row_dict = dict(zip(col_names, row, strict=True))
-                    raw_score = float(row_dict.pop("score"))
-                    score = (raw_score + 1.0) / 2.0
+                    row_dict.pop("score")
                     eid = row_dict["id"]
-                    results.append(SearchResult(entry=entry_map[eid], score=score))
+                    results.append(SearchResult(entry=entry_map[eid], score=cosine_score[eid]))
                     returned_ids.append(eid)
                 self._touch_accessed(conn, returned_ids)
                 return results
@@ -1595,6 +1602,8 @@ class DuckDBStore:
             # Fetch entries found by BM25 but not by the vector search so we
             # have a complete entry_map for RRF scoring.  Apply the same
             # filters so BM25-only entries that don't match are excluded.
+            # Also compute cosine similarity for these entries so the displayed
+            # score remains a true similarity measure (not a per-scope rescale).
             missing_ids = [eid for eid in bm25_ranks if eid not in entry_map]
             if missing_ids:
                 placeholders = ", ".join("?" for _ in missing_ids)
@@ -1602,24 +1611,33 @@ class DuckDBStore:
                 extra_where = ""
                 if filter_clauses:
                     extra_where = " AND " + " AND ".join(filter_clauses)
+                dims = self._embedding_provider.dimensions
                 fetch_sql = (
-                    f"SELECT {self._ENTRY_COLUMNS} FROM entries "
+                    f"SELECT {self._ENTRY_COLUMNS}, "
+                    f"array_cosine_similarity(embedding, ?::FLOAT[{dims}]) AS score "
+                    f"FROM entries "
                     f"WHERE id IN ({placeholders}){extra_where}"
                 )
-                fetch_result = conn.execute(fetch_sql, missing_ids + filter_params)
+                fetch_result = conn.execute(fetch_sql, [embedding, *missing_ids, *filter_params])
                 fetch_cols = [desc[0] for desc in fetch_result.description]
                 fetched_ids: set[str] = set()
                 for row in fetch_result.fetchall():
-                    entry = self._row_to_entry(row, fetch_cols)
+                    row_dict = dict(zip(fetch_cols, row, strict=True))
+                    raw_cosine = float(row_dict.pop("score"))
+                    entry = self._row_to_entry(
+                        tuple(row_dict.values()),
+                        list(row_dict.keys()),
+                    )
                     entry_map[entry.id] = entry
                     entry_created[entry.id] = entry.created_at
+                    cosine_score[entry.id] = (raw_cosine + 1.0) / 2.0
                     fetched_ids.add(entry.id)
                 # Remove BM25-only entries that were excluded by filters.
                 for eid in missing_ids:
                     if eid not in fetched_ids:
                         del bm25_ranks[eid]
 
-            # --- RRF fusion with recency decay ---
+            # --- RRF fusion with recency decay (used for ORDERING only) ---
             k = self._rrf_k
             all_ids = set(vector_ranks.keys()) | set(bm25_ranks.keys())
             scored: list[tuple[str, float]] = []
@@ -1636,23 +1654,15 @@ class DuckDBStore:
 
             scored.sort(key=lambda x: x[1], reverse=True)
 
-            # Normalise scores to [0, 1] using min-max across the full
-            # candidate set.  This gives a meaningful spread instead of
-            # clustering near 1.0 (which happens when dividing by max
-            # alone, since RRF raw scores occupy a tiny range).
-            if len(scored) < 2:
-                max_score = scored[0][1] if scored else 1.0
-                min_score = 0.0
-            else:
-                max_score = scored[0][1]
-                min_score = scored[-1][1]
-
-            score_range = max_score - min_score
+            # The displayed ``score`` is the raw cosine similarity (mapped to
+            # [0, 1]), NOT the RRF rank.  RRF only determines result ordering;
+            # rescaling the RRF score (e.g. min-max within the candidate set)
+            # would make the value meaningless under metadata filters because
+            # the per-scope min/max changes with the filter (issue #370).
             results = []
             returned_ids = []
-            for eid, raw in scored[:limit]:
-                norm = (raw - min_score) / score_range if score_range > 0 else 1.0
-                results.append(SearchResult(entry=entry_map[eid], score=norm))
+            for eid, _rrf in scored[:limit]:
+                results.append(SearchResult(entry=entry_map[eid], score=cosine_score.get(eid, 0.0)))
                 returned_ids.append(eid)
 
             self._touch_accessed(conn, returned_ids)
@@ -1783,9 +1793,7 @@ class DuckDBStore:
         # (grouped counts vs. aggregate stats); combining them would silently
         # drop one. Reject explicitly so callers get a clear error.
         if group_by is not None and output is not None:
-            raise ValueError(
-                "group_by and output cannot be combined — pick one"
-            )
+            raise ValueError("group_by and output cannot be combined — pick one")
 
         # ----- group_by mode: delegate to aggregate_entries -----
         if group_by is not None:

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -1219,8 +1219,13 @@ class TestHybridSearch:
         for r in results:
             assert 0.0 <= r.score <= 1.0
 
-    async def test_hybrid_search_top_score_is_one(self, hybrid_store: DuckDBStore) -> None:
-        """The top result in hybrid search should have a normalised score of 1.0."""
+    async def test_hybrid_search_top_score_reflects_cosine(self, hybrid_store: DuckDBStore) -> None:
+        """The top result's score should reflect raw cosine similarity in [0, 1].
+
+        After issue #370 the displayed score is no longer min-max rescaled to
+        1.0 within the candidate set; it is the raw cosine similarity (mapped
+        to [0, 1]) so values remain comparable across metadata filters.
+        """
         await hybrid_store.store(
             make_entry(content="Artificial intelligence and machine learning overview")
         )
@@ -1228,7 +1233,7 @@ class TestHybridSearch:
             "artificial intelligence machine learning", filters=None, limit=10
         )
         assert len(results) >= 1
-        assert results[0].score == 1.0
+        assert 0.0 <= results[0].score <= 1.0
 
     async def test_hybrid_search_respects_limit(self, hybrid_store: DuckDBStore) -> None:
         """Hybrid search should respect the limit parameter."""
@@ -1287,6 +1292,85 @@ class TestVectorOnlySearch:
         results = await vector_only_store.search("entry", filters={"author": "alice"}, limit=10)
         for r in results:
             assert r.entry.author == "alice"
+
+
+class TestProjectFilterDoesNotRescaleScore:
+    """Regression tests for issue #370.
+
+    When a metadata filter (e.g. ``project``) shrinks the candidate set, the
+    returned ``score`` must remain raw cosine similarity — not rescaled to
+    1.0 for the per-scope top hit.  Otherwise callers that threshold on
+    relevance accept irrelevant results inside a project filter.
+    """
+
+    @pytest.fixture
+    async def projects_store(self, deterministic_embedding_provider):  # type: ignore[no-untyped-def]
+        """Hybrid-mode store with two disjoint projects seeded with controlled
+        embeddings.  ``alpha`` and projA entries share a near-identical vector;
+        projB entries point in an orthogonal direction so cosine similarity to
+        ``alpha`` is roughly 0 (mapped to ~0.5 in [0, 1]).
+        """
+        provider = deterministic_embedding_provider
+        # Two near-orthogonal directions in 4D.
+        provider.register("alpha", [1.0, 0.0, 0.0, 0.0])
+        provider.register("projA entry 1: alpha", [1.0, 0.0, 0.0, 0.0])
+        provider.register("projA entry 2: beta", [0.95, 0.05, 0.0, 0.0])
+        provider.register("projA entry 3: gamma", [0.9, 0.1, 0.0, 0.0])
+        provider.register("projB entry 1: delta", [0.0, 1.0, 0.0, 0.0])
+        provider.register("projB entry 2: epsilon", [0.0, 0.95, 0.05, 0.0])
+        provider.register("projB entry 3: zeta", [0.0, 0.9, 0.1, 0.0])
+
+        s = DuckDBStore(
+            db_path=":memory:",
+            embedding_provider=provider,
+            hybrid_search=True,
+        )
+        await s.initialize()
+        for content, project in [
+            ("projA entry 1: alpha", "projA"),
+            ("projA entry 2: beta", "projA"),
+            ("projA entry 3: gamma", "projA"),
+            ("projB entry 1: delta", "projB"),
+            ("projB entry 2: epsilon", "projB"),
+            ("projB entry 3: zeta", "projB"),
+        ]:
+            await s.store(make_entry(content=content, project=project))
+        yield s
+        await s.close()
+
+    async def test_project_filtered_top_score_is_not_rescaled(
+        self, projects_store: DuckDBStore
+    ) -> None:
+        """Top hit inside a project that is unrelated to the query must not
+        be rescaled to 1.0.  ``projB`` entries are orthogonal to ``alpha``,
+        so cosine similarity is ~0 and the displayed score must reflect that
+        (well below 0.6, the dedup ``link`` threshold).
+        """
+        results = await projects_store.search("alpha", filters={"project": "projB"}, limit=10)
+        assert len(results) >= 1
+        # Issue #370: top score must NOT be rescaled to 1.0 just because it
+        # is the in-scope best.  The actual cosine similarity is ~0, mapped
+        # to ~0.5 in [0, 1] by the (cos+1)/2 transform.
+        assert results[0].score < 0.6
+        # All scores stay in [0, 1].
+        for r in results:
+            assert 0.0 <= r.score <= 1.0
+
+    async def test_project_filtered_score_matches_unfiltered(
+        self, projects_store: DuckDBStore
+    ) -> None:
+        """For an entry that is in the unfiltered top-K, its score should be
+        identical whether or not a project filter narrows the candidate set.
+        """
+        unfiltered = await projects_store.search("alpha", filters=None, limit=20)
+        filtered = await projects_store.search("alpha", filters={"project": "projB"}, limit=10)
+        # Build a {id: score} map from the unfiltered result for comparison.
+        unfiltered_scores = {r.entry.id: r.score for r in unfiltered}
+        for r in filtered:
+            assert r.entry.id in unfiltered_scores, (
+                "filtered result should also appear in the unfiltered top-K"
+            )
+            assert r.score == pytest.approx(unfiltered_scores[r.entry.id], abs=1e-6)
 
 
 class TestRecencyWeight:


### PR DESCRIPTION
## Summary

- Hybrid search min-max-normalized RRF scores across the candidate set, so a `project=` filter that shrunk the set caused the in-scope top hit to be rescaled to 1.0 even when its true cosine similarity was near zero.
- Use raw cosine similarity (mapped to `[0, 1]` via `(cos+1)/2`) as the displayed `score` in BOTH the vector-only and hybrid paths. RRF is retained for ordering only.
- For BM25-only candidates that don't appear in the vector top-K, the supplemental fetch now also computes cosine similarity so every returned entry carries a meaningful score.

## Test plan

- [x] New regression test `TestProjectFilterDoesNotRescaleScore` seeds two disjoint projects with controlled embeddings and asserts that searching for `alpha` with `project=projB` returns top score < 0.6 (orthogonal vectors map to ~0.5, not 1.0).
- [x] Companion test asserts that filtered scores match unfiltered scores byte-for-byte for entries appearing in both result sets.
- [x] Updated `test_hybrid_search_top_score_is_one` (which encoded the buggy behavior) to assert score in [0, 1] without claiming it must be 1.0.
- [x] `pytest -m unit` (1649 passed)
- [x] `pytest tests/test_duckdb_store.py` (117 passed)
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/distillery/store/duckdb.py tests/test_duckdb_store.py`
- [x] `mypy --strict src/distillery/`

Closes #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Search result scores now consistently mapped to [0, 1] range across all search modes.
  * Fixed hybrid search score normalization to prevent rescaling per candidate set or metadata filter.
  * Metadata filtering now preserves score consistency for filtered results.

* **Tests**
  * Updated hybrid search test suite for new score mapping behavior.
  * Added regression tests for metadata filtering score consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->