### PR TITLE
feat(mcp): add structural=["orphans"] filter to distillery_list (#141)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -659,6 +659,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         output: str | None = None,
         feed_url: str | None = None,
         include_archived: bool = False,
+        structural: list[str] | None = None,
     ) -> list[types.TextContent]:
         """List knowledge entries with optional filters and pagination (newest first).
 
@@ -708,8 +709,18 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             retrieve all items polled from e.g. "https://hnrss.org/frontpage".
           - include_archived (bool, optional, default=False): Include archived entries
             in the default view (same effect as status="any" when status is unset).
+          - structural (list[str], optional): Surface entries with specific graph
+            anomalies relative to ``entry_relations``. Accepted values:
+            ["orphans"] — entries that do not appear as either endpoint of any
+            relation row. Unknown values yield INVALID_PARAMS. Combines (AND) with
+            every other filter (project, tags, status, date range, stale_days,
+            etc.) — orphans are first restricted by those filters, then the
+            no-relations predicate is applied.
 
-        RETURNS (success): { entries: list, count: int, total_count: int, limit: int, offset: int }
+        RETURNS (success): { entries: list, count: int, total_count: int, limit: int,
+          offset: int, output_mode: str } — when ``structural`` is set, the payload
+          additionally includes ``structural_filter`` (comma-joined applied filters,
+          e.g. "orphans"). Existing fields are unchanged.
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
 
         RELATED: distillery_search (for semantic search),
@@ -738,6 +749,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 group_by=group_by,
                 output=output,
                 feed_url=feed_url,
+                structural=structural,
             ),
         )
         return await _handle_list(store=c["store"], arguments=args)

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -662,6 +662,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         published_after: str | None = None,
         published_before: str | None = None,
         include_evergreen: bool = False,
+        structural: list[str] | None = None,
     ) -> list[types.TextContent]:
         """List knowledge entries with optional filters and pagination (newest first).
 
@@ -721,8 +722,18 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             metadata.backfill=true so first-poll backfill items don't surface as
             "new intelligence". Set to True to surface older / evergreen items
             explicitly. See issue #444.
+          - structural (list[str], optional): Surface entries with specific graph
+            anomalies relative to ``entry_relations``. Accepted values:
+            ["orphans"] — entries that do not appear as either endpoint of any
+            relation row. Unknown values yield INVALID_PARAMS. Combines (AND) with
+            every other filter (project, tags, status, date range, stale_days,
+            etc.) — orphans are first restricted by those filters, then the
+            no-relations predicate is applied.
 
-        RETURNS (success): { entries: list, count: int, total_count: int, limit: int, offset: int }
+        RETURNS (success): { entries: list, count: int, total_count: int, limit: int,
+          offset: int, output_mode: str } — when ``structural`` is set, the payload
+          additionally includes ``structural_filter`` (comma-joined applied filters,
+          e.g. "orphans"). Existing fields are unchanged.
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
 
         RELATED: distillery_search (for semantic search),
@@ -754,6 +765,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 feed_url=feed_url,
                 published_after=published_after,
                 published_before=published_before,
