### PR TITLE
feat(mcp): add expand_graph + expand_hops to distillery_search (#138)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -758,6 +758,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         limit: int = 10,
         tag_prefix: str | None = None,
         include_archived: bool = False,
+        expand_graph: bool = False,
+        expand_hops: int = 1,
     ) -> list[types.TextContent]:
         """Search knowledge entries using semantic similarity (cosine distance, ranked descending).
 
@@ -769,6 +771,16 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         to search only archived entries, ``status="any"`` to include every
         status, or ``include_archived=true`` to add archived entries to the
         default candidate set.
+
+        When ``expand_graph=true``, after the semantic search returns its
+        seed result set, the tool BFS-expands 1 or 2 hops via
+        ``entry_relations`` to surface structurally connected entries.
+        Graph entries are scored at ``parent_score * 0.5 ** depth``, marked
+        with ``provenance="graph"``, and merged into the result list (sorted
+        by descending score, truncated to ``limit``).  Seeds are tagged
+        ``provenance="search"``.  The envelope gains a ``graph_expansion``
+        summary.  When ``expand_graph=false`` (default), the existing
+        envelope is unchanged — strictly additive.
 
         PARAMS:
           - query (str, required): Natural-language search query.
@@ -785,8 +797,16 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - tag_prefix (str, optional): Filter tags by namespace prefix.
           - include_archived (bool, optional, default=False): Include archived entries
             in the candidate set.
+          - expand_graph (bool, optional, default=False): When true, expand the seed
+            result set via ``entry_relations`` and merge the neighbours into the
+            results.
+          - expand_hops (int, optional, default=1): Depth of graph expansion when
+            ``expand_graph=true``.  Must be 1 or 2.
 
-        RETURNS (success): { results: [{ score: float, entry: {...} }], count: int }
+        RETURNS (success): { results: [{ score: float, entry: {...} }], count: int }.
+          When ``expand_graph=true`` each result also has ``provenance`` ("search" or
+          "graph"); graph results additionally carry ``depth`` and ``parent_id``, and
+          the envelope includes ``graph_expansion: { seed_count, expanded_count }``.
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
 
         RELATED: distillery_list (for filter-based browsing without semantic ranking),
@@ -797,6 +817,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             query=query,
             limit=limit,
             include_archived=include_archived,
+            expand_graph=expand_graph,
+            expand_hops=expand_hops,
             **_omit_none(
                 entry_type=entry_type,
                 author=author,

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -777,6 +777,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         published_after: str | None = None,
         published_before: str | None = None,
         include_evergreen: bool = False,
+        expand_graph: bool = False,
+        expand_hops: int = 1,
     ) -> list[types.TextContent]:
         """Search knowledge entries using semantic similarity (cosine distance, ranked descending).
 
@@ -788,6 +790,16 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         to search only archived entries, ``status="any"`` to include every
         status, or ``include_archived=true`` to add archived entries to the
         default candidate set.
+
+        When ``expand_graph=true``, after the semantic search returns its
+        seed result set, the tool BFS-expands 1 or 2 hops via
+        ``entry_relations`` to surface structurally connected entries.
+        Graph entries are scored at ``parent_score * 0.5 ** depth``, marked
+        with ``provenance="graph"``, and merged into the result list (sorted
+        by descending score, truncated to ``limit``).  Seeds are tagged
+        ``provenance="search"``.  The envelope gains a ``graph_expansion``
+        summary.  When ``expand_graph=false`` (default), the existing
+        envelope is unchanged — strictly additive.
 
         PARAMS:
           - query (str, required): Natural-language search query.
@@ -814,8 +826,16 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             metadata.backfill=true so first-poll backfill items don't surface as
             "new intelligence". Set to True to surface older / evergreen items
             explicitly. See issue #444.
+          - expand_graph (bool, optional, default=False): When true, expand the seed
+            result set via ``entry_relations`` and merge the neighbours into the
+            results.
+          - expand_hops (int, optional, default=1): Depth of graph expansion when
+            ``expand_graph=true``.  Must be 1 or 2.
 
-        RETURNS (success): { results: [{ score: float, entry: {...} }], count: int }
+        RETURNS (success): { results: [{ score: float, entry: {...} }], count: int }.
+          When ``expand_graph=true`` each result also has ``provenance`` ("search" or
+          "graph"); graph results additionally carry ``depth`` and ``parent_id``, and
+          the envelope includes ``graph_expansion: { seed_count, expanded_count }``.
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
 
         RELATED: distillery_list (for filter-based browsing without semantic ranking),
