### PR TITLE
feat(mcp): add action="metrics" to distillery_relations + [graph] extra (#138, #141)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ docs = [
     "mkdocs-material>=9.5",
 ]
 eval = []
+graph = [
+    "networkx>=3.2,<4.0",
+]
 ragas = [
     "ragas>=0.2.0",
     "datasets>=2.14.0",
@@ -105,6 +108,16 @@ module = [
     "ragas.*",
     "datasets",
     "datasets.*",
+]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# NetworkX is gated behind the optional [graph] extra and ships without
+# bundled stubs in the supported version range. Treat its imports as
+# untyped — the graph package keeps a typed surface around them.
+module = [
+    "networkx",
+    "networkx.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ docs = [
     "mkdocs-material>=9.5",
 ]
 eval = []
+graph = [
+    "networkx>=3.2,<4.0",
+]
 ragas = [
     "ragas>=0.2.0",
     "datasets>=2.14.0",
@@ -124,6 +127,16 @@ ignore_missing_imports = true
 # import in the TYPE_CHECKING block — silence missing-import noise when the
 # package is not installed in the dev environment.
 module = ["fastembed", "fastembed.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# NetworkX is gated behind the optional [graph] extra and ships without
+# bundled stubs in the supported version range. Treat its imports as
+# untyped — the graph package keeps a typed surface around them.
+module = [
+    "networkx",
+    "networkx.*",
+]
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/src/distillery/graph/__init__.py
+++ b/src/distillery/graph/__init__.py
@@ -1,0 +1,15 @@
+"""Graph analysis module — gated behind the [graph] optional extra."""
+
+from __future__ import annotations
+
+try:
+    import networkx as nx
+except ImportError:
+    nx = None
+
+__all__ = ["is_available", "nx"]
+
+
+def is_available() -> bool:
+    """Return True if networkx is installed."""
+    return nx is not None

--- a/src/distillery/graph/builders.py
+++ b/src/distillery/graph/builders.py
@@ -1,0 +1,36 @@
+"""Build NetworkX graphs from Distillery store data.
+
+These builders are *lazy*: they import nx via distillery.graph and raise a
+RuntimeError with installation guidance when the extra is not installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from distillery.graph import nx
+
+if TYPE_CHECKING:
+    import networkx as nx_types  # noqa: F401
+
+
+def _require_networkx() -> None:
+    if nx is None:
+        raise RuntimeError("NetworkX not installed; run: pip install distillery-mcp[graph]")
+
+
+def build_relations_graph(
+    relations: list[dict[str, Any]],
+    *,
+    directed: bool = True,
+) -> Any:  # nx.DiGraph | nx.Graph
+    """Build a graph from entry_relations rows.
+
+    Each row is expected to be ``{"from_id": str, "to_id": str, "relation_type": str}``.
+    The edge attribute ``relation_type`` is preserved.
+    """
+    _require_networkx()
+    g = nx.DiGraph() if directed else nx.Graph()
+    for r in relations:
+        g.add_edge(r["from_id"], r["to_id"], relation_type=r["relation_type"])
+    return g

--- a/src/distillery/graph/cache.py
+++ b/src/distillery/graph/cache.py
@@ -7,24 +7,39 @@ from typing import Any
 
 
 class TTLCache:
-    """Simple time-to-live cache keyed by string."""
+    """Simple time-to-live cache keyed by string.
+
+    Uses ``time.monotonic()`` to avoid wall-clock jumps and proactively evicts
+    expired entries on every ``get()`` and ``set()`` so high-cardinality
+    one-off keys do not accumulate forever (CodeRabbit, PR #426).
+    """
 
     def __init__(self, ttl_seconds: int = 300) -> None:
         self._ttl = ttl_seconds
         self._store: dict[str, tuple[float, Any]] = {}
 
+    def _evict_expired(self, now: float) -> None:
+        """Drop every entry whose timestamp is older than the TTL."""
+        expired = [k for k, (ts, _) in self._store.items() if now - ts > self._ttl]
+        for k in expired:
+            self._store.pop(k, None)
+
     def get(self, key: str) -> Any | None:
+        now = time.monotonic()
+        self._evict_expired(now)
         entry = self._store.get(key)
         if entry is None:
             return None
         ts, value = entry
-        if time.time() - ts > self._ttl:
+        if now - ts > self._ttl:
             self._store.pop(key, None)
             return None
         return value
 
     def set(self, key: str, value: Any) -> None:
-        self._store[key] = (time.time(), value)
+        now = time.monotonic()
+        self._evict_expired(now)
+        self._store[key] = (now, value)
 
 
 _default_cache = TTLCache(ttl_seconds=300)

--- a/src/distillery/graph/cache.py
+++ b/src/distillery/graph/cache.py
@@ -1,0 +1,34 @@
+"""Tiny TTL cache for graph builds."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+class TTLCache:
+    """Simple time-to-live cache keyed by string."""
+
+    def __init__(self, ttl_seconds: int = 300) -> None:
+        self._ttl = ttl_seconds
+        self._store: dict[str, tuple[float, Any]] = {}
+
+    def get(self, key: str) -> Any | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        ts, value = entry
+        if time.time() - ts > self._ttl:
+            self._store.pop(key, None)
+            return None
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = (time.time(), value)
+
+
+_default_cache = TTLCache(ttl_seconds=300)
+
+
+def default_cache() -> TTLCache:
+    return _default_cache

--- a/src/distillery/graph/metrics.py
+++ b/src/distillery/graph/metrics.py
@@ -1,0 +1,27 @@
+"""Graph metrics over relations subgraphs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from distillery.graph import nx
+from distillery.graph.builders import _require_networkx
+
+
+def bridges(g: Any, *, k: int = 10) -> list[tuple[str, float]]:
+    """Top-k entries by betweenness centrality (descending)."""
+    _require_networkx()
+    if g.number_of_nodes() == 0:
+        return []
+    centrality = nx.betweenness_centrality(g)
+    ranked = sorted(centrality.items(), key=lambda kv: kv[1], reverse=True)
+    return ranked[:k]
+
+
+def communities(g: Any) -> list[set[str]]:
+    """Louvain communities on the undirected projection."""
+    _require_networkx()
+    if g.number_of_nodes() == 0:
+        return []
+    undirected = g.to_undirected() if g.is_directed() else g
+    return list(nx.community.louvain_communities(undirected))

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1051,33 +1051,52 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         direction: str = "both",
         relation_id: str | None = None,
         hops: int = 2,
+        metric: str | None = None,
+        scope: str = "global",
+        limit: int = 10,
+        project: str | None = None,
+        tags: list[str] | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
     ) -> list[types.TextContent]:
         """Manage typed relations between knowledge entries.
 
         USE WHEN: linking entries together (e.g. marking one as blocking another,
-        citing a reference, or flagging duplicates), or walking the relation
-        graph from a seed entry to surface multi-hop neighbours.
+        citing a reference, or flagging duplicates), walking the relation
+        graph from a seed entry to surface multi-hop neighbours, or computing
+        graph metrics (bridges, communities) on the relations subgraph.
 
         PARAMS:
-          - action (str, required): Operation. Valid: [add, get, remove, traverse].
+          - action (str, required): Operation. Valid: [add, get, remove, traverse, metrics].
           - from_id (str, required for add): Source entry UUID.
           - to_id (str, required for add): Target entry UUID.
           - relation_type (str, required for add, optional for get/traverse): Relation type.
             Valid: [link, corrects, supersedes, related, blocks, depends_on, citation,
             duplicate, merge_source, sync_source].
-          - entry_id (str, required for get/traverse): Entry UUID to query relations for
-            (BFS root for traverse).
+          - entry_id (str, required for get/traverse, required for metrics scope='ego'):
+            Entry UUID to query relations for (BFS root for traverse / ego-graph).
           - direction (str, optional for get/traverse, default="both"): Filter direction.
             Valid: [outgoing, incoming, both].
           - relation_id (str, required for remove): UUID of the relation to delete.
           - hops (int, optional for traverse, default=2): BFS depth, capped at [1, 3].
+          - metric (str, required for metrics): Graph metric to compute.
+            Valid: [bridges, communities]. Requires the [graph] optional extra.
+          - scope (str, optional for metrics, default="global"): Subgraph scope.
+            Valid: [global, ego]. ``"ego"`` requires ``entry_id``.
+          - limit (int, optional for metrics, default=10): For ``metric="bridges"``
+            returns the top-k entries by betweenness centrality; for
+            ``metric="communities"`` returns the K largest communities.
+          - project / tags / date_from / date_to (optional, metrics global scope):
+            restrict the entries whose relations participate in the graph.
 
         RETURNS (success): { relation_id: str, from_id: str, to_id: str, relation_type: str } (add) or
           { entry_id: str, relations: list, count: int } (get) or
           { relation_id: str, removed: bool } (remove) or
           { action: "traverse", root: str, hops: int, direction: str, relation_type: str | null,
             nodes: [{id: str, depth: int}], edges: [{from_id, to_id, relation_type}],
-            node_count: int, edge_count: int } (traverse).
+            node_count: int, edge_count: int } (traverse) or
+          { action: "metrics", metric: str, scope: str, node_count: int, edge_count: int,
+            results: list, count: int, computed_at: str, cache_hit: bool } (metrics).
         RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "INTERNAL", message: "..." }
 
         RELATED: distillery_correct (creates 'corrects' relations automatically),
@@ -1096,6 +1115,13 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                     direction=direction,
                     relation_id=relation_id,
                     hops=hops,
+                    metric=metric,
+                    scope=scope,
+                    limit=limit,
+                    project=project,
+                    tags=tags,
+                    date_from=date_from,
+                    date_to=date_to,
                 ),
             ),
         )

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1106,33 +1106,52 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         direction: str = "both",
         relation_id: str | None = None,
         hops: int = 2,
