### PR TITLE
[bench] discipline scaffolding (HEADLINE, LIMITATIONS, METHODOLOGY)

### DIFF
--- a/bench/HEADLINE.md
+++ b/bench/HEADLINE.md
@@ -1,0 +1,61 @@
+# Headline configuration (pre-registered)
+
+This file pre-registers the single configuration cell of the LongMemEval bench whose
+results may be cited as the "Distillery LongMemEval headline." It is committed
+**before any number lands**, so that the choice of cell cannot be retro-fitted to
+whatever scored best.
+
+## The headline cell
+
+| Axis           | Value         |
+|----------------|---------------|
+| `retrieval`    | `hybrid`      |
+| `granularity`  | `session`     |
+| `recency`      | `on`          |
+| `embed`        | `bge-small`   |
+
+These four values together define one — and only one — cell of the bench matrix.
+Other cells (raw retrieval, per-turn granularity, recency off, alternate embed
+models) exist as Distillery-vs-Distillery ablations. They are **not** the headline
+and must never be quoted as such.
+
+## The headline metric
+
+The headline is **always** published as a triplet:
+
+- **R@5** — recall at 5
+- **R@10** — recall at 10
+- **NDCG@10** — normalised discounted cumulative gain at 10
+
+No single one of these is "the" number. Quoting one in isolation — on a badge,
+in a blog post, in a slide — is a discipline violation. Three values, every time,
+or none.
+
+## Change control
+
+The headline cell is immutable without:
+
+1. A merged Architecture Decision Record under `docs/adr/` explaining why the
+   cell is changing and what is being given up.
+2. A corresponding update to this file in the same PR as the ADR.
+3. The full headline triplet recomputed on the new cell, with provenance
+   (code SHA, dataset SHA, model SHA), before any number from the new cell is
+   published anywhere.
+
+A headline that drifts silently is the failure mode this file exists to prevent.
+
+## Rationale
+
+This pre-registration is rule (1) of the project's publication discipline
+("Pre-register the headline cell"). It exists to head off two specific
+cautionary tales:
+
+- **LongMemEval** itself ([Wu et al., ICLR 2025](https://arxiv.org/html/2410.10813v1)) —
+  the paper's primary metric is GPT-4o-judged QA accuracy (§3.4). Distillery is
+  a retrieval layer and does not produce that number. Pre-registering the cell
+  *and* the metric triplet keeps the framing honest about what we are measuring.
+- **Mempalace #875** ([github.com/mempalace/mempalace/issues/875](https://github.com/mempalace/mempalace/issues/875)) —
+  retracted LongMemEval claims after configuration drift, top-k bypass artefacts,
+  and metric-mixing with QA accuracy. The lesson is that without a pre-registered
+  cell + triplet, a project will over time anoint whichever number looks best on
+  whichever axis happened to win that night.

--- a/bench/LIMITATIONS.md
+++ b/bench/LIMITATIONS.md
@@ -1,0 +1,113 @@
+# Limitations — read this before quoting any number
+
+This file is the precondition for the LongMemEval bench existing in this
+project. **If any limitation listed here ever becomes unsupportable, the
+LongMemEval dataset is dropped from the project — not weakened in framing.**
+
+Reviewers: read this file before approving any PR that lands a number.
+
+---
+
+## WHAT THIS NUMBER DOES NOT CLAIM
+
+The headline triplet (R@5, R@10, NDCG@10) measures **retrieval recall and
+ranking quality** of the Distillery store on the LongMemEval-S corpus. It does
+**not** claim — and must not be cited as claiming — any of the following.
+
+### (a) Not comparable to the LongMemEval QA-accuracy leaderboard
+
+LongMemEval's *official primary metric* is **GPT-4o-judged QA accuracy** —
+a generator reads the retrieved context and answers the question, and a judge
+LLM scores correctness. This is described in the paper's §3.4 (Wu et al.,
+[arxiv 2410.10813](https://arxiv.org/html/2410.10813v1)). R@k and NDCG@k are
+diagnostic supplements that the paper itself uses for ablation, not the primary
+score.
+
+Distillery is a **retrieval layer**, not a QA system. It has no generator and
+no judge. So Distillery reports retrieval metrics — the diagnostic supplements —
+and **never** the primary QA-accuracy metric.
+
+Mixing the two is a **category error**. You cannot say "Distillery scores 0.X"
+on the same axis as a leaderboard entry that scores QA accuracy. They are
+different quantities measured in different units against different rubrics.
+
+This exact pattern — quoting recall numbers next to QA-accuracy numbers as if
+they were comparable — is what Mempalace's
+[issue #875](https://github.com/mempalace/mempalace/issues/875) cites as the
+cause of their retraction. We do not repeat it here.
+
+### (b) Cross-granularity numbers are non-comparable
+
+The bench supports two granularities:
+
+- `granularity=session` — one corpus document per haystack session. Document IDs
+  look like `<sess>`.
+- `granularity=turn` — one corpus document per user turn within a session.
+  Document IDs look like `<sess>_turn_<n>`.
+
+These produce different `corpus_id` namespaces and different corpus sizes. A
+"top-5 hit" in the per-turn corpus is a different event from a "top-5 hit" in
+the per-session corpus. **Comparing R@k across granularities is meaningless.**
+Numbers from different granularities are reported in separate tables and must
+never be averaged, ranked, or graphed against each other on a shared axis.
+
+### (c) Cross-embed-model numbers carry an HNSW caveat
+
+Different embedding models produce vectors of different dimensionality and
+different similarity-distribution shape. The HNSW index (via DuckDB VSS) is
+constructed from those vectors — so changing the embed model changes the graph,
+not just the points.
+
+This means a `bge-small` vs `bge-large` comparison is a **system-level**
+comparison (different model + different graph), not a pure model comparison.
+Cross-embed-model results are reported with this caveat in line. They are
+useful for "which configuration should we ship" decisions; they are not
+suitable for claims of the form "model X is better than model Y."
+
+### (d) No competitor comparison tables — anywhere
+
+This project publishes **Distillery-vs-Distillery comparisons only**. No table,
+chart, badge, blog post, or slide produced by this project will compare a
+Distillery number against a Mempalace, LangChain, LlamaIndex, vector-DB-vendor,
+or any other third-party number. Internal ablations only — raw vs hybrid,
+recency on vs off, granularity session vs turn, etc.
+
+This is rule (3) of the project's publication discipline. The reason is the
+same one as (a): the underlying numbers are not comparable across systems
+without controlling for the QA generator, judge model, prompt, retrieval-chunk
+shape, and embed model — none of which we control across the table.
+
+### (e) No SHAs ⇒ not a claim
+
+Every number this project publishes ships with a provenance panel:
+
+- `git_sha` — the Distillery commit that produced the run
+- `dataset_revision_sha` — the HuggingFace dataset commit
+- `embed_model_sha` — the model file digest
+- `python_version` — the interpreter
+
+A number without all four is not a Distillery claim. Reviewers, blog readers,
+and downstream tooling should treat any LongMemEval-shaped number that does not
+carry this panel as folklore until the panel is reconstructed.
+
+---
+
+## What this means in practice
+
+- A badge on the README shows the headline triplet **with a link to this file**.
+- The MkDocs benchmarks page leads with a callout pointing here.
+- Internal ablation tables are clearly labelled "Distillery configurations only."
+- Per-question JSONL receipts and `summary.json` files always carry the SHA panel.
+- A reviewer who finds a number anywhere in the project without the SHA panel
+  should reject the PR or open an issue to retract.
+
+## The escape hatch
+
+> **If any limitation in this file becomes unsupportable, the LongMemEval
+> dataset is dropped from the project, not weakened in framing.**
+
+Concretely, that means: if discipline (a)–(e) cannot all be honoured — for
+example, if the project is pressured to publish a single QA-accuracy-shaped
+number, or to compare against another system on a shared axis, or to drop SHA
+provenance for convenience — the correct response is to remove the LongMemEval
+bench from this repository, not to soften this file.

--- a/bench/LIMITATIONS.md
+++ b/bench/LIMITATIONS.md
@@ -97,7 +97,7 @@ carry this panel as folklore until the panel is reconstructed.
 - A badge on the README shows the headline triplet **with a link to this file**.
 - The MkDocs benchmarks page leads with a callout pointing here.
 - Internal ablation tables are clearly labelled "Distillery configurations only."
-- Per-question JSONL receipts and `summary.json` files always carry the SHA panel.
+- Per-question JSONL receipts (`results_*.jsonl`) and per-cell `summary_*.json` files always carry the SHA panel; the aggregated `bench/results/SUMMARY.md` is regenerated from them.
 - A reviewer who finds a number anywhere in the project without the SHA panel
   should reject the PR or open an issue to retract.
 

--- a/bench/METHODOLOGY.md
+++ b/bench/METHODOLOGY.md
@@ -1,0 +1,127 @@
+# Methodology
+
+This document describes how the Distillery LongMemEval bench is run, scored,
+and audited. It is the spec a reader needs to verify that the published
+numbers correspond to a reproducible procedure.
+
+For the limitations of these numbers, see [`LIMITATIONS.md`](./LIMITATIONS.md).
+For the pre-registered headline configuration, see [`HEADLINE.md`](./HEADLINE.md).
+
+## Dataset
+
+- **Source.** HuggingFace dataset
+  [`xiaowu0162/longmemeval-cleaned`](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned).
+- **Split.** LongMemEval-S — the 115K-token-haystack variant. File:
+  `longmemeval_s_cleaned.json`. ~500 questions.
+- **Pin.** The dataset is downloaded via
+  `huggingface_hub.snapshot_download(repo_id=..., revision=<commit_sha>)`. The
+  commit SHA is hard-coded as a constant in
+  `src/distillery/eval/longmemeval_dataset.py` and verified at load time.
+  Until the dataset loader lands the pin, this slot reads:
+  - `dataset_revision_sha = <TBD — populated by W1-dataset-loader>`
+- **Integrity check.** SHA-256 of `longmemeval_s_cleaned.json` is compared
+  against a constant in code. Mismatch ⇒ load fails loud, no silent fallback.
+- **Cache.** `$XDG_CACHE_HOME/distillery/longmemeval/` (defaults to
+  `~/.cache/distillery/longmemeval/`).
+- **Known upstream issue.** The dataset config raises a `FeaturesError` on the
+  `answer` column under some `datasets` versions. The loader handles this by
+  reading the JSON file directly rather than going through `datasets.load_dataset`.
+
+## Per-question protocol
+
+Every question in the dataset is evaluated in isolation:
+
+1. Instantiate a fresh `DuckDBStore(":memory:")`. No state survives between
+   questions.
+2. Set fixed PRNG seeds **before each question**:
+   - `random.seed(seed)`
+   - `numpy.random.seed(seed)`
+   - any framework-specific seed (DuckDB, fastembed batching) that affects
+     ordering
+   This neutralises HNSW insertion-order non-determinism so that re-runs at the
+   same seed produce identical rankings.
+3. Ingest each item from `haystack_sessions` as a Distillery entry. The
+   `haystack_session_id` (or `<sess>_turn_<n>` derivative for per-turn
+   granularity) is stored on `entry.metadata.session_id` so it can be recovered
+   from `SearchResult` after retrieval.
+4. Call `store.search(question, limit=50)`. Top-50 is wide enough that R@5,
+   R@10, and NDCG@10 are not truncated.
+5. Map each `SearchResult.entry.metadata["session_id"]` back through the
+   haystack to derive the predicted `answer_session_id`. Compare predicted
+   ranking to the gold `answer_session_ids` from the dataset.
+6. Emit one JSONL record per question with: question id, ranked predictions,
+   distances, gold answer set, the per-question metric values, and the SHA
+   panel.
+
+A unit test (`tests/eval/test_session_id_round_trip.py`, landing with the
+W1-fastembed slice) guards the round-trip — without it, a regression in
+metadata persistence would silently report 0% recall.
+
+## Metrics
+
+The headline triplet:
+
+- **R@5** — Recall at 5: of the gold answer sessions for a question, what
+  fraction appear in the top 5 retrieved? Averaged across questions.
+- **R@10** — Recall at 10: same as above, top 10.
+- **NDCG@10** — Normalised Discounted Cumulative Gain at 10: rewards getting
+  gold answer sessions ranked highly within the top 10. Normalised so a
+  perfect ranking scores 1.0.
+
+Plain English:
+
+- R@5 = "Did we put the right answer in the top 5? How often?"
+- R@10 = "Did we put the right answer in the top 10? How often?"
+- NDCG@10 = "When we did, how high did we put it?"
+
+Implementations will live in `src/distillery/eval/scoring.py` — that module
+will be populated by the W1-scoring slice, alongside its 12-row test table.
+This file will link to it directly once it lands. The functions are textbook
+`dcg`, `ndcg`, and
+`evaluate_retrieval` — reimplemented from scratch (not lifted from any other
+project) and validated by a 12-row test table that pins behaviour on edge
+cases (empty gold set, no hits, perfect ranking, etc.).
+
+The bench also reuses the existing project type
+`src/distillery/eval/retrieval_scorer.RetrievalMetrics` so that R@k / P@k / MRR
+have the same shape across the eval suite and the bench.
+
+## Variance protocol
+
+Per publication discipline rule (6), the **first production run is a 5-seed
+back-to-back execution of the headline cell**. We compute mean and standard
+deviation of R@5 across the five runs.
+
+- **If stddev(R@5) ≤ 0.5 percentage points:** the bench is a usable regression
+  signal. Numbers may be published with the variance reported alongside the
+  point estimate.
+- **If stddev(R@5) > 0.5 percentage points:** the bench is too noisy to be a
+  regression signal in its current form. Halt rollout. Audit determinism in
+  this order: HNSW insertion order, RRF tie-break, fastembed batching, DuckDB
+  query plan stability. Do not publish a number until the audit closes.
+
+The 5-seed result lands at `bench/results/variance_baseline.json` and is
+referenced from every public surface that quotes the headline.
+
+## Reproducibility envelope
+
+Every published number ships with the SHA panel from
+[`LIMITATIONS.md`](./LIMITATIONS.md) §(e):
+
+- `git_sha` (Distillery commit)
+- `dataset_revision_sha` (HuggingFace revision)
+- `embed_model_sha` (model file digest)
+- `python_version`
+
+Anyone with these four values, the dataset cache, and `pip install -e ".[dev,fastembed]"`
+should reproduce the same JSONL output bit-for-bit at the same seed.
+
+## Citation
+
+If you cite the LongMemEval dataset itself, cite the original paper:
+
+> Wu, D. et al. *LongMemEval: Benchmarking Chat Assistants on Long-Term
+> Interactive Memory.* ICLR 2025. <https://arxiv.org/html/2410.10813v1>
+
+Distillery's run of the bench is **not** an official LongMemEval result and
+should not be cited as one — see [`LIMITATIONS.md`](./LIMITATIONS.md) §(a).

--- a/bench/METHODOLOGY.md
+++ b/bench/METHODOLOGY.md
@@ -44,7 +44,7 @@ Every question in the dataset is evaluated in isolation:
    `haystack_session_id` (or `<sess>_turn_<n>` derivative for per-turn
    granularity) is stored on `entry.metadata.session_id` so it can be recovered
    from `SearchResult` after retrieval.
-4. Call `store.search(question, limit=50)`. Top-50 is wide enough that R@5,
+4. Call `await store.search(query=question, filters=None, limit=50)`. Top-50 is wide enough that R@5,
    R@10, and NDCG@10 are not truncated.
 5. Map each `SearchResult.entry.metadata["session_id"]` back through the
    haystack to derive the predicted `answer_session_id`. Compare predicted

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,55 @@
+# bench/ — Distillery LongMemEval bench
+
+This directory contains the discipline scaffolding, methodology, and (once
+nightly automation lands) the auditable result receipts for Distillery's run
+of the LongMemEval benchmark.
+
+**Read these first, in order:**
+
+1. [`HEADLINE.md`](./HEADLINE.md) — the pre-registered headline configuration
+   cell and metric triplet. Immutable without an ADR.
+2. [`LIMITATIONS.md`](./LIMITATIONS.md) — what the published numbers do and do
+   not claim. Read before quoting any number.
+3. [`METHODOLOGY.md`](./METHODOLOGY.md) — dataset, per-question protocol,
+   metric definitions, variance gate.
+
+## Quick reproduction
+
+```bash
+pip install -e ".[dev,fastembed]"
+distillery bench longmemeval \
+    --retrieval hybrid \
+    --granularity session \
+    --recency on \
+    --embed-model bge-small
+```
+
+The CLI flags above will be wired by the `bench/cli-bench-subcommand` slice
+(W2-cli). Until that lands, this command is the documented interface and not
+yet executable.
+
+Result JSONL files (one line per question, with the SHA provenance panel) will
+be written to `bench/results/` — that directory will be populated by the
+nightly automation slice (W2-workflow-yaml). A `bench/results/SUMMARY.md`
+table will be auto-updated per nightly run, and a `bench/badge.json` (Shields
+endpoint format) will carry the latest headline triplet for the README badges.
+
+## What is *not* in this directory
+
+- No competitor comparison tables (see [`LIMITATIONS.md`](./LIMITATIONS.md) §(d)).
+- No QA-accuracy numbers (see [`LIMITATIONS.md`](./LIMITATIONS.md) §(a)).
+- No bench numbers from before the variance gate has been characterised
+  (rule (6) of the project's publication discipline).
+
+## Structure (after all slices land)
+
+```
+bench/
+  HEADLINE.md          # pre-registered headline cell + metric triplet
+  LIMITATIONS.md       # what the numbers do not claim
+  METHODOLOGY.md       # dataset, protocol, metrics, variance gate
+  README.md            # this file
+  badge.json           # Shields endpoint — populated by nightly automation
+  results/             # auditable per-run JSONL receipts + SUMMARY.md
+                       #   populated by nightly automation
+```

--- a/bench/README.md
+++ b/bench/README.md
@@ -43,7 +43,7 @@ endpoint format) will carry the latest headline triplet for the README badges.
 
 ## Structure (after all slices land)
 
-```
+```text
 bench/
   HEADLINE.md          # pre-registered headline cell + metric triplet
   LIMITATIONS.md       # what the numbers do not claim


### PR DESCRIPTION
## Summary

These four docs are the conditions under which the LongMemEval dataset stays in scope. **Reviewers: read `bench/LIMITATIONS.md` before any number lands.**

This PR ships the publication-discipline scaffolding for the LongMemEval bench (W1-discipline-docs slice of the parallel-worktree plan) — *before* any number, runner, or workflow exists. The intent is that the framing for any future number is fixed in advance and cannot be retro-fitted.

Files added:

- `bench/HEADLINE.md` — pre-registers the headline cell (`retrieval=hybrid, granularity=session, recency=on, embed=bge-small`) and the metric triplet (R@5, R@10, NDCG@10). Immutable without an ADR.
- `bench/LIMITATIONS.md` — the most important file in this PR. Spells out, in five labelled sections, what these numbers do and do not claim. Headed by a literal "WHAT THIS NUMBER DOES NOT CLAIM" section so it is impossible to misread.
- `bench/METHODOLOGY.md` — dataset pin, per-question protocol, metric definitions, variance gate (5-seed run; halt rollout if R@5 stddev > 0.5pp).
- `bench/README.md` — quick-reproduction commands and pointers to the three docs above.

## Discipline rules covered

- (1) Pre-registered headline cell — `HEADLINE.md`
- (2) Triplet metric (R@5, R@10, NDCG@10) — `HEADLINE.md` + `METHODOLOGY.md`
- (3) No competitor comparison tables — `LIMITATIONS.md` §(d)
- (4) Limitations doc shipped before any number — this PR
- (5) Code/dataset/model SHAs in every record — `LIMITATIONS.md` §(e), `METHODOLOGY.md`
- (6) Variance characterised before trust — `METHODOLOGY.md` "Variance protocol"
- (7) No speculative claims — none present in any of the four files

## Out of scope for this PR

- Any actual bench numbers (will land via W2-bench-runner + W2-workflow-yaml + W3-variance-gate)
- The dataset loader (W1-dataset-loader will fill in `dataset_revision_sha`)
- The scoring module (W1-scoring will populate `src/distillery/eval/scoring.py`)
- README badges or `docs/benchmarks.md` (W3-public-surfaces)

Cross-references to those forthcoming files are phrased as "will be populated by …" so there are no broken links.

## Test plan

- [ ] Reviewer reads `bench/LIMITATIONS.md` end-to-end.
- [ ] Reviewer confirms `bench/HEADLINE.md` fits on one screen.
- [ ] Reviewer confirms no markdown link in this PR points to a file that does not exist within this PR (forward-references are phrased "will be populated by …").
- [ ] Reviewer confirms no bench numbers, no competitor tables, no speculative claims appear anywhere in the four files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Added benchmark governance defining immutable headline triplet, publication discipline, and change-control rules.
- Documented limitations and non-comparability constraints, required provenance panel for published numbers, and retraction guidance.
- Added full methodology: dataset/reproducibility specs, per-question evaluation protocol, metric/variance rules, and publication receipts/badge guidance for reproducible results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->