@@ -827,6 +847,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             limit=limit,
             include_archived=include_archived,
             include_evergreen=include_evergreen,
+            expand_graph=expand_graph,
+            expand_hops=expand_hops,
             **_omit_none(
                 entry_type=entry_type,
                 author=author,

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -48,17 +48,29 @@ async def _handle_search(
     logs the search to ``search_log`` for later implicit-feedback correlation via
     ``_handle_get``; failures to log do not affect the returned results.
 
+    When ``expand_graph=True`` is passed, after the semantic-search seed set is computed
+    a BFS expansion via ``store.get_related`` collects 1- or 2-hop neighbours, fetches
+    their entries, scores them with a ``0.5 ** depth`` discount of the parent score, and
+    merges them into a single result list sorted by descending score and capped at
+    ``limit``.  Each result then carries a ``provenance`` flag (``"search"`` or
+    ``"graph"``) and graph entries additionally carry ``depth`` and ``parent_id``.  The
+    response envelope gains a ``graph_expansion`` summary (``seed_count``,
+    ``expanded_count``).  When ``expand_graph=False`` (default) the existing behaviour
+    and envelope are unchanged.
+
     Parameters:
         store: Initialised :class:`~distillery.store.duckdb.DuckDBStore`.
         arguments: Dictionary containing at minimum the key `query` (str). May include
             optional filter keys (e.g., `entry_type`, `author`, `project`, `tags`,
-            `status`, `date_from`, `date_to`) and `limit` (int).
+            `status`, `date_from`, `date_to`), `limit` (int), and the additive
+            graph-expansion params `expand_graph` (bool) and `expand_hops` (int, 1 or 2).
         cfg: Optional configuration used to enforce embedding budget.
 
     Returns:
         MCP content list containing a single JSON object with `results` (list of objects
         each with `score` and `entry`) and `count` (int) describing the number of results
-        returned.
+        returned.  When ``expand_graph=True`` results also include ``provenance`` and the
+        envelope includes a ``graph_expansion`` field.
     """
     from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
 
@@ -72,6 +84,19 @@ async def _handle_search(
     if isinstance(limit_result, tuple):
         return error_response(*limit_result)
     limit = limit_result
+
+    # --- graph expansion params (validated BEFORE embedding budget) ---------
+    expand_graph: bool = bool(arguments.get("expand_graph", False))
+    expand_hops_raw: Any = arguments.get("expand_hops", 1)
+    # Reject bool explicitly: ``bool`` is a subclass of ``int`` in Python and we
+    # want to surface a clear error rather than silently coercing True/False.
+    if isinstance(expand_hops_raw, bool):
+        return error_response("INVALID_PARAMS", "expand_hops must be an integer")
+    if not isinstance(expand_hops_raw, int):
+        return error_response("INVALID_PARAMS", "expand_hops must be an integer")
+    expand_hops: int = expand_hops_raw
+    if expand_hops not in (1, 2):
+        return error_response("INVALID_PARAMS", "expand_hops must be 1 or 2")
 
     # --- embedding budget check (1 embed call per search) -------------------
     if cfg is not None:
@@ -104,9 +129,39 @@ async def _handle_search(
         logger.exception("Error in distillery_search")
         return error_response("INTERNAL", "Search failed")
 
-    results = [{"score": round(sr.score, 6), "entry": sr.entry.to_dict()} for sr in search_results]
+    if not expand_graph:
+        results = [
+            {"score": round(sr.score, 6), "entry": sr.entry.to_dict()} for sr in search_results
+        ]
 
-    # Log the search event to search_log for later implicit-feedback correlation.
+        # Log the search event to search_log for later implicit-feedback correlation.
+        search_logging = cfg is None or cfg.rate_limit.search_logging_enabled
+        if search_results and search_logging:
+            result_entry_ids = [sr.entry.id for sr in search_results]
+            result_scores = [sr.score for sr in search_results]
+            try:
+                await store.log_search(
+                    query=query,
+                    result_entry_ids=result_entry_ids,
+                    result_scores=result_scores,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to log search event; continuing without feedback tracking")
+
+        return success_response({"results": results, "count": len(results)})
+
+    # ------------------------------------------------------------------
+    # Graph expansion path (additive — only when expand_graph=True).
+    # ------------------------------------------------------------------
+    try:
+        merged_results, seed_count, expanded_count = await _expand_search_with_graph(
+            store, search_results, expand_hops, limit
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Error during graph expansion in distillery_search")
+        return error_response("INTERNAL", "Graph expansion failed")
+
+    # Log the seed search event (mirrors non-expand path).
     search_logging = cfg is None or cfg.rate_limit.search_logging_enabled
     if search_results and search_logging:
         result_entry_ids = [sr.entry.id for sr in search_results]
@@ -120,7 +175,101 @@ async def _handle_search(
         except Exception:  # noqa: BLE001
             logger.exception("Failed to log search event; continuing without feedback tracking")
 
-    return success_response({"results": results, "count": len(results)})
+    return success_response(
+        {
+            "results": merged_results,
+            "count": len(merged_results),
+            "graph_expansion": {
+                "seed_count": seed_count,
+                "expanded_count": expanded_count,
+            },
+        }
+    )
+
+
+async def _expand_search_with_graph(
+    store: Any,
+    search_results: list[Any],
+    expand_hops: int,
+    limit: int,
+) -> tuple[list[dict[str, Any]], int, int]:
+    """BFS-expand the seed search results via ``store.get_related``.
+
+    Returns ``(merged_results, seed_count, expanded_count)`` where
+    ``merged_results`` is a list of result dicts already sorted by descending
+    score and truncated to ``limit``.  Each dict carries a ``provenance``
+    field; graph-only entries also carry ``depth`` and ``parent_id``.
+    """
+    seed_ids: set[str] = {sr.entry.id for sr in search_results}
+    seed_score_by_id: dict[str, float] = {sr.entry.id: float(sr.score) for sr in search_results}
+
+    # Collected expansion entries keyed by id so we never duplicate one entry
+    # across hops (closer hops always win because we visit depth=1 before
+    # depth=2).
+    expanded: dict[str, dict[str, Any]] = {}
+
+    # depth-1 neighbours
+    depth1_score_by_id: dict[str, float] = {}
+    for sr in search_results:
+        seed_id = sr.entry.id
+        relations = await store.get_related(seed_id, direction="both")
+        for rel in relations:
+            other_id = rel["to_id"] if rel["from_id"] == seed_id else rel["from_id"]
+            if other_id in seed_ids or other_id in expanded:
+                continue
+            score = seed_score_by_id[seed_id] * 0.5
+            expanded[other_id] = {
+                "_score": score,
+                "_depth": 1,
+                "_parent_id": seed_id,
+            }
+            depth1_score_by_id[other_id] = score
+
+    # depth-2 neighbours (only when requested)
+    if expand_hops == 2:
+        for parent_id, parent_score in list(depth1_score_by_id.items()):
+            relations = await store.get_related(parent_id, direction="both")
+            for rel in relations:
+                other_id = rel["to_id"] if rel["from_id"] == parent_id else rel["from_id"]
+                if other_id in seed_ids or other_id in expanded:
+                    continue
+                score = parent_score * 0.5
+                expanded[other_id] = {
+                    "_score": score,
+                    "_depth": 2,
+                    "_parent_id": parent_id,
+                }
+
+    # Fetch entries for all expanded ids; skip any that have been deleted.
+    expanded_results: list[dict[str, Any]] = []
+    for entry_id, info in expanded.items():
+        entry = await store.get(entry_id)
+        if entry is None:
+            continue
+        expanded_results.append(
+            {
+                "score": round(info["_score"], 6),
+                "entry": entry.to_dict(),
+                "provenance": "graph",
+                "depth": info["_depth"],
+                "parent_id": info["_parent_id"],
+            }
+        )
+
+    seed_dicts: list[dict[str, Any]] = [
+        {
+            "score": round(sr.score, 6),
+            "entry": sr.entry.to_dict(),
+            "provenance": "search",
+        }
+        for sr in search_results
+    ]
+
+    merged: list[dict[str, Any]] = sorted(
+        seed_dicts + expanded_results, key=lambda r: r["score"], reverse=True
+    )[:limit]
+
+    return merged, len(seed_dicts), len(expanded_results)
 
 
 # ---------------------------------------------------------------------------

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -153,9 +153,15 @@ async def _handle_search(
     # ------------------------------------------------------------------
     # Graph expansion path (additive — only when expand_graph=True).
     # ------------------------------------------------------------------
+    # Derive the status visibility contract that was applied to the seed
+    # search so we can apply the same contract to BFS-expanded neighbours.
+    # ``filters`` here is the post-``_apply_default_status_filter`` dict —
+    # if it carries a ``status`` key, that is the allow-list (string or
+    # list of strings).  Absence of ``status`` means "any status is ok".
+    allowed_statuses: set[str] | None = _allowed_statuses_from_filters(filters)
     try:
         merged_results, seed_count, expanded_count = await _expand_search_with_graph(
-            store, search_results, expand_hops, limit
+            store, search_results, expand_hops, limit, allowed_statuses
         )
     except Exception:  # noqa: BLE001
         logger.exception("Error during graph expansion in distillery_search")
@@ -187,11 +193,32 @@ async def _handle_search(
     )
 
 
+def _allowed_statuses_from_filters(
+    filters: dict[str, Any] | None,
+) -> set[str] | None:
+    """Return the set of status strings allowed by the seed search filter.
+
+    Returns ``None`` when no status filter is present (i.e. all statuses are
+    allowed — the caller passed ``include_archived=True`` or
+    ``status="any"``).  Otherwise returns a set of status strings (e.g.
+    ``{"active", "pending_review"}``) that the seed search would have
+    surfaced; expanded BFS neighbours must be filtered to this set so graph
+    expansion does not leak entries the seed search would have hidden.
+    """
+    if filters is None or "status" not in filters:
+        return None
+    status_value = filters["status"]
+    if isinstance(status_value, list):
+        return {str(v) for v in status_value}
+    return {str(status_value)}
+
+
 async def _expand_search_with_graph(
     store: Any,
     search_results: list[Any],
     expand_hops: int,
     limit: int,
+    allowed_statuses: set[str] | None = None,
 ) -> tuple[list[dict[str, Any]], int, int]:
     """BFS-expand the seed search results via ``store.get_related``.
 
@@ -199,6 +226,13 @@ async def _expand_search_with_graph(
     ``merged_results`` is a list of result dicts already sorted by descending
     score and truncated to ``limit``.  Each dict carries a ``provenance``
     field; graph-only entries also carry ``depth`` and ``parent_id``.
+
+    ``allowed_statuses`` mirrors the status-visibility contract that the
+    seed ``store.search`` call applied.  When provided, BFS-expanded
+    neighbours whose ``status`` is not in this set are dropped before the
+    merge — preventing archived (or otherwise-filtered) entries from
+    leaking into the result via graph expansion.  When ``None`` no
+    status-based filtering is applied to expanded entries.
     """
     seed_ids: set[str] = {sr.entry.id for sr in search_results}
     seed_score_by_id: dict[str, float] = {sr.entry.id: float(sr.score) for sr in search_results}
@@ -240,11 +274,17 @@ async def _expand_search_with_graph(
                     "_parent_id": parent_id,
                 }
 
-    # Fetch entries for all expanded ids; skip any that have been deleted.
+    # Fetch entries for all expanded ids; skip any that have been deleted
+    # or whose status would have been filtered out by the seed search.
     expanded_results: list[dict[str, Any]] = []
     for entry_id, info in expanded.items():
         entry = await store.get(entry_id)
         if entry is None:
+            continue
+        if allowed_statuses is not None and str(entry.status) not in allowed_statuses:
+            # The seed search would have hidden this status; honour the same
+            # contract for graph-expanded neighbours so archived (or other
+            # filtered) entries never leak in via BFS.
             continue
         expanded_results.append(
             {

--- a/tests/test_mcp_tools/test_search_expand_graph.py
+++ b/tests/test_mcp_tools/test_search_expand_graph.py
@@ -17,7 +17,7 @@ import pytest
 
 from distillery.config import DistilleryConfig, load_config
 from distillery.mcp.tools.search import _handle_search
-from distillery.models import EntryType
+from distillery.models import EntryStatus, EntryType
 from distillery.store.duckdb import DuckDBStore
 from tests.conftest import ControlledEmbeddingProvider, make_entry, parse_mcp_response
 
@@ -447,3 +447,109 @@ async def test_expand_graph_handles_seed_with_no_relations(
     assert data["graph_expansion"]["expanded_count"] == 0
     assert data["graph_expansion"]["seed_count"] >= 1
     assert _ids_with_provenance(data["results"], "graph") == set()
+
+
+# ===========================================================================
+# Status-visibility contract: archived neighbours are filtered out by default
+# (CodeRabbit finding on PR #425).  Graph expansion must honour the same
+# archived-visibility contract that the seed ``store.search`` call applied —
+# otherwise ``expand_graph=true`` silently leaks ARCHIVED entries that the
+# default search contract hides.
+# ===========================================================================
+
+
+async def test_expand_graph_excludes_archived_neighbours_by_default(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """A (active) matches the search; B (archived) is related to A.
+
+    Default search hides archived entries, so graph expansion must not leak
+    B into the result list.  Asserts: A present, B absent.
+    """
+    embedding_provider.register("archived seed a", _UNIT_A)
+    embedding_provider.register("archived query", _UNIT_A)
+    embedding_provider.register("archived neighbour b", _UNIT_B)
+
+    a = make_entry(
+        content="archived seed a",
+        entry_type=EntryType.INBOX,
+        tags=["seed"],
+        status=EntryStatus.ACTIVE,
+    )
+    await store.store(a)
+    b = make_entry(
+        content="archived neighbour b",
+        entry_type=EntryType.INBOX,
+        tags=["neighbour"],
+        status=EntryStatus.ARCHIVED,
+    )
+    await store.store(b)
+    await store.add_relation(a.id, b.id, "link")
+
+    response = await _handle_search(
+        store,
+        {
+            "query": "archived query",
+            "tags": ["seed"],
+            "expand_graph": True,
+            "expand_hops": 1,
+        },
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+
+    result_ids = {r["entry"]["id"] for r in data["results"]}
+    assert a.id in result_ids
+    assert b.id not in result_ids
+    # The archived neighbour must not show up under graph provenance either.
+    assert b.id not in _ids_with_provenance(data["results"], "graph")
+    # ``expanded_count`` reflects entries actually included after the
+    # status filter, not raw BFS visitation count.
+    assert data["graph_expansion"]["expanded_count"] == 0
+
+
+async def test_expand_graph_includes_archived_when_include_archived_true(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """Inverse of the above: when the caller explicitly passes
+    ``include_archived=True`` the seed search returns archived entries, so
+    graph expansion must also include archived neighbours."""
+    embedding_provider.register("ia seed a", _UNIT_A)
+    embedding_provider.register("ia query", _UNIT_A)
+    embedding_provider.register("ia neighbour b", _UNIT_B)
+
+    a = make_entry(
+        content="ia seed a",
+        entry_type=EntryType.INBOX,
+        tags=["seed"],
+        status=EntryStatus.ACTIVE,
+    )
+    await store.store(a)
+    b = make_entry(
+        content="ia neighbour b",
+        entry_type=EntryType.INBOX,
+        tags=["neighbour"],
+        status=EntryStatus.ARCHIVED,
+    )
+    await store.store(b)
+    await store.add_relation(a.id, b.id, "link")
+
+    response = await _handle_search(
+        store,
+        {
+            "query": "ia query",
+            "tags": ["seed"],
+            "expand_graph": True,
+            "expand_hops": 1,
+            "include_archived": True,
+        },
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+
+    graph_ids = _ids_with_provenance(data["results"], "graph")
+    assert b.id in graph_ids

--- a/tests/test_mcp_tools/test_search_expand_graph.py
+++ b/tests/test_mcp_tools/test_search_expand_graph.py
@@ -1,0 +1,449 @@
+"""Tests for _handle_search graph-expansion parameters (Phase 4 / #138).
+
+Tests cover the new optional parameters added to _handle_search:
+  - expand_graph: bool — when True, BFS-expand seeds via entry_relations
+  - expand_hops: int — depth of expansion (1 or 2)
+
+When ``expand_graph=False`` (default) the existing envelope is unchanged —
+no ``provenance`` field on results, no ``graph_expansion`` on the envelope.
+
+Mirrors fixture patterns from ``tests/test_find_similar_extended.py``:
+ControlledEmbeddingProvider with 8-D unit vectors plus an in-memory store.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.config import DistilleryConfig, load_config
+from distillery.mcp.tools.search import _handle_search
+from distillery.models import EntryType
+from distillery.store.duckdb import DuckDBStore
+from tests.conftest import ControlledEmbeddingProvider, make_entry, parse_mcp_response
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Unit vectors for deterministic similarity
+# ---------------------------------------------------------------------------
+
+_UNIT_A = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+_UNIT_B = [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def embedding_provider(
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> ControlledEmbeddingProvider:
+    return controlled_embedding_provider
+
+
+@pytest.fixture
+async def store(embedding_provider: ControlledEmbeddingProvider) -> DuckDBStore:  # type: ignore[return]
+    s = DuckDBStore(db_path=":memory:", embedding_provider=embedding_provider)
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+@pytest.fixture
+def cfg() -> DistilleryConfig:
+    """Return a DistilleryConfig with default settings."""
+    return load_config()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _store_entry(
+    store: DuckDBStore,
+    content: str,
+    *,
+    tags: list[str] | None = None,
+) -> str:
+    """Store an entry (always ``EntryType.INBOX``) and return its id.
+
+    Tests use the ``tags`` filter on ``store.search`` to constrain the seed
+    set so we can verify graph expansion in isolation.
+    """
+    kwargs: dict = {"content": content, "entry_type": EntryType.INBOX}
+    if tags is not None:
+        kwargs["tags"] = tags
+    entry = make_entry(**kwargs)
+    await store.store(entry)
+    return entry.id
+
+
+def _ids_with_provenance(results: list, provenance: str) -> set[str]:
+    """Return the set of entry ids whose result dict has the given provenance."""
+    return {r["entry"]["id"] for r in results if r.get("provenance") == provenance}
+
+
+# ===========================================================================
+# Baseline: expand_graph=False keeps the existing envelope unchanged
+# ===========================================================================
+
+
+async def test_expand_graph_false_unchanged(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """With expand_graph omitted/False, the response envelope must NOT contain
+    ``graph_expansion`` and individual results must NOT carry ``provenance``."""
+    embedding_provider.register("seed entry x", _UNIT_A)
+    embedding_provider.register("x", _UNIT_A)
+    await _store_entry(store, "seed entry x")
+
+    response = await _handle_search(store, {"query": "x"}, cfg=cfg)
+    data = parse_mcp_response(response)
+
+    assert "graph_expansion" not in data
+    assert "results" in data
+    for r in data["results"]:
+        assert "provenance" not in r
+        assert "depth" not in r
+        assert "parent_id" not in r
+
+
+# ===========================================================================
+# 1-hop expansion
+# ===========================================================================
+
+
+async def test_expand_graph_one_hop(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """A matches the search query; B is related to A but is filtered out
+    of the seed set.  With expand_graph=True, expand_hops=1 the response
+    must include B at provenance="graph", depth=1, parent_id=A.id.
+
+    Note: ``store.search`` is unthresholded — every stored entry is a
+    candidate.  We isolate B from the seed set by giving it a different
+    ``entry_type`` and filtering the search to ``entry_type="inbox"``.
+    Graph expansion uses ``get_related`` which has no such filter, so B is
+    pulled in purely through the relation.
+    """
+    embedding_provider.register("seed match a", _UNIT_A)
+    embedding_provider.register("query a", _UNIT_A)
+    embedding_provider.register("unrelated text b", _UNIT_B)
+
+    a_id = await _store_entry(store, "seed match a", tags=["seed"])
+    b_id = await _store_entry(store, "unrelated text b", tags=["neighbour"])
+    await store.add_relation(a_id, b_id, "link")
+
+    response = await _handle_search(
+        store,
+        {
+            "query": "query a",
+            "tags": ["seed"],
+            "expand_graph": True,
+            "expand_hops": 1,
+        },
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+
+    assert "graph_expansion" in data
+    search_ids = _ids_with_provenance(data["results"], "search")
+    graph_ids = _ids_with_provenance(data["results"], "graph")
+
+    assert a_id in search_ids
+    assert b_id in graph_ids
+
+    b_result = next(r for r in data["results"] if r["entry"]["id"] == b_id)
+    assert b_result["depth"] == 1
+    assert b_result["parent_id"] == a_id
+
+
+# ===========================================================================
+# 2-hop expansion
+# ===========================================================================
+
+
+async def test_expand_graph_two_hops(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """A→B→C chain. Only A is in the seed set (entry_type filter); C is
+    reachable purely through 2-hop graph expansion."""
+    embedding_provider.register("chain seed a", _UNIT_A)
+    embedding_provider.register("chain query a", _UNIT_A)
+    embedding_provider.register("hop b", _UNIT_B)
+    embedding_provider.register("hop c", [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+    a_id = await _store_entry(store, "chain seed a", tags=["seed"])
+    b_id = await _store_entry(store, "hop b", tags=["neighbour"])
+    c_id = await _store_entry(store, "hop c", tags=["neighbour"])
+    await store.add_relation(a_id, b_id, "link")
+    await store.add_relation(b_id, c_id, "link")
+
+    response = await _handle_search(
+        store,
+        {
+            "query": "chain query a",
+            "tags": ["seed"],
+            "expand_graph": True,
+            "expand_hops": 2,
+        },
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+
+    graph_ids = _ids_with_provenance(data["results"], "graph")
+    assert c_id in graph_ids
+
+    c_result = next(r for r in data["results"] if r["entry"]["id"] == c_id)
+    assert c_result["depth"] == 2
+    assert c_result["parent_id"] == b_id
+
+
+# ===========================================================================
+# No duplicates between seeds and graph expansion
+# ===========================================================================
+
+
+async def test_expand_graph_does_not_duplicate_entries_already_in_seeds(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """Both A and B match the search; A is linked to B. B must appear once
+    (provenance="search"), never duplicated as a graph entry."""
+    embedding_provider.register("dup seed a", _UNIT_A)
+    embedding_provider.register("dup seed b", _UNIT_A)
+    embedding_provider.register("dup query", _UNIT_A)
+
+    a_id = await _store_entry(store, "dup seed a")
+    b_id = await _store_entry(store, "dup seed b")
+    await store.add_relation(a_id, b_id, "link")
+
+    response = await _handle_search(
+        store,
+        {"query": "dup query", "expand_graph": True, "expand_hops": 1, "limit": 10},
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+
+    # B should appear exactly once, with provenance="search".
+    b_results = [r for r in data["results"] if r["entry"]["id"] == b_id]
+    assert len(b_results) == 1
+    assert b_results[0]["provenance"] == "search"
+    # And B must not also appear as a graph entry.
+    assert b_id not in _ids_with_provenance(data["results"], "graph")
+
+
+# ===========================================================================
+# Final result list respects ``limit``
+# ===========================================================================
+
+
+async def test_expand_graph_respects_limit(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """With many seeds + many neighbours and limit=5, the merged result list
+    must be truncated to 5 entries (sorted by descending score).
+
+    Seeds carry tag ``"seed"`` and the search filters on it; neighbours
+    carry tag ``"neighbour"`` and only enter the result list via graph
+    expansion.
+    """
+    embedding_provider.register("limit query", _UNIT_A)
+
+    seed_ids: list[str] = []
+    for i in range(4):
+        text = f"limit seed {i}"
+        embedding_provider.register(text, _UNIT_A)
+        seed_ids.append(await _store_entry(store, text, tags=["seed"]))
+
+    # 12 unique neighbours; not in the seed set because of the tags filter.
+    neighbour_ids: list[str] = []
+    for i in range(12):
+        text = f"limit neighbour {i}"
+        embedding_provider.register(text, _UNIT_B)
+        neighbour_ids.append(await _store_entry(store, text, tags=["neighbour"]))
+
+    # Wire each seed to 3 distinct neighbours.
+    idx = 0
+    for s_id in seed_ids:
+        for _ in range(3):
+            await store.add_relation(s_id, neighbour_ids[idx], "link")
+            idx += 1
+
+    response = await _handle_search(
+        store,
+        {
+            "query": "limit query",
+            "tags": ["seed"],
+            "expand_graph": True,
+            "expand_hops": 1,
+            "limit": 5,
+        },
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+
+    assert len(data["results"]) <= 5
+    assert data["count"] == len(data["results"])
+    # results must be sorted by descending score
+    scores = [r["score"] for r in data["results"]]
+    assert scores == sorted(scores, reverse=True)
+    # We had 4 seeds + 12 candidate graph entries; limit must truncate.
+    assert data["graph_expansion"]["seed_count"] == 4
+    assert data["graph_expansion"]["expanded_count"] == 12
+
+
+# ===========================================================================
+# Score discount: depth-1 neighbour gets parent_score * 0.5
+# ===========================================================================
+
+
+async def test_expand_graph_score_discount(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """A neighbour at depth=1 receives a score equal to parent_score * 0.5."""
+    embedding_provider.register("discount seed", _UNIT_A)
+    embedding_provider.register("discount query", _UNIT_A)
+    embedding_provider.register("discount neighbour", _UNIT_B)
+
+    a_id = await _store_entry(store, "discount seed", tags=["seed"])
+    b_id = await _store_entry(store, "discount neighbour", tags=["neighbour"])
+    await store.add_relation(a_id, b_id, "link")
+
+    response = await _handle_search(
+        store,
+        {
+            "query": "discount query",
+            "tags": ["seed"],
+            "expand_graph": True,
+            "expand_hops": 1,
+        },
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+
+    a_result = next(r for r in data["results"] if r["entry"]["id"] == a_id)
+    b_result = next(r for r in data["results"] if r["entry"]["id"] == b_id)
+
+    assert a_result["provenance"] == "search"
+    assert b_result["provenance"] == "graph"
+    # The seed score is rounded to 6 decimals in the response; the discount
+    # is applied to the un-rounded raw score in the handler, so allow a
+    # small tolerance via pytest.approx.
+    assert b_result["score"] == pytest.approx(a_result["score"] * 0.5, abs=1e-6)
+
+
+# ===========================================================================
+# Validation: invalid expand_hops
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("bad_value", "expected_msg"),
+    [
+        (0, "expand_hops must be 1 or 2"),
+        (3, "expand_hops must be 1 or 2"),
+        (True, "expand_hops must be an integer"),
+    ],
+)
+async def test_invalid_expand_hops_returns_invalid_params(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+    bad_value: object,
+    expected_msg: str,
+) -> None:
+    """expand_hops out of [1, 2] (or a bool) must surface INVALID_PARAMS."""
+    embedding_provider.register("invalid hops", _UNIT_A)
+    response = await _handle_search(
+        store,
+        {"query": "invalid hops", "expand_graph": True, "expand_hops": bad_value},
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+    assert data.get("error") is True
+    assert data["code"] == "INVALID_PARAMS"
+    assert expected_msg in data["message"]
+
+
+# ===========================================================================
+# Envelope shape: graph_expansion summary
+# ===========================================================================
+
+
+async def test_graph_expansion_field_in_envelope(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """When expand_graph=True the envelope must contain
+    ``graph_expansion: {seed_count, expanded_count}``."""
+    embedding_provider.register("envelope seed", _UNIT_A)
+    embedding_provider.register("envelope query", _UNIT_A)
+    embedding_provider.register("envelope neighbour", _UNIT_B)
+
+    a_id = await _store_entry(store, "envelope seed", tags=["seed"])
+    b_id = await _store_entry(store, "envelope neighbour", tags=["neighbour"])
+    await store.add_relation(a_id, b_id, "link")
+
+    response = await _handle_search(
+        store,
+        {
+            "query": "envelope query",
+            "tags": ["seed"],
+            "expand_graph": True,
+            "expand_hops": 1,
+        },
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+
+    assert "graph_expansion" in data
+    ge = data["graph_expansion"]
+    assert isinstance(ge.get("seed_count"), int)
+    assert isinstance(ge.get("expanded_count"), int)
+    assert ge["seed_count"] >= 1
+    assert ge["expanded_count"] >= 1
+    assert b_id in _ids_with_provenance(data["results"], "graph")
+
+
+# ===========================================================================
+# No relations: expansion silently produces zero extras
+# ===========================================================================
+
+
+async def test_expand_graph_handles_seed_with_no_relations(
+    store: DuckDBStore,
+    embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """When the seed set has no entry_relations rows, expansion silently
+    produces zero extras and the envelope reports ``expanded_count: 0``."""
+    embedding_provider.register("orphan seed", _UNIT_A)
+    embedding_provider.register("orphan query", _UNIT_A)
+    await _store_entry(store, "orphan seed")
+
+    response = await _handle_search(
+        store,
+        {"query": "orphan query", "expand_graph": True, "expand_hops": 2},
+        cfg=cfg,
+    )
+    data = parse_mcp_response(response)
+
+    assert data["graph_expansion"]["expanded_count"] == 0
+    assert data["graph_expansion"]["seed_count"] >= 1
+    assert _ids_with_provenance(data["results"], "graph") == set()


### PR DESCRIPTION
## Summary

Adds graph-expanded retrieval as additive params on the existing `distillery_search` tool. After the semantic-search seed set, BFS over `entry_relations` pulls in 1- or 2-hop neighbours; results merge with `provenance` (`"search"` vs `"graph"`), `depth`, and `parent_id`. Score discount of 0.5 per hop.

Conforms to v0.4.0 stability pledge — no breaking changes, envelope unchanged unless `expand_graph=true`. When set, adds `graph_expansion: {seed_count, expanded_count}` to the response.

This unblocks `/pour --graph` (Phase 4 of the graph plan).

## Plan

Phase 4 of `/Users/norrie/.claude/plans/review-all-open-issue-luminous-treehouse.md`.

## Test plan

- [x] 11 new unit tests in `tests/test_mcp_tools/test_search_expand_graph.py`
- [x] Existing `test_find_similar_extended.py` (25 tests) unchanged
- [x] 275-test broader regression sweep across MCP tools / feedback / list / tags / coverage / relations — green
- [x] `ruff check`, `ruff format --check`, `mypy --strict` clean

## Notes

`expand_hops` validation rejects bool (since bool is int subclass) and is checked BEFORE the embedding-budget check — no point spending budget on invalid input.

Closes part of #138.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results can now be expanded to show related entries via graph traversal
  * New optional parameters control whether expansion is enabled and the depth of relationships to explore (1-2 levels)
  * Results include metadata indicating whether entries came from the initial search or from expansion
  * Score adjustments applied to expanded entries based on their distance from search results

* **Tests**
  * Added comprehensive test coverage for the new graph expansion functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->