+                structural=structural,
             ),
         )
         return await _handle_list(store=c["store"], arguments=args)

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -1385,6 +1385,16 @@ async def _handle_list(
                 seen.add(v)
                 structural.append(v)
 
+        # Structural is post-applied after the wide fetch and is incompatible
+        # with the aggregate code paths.  Reject the combo loudly instead of
+        # silently dropping the structural filter and returning unfiltered
+        # aggregates.
+        if structural and (group_by_raw is not None or output_raw == "stats"):
+            return error_response(
+                "INVALID_PARAMS",
+                "Field 'structural' cannot be combined with 'group_by' or output='stats'",
+            )
+
     # --- mutual exclusivity: group_by and output="stats" ---------------------
     if group_by is not None and output == "stats":
         return error_response(
@@ -1493,6 +1503,23 @@ async def _handle_list(
     # surface stays unchanged (Phase 3 plan, option (b)).  We fetch a wider
     # window using a safety cap, post-filter, then re-slice for offset/limit.
     if structural is not None:
+        # Fail fast if the candidate set already exceeds the safety cap —
+        # otherwise pagination + total_count would silently lie about anything
+        # beyond ``_STRUCTURAL_FETCH_CAP`` rows.  Probe the count up front and
+        # ask the caller to narrow filters instead.
+        try:
+            candidate_count = await store.count_entries(filters=filters, stale_days=stale_days)
+        except Exception:  # noqa: BLE001
+            logger.exception("Error in distillery_list (structural count)")
+            return error_response("INTERNAL", "count_entries failed")
+        if candidate_count > _STRUCTURAL_FETCH_CAP:
+            return error_response(
+                "INVALID_PARAMS",
+                f"Structural filter on {candidate_count} candidate rows exceeds "
+                f"{_STRUCTURAL_FETCH_CAP} cap; tighten filters "
+                f"(project, tags, status, date_from/date_to, stale_days).",
+            )
+
         try:
             wide_entries = await store.list_entries(
                 filters=filters,

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -1187,6 +1187,21 @@ async def _handle_update(
 _VALID_OUTPUT_MODES = frozenset({"full", "summary", "ids", "review"})
 _VALID_GROUP_BY_VALUES = frozenset({"entry_type", "status", "author", "project", "source", "tags"})
 
+# Structural filters surface entries with anomalous graph properties relative
+# to ``entry_relations``.  ``"orphans"`` returns entries that do not appear as
+# either endpoint of any relation row.  Future values may include
+# ``"isolated_clusters"`` etc.; the set is intentionally small so that unknown
+# values fail loudly with INVALID_PARAMS rather than silently no-op.
+_VALID_STRUCTURAL_FILTERS = frozenset({"orphans"})
+
+# Safety cap on the entry batch fetched when a structural filter is active.
+# Structural filters are post-applied at the handler layer (option (b) in the
+# Phase 3 plan: keep store.list_entries unchanged), so we must fetch enough
+# rows up front to apply the filter and then slice with offset/limit.  10k
+# entries comfortably exceeds typical knowledge-base sizes while keeping the
+# filter cost bounded.
+_STRUCTURAL_FETCH_CAP = 10_000
+
 # Summary-mode content preview length (characters).  Chosen to keep each
 # entry ~300-500 bytes so a full ``distillery_list(limit=50)`` fits in a
 # few tens of KB rather than hundreds.
@@ -1343,6 +1358,33 @@ async def _handle_list(
             return error_response("INVALID_PARAMS", "Field 'output' only accepts 'stats'")
         output = output_raw
 
+    # --- validate structural -------------------------------------------------
+    # Structural filters AND with the existing project/tags/status/date filters
+    # to narrow results to entries with specific graph anomalies (see
+    # ``_VALID_STRUCTURAL_FILTERS``).  Issue #141: surface orphans (entries
+    # with zero rows in ``entry_relations``).
+    structural_raw = arguments.get("structural")
+    structural: list[str] | None = None
+    if structural_raw is not None:
+        if not isinstance(structural_raw, list):
+            return error_response("INVALID_PARAMS", "Field 'structural' must be a list of strings")
+        if not all(isinstance(item, str) for item in structural_raw):
+            return error_response("INVALID_PARAMS", "Field 'structural' must be a list of strings")
+        unknown = [v for v in structural_raw if v not in _VALID_STRUCTURAL_FILTERS]
+        if unknown:
+            return error_response(
+                "INVALID_PARAMS",
+                f"Unknown structural filter value(s): {', '.join(repr(v) for v in unknown)}. "
+                f"Valid values: {', '.join(sorted(_VALID_STRUCTURAL_FILTERS))}.",
+            )
+        # Preserve caller order (and dedupe) for deterministic envelope output.
+        seen: set[str] = set()
+        structural = []
+        for v in structural_raw:
+            if v not in seen:
+                seen.add(v)
+                structural.append(v)
+
     # --- mutual exclusivity: group_by and output="stats" ---------------------
     if group_by is not None and output == "stats":
         return error_response(
@@ -1446,22 +1488,49 @@ async def _handle_list(
         return success_response(result)
 
     # --- default list mode ---------------------------------------------------
-    try:
-        entries = await store.list_entries(
-            filters=filters,
-            limit=limit,
-            offset=offset,
-            stale_days=stale_days,
-        )
-    except Exception:  # noqa: BLE001
-        logger.exception("Error in distillery_list")
-        return error_response("INTERNAL", "list_entries failed")
+    # Structural filters (e.g. ``orphans``) are applied at the handler layer
+    # rather than pushed into ``store.list_entries`` so that the store's list
+    # surface stays unchanged (Phase 3 plan, option (b)).  We fetch a wider
+    # window using a safety cap, post-filter, then re-slice for offset/limit.
+    if structural is not None:
+        try:
+            wide_entries = await store.list_entries(
+                filters=filters,
+                limit=_STRUCTURAL_FETCH_CAP,
+                offset=0,
+                stale_days=stale_days,
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("Error in distillery_list (structural fetch)")
+            return error_response("INTERNAL", "list_entries failed")
 
-    try:
-        total_count = await store.count_entries(filters=filters, stale_days=stale_days)
-    except Exception:  # noqa: BLE001
-        logger.debug("count_entries failed, falling back to len(entries)", exc_info=True)
-        total_count = len(entries)
+        if "orphans" in structural:
+            try:
+                related_ids = await store.get_all_related_entry_ids()
+            except Exception:  # noqa: BLE001
+                logger.exception("Error in distillery_list (get_all_related_entry_ids)")
+                return error_response("INTERNAL", "get_all_related_entry_ids failed")
+            wide_entries = [e for e in wide_entries if e.id not in related_ids]
+
+        total_count = len(wide_entries)
+        entries = wide_entries[offset : offset + limit]
+    else:
+        try:
+            entries = await store.list_entries(
+                filters=filters,
+                limit=limit,
+                offset=offset,
+                stale_days=stale_days,
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("Error in distillery_list")
+            return error_response("INTERNAL", "list_entries failed")
+
+        try:
+            total_count = await store.count_entries(filters=filters, stale_days=stale_days)
+        except Exception:  # noqa: BLE001
+            logger.debug("count_entries failed, falling back to len(entries)", exc_info=True)
+            total_count = len(entries)
 
     if output_mode == "summary":
         serialised = [_entry_to_summary_dict(e) for e in entries]
@@ -1494,16 +1563,19 @@ async def _handle_list(
         else:
             serialised = [e.to_dict() for e in entries]
 
-    return success_response(
-        {
-            "entries": serialised,
-            "count": len(entries),
-            "total_count": total_count,
-            "limit": limit,
-            "offset": offset,
-            "output_mode": output_mode,
-        }
-    )
+    payload: dict[str, Any] = {
+        "entries": serialised,
+        "count": len(entries),
+        "total_count": total_count,
+        "limit": limit,
+        "offset": offset,
+        "output_mode": output_mode,
+    }
+    if structural is not None:
+        # Comma-joined for forward compatibility with multi-value structural
+        # filters; today only "orphans" is recognised.
+        payload["structural_filter"] = ",".join(structural)
+    return success_response(payload)
 
 
 # ---------------------------------------------------------------------------

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2885,3 +2885,27 @@ class DuckDBStore:
             ``True`` if the row existed and was deleted, ``False`` otherwise.
         """
         return await self._run_sync(self._sync_remove_relation, relation_id)
+
+    def _sync_get_all_related_entry_ids(self) -> set[str]:
+        """Synchronous implementation of get_all_related_entry_ids()."""
+        assert self._conn is not None
+        # Single scan over entry_relations to collect every entry id that
+        # appears as either endpoint of any relation. Used by the orphan
+        # filter on distillery_list to identify entries with no relations.
+        rows = self._conn.execute(
+            "SELECT from_id FROM entry_relations UNION SELECT to_id FROM entry_relations"
+        ).fetchall()
+        return {row[0] for row in rows}
+
+    async def get_all_related_entry_ids(self) -> set[str]:
+        """Return the set of entry IDs that appear in any ``entry_relations`` row.
+
+        Used by structural filters (e.g. orphan detection) on
+        ``distillery_list``: the complement set is the orphan set. Returns
+        an empty set when no relations exist.
+
+        Returns:
+            Set of entry UUID strings appearing as either ``from_id`` or
+            ``to_id`` in at least one row of ``entry_relations``.
+        """
+        return await self._run_sync(self._sync_get_all_related_entry_ids)

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -3022,3 +3022,27 @@ class DuckDBStore:
             ascending ``created_at``.
         """
         return await self._run_sync(self._sync_list_relations)
+
+    def _sync_get_all_related_entry_ids(self) -> set[str]:
+        """Synchronous implementation of get_all_related_entry_ids()."""
+        assert self._conn is not None
+        # Single scan over entry_relations to collect every entry id that
+        # appears as either endpoint of any relation. Used by the orphan
+        # filter on distillery_list to identify entries with no relations.
+        rows = self._conn.execute(
+            "SELECT from_id FROM entry_relations UNION SELECT to_id FROM entry_relations"
+        ).fetchall()
+        return {row[0] for row in rows}
+
+    async def get_all_related_entry_ids(self) -> set[str]:
+        """Return the set of entry IDs that appear in any ``entry_relations`` row.
+
+        Used by structural filters (e.g. orphan detection) on
+        ``distillery_list``: the complement set is the orphan set. Returns
+        an empty set when no relations exist.
+
+        Returns:
+            Set of entry UUID strings appearing as either ``from_id`` or
+            ``to_id`` in at least one row of ``entry_relations``.
+        """
+        return await self._run_sync(self._sync_get_all_related_entry_ids)

--- a/tests/test_mcp_tools/test_list_structural.py
+++ b/tests/test_mcp_tools/test_list_structural.py
@@ -1,0 +1,149 @@
+"""Tests for distillery_list ``structural`` filter (Phase 3, issue #141 partial).
+
+The ``structural`` parameter accepts a list of named anomaly filters.  The
+first supported value is ``"orphans"`` — entries with zero rows in
+``entry_relations`` (no relation in either direction).  Unknown values must
+fail loudly with ``INVALID_PARAMS`` rather than silently no-op.
+
+Filters AND together with the existing project/tags/status/date filters.
+
+Mirrors the fixture style of ``tests/test_list_archived_default.py`` and
+``tests/test_list_output_modes.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.mcp.tools.crud import _handle_list
+from tests.conftest import make_entry, parse_mcp_response
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _store_entry(store, **kwargs):  # type: ignore[no-untyped-def]
+    """Create + persist an entry, returning the stored object with its id."""
+    entry = make_entry(**kwargs)
+    await store.store(entry)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Behaviour tests
+# ---------------------------------------------------------------------------
+
+
+async def test_orphans_returns_only_unrelated_entries(store) -> None:  # type: ignore[no-untyped-def]
+    a = await _store_entry(store, content="entry A")
+    b = await _store_entry(store, content="entry B")
+    c = await _store_entry(store, content="entry C")
+
+    # Link A <-> B; C remains orphaned.
+    await store.add_relation(a.id, b.id, "link")
+
+    result = await _handle_list(
+        store=store,
+        arguments={"limit": 50, "structural": ["orphans"], "output_mode": "ids"},
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is not True, data
+
+    returned_ids = {e["id"] for e in data["entries"]}
+    assert returned_ids == {c.id}
+    assert a.id not in returned_ids
+    assert b.id not in returned_ids
+    assert data["count"] == 1
+    assert data["total_count"] == 1
+
+
+async def test_orphans_combines_with_existing_filters(store) -> None:  # type: ignore[no-untyped-def]
+    # Two orphans across two different projects.
+    orphan_x = await _store_entry(store, content="orphan in x", project="x")
+    orphan_y = await _store_entry(store, content="orphan in y", project="y")
+    # Plus a related pair in project x to confirm relations are still excluded.
+    a_x = await _store_entry(store, content="related a in x", project="x")
+    b_x = await _store_entry(store, content="related b in x", project="x")
+    await store.add_relation(a_x.id, b_x.id, "link")
+
+    result = await _handle_list(
+        store=store,
+        arguments={
+            "limit": 50,
+            "structural": ["orphans"],
+            "project": "x",
+            "output_mode": "ids",
+        },
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is not True, data
+
+    returned_ids = {e["id"] for e in data["entries"]}
+    assert returned_ids == {orphan_x.id}
+    assert orphan_y.id not in returned_ids  # filtered by project
+    assert a_x.id not in returned_ids  # has a relation
+    assert b_x.id not in returned_ids  # has a relation
+
+
+async def test_unknown_structural_value_returns_invalid_params(store) -> None:  # type: ignore[no-untyped-def]
+    result = await _handle_list(
+        store=store,
+        arguments={"limit": 10, "structural": ["bogus"]},
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is True
+    assert data.get("code") == "INVALID_PARAMS"
+    assert "bogus" in data.get("message", "")
+
+
+async def test_structural_filter_appears_in_envelope_when_set(store) -> None:  # type: ignore[no-untyped-def]
+    await _store_entry(store, content="solo entry")
+    result = await _handle_list(
+        store=store,
+        arguments={"limit": 10, "structural": ["orphans"], "output_mode": "ids"},
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is not True, data
+    assert data.get("structural_filter") == "orphans"
+
+
+async def test_structural_filter_omitted_when_unset(store) -> None:  # type: ignore[no-untyped-def]
+    await _store_entry(store, content="solo entry")
+    result = await _handle_list(
+        store=store,
+        arguments={"limit": 10, "output_mode": "ids"},
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is not True, data
+    assert "structural_filter" not in data
+
+
+async def test_orphans_with_no_orphans_returns_empty(store) -> None:  # type: ignore[no-untyped-def]
+    a = await _store_entry(store, content="entry A")
+    b = await _store_entry(store, content="entry B")
+    await store.add_relation(a.id, b.id, "link")
+
+    result = await _handle_list(
+        store=store,
+        arguments={"limit": 50, "structural": ["orphans"], "output_mode": "ids"},
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is not True, data
+    assert data["count"] == 0
+    assert data["entries"] == []
+    assert data["total_count"] == 0
+
+
+async def test_structural_must_be_list(store) -> None:  # type: ignore[no-untyped-def]
+    result = await _handle_list(
+        store=store,
+        arguments={"limit": 10, "structural": "orphans"},
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is True
+    assert data.get("code") == "INVALID_PARAMS"
+    assert "structural" in data.get("message", "")

--- a/tests/test_mcp_tools/test_list_structural.py
+++ b/tests/test_mcp_tools/test_list_structural.py
@@ -147,3 +147,64 @@ async def test_structural_must_be_list(store) -> None:  # type: ignore[no-untype
     assert data.get("error") is True
     assert data.get("code") == "INVALID_PARAMS"
     assert "structural" in data.get("message", "")
+
+
+async def test_structural_with_group_by_returns_invalid_params(store) -> None:  # type: ignore[no-untyped-def]
+    """Combining structural + group_by must fail loudly, not silently ignore.
+
+    Aggregate code paths skip the post-filter wide fetch, so silently
+    accepting the combo would return UNFILTERED group counts with a success
+    response.
+    """
+    result = await _handle_list(
+        store=store,
+        arguments={
+            "limit": 10,
+            "structural": ["orphans"],
+            "group_by": "entry_type",
+        },
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is True
+    assert data.get("code") == "INVALID_PARAMS"
+    assert "group_by" in data.get("message", "")
+
+
+async def test_structural_with_output_stats_returns_invalid_params(store) -> None:  # type: ignore[no-untyped-def]
+    """Combining structural + output='stats' must fail loudly, not silently ignore."""
+    result = await _handle_list(
+        store=store,
+        arguments={
+            "limit": 10,
+            "structural": ["orphans"],
+            "output": "stats",
+        },
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is True
+    assert data.get("code") == "INVALID_PARAMS"
+    assert "stats" in data.get("message", "")
+
+
+async def test_structural_fetch_cap_exceeded_fails_fast(store, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """When candidate rows exceed ``_STRUCTURAL_FETCH_CAP`` we must fail fast
+    instead of returning truncated pagination/total_count.
+    """
+    from distillery.mcp.tools import crud as crud_module
+
+    # Shrink the cap so we don't have to seed 10k rows.
+    monkeypatch.setattr(crud_module, "_STRUCTURAL_FETCH_CAP", 2)
+
+    # Three candidate rows with no relations — exceeds the (patched) cap.
+    await _store_entry(store, content="entry 1")
+    await _store_entry(store, content="entry 2")
+    await _store_entry(store, content="entry 3")
+
+    result = await _handle_list(
+        store=store,
+        arguments={"limit": 10, "structural": ["orphans"], "output_mode": "ids"},
+    )
+    data = parse_mcp_response(result)
+    assert data.get("error") is True
+    assert data.get("code") == "INVALID_PARAMS"
+    assert "cap" in data.get("message", "").lower()


### PR DESCRIPTION
## Summary

Adds an additive `structural` filter to the `distillery_list` MCP tool. First supported value: `"orphans"` — entries with no rows in `entry_relations` (either direction). Combines with existing project/tags/status/date filters via AND.

Conforms to v0.4.0 stability pledge — no breaking changes, response envelope unchanged unless the filter is set; when set, adds `structural_filter` field.

## Plan

Phase 3 of `/Users/norrie/.claude/plans/review-all-open-issue-luminous-treehouse.md`.

## Test plan

- [x] 7 new unit tests in `tests/test_mcp_tools/test_list_structural.py`
- [x] Existing list tests still pass (258-test broader regression sweep — green)
- [x] `ruff check`, `ruff format --check`, `mypy --strict` clean

## Notes

Adds one minimal `DuckDBStore.get_all_related_entry_ids() -> set[str]` helper (single UNION query) used by the handler-level orphan filter. Not added to the `DistilleryStore` protocol — handlers type `store: Any`. `_STRUCTURAL_FETCH_CAP = 10_000` safety bound documented inline.

Closes part of #141.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "structural" filter to entry browsing, enabling relationship-based post-filtering (e.g., "orphans" to show entries without relations).
  * When used, responses include a structural_filter field describing the applied criteria.
  * Structural filtering respects pagination and order, validates input, and rejects unknown or incompatible modes (e.g., certain aggregation outputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->