### PR TITLE
fix(feeds): update last_polled_at on async poll completion

### DIFF
--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -532,7 +532,11 @@ class FeedPoller:
         except Exception:  # noqa: BLE001
             logger.debug("FeedPoller: keyword map build failed — topic tagging disabled")
 
-        # Poll all sources concurrently — each _poll_source is independent.
+        # Poll all sources concurrently — each ``_poll_source`` persists its
+        # own liveness (``last_polled_at``) before returning so a partial
+        # cycle (e.g. the webhook background task is cancelled mid-gather)
+        # still advances the per-source timestamps for sources that did
+        # complete (issue #404).
         results = await asyncio.gather(
             *(self._poll_source(source, scorer, keyword_map=keyword_map) for source in sources),
             return_exceptions=True,
@@ -540,7 +544,10 @@ class FeedPoller:
 
         for idx, result in enumerate(results):
             if isinstance(result, BaseException):
-                # Unexpected exception from _poll_source — record as errored.
+                # Unexpected exception escaping ``_poll_source`` — its own
+                # ``finally`` clause did not get to run (e.g. raised before
+                # the wrapping ``try``), so record liveness one more time
+                # here so the source isn't left as "never polled".
                 err_result = PollResult(
                     source_url=sources[idx].url,
                     source_type=sources[idx].source_type,
@@ -564,7 +571,7 @@ class FeedPoller:
                 summary.sources_polled += 1
                 if result.errors:
                     summary.sources_errored += 1
-                await self._persist_poll_status(result)
+                # Liveness is already persisted inside ``_poll_source``.
 
         summary.finished_at = datetime.now(tz=UTC)
         return summary
@@ -595,7 +602,9 @@ class FeedPoller:
         raw_error = result.errors[0] if result.errors else None
         if raw_error is not None:
             sanitised = re.sub(r"\s+", " ", raw_error).strip()
-            error_msg: str | None = sanitised[:199] + "…" if len(sanitised) > 200 else sanitised or None
+            error_msg: str | None = (
+                sanitised[:199] + "…" if len(sanitised) > 200 else sanitised or None
+            )
         else:
             error_msg = None
         try:
@@ -624,6 +633,18 @@ class FeedPoller:
     ) -> PollResult:
         """Poll a single source and return a :class:`PollResult`.
 
+        Liveness metadata (``last_polled_at``/``last_item_count``/
+        ``last_error``) is persisted **inside this method** — in a
+        ``finally`` clause — so that ``feed_sources.last_polled_at``
+        advances even when the surrounding poll cycle is cancelled
+        mid-gather (e.g. the webhook background task is killed by an
+        auto-stopping host before the post-gather loop runs).  Without
+        this, items could be ingested but the per-source liveness
+        fields would stay ``NULL``, leaving
+        ``distillery_status.last_feed_poll`` and
+        ``distillery_watch(action='list').next_poll_at`` stuck at their
+        prior values (issue #404).
+
         Args:
             source: The configured feed source.
             scorer: The :class:`~distillery.feeds.scorer.RelevanceScorer` to use.
@@ -638,13 +659,45 @@ class FeedPoller:
             source_type=source.source_type,
         )
 
+        try:
+            await self._do_poll_source(source, scorer, result, keyword_map=keyword_map)
+        finally:
+            # Persist liveness on every exit — success, handled error,
+            # or cancellation — so a partial cycle still advances
+            # ``last_polled_at`` for this source.  ``asyncio.shield``
+            # protects the persist call when the surrounding task is
+            # being cancelled: a bare ``await`` inside ``finally`` would
+            # re-raise CancelledError immediately and the persist would
+            # never reach the DB.  ``shield`` lets the inner coroutine
+            # run to completion in the background while the outer task
+            # cancellation still propagates after the shield returns.
+            # Failures inside ``_persist_poll_status`` are logged and
+            # swallowed there.
+            await asyncio.shield(self._persist_poll_status(result))
+        return result
+
+    async def _do_poll_source(
+        self,
+        source: FeedSourceConfig,
+        scorer: RelevanceScorer,
+        result: PollResult,
+        *,
+        keyword_map: dict[str, str] | None = None,
+    ) -> None:
+        """Inner poll loop; mutates *result* in place.
+
+        Split out from :meth:`_poll_source` so the wrapper can persist
+        liveness exactly once via a ``try/finally`` regardless of which
+        early-return branch (or unhandled exception) the inner work
+        takes.
+        """
         # Build adapter
         try:
             adapter = _build_adapter(source)
         except ValueError as exc:
             result.errors.append(f"Failed to build adapter: {exc}")
             logger.warning("FeedPoller: %s", exc)
-            return result
+            return
 
         # Fetch items (synchronous I/O — run in a thread)
         try:
@@ -652,7 +705,7 @@ class FeedPoller:
         except Exception as exc:  # noqa: BLE001
             result.errors.append(f"Adapter fetch failed: {exc}")
             logger.warning("FeedPoller: fetch failed for %s: %s", source.url, exc)
-            return result
+            return
 
         result.items_fetched = len(items)
         logger.debug("FeedPoller: fetched %d items from %s", result.items_fetched, source.url)
@@ -728,8 +781,6 @@ class FeedPoller:
                     source.url,
                     exc,
                 )
-
-        return result
 
     async def rescore(self, *, limit: int = 100) -> dict[str, Any]:
         """Re-score existing feed entries against the current store state.

--- a/src/distillery/mcp/tools/meta.py
+++ b/src/distillery/mcp/tools/meta.py
@@ -42,6 +42,32 @@ def _db_size_bytes(config: DistilleryConfig) -> int | None:
         return None
 
 
+def _max_last_polled_at(sources: list[dict[str, Any]]) -> str | None:
+    """Return the most recent ``last_polled_at`` ISO timestamp across *sources*.
+
+    ``sources`` is the list returned by
+    :meth:`~distillery.store.protocol.DistilleryStore.list_feed_sources`,
+    where each entry has a ``last_polled_at`` value that is either an ISO
+    8601 string or ``None``.  Returns the lexicographically-greatest valid
+    string (which is also the chronological maximum because every poll
+    persists timestamps in the same UTC offset, ``+00:00``), or ``None``
+    when no source has ever been polled.
+
+    Used by :func:`_handle_status` so ``last_feed_poll.last_poll_at``
+    reflects the per-source liveness column, which is updated synchronously
+    by each :class:`~distillery.feeds.poller.FeedPoller` source poll —
+    rather than the ``webhook_audit:poll`` metadata row, which is only
+    written at the end of a webhook background task and can be lost when
+    the host auto-stops mid-cycle (issue #404).
+    """
+    candidates: list[str] = [
+        s["last_polled_at"] for s in sources if isinstance(s.get("last_polled_at"), str)
+    ]
+    if not candidates:
+        return None
+    return max(candidates)
+
+
 async def _handle_status(
     *,
     store: DistilleryStore,
@@ -115,6 +141,7 @@ async def _handle_status(
     # --- feed poll summary (optional, best-effort) ---------------------------
     feed_summary: dict[str, Any] = {"source_count": 0, "last_poll_at": None}
     feed_error: str | None = None
+    sources: list[dict[str, Any]] = []
     try:
         sources = await store.list_feed_sources()
         feed_summary["source_count"] = len(sources)
@@ -124,15 +151,27 @@ async def _handle_status(
         degraded_reasons.append(feed_error)
         logger.exception("distillery_status: list_feed_sources failed")
 
-    with contextlib.suppress(Exception):
-        raw_audit = await store.get_metadata("webhook_audit:poll")
-        if raw_audit:
-            try:
-                audit = json.loads(raw_audit)
-                if isinstance(audit, dict) and isinstance(audit.get("timestamp"), str):
-                    feed_summary["last_poll_at"] = audit["timestamp"]
-            except (TypeError, ValueError):
-                pass
+    # Prefer ``MAX(feed_sources.last_polled_at)`` over the webhook audit
+    # record: per-source liveness is updated synchronously by each
+    # ``_poll_source`` call (see :class:`distillery.feeds.poller.FeedPoller`),
+    # so it advances even when the webhook background task is cancelled
+    # before it can write ``webhook_audit:poll`` (issue #404).  Fall back
+    # to the audit record only when no source has ever been polled — this
+    # preserves the previous behaviour for fresh installs whose first
+    # poll may have logged an audit but failed to update any source.
+    max_last_polled: str | None = _max_last_polled_at(sources)
+    if max_last_polled is not None:
+        feed_summary["last_poll_at"] = max_last_polled
+    else:
+        with contextlib.suppress(Exception):
+            raw_audit = await store.get_metadata("webhook_audit:poll")
+            if raw_audit:
+                try:
+                    audit = json.loads(raw_audit)
+                    if isinstance(audit, dict) and isinstance(audit.get("timestamp"), str):
+                        feed_summary["last_poll_at"] = audit["timestamp"]
+                except (TypeError, ValueError):
+                    pass
     payload["last_feed_poll"] = feed_summary
 
     # --- readiness probe (issue #363 follow-up) -----------------------------
@@ -152,9 +191,7 @@ async def _handle_status(
             # Log the raw probe error server-side; expose only the stable
             # generic code to clients.
             if raw_ready_error:
-                logger.warning(
-                    "distillery_status: readiness probe failed: %s", raw_ready_error
-                )
+                logger.warning("distillery_status: readiness probe failed: %s", raw_ready_error)
             stable_code = "readiness_probe_failed"
             payload["store_ready_error"] = stable_code
             degraded_reasons.append(stable_code)

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -850,7 +850,13 @@ class TestPersistPollStatus:
         # Use MagicMock (not AsyncMock) so getattr(store, "record_poll_status", None)
         # returns the default None for missing attrs.  spec limits attribute access.
         store = MagicMock(
-            spec=["find_similar", "list_entries", "store", "list_feed_sources", "get_tag_vocabulary"]
+            spec=[
+                "find_similar",
+                "list_entries",
+                "store",
+                "list_feed_sources",
+                "get_tag_vocabulary",
+            ]
         )
         store.find_similar = AsyncMock(return_value=[])
         store.list_entries = AsyncMock(return_value=[])
@@ -868,3 +874,177 @@ class TestPersistPollStatus:
             summary = await poller.poll()
 
         assert summary.sources_polled == 1
+
+
+class TestPersistOnPartialCycle:
+    """Issue #404: per-source liveness must be persisted even when the
+    surrounding poll cycle does not run to completion (e.g. the webhook
+    background task is cancelled mid-gather, an unhandled exception
+    escapes the inner work, or only the inner ``_do_poll_source`` call
+    finishes for a single source).
+
+    These tests guard the ``try/finally`` placement inside
+    ``FeedPoller._poll_source`` — moving the persist back to a
+    post-``gather`` loop in ``poll()`` (the pre-#404 behaviour) would
+    regress all of these.
+    """
+
+    async def test_persist_runs_even_when_inner_raises(self) -> None:
+        """An unhandled exception inside the per-item loop must not bypass
+        the ``finally``-clause persist of liveness.
+        """
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.0)
+
+        # Force the inner ``_do_poll_source`` to raise after the adapter
+        # has fetched items but before the post-gather loop would run.
+        # ``_has_external_id`` is awaited deep in the per-item loop, so
+        # raising there exercises the ``finally`` path under realistic
+        # ordering.
+        items = [_make_feed_item(item_id="id1", title="T", content="B")]
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+
+            async def _boom(_item_id: str) -> bool:
+                raise RuntimeError("boom")
+
+            with patch.object(poller, "_has_external_id", side_effect=_boom):
+                # The exception escapes _poll_source and surfaces as a
+                # gather() result; ``poll()`` wraps it as an err_result.
+                summary = await poller.poll()
+
+        # Exactly one persist — from ``_poll_source``'s ``finally`` —
+        # plus one more from the err_result branch in ``poll()`` for the
+        # excepted gather entry.  Both target the same URL.
+        urls = [c.args[0] for c in store.record_poll_status.call_args_list]
+        assert "https://example.com/rss" in urls
+        # The summary records the source as polled+errored (via err_result).
+        assert summary.sources_polled == 1
+        assert summary.sources_errored == 1
+
+    async def test_persist_runs_when_inner_call_cancelled(self) -> None:
+        """If a per-item await inside ``_do_poll_source`` is cancelled
+        (simulating a host kill mid-fetch), the ``finally`` clause in
+        ``_poll_source`` still persists liveness — protected from a
+        cascading cancellation by ``asyncio.shield`` on the persist call.
+
+        This is the production failure mode in issue #404: the webhook
+        background task is cancelled by the host between item-store and
+        the post-gather loop, leaving ``last_polled_at`` stuck at its
+        prior value.  Without the ``finally`` + ``shield`` belt-and-
+        braces in ``_poll_source``, the persist call never reaches the
+        store.
+        """
+        import asyncio
+
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.0)
+
+        # Have ``_has_external_id`` raise CancelledError on first call to
+        # simulate a host-driven cancellation reaching the per-item loop
+        # while the surrounding task is still otherwise valid.  This
+        # avoids the more complex full-task-cancel scenario whose pytest
+        # cleanup races the shielded persist task.
+        items = [_make_feed_item(item_id="id1", title="T", content="B")]
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+
+            async def _cancel(_item_id: str) -> bool:
+                raise asyncio.CancelledError("simulated host cancel")
+
+            with patch.object(poller, "_has_external_id", side_effect=_cancel):
+                # The CancelledError escapes _poll_source.  ``poll()``
+                # surfaces it as an err_result via ``return_exceptions=True``
+                # to gather, but the ``finally`` clause inside
+                # ``_poll_source`` runs first and records liveness.
+                summary = await poller.poll()
+
+        urls = [c.args[0] for c in store.record_poll_status.call_args_list]
+        assert "https://example.com/rss" in urls, (
+            "last_polled_at must be persisted even when the per-item loop "
+            "is cancelled mid-flight (#404)"
+        )
+        # gather's err_result branch ALSO calls _persist_poll_status, so
+        # we accept >=1 calls.  The important guarantee is that AT LEAST
+        # one persist made it to the store before the cycle terminated.
+        assert summary.sources_polled == 1
+
+
+class TestLastPolledAtAdvancesPerSource:
+    """Issue #404 regression: ``feed_sources.last_polled_at`` must be
+    written by every successful per-source poll so that
+    ``distillery_status.last_feed_poll.last_poll_at`` and
+    ``distillery_watch(action='list').next_poll_at`` advance even when
+    the surrounding webhook background task does not reach its audit
+    write (e.g. host auto-stop after returning 202).
+    """
+
+    async def test_real_store_last_polled_at_updates(self) -> None:
+        """End-to-end: a real DuckDBStore observes ``last_polled_at``
+        advance on every poll.
+        """
+        from datetime import UTC, datetime
+
+        from distillery.embedding.protocol import EmbeddingProvider
+        from distillery.store.duckdb import DuckDBStore
+
+        class _StubEmbedding:
+            model_name = "stub"
+            dimensions = 4
+
+            async def embed(self, text: str) -> list[float]:
+                return [0.1, 0.1, 0.1, 0.1]
+
+            async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+                return [[0.1, 0.1, 0.1, 0.1] for _ in texts]
+
+        embedder: EmbeddingProvider = _StubEmbedding()  # type: ignore[assignment]
+        store = DuckDBStore(db_path=":memory:", embedding_provider=embedder)
+        await store.initialize()
+        try:
+            await store.add_feed_source(
+                url="https://example.com/rss",
+                source_type="rss",
+                poll_interval_minutes=60,
+            )
+
+            t0 = datetime.now(tz=UTC)
+
+            cfg = _make_config(
+                sources=[FeedSourceConfig(url="https://example.com/rss", source_type="rss")],
+                digest_threshold=0.0,
+            )
+            with patch("distillery.feeds.poller._build_adapter") as mock_build:
+                mock_adapter = MagicMock()
+                mock_adapter.fetch.return_value = []
+                mock_build.return_value = mock_adapter
+
+                poller = FeedPoller(store=store, config=cfg)
+                await poller.poll()
+
+            sources = await store.list_feed_sources()
+            assert len(sources) == 1
+            ts_iso = sources[0]["last_polled_at"]
+            assert isinstance(ts_iso, str), (
+                "last_polled_at must be set after a successful poll cycle (#404)"
+            )
+            ts = datetime.fromisoformat(ts_iso)
+            assert ts >= t0, f"last_polled_at {ts!r} should be >= t0 {t0!r}"
+
+            # next_poll_at is derived from last_polled_at + interval and
+            # should also be non-null now.
+            assert sources[0]["next_poll_at"] is not None
+        finally:
+            await store.close()

--- a/tests/test_store_rollback_on_error.py
+++ b/tests/test_store_rollback_on_error.py
@@ -187,3 +187,97 @@ class TestStatusDegraded:
         # ``exc_info``; ``caplog.text`` renders it so the raw message is
         # searchable there.
         assert "DB unreadable" in caplog.text
+
+
+class TestStatusLastPollAt:
+    """Issue #404: ``distillery_status.last_feed_poll.last_poll_at`` must
+    reflect the most recent ``feed_sources.last_polled_at`` value, not the
+    ``webhook_audit:poll`` metadata row whose write was lost when the
+    background task was cancelled.
+    """
+
+    async def test_last_poll_at_uses_max_feed_sources_last_polled_at(
+        self, store: DuckDBStore, mock_embedding_provider: object
+    ) -> None:
+        """When a feed source has been polled, status reports its timestamp
+        even if no ``webhook_audit:poll`` metadata row exists.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        from distillery.config import DistilleryConfig
+        from distillery.mcp.tools.meta import _handle_status
+
+        from .conftest import parse_mcp_response
+
+        await store.add_feed_source(
+            url="https://example.com/rss",
+            source_type="rss",
+            poll_interval_minutes=60,
+        )
+        # Persist a fresh poll outcome — this is the production code
+        # path (``FeedPoller._persist_poll_status`` calls this directly).
+        polled_at = datetime.now(tz=UTC) - timedelta(minutes=1)
+        await store.record_poll_status(
+            "https://example.com/rss",
+            polled_at=polled_at,
+            item_count=3,
+            error=None,
+        )
+
+        # Deliberately do NOT write ``webhook_audit:poll`` — this is the
+        # production scenario where the bg task was cancelled before
+        # ``_record_audit`` could run.
+
+        result = await _handle_status(
+            store=store,
+            config=DistilleryConfig(),
+            embedding_provider=mock_embedding_provider,
+            tool_count=16,
+            transport="http",
+            started_at=None,
+        )
+        payload = parse_mcp_response(result)
+
+        last_poll_at = payload["last_feed_poll"]["last_poll_at"]
+        assert isinstance(last_poll_at, str), payload
+        # Tolerate sub-second formatting differences — the assertion
+        # that matters is that the timestamp is fresh (within the last
+        # 5 minutes) rather than ``None``.
+        from datetime import datetime as _dt
+
+        parsed = _dt.fromisoformat(last_poll_at)
+        assert (datetime.now(tz=UTC) - parsed).total_seconds() < 300
+
+    async def test_last_poll_at_falls_back_to_audit_when_no_sources_polled(
+        self, store: DuckDBStore, mock_embedding_provider: object
+    ) -> None:
+        """When no feed source has been polled, status falls back to the
+        ``webhook_audit:poll`` row (preserves the previous behaviour for
+        fresh installs whose first poll-cycle write may have failed).
+        """
+        import json
+
+        from distillery.config import DistilleryConfig
+        from distillery.mcp.tools.meta import _handle_status
+
+        from .conftest import parse_mcp_response
+
+        # No feed sources, no last_polled_at anywhere — but a webhook
+        # audit row was written (the deprecated path).
+        audit_ts = "2026-04-23T14:16:34.768785+00:00"
+        await store.set_metadata(
+            "webhook_audit:poll",
+            json.dumps({"timestamp": audit_ts, "status": 200, "ok": True}),
+        )
+
+        result = await _handle_status(
+            store=store,
+            config=DistilleryConfig(),
+            embedding_provider=mock_embedding_provider,
+            tool_count=16,
+            transport="http",
+            started_at=None,
+        )
+        payload = parse_mcp_response(result)
+
+        assert payload["last_feed_poll"]["last_poll_at"] == audit_ts

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -403,6 +403,62 @@ async def test_poll_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.unit
+async def test_poll_advances_last_polled_at_in_store(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #404: ``POST /poll`` must advance ``feed_sources.last_polled_at``
+    on the store, regardless of whether the webhook background task lives
+    long enough to write ``webhook_audit:poll``.
+
+    Drives the real :class:`FeedPoller` against an in-memory DuckDBStore
+    with a stubbed adapter so the test exercises the production code path:
+    parse → 202 → bg task → ``_poll_source`` → ``_persist_poll_status``.
+    """
+    from datetime import UTC, datetime
+    from unittest.mock import MagicMock, patch
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+
+    # Seed a real feed source so list_feed_sources() returns something
+    # for the poller to iterate over.
+    await store.add_feed_source(
+        url="https://example.com/rss",
+        source_type="rss",
+        poll_interval_minutes=60,
+    )
+
+    shared = _make_shared_state(store)
+
+    # Capture t0 BEFORE the webhook fires so the assertion is robust to
+    # event-loop scheduling skew.
+    t0 = datetime.now(tz=UTC)
+
+    with patch("distillery.feeds.poller._build_adapter") as mock_build:
+        mock_adapter = MagicMock()
+        mock_adapter.fetch.return_value = []  # no items → fast poll
+        mock_build.return_value = mock_adapter
+
+        app = create_webhook_app(shared, config)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post("/poll", headers=_AUTH_HEADER)
+            assert resp.status_code == 202, resp.text
+            _wait_for_job(client, resp.json()["job_id"])
+
+    sources = await store.list_feed_sources()
+    assert len(sources) == 1
+    last = sources[0]["last_polled_at"]
+    assert isinstance(last, str), (
+        "POST /poll must update feed_sources.last_polled_at via the "
+        "real FeedPoller (#404 — was stuck at NULL after async refactor)"
+    )
+    assert datetime.fromisoformat(last) >= t0
+    # next_poll_at is derived from last_polled_at + interval — also
+    # asserted because the issue notes it was always null.
+    assert sources[0]["next_poll_at"] is not None
+
+
+@pytest.mark.unit
 async def test_rescore_handler(store: DuckDBStore, monkeypatch: pytest.MonkeyPatch) -> None:
     """POST /rescore with body {limit: 50} returns 202; the background job
     forwards limit=50 to FeedPoller.rescore() and the job result carries the stats."""
@@ -943,9 +999,7 @@ async def test_failed_job_records_audit(
     # branch exited without writing one, leaving the DB silent on the
     # most-interesting path.
     audit_raw = await store.get_metadata("webhook_audit:poll")
-    assert audit_raw is not None, (
-        "webhook_audit:poll must be written even when the runner raises"
-    )
+    assert audit_raw is not None, "webhook_audit:poll must be written even when the runner raises"
     import json as _json
 
     record = _json.loads(audit_raw)


### PR DESCRIPTION
Closes #404

After PR #397 made `/api/poll` async, `distillery_status.last_feed_poll.last_poll_at` and `distillery_watch(action='list').next_poll_at` could remain pinned at pre-refactor values even when polls ingested entries.

## Root cause (two compounding bugs)

1. **Per-source liveness persisted in a post-gather loop.** `FeedPoller.poll()` ran every `_poll_source` concurrently via `asyncio.gather`, then walked the results and called `_persist_poll_status` for each. When the webhook background task was cancelled mid-cycle (e.g. host auto-stop after returning 202), individual sources had completed and stored their entries but the post-gather loop never ran — so `feed_sources.last_polled_at` stayed `NULL` for every source.

2. **`distillery_status` read from the wrong row.** The status handler derived `last_poll_at` from the `webhook_audit:poll` metadata row, which `_execute_job` only writes at the *end* of the background task. Same cancel-window problem.

## Fix

- Moved `_persist_poll_status` inside `_poll_source` itself, wrapped in a `try/finally` and protected by `asyncio.shield` so cancellation cannot abort the liveness write.
- Switched `distillery_status` to derive `last_poll_at` from `MAX(feed_sources.last_polled_at)`, falling back to `webhook_audit:poll` only when no source has ever been polled (preserves prior behaviour for fresh installs).

## Test plan
- [x] unit (`pytest -m unit` — 1655 passed)
- [x] integration (`pytest -m integration` — 757 passed)
- [x] mypy strict (`mypy --strict src/distillery/`)
- [x] ruff (`ruff check src/ tests/` and format check on changed files)

New tests:
- `test_poller.py::TestPersistOnPartialCycle` — `finally` runs even when inner work raises or is cancelled mid-loop.
- `test_poller.py::TestLastPolledAtAdvancesPerSource` — real DuckDBStore observes `last_polled_at`/`next_poll_at` advance after a poll.
- `test_webhooks.py::test_poll_advances_last_polled_at_in_store` — full `POST /poll` → bg task → DB update path with the real `FeedPoller`.
- `test_store_rollback_on_error.py::TestStatusLastPollAt` — `_handle_status` prefers feed-sources `MAX(last_polled_at)` and falls back to the audit row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of feed source polling status persistence, ensuring last-polled timestamps are recorded correctly even when processing errors or interruptions occur.

* **Tests**
  * Added comprehensive regression tests to verify feed polling status is properly persisted across various error scenarios and normal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->