+        metric: str | None = None,
+        scope: str = "global",
+        limit: int = 10,
+        project: str | None = None,
+        tags: list[str] | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
     ) -> list[types.TextContent]:
         """Manage typed relations between knowledge entries.
 
         USE WHEN: linking entries together (e.g. marking one as blocking another,
-        citing a reference, or flagging duplicates), or walking the relation
-        graph from a seed entry to surface multi-hop neighbours.
+        citing a reference, or flagging duplicates), walking the relation
+        graph from a seed entry to surface multi-hop neighbours, or computing
+        graph metrics (bridges, communities) on the relations subgraph.
 
         PARAMS:
-          - action (str, required): Operation. Valid: [add, get, remove, traverse].
+          - action (str, required): Operation. Valid: [add, get, remove, traverse, metrics].
           - from_id (str, required for add): Source entry UUID.
           - to_id (str, required for add): Target entry UUID.
           - relation_type (str, required for add, optional for get/traverse): Relation type.
             Valid: [link, corrects, supersedes, related, blocks, depends_on, citation,
             duplicate, merge_source, sync_source].
-          - entry_id (str, required for get/traverse): Entry UUID to query relations for
-            (BFS root for traverse).
+          - entry_id (str, required for get/traverse, required for metrics scope='ego'):
+            Entry UUID to query relations for (BFS root for traverse / ego-graph).
           - direction (str, optional for get/traverse, default="both"): Filter direction.
             Valid: [outgoing, incoming, both].
           - relation_id (str, required for remove): UUID of the relation to delete.
           - hops (int, optional for traverse, default=2): BFS depth, capped at [1, 3].
+          - metric (str, required for metrics): Graph metric to compute.
+            Valid: [bridges, communities]. Requires the [graph] optional extra.
+          - scope (str, optional for metrics, default="global"): Subgraph scope.
+            Valid: [global, ego]. ``"ego"`` requires ``entry_id``.
+          - limit (int, optional for metrics, default=10): For ``metric="bridges"``
+            returns the top-k entries by betweenness centrality; for
+            ``metric="communities"`` returns the K largest communities.
+          - project / tags / date_from / date_to (optional, metrics global scope):
+            restrict the entries whose relations participate in the graph.
 
         RETURNS (success): { relation_id: str, from_id: str, to_id: str, relation_type: str } (add) or
           { entry_id: str, relations: list, count: int } (get) or
           { relation_id: str, removed: bool } (remove) or
           { action: "traverse", root: str, hops: int, direction: str, relation_type: str | null,
             nodes: [{id: str, depth: int}], edges: [{from_id, to_id, relation_type}],
-            node_count: int, edge_count: int } (traverse).
+            node_count: int, edge_count: int } (traverse) or
+          { action: "metrics", metric: str, scope: str, node_count: int, edge_count: int,
+            results: list, count: int, computed_at: str, cache_hit: bool } (metrics).
         RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "INTERNAL", message: "..." }
 
         RELATED: distillery_correct (creates 'corrects' relations automatically),
@@ -1151,6 +1170,13 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                     direction=direction,
                     relation_id=relation_id,
                     hops=hops,
+                    metric=metric,
+                    scope=scope,
+                    limit=limit,
+                    project=project,
+                    tags=tags,
+                    date_from=date_from,
+                    date_to=date_to,
                 ),
             ),
         )

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -29,6 +29,13 @@ _TRAVERSE_MAX_HOPS = 3
 # Fixed BFS depth used to assemble the ego-graph for action="metrics" / scope="ego".
 _METRICS_EGO_HOPS = 2
 
+# Pagination page size and hard cap when filtering the entries corpus down to
+# the set whose IDs anchor a global-scope relations graph.  A single
+# ``list_entries`` call could truncate IDs on large corpora; we paginate until
+# the corpus is exhausted or the cap is hit (CodeRabbit, PR #426).
+_GRAPH_METRICS_PAGE_SIZE = 1000
+_GRAPH_METRICS_MAX_IDS = 100_000
+
 _VALID_METRICS = {"bridges", "communities"}
 _VALID_SCOPES = {"global", "ego"}
 
@@ -389,24 +396,11 @@ async def _collect_global_relations(
 ) -> list[dict[str, Any]]:
     """Fetch all entry_relations rows, optionally filtered by entry-side filters.
 
