### PR TITLE
fix(feeds): poller dedup fail-closed + FTS rebuild rollback (#414)

### DIFF
--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -1045,11 +1045,23 @@ class FeedPoller:
         Uses ``list_entries`` with a metadata filter rather than a full
         similarity search, making this a cheap pre-check before scoring.
 
+        Fails closed: when the lookup raises (e.g. the shared DuckDB
+        connection is in an aborted-transaction state from an unrelated
+        prior failure), this returns ``True`` so the caller skips the
+        item rather than storing a potential duplicate.  Returning
+        ``False`` here was the root cause of issue #414 — a transient
+        store error silently disabled dedup and re-stored every item
+        the previous cycle had already persisted.
+
         Args:
             external_id: The feed-item identifier to look for.
 
         Returns:
-            ``True`` if a matching entry exists.
+            ``True`` if a matching entry exists OR if the lookup itself
+            failed.  Returning ``True`` on failure trades a small amount
+            of false-skip risk (one polling cycle) for guaranteed
+            duplicate prevention — items the next healthy poll will
+            re-fetch and re-store correctly.
         """
         try:
             results = await self._store.list_entries(
@@ -1058,12 +1070,14 @@ class FeedPoller:
                 offset=0,
             )
             return bool(results)
-        except Exception:  # noqa: BLE001
-            logger.debug(
-                "FeedPoller: external_id lookup failed for %r — falling through",
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "FeedPoller: external_id lookup failed for %r — treating as duplicate "
+                "to prevent dupes (issue #414): %s",
                 external_id,
+                exc,
             )
-            return False
+            return True
 
     async def _is_duplicate(
         self,

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -325,6 +325,15 @@ class DuckDBStore:
         except duckdb.Error as exc:
             logger.warning("FTS index rebuild failed: %s", exc)
             self._fts_available = False
+            # ROLLBACK the aborted transaction so the connection is usable
+            # for the next caller.  Without this, the PRAGMA failure leaves
+            # the connection in an aborted-transaction state that propagates
+            # to every subsequent statement as ``TransactionContext Error:
+            # Current transaction is aborted (please ROLLBACK)``.  That
+            # cascade silently disables ``FeedPoller._has_external_id``
+            # (issue #414), which fails closed but still represents a
+            # temporary loss of dedup until the next healthy lookup.
+            self._rollback_quietly(conn)
             return
 
         # Force a CHECKPOINT so the FTS schema DDL is persisted to the

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -1534,6 +1534,44 @@ class TestConnectionLockSerialization:
         await s.close()
 
 
+class TestFTSRebuildRollback:
+    """Issue #414: a failed FTS rebuild must leave the connection usable.
+
+    Before the fix, ``_rebuild_fts_index`` swallowed the ``duckdb.Error``
+    from a failing ``PRAGMA create_fts_index`` and returned without
+    rolling back, leaving the connection in an aborted-transaction state.
+    Subsequent statements then failed with ``TransactionContext Error:
+    Current transaction is aborted (please ROLLBACK)``, which silently
+    disabled ``FeedPoller._has_external_id`` (it caught the error and
+    returned ``False``) and caused duplicate feed entries to accumulate.
+    """
+
+    async def test_fts_rebuild_failure_invokes_rollback(
+        self, hybrid_store: DuckDBStore
+    ) -> None:
+        """A failed PRAGMA must trigger ``conn.rollback()`` before returning.
+
+        DuckDB ``DuckDBPyConnection.execute`` is a read-only attribute on
+        the real object, so we simulate the PRAGMA failure with a mock
+        connection that mimics the surface area used by
+        ``_rebuild_fts_index``.  The assertion is that ``rollback()`` is
+        invoked on the failure path — which is what restores the shared
+        connection to a usable state in production.
+        """
+        from unittest.mock import MagicMock
+
+        import duckdb
+
+        mock_conn = MagicMock()
+        mock_conn.execute.side_effect = duckdb.Error("simulated PRAGMA failure")
+
+        hybrid_store._fts_available = True  # noqa: SLF001 — force the rebuild path
+        hybrid_store._rebuild_fts_index(mock_conn)  # noqa: SLF001
+
+        assert hybrid_store._fts_available is False  # noqa: SLF001 — failure recorded
+        mock_conn.rollback.assert_called_once()
+
+
 class TestHybridGracefulFallback:
     """Verify graceful fallback to vector-only when FTS is unavailable."""
 

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -314,6 +314,38 @@ class TestFeedPollerRSS:
         assert summary.total_stored == 0
         store.store.assert_not_called()
 
+    async def test_external_id_lookup_failure_treated_as_duplicate(self) -> None:
+        """Issue #414: ``_has_external_id`` failing must skip the item, not store it.
+
+        When the shared DuckDB connection is in an aborted-transaction state
+        (e.g. after a failed FTS rebuild), every ``list_entries`` call raises
+        ``TransactionContext Error``.  Returning ``False`` from
+        ``_has_external_id`` in that path silently disabled dedup and caused
+        every item the previous cycle had stored to be re-stored as a
+        duplicate.  The fix is fail-closed: treat lookup failure as a
+        possible duplicate and skip storage for this cycle.
+        """
+        items = [_make_feed_item(item_id="id1", title="Dup", content="Body")]
+        src = self._rss_source()
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.0)
+
+        store.list_entries.side_effect = RuntimeError(
+            "TransactionContext Error: Current transaction is aborted (please ROLLBACK)"
+        )
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.total_skipped_dedup == 1
+        assert summary.total_stored == 0
+        store.store.assert_not_called()
+
     async def test_adapter_fetch_error_recorded(self) -> None:
         src = self._rss_source()
         store = _make_store(feed_sources=[_source_to_dict(src)])


### PR DESCRIPTION
Fixes #414.

## Root cause

`FeedPoller._has_external_id` returned `False` whenever its `list_entries` lookup raised, silently disabling dedup. The lookup was raising because `DuckDBStore._rebuild_fts_index` swallowed the `duckdb.Error` from a failing `PRAGMA create_fts_index` without rolling back, leaving the shared connection in an aborted-transaction state. Every subsequent statement then failed with `TransactionContext Error: Current transaction is aborted (please ROLLBACK)` until the connection was recycled. Over two consecutive poll cycles this produced 12 active feed entries sharing `metadata.external_id` with another active entry.

## Changes

- `src/distillery/feeds/poller.py` — `_has_external_id` returns `True` (treat as duplicate) when the lookup raises. Logged at WARNING with the original exception so degraded states are visible.
- `src/distillery/store/duckdb.py` — `_rebuild_fts_index` calls `_rollback_quietly(conn)` in the `except duckdb.Error` branch so the connection is usable for the next caller after a PRAGMA failure.
- `tests/test_poller.py` — new test `test_external_id_lookup_failure_treated_as_duplicate` verifies fail-closed behavior.
- `tests/test_duckdb_store.py` — new test `TestFTSRebuildRollback::test_fts_rebuild_failure_invokes_rollback` verifies `conn.rollback()` is called on PRAGMA failure.

## Acceptance

- `pytest tests/test_poller.py tests/test_duckdb_store.py` — 167 passed.
- `ruff check` and `mypy --strict` clean on the touched files.
- `test_duplicate_items_are_skipped_via_external_id` (existing) still passes.

## Notes

The concurrent-connection race that originally triggered the FTS rebuild failure (`Invalid Input Error: Attempting to execute an unsuccessful or closed pending query result` — multiple `to_thread` workers touching the unlocked DuckDB connection during `asyncio.gather` across feed sources) is a separate issue. The fixes above stop duplicates from reaching the store regardless of which underlying error poisons the lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience during feed polling: when external ID lookups fail, items are now safely skipped rather than risking duplicate prevention bypass.
  * Enhanced database connection stability: when full-text search index rebuilds fail, the connection is properly recovered to prevent cascading failures on subsequent queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->