### PR TITLE
ci(cosign): bump installer + binary pins, add post-install verify (#432)

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -205,8 +205,25 @@ jobs:
           build-args: |
             BUILD_SHA=${{ github.sha }}
 
+      # Cosign installer pinned to the v3.10.1 release SHA (latest v3.x as of
+      # 2026-05-03).  Cosign binary pinned to v2.6.3 (latest v2.x); v2 keeps
+      # the attestation format we already produce — moving to v3.0.x changes
+      # the predicate structure and would require coordinating with verifier
+      # tooling.  Bumping pins addresses issue #432 by replacing 5-month-old
+      # bootstrap script & binary URLs that hit a transient release-CDN miss.
       - name: Install Cosign
-        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        with:
+          cosign-release: v2.6.3
+
+      # Sanity-check the binary downloaded successfully.  ``Install Cosign``
+      # is a shell script under the hood — if its release-CDN fetch fails
+      # silently in some future regression, surface the problem here rather
+      # than letting the next step blow up with "cosign: command not found".
+      - name: Verify Cosign install
+        run: |
+          cosign version
+          which cosign
 
       - name: Sign container image
         env:


### PR DESCRIPTION
Fixes #432.

## Changes

- `sigstore/cosign-installer`: pinned SHA bumped from `f713795` (commented `# v3`, no specific tag — currently 5 months old) to `7e8b541` (v3.10.1, latest v3.x release).
- `cosign-release`: `v2.5.2` (2025-06-18) → `v2.6.3` (2026-04-06). Stay on v2.x to keep the existing attestation predicate format.
- New `Verify Cosign install` step runs `cosign version && which cosign` immediately after install. A future installer regression fails loudly here, not 3 steps later with cryptic "cosign: command not found".

## Why bump

The transient release-CDN miss that bit run 25272889594 (#421's distroless merge) is exactly the kind of failure a fresher bootstrap script handles better — upstream has continued hardening the installer's retry/error handling since v3 (commit `f713795`). Pinning to the current v3 head reduces the risk window.

## Trade-off

Newer installer SHA means re-trusting upstream code. Mitigated by:
- Pinning to a specific commit SHA (not a moving tag).
- The `Verify Cosign install` step that validates the binary actually works.
- v2.x → v2.x — same major attestation format, no consumer-side change required.

## Recovery for the unsigned image

Already kicked: `gh run rerun 25272889594 --failed`. That re-runs the Publish job for the existing digest, attaching signature + SBOM/SLSA attestations + triggering the distill_ops deploy that was skipped.

## Acceptance

- Next push to main runs `Install Cosign` against the new pins, then `Verify Cosign install` reports a non-empty version, then signs successfully.
- No change to the resulting image content or signature predicate format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supply chain security tooling to newer stable versions with enhanced verification checks to ensure proper installation during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->