-    For v1 we query DuckDB directly via ``store.connection`` to keep the surface
-    minimal — extending the store protocol with a bulk relations reader can come
-    later if other call sites need it.
+    Goes through ``store.list_relations`` (an async store method) so all DB I/O
+    runs off the event loop via the shared ``_run_sync`` lock — no direct sync
+    ``conn.execute()`` from this async handler (CodeRabbit, PR #426).
     """
-    conn = store.connection
-    rows = conn.execute(
-        "SELECT id, from_id, to_id, relation_type, created_at FROM entry_relations"
-    ).fetchall()
-    relations: list[dict[str, Any]] = [
-        {
-            "id": r[0],
-            "from_id": r[1],
-            "to_id": r[2],
-            "relation_type": r[3],
-            "created_at": r[4],
-        }
-        for r in rows
-    ]
+    relations: list[dict[str, Any]] = await store.list_relations()
 
     if not (project or tags or date_from or date_to):
         return relations
@@ -423,10 +417,30 @@ async def _collect_global_relations(
     if date_to is not None:
         filters["date_to"] = date_to
 
-    # Pull a generous slice; v1 does not paginate the metrics scope. A future
-    # improvement could stream in batches if the corpus is very large.
-    matching = await store.list_entries(filters=filters, limit=10_000, offset=0)
-    matching_ids = {entry.id for entry in matching}
+    # Paginate so corpora larger than a single page are not silently truncated.
+    matching_ids: set[str] = set()
+    offset = 0
+    while True:
+        page = await store.list_entries(
+            filters=filters,
+            limit=_GRAPH_METRICS_PAGE_SIZE,
+            offset=offset,
+        )
+        if not page:
+            break
+        for entry in page:
+            matching_ids.add(entry.id)
+        if len(page) < _GRAPH_METRICS_PAGE_SIZE:
+            break
+        offset += _GRAPH_METRICS_PAGE_SIZE
+        # Safety bound — refuse to materialise an unbounded id set in memory.
+        if len(matching_ids) >= _GRAPH_METRICS_MAX_IDS:
+            logger.warning(
+                "graph metrics: matching_ids exceeds %d cap; truncating",
+                _GRAPH_METRICS_MAX_IDS,
+            )
+            break
+
     return [r for r in relations if r["from_id"] in matching_ids and r["to_id"] in matching_ids]
 
 
@@ -583,10 +597,12 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
             cache.set(cache_key, g)
         else:
             g = cached_graph
-    except RuntimeError as exc:
+    except RuntimeError:
         # build_relations_graph raises this when nx is missing — but we already
         # gated on is_available() above, so this is purely a defensive path.
-        return error_response("INTERNAL", str(exc))
+        # Log the raw exception server-side; never leak it to the client.
+        logger.exception("distillery_relations metrics: runtime error during graph build")
+        return error_response("INTERNAL", "Failed to build relations graph")
     except Exception:  # noqa: BLE001
         logger.exception("distillery_relations metrics: failed to build graph")
         return error_response("INTERNAL", "Failed to build relations graph")

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -2,13 +2,14 @@
 
 Implements the following tool:
   - distillery_relations: Manage typed relations between knowledge entries.
-    Actions: 'add', 'get', 'remove', 'traverse'.
+    Actions: 'add', 'get', 'remove', 'traverse', 'metrics'.
 """
 
 from __future__ import annotations
 
 import logging
 from collections import deque
+from datetime import UTC, datetime
 from typing import Any
 
 from mcp import types
@@ -24,6 +25,12 @@ logger = logging.getLogger(__name__)
 # and prevent runaway traversal on heavily connected subgraphs.
 _TRAVERSE_MIN_HOPS = 1
 _TRAVERSE_MAX_HOPS = 3
+
+# Fixed BFS depth used to assemble the ego-graph for action="metrics" / scope="ego".
+_METRICS_EGO_HOPS = 2
+
+_VALID_METRICS = {"bridges", "communities"}
+_VALID_SCOPES = {"global", "ego"}
 
 # ---------------------------------------------------------------------------
 # distillery_relations handler
@@ -69,10 +76,10 @@ async def _handle_relations(
         )
     action = action_raw.strip().lower()
 
-    if action not in ("add", "get", "remove", "traverse"):
+    if action not in ("add", "get", "remove", "traverse", "metrics"):
         return error_response(
             "INVALID_PARAMS",
-            f"action must be one of 'add', 'get', 'remove', 'traverse'; got: {action!r}",
+            f"action must be one of 'add', 'get', 'remove', 'traverse', 'metrics'; got: {action!r}",
         )
 
     # ------------------------------------------------------------------
@@ -307,6 +314,12 @@ async def _handle_relations(
         )
 
     # ------------------------------------------------------------------
+    # action == "metrics"
+    # ------------------------------------------------------------------
+    if action == "metrics":
+        return await _handle_metrics(store, arguments)
+
+    # ------------------------------------------------------------------
     # action == "remove"
     # ------------------------------------------------------------------
     relation_id_raw = arguments.get("relation_id")
@@ -326,5 +339,283 @@ async def _handle_relations(
         {
             "relation_id": relation_id,
             "removed": removed,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# action == "metrics" — graph metrics over relations subgraph
+# ---------------------------------------------------------------------------
+
+
+def _validate_optional_str(
+    arguments: dict[str, Any], field: str
+) -> tuple[str | None, list[types.TextContent] | None]:
+    """Return (value-or-None, error-response-or-None) for an optional string field."""
+    raw = arguments.get(field)
+    if raw is None:
+        return None, None
+    if not isinstance(raw, str):
+        return None, error_response(
+            "INVALID_PARAMS",
+            f"{field} must be a string, got: {type(raw).__name__}",
+        )
+    stripped = raw.strip()
+    return (stripped or None), None
+
+
+def _validate_optional_str_list(
+    arguments: dict[str, Any], field: str
+) -> tuple[list[str] | None, list[types.TextContent] | None]:
+    """Return (value-or-None, error-response-or-None) for an optional list-of-strings field."""
+    raw = arguments.get(field)
+    if raw is None:
+        return None, None
+    if not isinstance(raw, list) or not all(isinstance(t, str) for t in raw):
+        return None, error_response(
+            "INVALID_PARAMS",
+            f"{field} must be a list of strings",
+        )
+    return list(raw), None
+
+
+async def _collect_global_relations(
+    store: Any,
+    *,
+    project: str | None,
+    tags: list[str] | None,
+    date_from: str | None,
+    date_to: str | None,
+) -> list[dict[str, Any]]:
+    """Fetch all entry_relations rows, optionally filtered by entry-side filters.
+
+    For v1 we query DuckDB directly via ``store.connection`` to keep the surface
+    minimal — extending the store protocol with a bulk relations reader can come
+    later if other call sites need it.
+    """
+    conn = store.connection
+    rows = conn.execute(
+        "SELECT id, from_id, to_id, relation_type, created_at FROM entry_relations"
+    ).fetchall()
+    relations: list[dict[str, Any]] = [
+        {
+            "id": r[0],
+            "from_id": r[1],
+            "to_id": r[2],
+            "relation_type": r[3],
+            "created_at": r[4],
+        }
+        for r in rows
+    ]
+
+    if not (project or tags or date_from or date_to):
+        return relations
+
+    # Use store.list_entries to resolve which entry ids match the filter set;
+    # then keep relations whose endpoints both fall within that set.
+    filters: dict[str, Any] = {}
+    if project is not None:
+        filters["project"] = project
+    if tags:
+        filters["tags"] = tags
+    if date_from is not None:
+        filters["date_from"] = date_from
+    if date_to is not None:
+        filters["date_to"] = date_to
+
+    # Pull a generous slice; v1 does not paginate the metrics scope. A future
+    # improvement could stream in batches if the corpus is very large.
+    matching = await store.list_entries(filters=filters, limit=10_000, offset=0)
+    matching_ids = {entry.id for entry in matching}
+    return [r for r in relations if r["from_id"] in matching_ids and r["to_id"] in matching_ids]
+
+
+async def _collect_ego_relations(
+    store: Any,
+    *,
+    root_id: str,
+    hops: int,
+) -> list[dict[str, Any]]:
+    """BFS the relations graph from ``root_id`` to ``hops`` depth and collect edges."""
+    visited: set[str] = {root_id}
+    edges: list[dict[str, Any]] = []
+    edge_keys: set[tuple[str, str, str]] = set()
+    queue: deque[tuple[str, int]] = deque([(root_id, 0)])
+
+    while queue:
+        node_id, depth = queue.popleft()
+        if depth >= hops:
+            continue
+        neighbours = await store.get_related(node_id, direction="both", relation_type=None)
+        for row in neighbours:
+            from_id = row["from_id"]
+            to_id = row["to_id"]
+            rel_type = row["relation_type"]
+            edge_key = (from_id, to_id, rel_type)
+            if edge_key not in edge_keys:
+                edge_keys.add(edge_key)
+                edges.append(
+                    {
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "relation_type": rel_type,
+                    }
+                )
+            if from_id == node_id:
+                other = to_id
+            elif to_id == node_id:
+                other = from_id
+            else:
+                continue
+            if other not in visited:
+                visited.add(other)
+                queue.append((other, depth + 1))
+    return edges
+
+
+async def _handle_metrics(  # noqa: PLR0911, PLR0912
+    store: Any,
+    arguments: dict[str, Any],
+) -> list[types.TextContent]:
+    """Compute graph metrics on the relations subgraph.
+
+    See module docstring for the response envelope and failure modes.
+    """
+    # NetworkX availability gate.
+    from distillery.graph import is_available
+
+    if not is_available():
+        return error_response(
+            "INTERNAL",
+            "NetworkX not installed; run: pip install distillery-mcp[graph]",
+        )
+
+    # ----- metric -----
+    metric_raw = arguments.get("metric")
+    if metric_raw is None or not isinstance(metric_raw, str):
+        return error_response("INVALID_PARAMS", "metric is required for action='metrics'")
+    metric = metric_raw.strip().lower()
+    if metric not in _VALID_METRICS:
+        return error_response(
+            "INVALID_PARAMS",
+            f"metric must be one of {sorted(_VALID_METRICS)}, got: {metric_raw!r}",
+        )
+
+    # ----- scope -----
+    scope_raw = arguments.get("scope", "global")
+    if not isinstance(scope_raw, str):
+        return error_response(
+            "INVALID_PARAMS",
+            f"scope must be a string, got: {type(scope_raw).__name__}",
+        )
+    scope = scope_raw.strip().lower() or "global"
+    if scope not in _VALID_SCOPES:
+        return error_response(
+            "INVALID_PARAMS",
+            f"scope must be one of {sorted(_VALID_SCOPES)}, got: {scope_raw!r}",
+        )
+
+    # ----- entry_id (required for ego scope) -----
+    entry_id_value, err = _validate_optional_str(arguments, "entry_id")
+    if err is not None:
+        return err
+    if scope == "ego" and not entry_id_value:
+        return error_response(
+            "INVALID_PARAMS",
+            "entry_id is required when scope='ego'",
+        )
+
+    # ----- limit -----
+    limit_raw = arguments.get("limit", 10)
+    if isinstance(limit_raw, bool) or not isinstance(limit_raw, int) or limit_raw < 1:
+        return error_response("INVALID_PARAMS", "limit must be a positive integer")
+    limit = int(limit_raw)
+
+    # ----- entry-side filters (global scope only) -----
+    project, err = _validate_optional_str(arguments, "project")
+    if err is not None:
+        return err
+    tags, err = _validate_optional_str_list(arguments, "tags")
+    if err is not None:
+        return err
+    date_from, err = _validate_optional_str(arguments, "date_from")
+    if err is not None:
+        return err
+    date_to, err = _validate_optional_str(arguments, "date_to")
+    if err is not None:
+        return err
+
+    # ----- cache lookup -----
+    from distillery.graph.builders import build_relations_graph
+    from distillery.graph.cache import default_cache
+    from distillery.graph.metrics import bridges, communities
+
+    cache = default_cache()
+    cache_key = (
+        f"{scope}:{entry_id_value or ''}:{project or ''}:"
+        f"{','.join(tags or [])}:{date_from or ''}:{date_to or ''}"
+    )
+    cached_graph = cache.get(cache_key)
+    cache_hit = cached_graph is not None
+
+    # ----- assemble graph (fetch + build) on miss -----
+    try:
+        if cached_graph is None:
+            if scope == "ego":
+                # Verify root exists before traversal.
+                assert entry_id_value is not None  # for mypy — checked above
+                root_id = entry_id_value
+                root_entry = await store.get(root_id)
+                if root_entry is None:
+                    return error_response("NOT_FOUND", f"Entry not found: {root_id!r}")
+                relations = await _collect_ego_relations(
+                    store, root_id=root_id, hops=_METRICS_EGO_HOPS
+                )
+            else:
+                relations = await _collect_global_relations(
+                    store,
+                    project=project,
+                    tags=tags,
+                    date_from=date_from,
+                    date_to=date_to,
+                )
+            g = build_relations_graph(relations, directed=True)
+            cache.set(cache_key, g)
+        else:
+            g = cached_graph
+    except RuntimeError as exc:
+        # build_relations_graph raises this when nx is missing — but we already
+        # gated on is_available() above, so this is purely a defensive path.
+        return error_response("INTERNAL", str(exc))
+    except Exception:  # noqa: BLE001
+        logger.exception("distillery_relations metrics: failed to build graph")
+        return error_response("INTERNAL", "Failed to build relations graph")
+
+    # ----- compute metric -----
+    try:
+        if metric == "bridges":
+            ranked = bridges(g, k=limit)
+            results: list[dict[str, Any]] = [
+                {"id": node, "score": round(score, 6)} for node, score in ranked
+            ]
+        else:  # metric == "communities"
+            comms = communities(g)
+            comms_sorted = sorted(comms, key=lambda c: len(c), reverse=True)[:limit]
+            results = [{"members": sorted(c)} for c in comms_sorted]
+    except Exception:  # noqa: BLE001
+        logger.exception("distillery_relations metrics: metric computation failed")
+        return error_response("INTERNAL", "Failed to compute graph metric")
+
+    return success_response(
+        {
+            "action": "metrics",
+            "metric": metric,
+            "scope": scope,
+            "node_count": g.number_of_nodes(),
+            "edge_count": g.number_of_edges(),
+            "results": results,
+            "count": len(results),
+            "computed_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "cache_hit": cache_hit,
         }
     )

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2952,3 +2952,38 @@ class DuckDBStore:
             ``True`` if the row existed and was deleted, ``False`` otherwise.
         """
         return await self._run_sync(self._sync_remove_relation, relation_id)
+
+    def _sync_list_relations(self) -> list[dict[str, Any]]:
+        """Synchronous implementation of list_relations(); called via asyncio.to_thread."""
+        assert self._conn is not None
+        rows = self._conn.execute(
+            "SELECT id, from_id, to_id, relation_type, "
+            "strftime(created_at, '%Y-%m-%dT%H:%M:%S') || 'Z' "
+            "FROM entry_relations ORDER BY created_at ASC"
+        ).fetchall()
+        return [
+            {
+                "id": row[0],
+                "from_id": row[1],
+                "to_id": row[2],
+                "relation_type": row[3],
+                "created_at": row[4],
+            }
+            for row in rows
+        ]
+
+    async def list_relations(self) -> list[dict[str, Any]]:
+        """Return every row from ``entry_relations`` as a list of dicts.
+
+        Used by graph metrics (``distillery_relations`` action="metrics") to
+        assemble the full subgraph for global-scope analysis. Goes through
+        :meth:`_run_sync` so the async event loop is never blocked by sync
+        DuckDB I/O and the shared connection is serialised under the same
+        lock as every other store operation.
+
+        Returns:
+            List of dicts with keys: ``id``, ``from_id``, ``to_id``,
+            ``relation_type``, ``created_at`` (ISO 8601 str).  Ordered by
+            ascending ``created_at``.
+        """
+        return await self._run_sync(self._sync_list_relations)

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2987,3 +2987,38 @@ class DuckDBStore:
             ``True`` if the row existed and was deleted, ``False`` otherwise.
         """
         return await self._run_sync(self._sync_remove_relation, relation_id)
+
+    def _sync_list_relations(self) -> list[dict[str, Any]]:
+        """Synchronous implementation of list_relations(); called via asyncio.to_thread."""
+        assert self._conn is not None
+        rows = self._conn.execute(
+            "SELECT id, from_id, to_id, relation_type, "
+            "strftime(created_at, '%Y-%m-%dT%H:%M:%S') || 'Z' "
+            "FROM entry_relations ORDER BY created_at ASC"
+        ).fetchall()
+        return [
+            {
+                "id": row[0],
+                "from_id": row[1],
+                "to_id": row[2],
+                "relation_type": row[3],
+                "created_at": row[4],
+            }
+            for row in rows
+        ]
+
+    async def list_relations(self) -> list[dict[str, Any]]:
+        """Return every row from ``entry_relations`` as a list of dicts.
+
+        Used by graph metrics (``distillery_relations`` action="metrics") to
+        assemble the full subgraph for global-scope analysis. Goes through
+        :meth:`_run_sync` so the async event loop is never blocked by sync
+        DuckDB I/O and the shared connection is serialised under the same
+        lock as every other store operation.
+
+        Returns:
+            List of dicts with keys: ``id``, ``from_id``, ``to_id``,
+            ``relation_type``, ``created_at`` (ISO 8601 str).  Ordered by
+            ascending ``created_at``.
+        """
+        return await self._run_sync(self._sync_list_relations)

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -511,6 +511,20 @@ class DistilleryStore(Protocol):
         """
         ...
 
+    async def list_relations(self) -> list[dict[str, Any]]:
+        """Return every row from ``entry_relations`` as a list of dicts.
+
+        Intended for graph metrics computation that needs the entire relations
+        subgraph in one shot.  Implementations must run any underlying sync
+        I/O off the event loop so async callers are not blocked.
+
+        Returns:
+            List of dicts with keys: ``id``, ``from_id``, ``to_id``,
+            ``relation_type``, ``created_at`` (ISO 8601 str).  Ordered by
+            ascending ``created_at``.
+        """
+        ...
+
     async def get_metadata(self, key: str) -> str | None:
         """Read a value from the ``_meta`` key-value table.
 

--- a/tests/graph/test_builders.py
+++ b/tests/graph/test_builders.py
@@ -1,0 +1,57 @@
+"""Tests for distillery.graph.builders.
+
+Wrapped with ``pytest.importorskip("networkx")`` so these tests run only when
+the [graph] extra is installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("networkx")
+
+from distillery.graph import builders  # noqa: E402
+from distillery.graph.builders import _require_networkx, build_relations_graph  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_relations_graph_empty_returns_empty_graph() -> None:
+    g = build_relations_graph([], directed=True)
+    assert g.number_of_nodes() == 0
+    assert g.number_of_edges() == 0
+
+
+def test_build_relations_graph_three_edges() -> None:
+    rels = [
+        {"from_id": "a", "to_id": "b", "relation_type": "link"},
+        {"from_id": "b", "to_id": "c", "relation_type": "link"},
+        {"from_id": "c", "to_id": "a", "relation_type": "depends_on"},
+    ]
+    g = build_relations_graph(rels, directed=True)
+    assert set(g.nodes()) == {"a", "b", "c"}
+    assert g.number_of_edges() == 3
+    # Edge attribute should round-trip.
+    assert g.edges["a", "b"]["relation_type"] == "link"
+    assert g.edges["c", "a"]["relation_type"] == "depends_on"
+
+
+def test_build_relations_graph_undirected_collapses_pair() -> None:
+    rels = [
+        {"from_id": "a", "to_id": "b", "relation_type": "link"},
+        # In a directed graph, this would be a second distinct edge. In an
+        # undirected graph, it collapses on top of the first because the
+        # endpoint pair is identical.
+        {"from_id": "b", "to_id": "a", "relation_type": "link"},
+    ]
+    g = build_relations_graph(rels, directed=False)
+    assert g.is_directed() is False
+    assert g.number_of_nodes() == 2
+    assert g.number_of_edges() == 1
+
+
+def test_require_networkx_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``distillery.graph.nx`` is None, ``_require_networkx`` raises."""
+    monkeypatch.setattr(builders, "nx", None)
+    with pytest.raises(RuntimeError, match="NetworkX not installed"):
+        _require_networkx()

--- a/tests/graph/test_cache.py
+++ b/tests/graph/test_cache.py
@@ -1,0 +1,88 @@
+"""Tests for distillery.graph.cache.
+
+These tests do not depend on the [graph] extra (NetworkX) — they exercise the
+TTLCache primitive directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.graph.cache import TTLCache
+
+pytestmark = pytest.mark.unit
+
+
+def test_cache_evicts_expired_entries_proactively(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Calling set() after the TTL elapses should drop every stale key, not just
+    the one being touched. Prevents high-cardinality one-off keys from
+    accumulating forever (CodeRabbit, PR #426).
+    """
+    cache = TTLCache(ttl_seconds=10)
+
+    fake_now = {"t": 100.0}
+
+    def _now() -> float:
+        return fake_now["t"]
+
+    # Patch the monotonic clock used by the cache.
+    monkeypatch.setattr("distillery.graph.cache.time.monotonic", _now)
+
+    # Populate many keys at t=100.
+    for i in range(50):
+        cache.set(f"key-{i}", i)
+    assert len(cache._store) == 50
+
+    # Advance well past the TTL.
+    fake_now["t"] = 200.0
+
+    # A single set() call must trigger a full sweep of expired entries.
+    cache.set("fresh", "value")
+
+    assert "fresh" in cache._store
+    for i in range(50):
+        assert f"key-{i}" not in cache._store, "stale keys should have been evicted"
+    assert len(cache._store) == 1
+
+
+def test_cache_get_also_evicts_expired_entries(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """get() must also sweep expired keys so a long stretch of misses cannot
+    leak unbounded memory."""
+    cache = TTLCache(ttl_seconds=10)
+
+    fake_now = {"t": 0.0}
+
+    def _now() -> float:
+        return fake_now["t"]
+
+    monkeypatch.setattr("distillery.graph.cache.time.monotonic", _now)
+
+    for i in range(20):
+        cache.set(f"k{i}", i)
+    assert len(cache._store) == 20
+
+    fake_now["t"] = 100.0
+    # Looking up an unrelated missing key must still purge the expired ones.
+    assert cache.get("does-not-exist") is None
+    assert len(cache._store) == 0
+
+
+def test_cache_returns_value_within_ttl(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Sanity check: values stored within the TTL window are returned by get()."""
+    cache = TTLCache(ttl_seconds=10)
+
+    fake_now = {"t": 0.0}
+
+    def _now() -> float:
+        return fake_now["t"]
+
+    monkeypatch.setattr("distillery.graph.cache.time.monotonic", _now)
+
+    cache.set("hello", "world")
+    assert cache.get("hello") == "world"
+
+    fake_now["t"] = 5.0  # still within TTL
+    assert cache.get("hello") == "world"
+
+    fake_now["t"] = 100.0  # well past TTL
+    assert cache.get("hello") is None

--- a/tests/graph/test_metrics.py
+++ b/tests/graph/test_metrics.py
@@ -1,0 +1,56 @@
+"""Tests for distillery.graph.metrics.
+
+Wrapped with ``pytest.importorskip("networkx")`` so these tests run only when
+the [graph] extra is installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("networkx")
+
+from distillery.graph.builders import build_relations_graph  # noqa: E402
+from distillery.graph.metrics import bridges, communities  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_bridges_star_graph_center_first() -> None:
+    """In a star A-{B,C,D}, the centre A has the highest betweenness."""
+    rels = [
+        {"from_id": "A", "to_id": "B", "relation_type": "link"},
+        {"from_id": "A", "to_id": "C", "relation_type": "link"},
+        {"from_id": "A", "to_id": "D", "relation_type": "link"},
+    ]
+    g = build_relations_graph(rels, directed=True)
+    ranked = bridges(g, k=4)
+    assert ranked, "ranked list should be non-empty for a 4-node graph"
+    assert ranked[0][0] == "A"
+
+
+def test_bridges_empty_graph_returns_empty() -> None:
+    g = build_relations_graph([], directed=True)
+    assert bridges(g, k=10) == []
+
+
+def test_communities_two_clusters_with_bridge() -> None:
+    """Two triangles connected by a single bridge edge — Louvain should split them."""
+    rels = [
+        # Triangle 1
+        {"from_id": "A", "to_id": "B", "relation_type": "link"},
+        {"from_id": "B", "to_id": "C", "relation_type": "link"},
+        {"from_id": "C", "to_id": "A", "relation_type": "link"},
+        # Triangle 2
+        {"from_id": "X", "to_id": "Y", "relation_type": "link"},
+        {"from_id": "Y", "to_id": "Z", "relation_type": "link"},
+        {"from_id": "Z", "to_id": "X", "relation_type": "link"},
+        # Single bridge
+        {"from_id": "C", "to_id": "X", "relation_type": "link"},
+    ]
+    g = build_relations_graph(rels, directed=True)
+    comms = communities(g)
+    # Expect exactly two communities aligned with the triangles.
+    assert len(comms) == 2
+    members = sorted([sorted(c) for c in comms], key=lambda x: x[0])
+    assert members == [["A", "B", "C"], ["X", "Y", "Z"]]

--- a/tests/test_mcp_tools/test_relations_metrics.py
+++ b/tests/test_mcp_tools/test_relations_metrics.py
@@ -252,3 +252,72 @@ async def test_metrics_returns_internal_when_nx_missing(  # type: ignore[no-unty
     assert data["error"] is True
     assert data["code"] == "INTERNAL"
     assert "NetworkX not installed" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# Pagination + error-handling regressions (CodeRabbit, PR #426).
+# ---------------------------------------------------------------------------
+
+
+async def test_metrics_paginates_large_corpus(store, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Global-scope metrics must paginate ``list_entries`` so large corpora are
+    not silently truncated by a single 10k-row page (CodeRabbit, PR #426).
+    """
+    pytest.importorskip("networkx")
+
+    # Force a tiny page size so pagination is exercised even with a few entries.
+    monkeypatch.setattr(
+        "distillery.mcp.tools.relations._GRAPH_METRICS_PAGE_SIZE",
+        2,
+    )
+
+    # Seed five entries on a single project, fully connected in a star pattern.
+    project = "paginate-me"
+    ids: list[str] = []
+    for i in range(5):
+        ids.append(await _store_entry(store, content=f"node {i}", project=project))
+    for j in range(1, 5):
+        await store.add_relation(ids[0], ids[j], "link")
+
+    result = await _handle_relations(
+        store,
+        {
+            "action": "metrics",
+            "metric": "bridges",
+            "scope": "global",
+            "project": project,
+        },
+    )
+    data = _parse(result)
+    assert data.get("error") is not True
+    # All 5 nodes must appear in the graph despite the page size of 2 — that
+    # only happens if pagination loops past the first page.
+    assert data["node_count"] == 5
+    assert data["edge_count"] == 4
+
+
+async def test_metrics_runtime_error_returns_generic_message(  # type: ignore[no-untyped-def]
+    store, monkeypatch
+) -> None:
+    """A RuntimeError raised during graph build must NOT leak its message text
+    to the client; the handler logs it server-side and returns a generic
+    INTERNAL response (CodeRabbit, PR #426).
+    """
+    pytest.importorskip("networkx")
+
+    secret = "super secret internal detail xyzzy"
+
+    def _boom(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError(secret)
+
+    # Patch the symbol referenced inside ``_handle_metrics`` (it does a local
+    # import, so we patch it on the source module).
+    monkeypatch.setattr("distillery.graph.builders.build_relations_graph", _boom)
+
+    result = await _handle_relations(
+        store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+    )
+    data = _parse(result)
+    assert data["error"] is True
+    assert data["code"] == "INTERNAL"
+    assert secret not in data["message"], "raw exception text must not leak"

--- a/tests/test_mcp_tools/test_relations_metrics.py
+++ b/tests/test_mcp_tools/test_relations_metrics.py
@@ -1,0 +1,254 @@
+"""Unit tests for the ``metrics`` action of ``distillery_relations``.
+
+Covers graph metrics (bridges, communities) over the relations subgraph.
+Most tests require NetworkX (gated via ``pytest.importorskip``); one test
+exercises the missing-NetworkX path by monkeypatching the module attribute.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+
+import pytest
+
+from distillery.mcp.tools.relations import _handle_relations
+from tests.conftest import make_entry
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _store_entry(store, **kwargs):  # type: ignore[no-untyped-def]
+    entry = make_entry(**kwargs)
+    await store.store(entry)
+    return entry.id
+
+
+def _parse(result: list) -> dict:  # type: ignore[type-arg]
+    assert len(result) == 1
+    return json.loads(result[0].text)  # type: ignore[no-any-return]
+
+
+async def _seed_star_relations(store):  # type: ignore[no-untyped-def]
+    """Star A->{B,C,D} so betweenness centrality on A is non-zero."""
+    a = await _store_entry(store, content="entry A")
+    b = await _store_entry(store, content="entry B")
+    c = await _store_entry(store, content="entry C")
+    d = await _store_entry(store, content="entry D")
+    await store.add_relation(a, b, "link")
+    await store.add_relation(a, c, "link")
+    await store.add_relation(a, d, "link")
+    return a, b, c, d
+
+
+def _reset_graph_cache() -> None:
+    """Drop cached graphs between tests so cache_hit assertions are deterministic."""
+    from distillery.graph.cache import default_cache
+
+    cache = default_cache()
+    cache._store.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests requiring NetworkX
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_graph_cache():  # type: ignore[no-untyped-def]
+    """Ensure a clean cache for every test."""
+    with contextlib.suppress(Exception):
+        _reset_graph_cache()
+    yield
+    with contextlib.suppress(Exception):
+        _reset_graph_cache()
+
+
+async def test_metrics_bridges_global(store) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("networkx")
+
+    a, _, _, _ = await _seed_star_relations(store)
+
+    result = await _handle_relations(
+        store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+    )
+    data = _parse(result)
+
+    assert data.get("error") is not True
+    assert data["action"] == "metrics"
+    assert data["metric"] == "bridges"
+    assert data["scope"] == "global"
+    assert data["node_count"] >= 4
+    assert data["edge_count"] >= 3
+    assert isinstance(data["results"], list)
+    assert len(data["results"]) > 0
+    assert data["count"] == len(data["results"])
+    # Each row should carry a node id and a numeric score.
+    for row in data["results"]:
+        assert "id" in row
+        assert "score" in row
+    # Cache must report a miss on first call.
+    assert data["cache_hit"] is False
+    # Centre of the star should be present in the top-k.
+    assert any(row["id"] == a for row in data["results"])
+
+
+async def test_metrics_communities_global(store) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("networkx")
+
+    # Two separate triangles linked by one bridge edge.
+    nodes = {}
+    for name in ("A", "B", "C", "X", "Y", "Z"):
+        nodes[name] = await _store_entry(store, content=f"entry {name}")
+    pairs = [
+        ("A", "B"),
+        ("B", "C"),
+        ("C", "A"),
+        ("X", "Y"),
+        ("Y", "Z"),
+        ("Z", "X"),
+        ("C", "X"),  # bridge
+    ]
+    for src, dst in pairs:
+        await store.add_relation(nodes[src], nodes[dst], "link")
+
+    result = await _handle_relations(
+        store, {"action": "metrics", "metric": "communities", "scope": "global"}
+    )
+    data = _parse(result)
+
+    assert data.get("error") is not True
+    assert data["metric"] == "communities"
+    assert isinstance(data["results"], list)
+    assert len(data["results"]) >= 1
+    # Each entry is a {"members": [...]} dict.
+    for row in data["results"]:
+        assert "members" in row
+        assert isinstance(row["members"], list)
+
+
+async def test_metrics_invalid_metric_returns_invalid_params(store) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("networkx")
+
+    result = await _handle_relations(
+        store, {"action": "metrics", "metric": "bogus", "scope": "global"}
+    )
+    data = _parse(result)
+    assert data["error"] is True
+    assert data["code"] == "INVALID_PARAMS"
+    assert "metric" in data["message"]
+
+
+async def test_metrics_invalid_scope_returns_invalid_params(store) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("networkx")
+
+    result = await _handle_relations(
+        store, {"action": "metrics", "metric": "bridges", "scope": "galactic"}
+    )
+    data = _parse(result)
+    assert data["error"] is True
+    assert data["code"] == "INVALID_PARAMS"
+    assert "scope" in data["message"]
+
+
+async def test_metrics_ego_scope_requires_entry_id(store) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("networkx")
+
+    result = await _handle_relations(
+        store, {"action": "metrics", "metric": "bridges", "scope": "ego"}
+    )
+    data = _parse(result)
+    assert data["error"] is True
+    assert data["code"] == "INVALID_PARAMS"
+    assert "entry_id" in data["message"]
+
+
+async def test_metrics_ego_scope_unknown_entry_id_returns_not_found(store) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("networkx")
+
+    result = await _handle_relations(
+        store,
+        {
+            "action": "metrics",
+            "metric": "bridges",
+            "scope": "ego",
+            "entry_id": "no-such-uuid",
+        },
+    )
+    data = _parse(result)
+    assert data["error"] is True
+    assert data["code"] == "NOT_FOUND"
+
+
+async def test_metrics_response_envelope_shape(store) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("networkx")
+
+    await _seed_star_relations(store)
+    result = await _handle_relations(
+        store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+    )
+    data = _parse(result)
+
+    expected_keys = {
+        "action",
+        "metric",
+        "scope",
+        "node_count",
+        "edge_count",
+        "results",
+        "count",
+        "computed_at",
+        "cache_hit",
+    }
+    assert expected_keys.issubset(set(data.keys()))
+
+
+async def test_metrics_cache_hit_flips_on_second_call(store) -> None:  # type: ignore[no-untyped-def]
+    pytest.importorskip("networkx")
+
+    await _seed_star_relations(store)
+
+    first = _parse(
+        await _handle_relations(
+            store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+        )
+    )
+    second = _parse(
+        await _handle_relations(
+            store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+        )
+    )
+
+    assert first["cache_hit"] is False
+    assert second["cache_hit"] is True
+
+
+# ---------------------------------------------------------------------------
+# NetworkX missing — runs even without the [graph] extra installed.
+# ---------------------------------------------------------------------------
+
+
+async def test_metrics_returns_internal_when_nx_missing(  # type: ignore[no-untyped-def]
+    store, monkeypatch
+) -> None:
+    """Even when networkx is installed, simulate the missing-extra path.
+
+    We monkeypatch ``distillery.graph.nx`` to None so the gate in
+    ``_handle_metrics`` (via ``is_available()``) reports the extra missing.
+    """
+    import distillery.graph as graph_pkg
+
+    monkeypatch.setattr(graph_pkg, "nx", None)
+
+    result = await _handle_relations(
+        store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+    )
+    data = _parse(result)
+    assert data["error"] is True
+    assert data["code"] == "INTERNAL"
+    assert "NetworkX not installed" in data["message"]


### PR DESCRIPTION
## Summary

Introduces NetworkX as an OPTIONAL dependency under the `[graph]` extra. Adds two graph metrics on the relations subgraph, exposed via additive `action="metrics"` on the existing `distillery_relations` tool:

- `metric="bridges"` — top-k entries by betweenness centrality
- `metric="communities"` — Louvain communities

Supports `scope="global"` (all relations, with optional project/tags/date filters) or `scope="ego"` (BFS depth-2 around an `entry_id`).

Core install unaffected; metrics action returns `INTERNAL` with `"NetworkX not installed; run: pip install distillery-mcp[graph]"` when nx is not present. TTL cache (300s default) on graph builds.

## Base branch

This PR is based on `feat/graph-phase2a-relations-traverse` (#424). It will need rebasing onto main once #424 merges.

## Plan

Phase 2B of `/Users/norrie/.claude/plans/review-all-open-issue-luminous-treehouse.md`.

## Test plan

- [x] **With NetworkX**: 64 tests pass across `tests/graph/`, `test_relations_metrics.py`, `test_relations_traverse.py`, `test_relations.py`
- [x] **Full suite with `[graph]`**: 2520 passed, 73 skipped
- [x] **Without NetworkX**: traverse + base relations 48 pass; metrics module — only the missing-nx test runs (1 pass, 8 skipped); graph package modules `importorskip`-ped
- [x] `ruff check`, `ruff format --check` clean
- [x] `mypy --strict` clean on full `src/distillery/`

## Files

- NEW: `src/distillery/graph/{__init__,builders,metrics,cache}.py`
- NEW: `tests/graph/{__init__,test_builders,test_metrics}.py`
- NEW: `tests/test_mcp_tools/test_relations_metrics.py`
- MODIFIED: `src/distillery/mcp/tools/relations.py`, `src/distillery/mcp/server.py`
- MODIFIED: `pyproject.toml` (`[graph]` extra; mypy override `ignore_missing_imports` for networkx)

Closes part of #138 and #141.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional graph-analysis support for relation networks (install the "graph" extra)
  * Compute graph metrics: bridges (key nodes) and communities (clusters)
  * Extended relation queries with metric, scope, filtering and limit options
  * In-memory caching (TTL) to speed repeated metric computations

* **Tests**
  * Added comprehensive tests for graph builders, metrics, caching, and relation metrics endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->