### PR TITLE
[bench] fastembed local provider + session_id round-trip test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,12 @@ ragas = [
     "ragas>=0.2.0",
     "datasets>=2.14.0",
 ]
+fastembed = [
+    # Pinned exactly for benchmark reproducibility — anyone reruns the bench
+    # offline and gets byte-identical embeddings.  Bump only with a SHA panel
+    # update in bench/results/.
+    "fastembed==0.8.0",
+]
 
 [project.scripts]
 distillery = "distillery.cli:main"
@@ -106,6 +112,14 @@ module = [
     "datasets",
     "datasets.*",
 ]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# fastembed is an optional dependency exposed via the [fastembed] dep group.
+# The provider module imports it lazily, but mypy needs to resolve the type
+# import in the TYPE_CHECKING block — silence missing-import noise when the
+# package is not installed in the dev environment.
+module = ["fastembed", "fastembed.*"]
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/src/distillery/embedding/fastembed.py
+++ b/src/distillery/embedding/fastembed.py
@@ -1,0 +1,227 @@
+"""Fastembed (local, on-device) embedding provider implementation.
+
+Wraps the ``fastembed`` package's :class:`fastembed.TextEmbedding` so that
+Distillery can produce embeddings entirely offline.  The default model
+``BAAI/bge-small-en-v1.5`` is ~67 MB and produces 384-dimensional vectors,
+making it suitable for reproducible benchmarking and for local development
+without an API key.
+
+Why a local provider?
+---------------------
+
+* **Reproducibility (primary).**  Pinning the fastembed version + model
+  identifier yields byte-identical embeddings across runs.  Hosted APIs
+  (Jina, OpenAI) can update a model under the same name silently, which
+  poisons longitudinal benchmark numbers.
+* **Cost (secondary).**  No per-token billing for benchmark loops or
+  CI.  All computation happens on-device.
+
+The ``fastembed`` package itself is an *optional* dependency exposed via
+``pip install distillery-mcp[fastembed]`` so we don't bloat the default
+install with onnxruntime.  Importing this module is safe even when the
+package is missing — the import is deferred until first use and surfaces
+a clear ``ImportError`` if the dep group has not been installed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fastembed import TextEmbedding  # pragma: no cover - typing only
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model registry
+# ---------------------------------------------------------------------------
+
+#: Default model identifier — small (~67 MB), 384-dimensional, English.
+DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+
+#: Friendly aliases for the small set of models the bench / docs reference.
+#: The full set is available via :func:`fastembed.TextEmbedding.list_supported_models`.
+MODEL_ALIASES: dict[str, str] = {
+    "bge-small": "BAAI/bge-small-en-v1.5",
+    "bge-base": "BAAI/bge-base-en-v1.5",
+    "bge-large": "BAAI/bge-large-en-v1.5",
+    "nomic": "nomic-ai/nomic-embed-text-v1.5",
+    "mxbai": "mixedbread-ai/mxbai-embed-large-v1",
+}
+
+#: Embedding dimensions for known models.  Used so :attr:`dimensions` can be
+#: answered before the model has been lazy-loaded (e.g. by config validators).
+#: The fastembed library is the source of truth; this map mirrors its
+#: ``DenseModelDescription.dim`` values for the aliased models.
+_KNOWN_DIMENSIONS: dict[str, int] = {
+    "BAAI/bge-small-en-v1.5": 384,
+    "BAAI/bge-base-en-v1.5": 768,
+    "BAAI/bge-large-en-v1.5": 1024,
+    "nomic-ai/nomic-embed-text-v1.5": 768,
+    "mixedbread-ai/mxbai-embed-large-v1": 1024,
+}
+
+
+def _resolve_model_name(model: str) -> str:
+    """Resolve an alias (e.g. ``"bge-small"``) to its full identifier.
+
+    Pass-through for any value not registered in :data:`MODEL_ALIASES`.
+    """
+    return MODEL_ALIASES.get(model, model)
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class FastembedProvider:
+    """Local embedding provider backed by the ``fastembed`` ONNX runtime.
+
+    Implements the :class:`distillery.embedding.protocol.EmbeddingProvider`
+    protocol.  The underlying :class:`fastembed.TextEmbedding` is *lazy
+    loaded* on the first :meth:`embed` or :meth:`embed_batch` call so that
+    constructing a provider is cheap and so that misconfigured deployments
+    fail at first use rather than at import.
+
+    Parameters
+    ----------
+    model:
+        Either a full HuggingFace identifier (e.g.
+        ``"BAAI/bge-small-en-v1.5"``) or a friendly alias from
+        :data:`MODEL_ALIASES` (``"bge-small"``, ``"bge-base"``,
+        ``"bge-large"``, ``"nomic"``, ``"mxbai"``).  Defaults to
+        :data:`DEFAULT_MODEL` (384-dim, ~67 MB).
+    cache_dir:
+        Directory in which fastembed caches downloaded ONNX weights.  If
+        ``None`` the package default is used (``~/.cache/fastembed``).
+    threads:
+        Optional thread count override forwarded to fastembed's ONNX
+        runtime session.  ``None`` lets onnxruntime pick.
+
+    Raises
+    ------
+    ImportError
+        If the optional ``fastembed`` package is not installed.  Surfaces
+        only at first :meth:`embed`/:meth:`embed_batch` call (lazy load),
+        not at construction time, so config validators can probe the
+        provider without forcing an import.
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        cache_dir: str | None = None,
+        threads: int | None = None,
+    ) -> None:
+        self._model_name = _resolve_model_name(model)
+        self._cache_dir = cache_dir
+        self._threads = threads
+        self._dimensions: int | None = _KNOWN_DIMENSIONS.get(self._model_name)
+        # Lazy-loaded TextEmbedding instance.  Typed as Any so this module
+        # imports cleanly when fastembed is not installed.
+        self._embedder: Any | None = None
+
+    # ------------------------------------------------------------------
+    # Lazy loader
+    # ------------------------------------------------------------------
+
+    def _load(self) -> Any:
+        """Instantiate the underlying :class:`fastembed.TextEmbedding`.
+
+        Imports ``fastembed`` lazily so the module remains importable
+        without the optional dep group installed.  Caches the embedder so
+        the model is loaded at most once per provider instance.
+        """
+        if self._embedder is not None:
+            return self._embedder
+
+        try:
+            from fastembed import TextEmbedding
+        except ImportError as exc:  # pragma: no cover - exercised manually
+            raise ImportError(
+                "The 'fastembed' package is required for FastembedProvider. "
+                "Install it with: pip install distillery-mcp[fastembed]"
+            ) from exc
+
+        logger.info(
+            "Loading fastembed model %s (cache_dir=%s, threads=%s)",
+            self._model_name,
+            self._cache_dir,
+            self._threads,
+        )
+        embedder: TextEmbedding = TextEmbedding(
+            model_name=self._model_name,
+            cache_dir=self._cache_dir,
+            threads=self._threads,
+        )
+
+        # Update cached dimensions from the embedder when not pre-known
+        # (e.g. a custom model registered at runtime).
+        if self._dimensions is None:
+            self._dimensions = int(embedder.embedding_size)
+
+        self._embedder = embedder
+        return embedder
+
+    # ------------------------------------------------------------------
+    # EmbeddingProvider protocol
+    # ------------------------------------------------------------------
+
+    def embed(self, text: str) -> list[float]:
+        """Embed a single text string into a vector.
+
+        Args:
+            text: The text to embed.
+
+        Returns:
+            A list of floats representing the embedding vector.
+        """
+        return self.embed_batch([text])[0]
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts.
+
+        ``fastembed`` is fully synchronous and CPU-bound; this method
+        materialises the underlying generator into a list of native Python
+        ``list[float]`` so callers don't have to depend on ``numpy``.
+
+        Args:
+            texts: The texts to embed.  Empty list returns an empty list
+                without loading the model.
+
+        Returns:
+            A list of embedding vectors in the same order as the input.
+        """
+        if not texts:
+            return []
+
+        embedder = self._load()
+        # ``TextEmbedding.embed`` returns an iterator of numpy arrays; convert
+        # each to a plain list[float] so the public contract is dependency-free.
+        result: list[list[float]] = [[float(v) for v in vector] for vector in embedder.embed(texts)]
+        return result
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def dimensions(self) -> int:
+        """Return the dimensionality of the embedding vectors.
+
+        For aliased / well-known models the dimension is returned without
+        loading the model.  For unknown identifiers the model is loaded
+        lazily on first access.
+        """
+        if self._dimensions is None:
+            self._load()
+        # _dimensions is guaranteed populated after _load()
+        assert self._dimensions is not None
+        return self._dimensions
+
+    @property
+    def model_name(self) -> str:
+        """Return the resolved HuggingFace model identifier."""
+        return self._model_name

--- a/src/distillery/embedding/fastembed.py
+++ b/src/distillery/embedding/fastembed.py
@@ -26,6 +26,7 @@ a clear ``ImportError`` if the dep group has not been installed.
 from __future__ import annotations
 
 import logging
+import threading
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -122,6 +123,10 @@ class FastembedProvider:
         # Lazy-loaded TextEmbedding instance.  Typed as Any so this module
         # imports cleanly when fastembed is not installed.
         self._embedder: Any | None = None
+        # Guards lazy initialization in :meth:`_load` so concurrent first
+        # callers (e.g. from FastMCP's worker pool) cannot construct multiple
+        # ``TextEmbedding`` instances and race on the assignment.
+        self._load_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Lazy loader
@@ -133,37 +138,48 @@ class FastembedProvider:
         Imports ``fastembed`` lazily so the module remains importable
         without the optional dep group installed.  Caches the embedder so
         the model is loaded at most once per provider instance.
+
+        Uses double-checked locking on :attr:`_load_lock` so that concurrent
+        first callers (FastMCP runs tools on a worker pool) cannot construct
+        multiple :class:`fastembed.TextEmbedding` instances and race on the
+        cache assignment, which would leak ONNX sessions and file handles.
         """
         if self._embedder is not None:
             return self._embedder
 
-        try:
-            from fastembed import TextEmbedding
-        except ImportError as exc:  # pragma: no cover - exercised manually
-            raise ImportError(
-                "The 'fastembed' package is required for FastembedProvider. "
-                "Install it with: pip install distillery-mcp[fastembed]"
-            ) from exc
+        with self._load_lock:
+            # Re-check inside the lock: another thread may have completed the
+            # load while we were waiting to acquire it.
+            if self._embedder is not None:
+                return self._embedder
 
-        logger.info(
-            "Loading fastembed model %s (cache_dir=%s, threads=%s)",
-            self._model_name,
-            self._cache_dir,
-            self._threads,
-        )
-        embedder: TextEmbedding = TextEmbedding(
-            model_name=self._model_name,
-            cache_dir=self._cache_dir,
-            threads=self._threads,
-        )
+            try:
+                from fastembed import TextEmbedding
+            except ImportError as exc:  # pragma: no cover - exercised manually
+                raise ImportError(
+                    "The 'fastembed' package is required for FastembedProvider. "
+                    "Install it with: pip install distillery-mcp[fastembed]"
+                ) from exc
 
-        # Update cached dimensions from the embedder when not pre-known
-        # (e.g. a custom model registered at runtime).
-        if self._dimensions is None:
-            self._dimensions = int(embedder.embedding_size)
+            logger.info(
+                "Loading fastembed model %s (cache_dir=%s, threads=%s)",
+                self._model_name,
+                self._cache_dir,
+                self._threads,
+            )
+            embedder: TextEmbedding = TextEmbedding(
+                model_name=self._model_name,
+                cache_dir=self._cache_dir,
+                threads=self._threads,
+            )
 
-        self._embedder = embedder
-        return embedder
+            # Update cached dimensions from the embedder when not pre-known
+            # (e.g. a custom model registered at runtime).
+            if self._dimensions is None:
+                self._dimensions = int(embedder.embedding_size)
+
+            self._embedder = embedder
+            return embedder
 
     # ------------------------------------------------------------------
     # EmbeddingProvider protocol

--- a/tests/eval/test_session_id_round_trip.py
+++ b/tests/eval/test_session_id_round_trip.py
@@ -1,0 +1,84 @@
+"""Guard test: ``metadata.session_id`` round-trips through ``DuckDBStore.search()``.
+
+The LongMemEval bench stores haystack sessions as entries with
+``metadata={"session_id": "<haystack_id>"}`` and then maps each
+``SearchResult.entry.metadata["session_id"]`` back to the gold answer set.
+If the store ever drops or renames that key during the JSON round-trip,
+the bench will silently report 0% recall — every result's session_id will
+be missing and no comparison will match.
+
+This test pins the round-trip behaviour so a regression in the metadata
+serialisation layer (``store/duckdb.py::_row_to_entry``) is caught locally
+before it can poison the published numbers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import make_entry
+
+pytestmark = pytest.mark.unit
+
+
+async def test_metadata_session_id_round_trips_via_search(store) -> None:  # type: ignore[no-untyped-def]
+    """Storing ``metadata={"session_id": X}`` returns ``X`` from search.
+
+    Steps:
+      1. Store an entry whose metadata carries a ``session_id`` key.
+      2. Run a semantic search whose query embedding hits the entry.
+      3. Confirm the returned ``Entry.metadata["session_id"]`` equals the
+         exact value supplied at store time (no coercion, no drop).
+    """
+    expected_session_id = "haystack-session-abc-123"
+    entry = make_entry(
+        content="A unique sentence about quokkas and cheese.",
+        metadata={"session_id": expected_session_id},
+    )
+
+    entry_id = await store.store(entry)
+
+    # Use the same content as the query so the mock provider produces an
+    # identical hash-based vector and the entry surfaces as the top result.
+    results = await store.search(
+        query="A unique sentence about quokkas and cheese.",
+        filters=None,
+        limit=5,
+    )
+
+    matching = [r for r in results if r.entry.id == entry_id]
+    assert matching, (
+        f"Stored entry {entry_id!r} did not appear in search results; "
+        f"got {[r.entry.id for r in results]!r}"
+    )
+
+    returned_metadata = matching[0].entry.metadata
+    assert "session_id" in returned_metadata, (
+        f"metadata.session_id was dropped during round-trip; "
+        f"returned metadata keys: {list(returned_metadata.keys())!r}"
+    )
+    assert returned_metadata["session_id"] == expected_session_id, (
+        f"metadata.session_id was altered during round-trip; "
+        f"expected {expected_session_id!r}, got {returned_metadata['session_id']!r}"
+    )
+
+
+async def test_metadata_session_id_round_trips_via_get(store) -> None:  # type: ignore[no-untyped-def]
+    """Defence-in-depth: same key survives ``get(entry_id)`` too.
+
+    ``search()`` and ``get()`` share ``_row_to_entry`` but exercise
+    slightly different SQL paths.  Pinning both keeps the bench safe if a
+    future refactor splits them.
+    """
+    expected_session_id = "haystack-session-xyz-789"
+    entry = make_entry(
+        content="Round-trip via get, not search.",
+        metadata={"session_id": expected_session_id, "extra": "preserved"},
+    )
+
+    entry_id = await store.store(entry)
+
+    fetched = await store.get(entry_id)
+    assert fetched is not None, f"Stored entry {entry_id!r} could not be fetched"
+    assert fetched.metadata.get("session_id") == expected_session_id
+    assert fetched.metadata.get("extra") == "preserved"

--- a/tests/test_fastembed_provider.py
+++ b/tests/test_fastembed_provider.py
@@ -1,0 +1,133 @@
+"""Unit tests for the local fastembed embedding provider.
+
+Skipped automatically when the optional ``fastembed`` dep is not installed
+(installable via ``pip install distillery-mcp[fastembed]``).  The first
+test downloads / caches the BAAI/bge-small-en-v1.5 ONNX model on the
+machine running the suite — subsequent runs are warm and fast.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Skip the entire module unless the optional dep is installed.  Done with
+# importorskip so the standard dev install (`pip install -e ".[dev]"`)
+# still passes `pytest -m unit` with no fastembed extras.
+pytest.importorskip("fastembed")
+
+from distillery.embedding.fastembed import (  # noqa: E402  (import after skip)
+    DEFAULT_MODEL,
+    MODEL_ALIASES,
+    FastembedProvider,
+    _resolve_model_name,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python helpers (do not need the model to be loaded)
+# ---------------------------------------------------------------------------
+
+
+def test_model_aliases_resolve() -> None:
+    """``bge-small`` and friends map to their full HuggingFace identifiers."""
+    assert _resolve_model_name("bge-small") == "BAAI/bge-small-en-v1.5"
+    assert _resolve_model_name("bge-base") == "BAAI/bge-base-en-v1.5"
+    assert _resolve_model_name("bge-large") == "BAAI/bge-large-en-v1.5"
+    assert _resolve_model_name("nomic") == "nomic-ai/nomic-embed-text-v1.5"
+    assert _resolve_model_name("mxbai") == "mixedbread-ai/mxbai-embed-large-v1"
+
+
+def test_unknown_model_passes_through() -> None:
+    """Non-aliased identifiers are returned as-is for fastembed to validate."""
+    assert _resolve_model_name("BAAI/bge-small-en-v1.5") == "BAAI/bge-small-en-v1.5"
+    assert _resolve_model_name("custom/model-x") == "custom/model-x"
+
+
+def test_default_model_is_bge_small() -> None:
+    """Default stays pinned to the small bge model documented in the bench."""
+    assert DEFAULT_MODEL == "BAAI/bge-small-en-v1.5"
+    assert "bge-small" in MODEL_ALIASES
+
+
+def test_construction_does_not_load_model() -> None:
+    """Constructor is cheap — no ONNX session is created until first embed."""
+    provider = FastembedProvider()
+    assert provider._embedder is None  # noqa: SLF001
+    # Dimensions for known aliases is answerable without loading the model.
+    assert provider.dimensions == 384
+    assert provider._embedder is None  # noqa: SLF001
+
+
+def test_model_name_resolves_alias_in_constructor() -> None:
+    """Passing ``"bge-small"`` resolves to the full identifier on the property."""
+    provider = FastembedProvider(model="bge-small")
+    assert provider.model_name == "BAAI/bge-small-en-v1.5"
+
+
+# ---------------------------------------------------------------------------
+# Integration with the actual model — downloads weights on first run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def provider() -> FastembedProvider:
+    """Module-scoped provider so the ONNX model is loaded only once."""
+    return FastembedProvider()
+
+
+def test_embed_returns_correct_dimensions(provider: FastembedProvider) -> None:
+    """``embed`` produces a 384-dimensional vector for bge-small."""
+    vector = provider.embed("hello world")
+    assert isinstance(vector, list)
+    assert len(vector) == 384
+    assert all(isinstance(v, float) for v in vector)
+
+
+def test_embed_batch_returns_correct_shape(provider: FastembedProvider) -> None:
+    """``embed_batch`` returns one 384-dim vector per input, in order."""
+    texts = ["alpha", "beta", "gamma"]
+    vectors = provider.embed_batch(texts)
+    assert len(vectors) == len(texts)
+    for v in vectors:
+        assert len(v) == 384
+
+
+def test_empty_batch_returns_empty_list(provider: FastembedProvider) -> None:
+    """An empty input list is a no-op and does not load the model."""
+    fresh = FastembedProvider()
+    assert fresh.embed_batch([]) == []
+    # Empty-batch fast path must not have triggered model loading.
+    assert fresh._embedder is None  # noqa: SLF001
+
+
+def test_embed_is_deterministic(provider: FastembedProvider) -> None:
+    """Two calls with the same input produce identical vectors.
+
+    Without this, the bench cannot characterise variance — embedding noise
+    would dwarf any retrieval-quality signal.  fastembed's ONNX runtime is
+    deterministic on CPU; this test pins that contract.
+    """
+    text = "The quokka is a small marsupial native to Western Australia."
+    v1 = provider.embed(text)
+    v2 = provider.embed(text)
+    assert v1 == v2
+
+
+def test_batch_matches_singletons(provider: FastembedProvider) -> None:
+    """Batching does not change the output: embed_batch == [embed, embed, ...].
+
+    Distillery's bench ingests sessions in batches; if batched outputs
+    diverged from per-document outputs, the recall numbers would not
+    reproduce when run document-by-document for debugging.
+    """
+    texts = ["first sentence", "second sentence", "third sentence"]
+    batched = provider.embed_batch(texts)
+    singletons = [provider.embed(t) for t in texts]
+    assert batched == singletons
+
+
+def test_model_name_property(provider: FastembedProvider) -> None:
+    """``model_name`` exposes the resolved HuggingFace identifier."""
+    assert provider.model_name == DEFAULT_MODEL

--- a/tests/test_fastembed_provider.py
+++ b/tests/test_fastembed_provider.py
@@ -22,7 +22,10 @@ from distillery.embedding.fastembed import (  # noqa: E402  (import after skip)
     _resolve_model_name,
 )
 
-pytestmark = pytest.mark.unit
+# NOTE: Markers are applied per-test below rather than via a module-level
+# ``pytestmark`` because the file mixes pure-Python checks (unit) with tests
+# that load the real ONNX model (integration — slow + downloads weights on
+# first run).  Per CLAUDE.md test-marker conventions.
 
 
 # ---------------------------------------------------------------------------
@@ -30,6 +33,7 @@ pytestmark = pytest.mark.unit
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_model_aliases_resolve() -> None:
     """``bge-small`` and friends map to their full HuggingFace identifiers."""
     assert _resolve_model_name("bge-small") == "BAAI/bge-small-en-v1.5"
@@ -39,18 +43,21 @@ def test_model_aliases_resolve() -> None:
     assert _resolve_model_name("mxbai") == "mixedbread-ai/mxbai-embed-large-v1"
 
 
+@pytest.mark.unit
 def test_unknown_model_passes_through() -> None:
     """Non-aliased identifiers are returned as-is for fastembed to validate."""
     assert _resolve_model_name("BAAI/bge-small-en-v1.5") == "BAAI/bge-small-en-v1.5"
     assert _resolve_model_name("custom/model-x") == "custom/model-x"
 
 
+@pytest.mark.unit
 def test_default_model_is_bge_small() -> None:
     """Default stays pinned to the small bge model documented in the bench."""
     assert DEFAULT_MODEL == "BAAI/bge-small-en-v1.5"
     assert "bge-small" in MODEL_ALIASES
 
 
+@pytest.mark.unit
 def test_construction_does_not_load_model() -> None:
     """Constructor is cheap — no ONNX session is created until first embed."""
     provider = FastembedProvider()
@@ -60,10 +67,72 @@ def test_construction_does_not_load_model() -> None:
     assert provider._embedder is None  # noqa: SLF001
 
 
+@pytest.mark.unit
 def test_model_name_resolves_alias_in_constructor() -> None:
     """Passing ``"bge-small"`` resolves to the full identifier on the property."""
     provider = FastembedProvider(model="bge-small")
     assert provider.model_name == "BAAI/bge-small-en-v1.5"
+
+
+@pytest.mark.unit
+def test_concurrent_load_constructs_single_embedder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Threaded first-callers must share a single ``TextEmbedding`` instance.
+
+    Regression test for the lazy-load race condition — without the
+    ``_load_lock`` guard, four concurrent ``embed`` calls could each race
+    past the ``self._embedder is None`` check and construct their own
+    ONNX session, leaking memory and file handles.
+    """
+    import threading
+
+    import fastembed as fastembed_mod
+
+    call_count = 0
+    construct_lock = threading.Lock()
+    # Block constructor until all worker threads are inside it, so the test
+    # forces the race condition to manifest if the lock is missing.
+    inside_constructor = threading.Event()
+    proceed = threading.Event()
+
+    class _StubEmbedder:
+        embedding_size = 384
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            nonlocal call_count
+            with construct_lock:
+                call_count += 1
+            inside_constructor.set()
+            # Hold here briefly so other threads have a chance to enter
+            # (or, without the lock, race past) the check-then-set.
+            proceed.wait(timeout=2.0)
+
+        def embed(self, texts: list[str]) -> list[list[float]]:
+            return [[0.0] * 384 for _ in texts]
+
+    monkeypatch.setattr(fastembed_mod, "TextEmbedding", _StubEmbedder)
+
+    provider = FastembedProvider()
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            provider.embed("x")
+        except BaseException as exc:  # pragma: no cover - surfaced via assert
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    # Once one thread is inside the constructor, release it so all workers
+    # complete; with the lock, the other three will block then short-circuit
+    # on the double-check.
+    inside_constructor.wait(timeout=2.0)
+    proceed.set()
+    for t in threads:
+        t.join(timeout=5.0)
+
+    assert errors == []
+    assert call_count == 1, f"Expected single TextEmbedding construction, got {call_count}"
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +146,7 @@ def provider() -> FastembedProvider:
     return FastembedProvider()
 
 
+@pytest.mark.integration
 def test_embed_returns_correct_dimensions(provider: FastembedProvider) -> None:
     """``embed`` produces a 384-dimensional vector for bge-small."""
     vector = provider.embed("hello world")
@@ -85,6 +155,7 @@ def test_embed_returns_correct_dimensions(provider: FastembedProvider) -> None:
     assert all(isinstance(v, float) for v in vector)
 
 
+@pytest.mark.integration
 def test_embed_batch_returns_correct_shape(provider: FastembedProvider) -> None:
     """``embed_batch`` returns one 384-dim vector per input, in order."""
     texts = ["alpha", "beta", "gamma"]
@@ -94,6 +165,7 @@ def test_embed_batch_returns_correct_shape(provider: FastembedProvider) -> None:
         assert len(v) == 384
 
 
+@pytest.mark.integration
 def test_empty_batch_returns_empty_list(provider: FastembedProvider) -> None:
     """An empty input list is a no-op and does not load the model."""
     fresh = FastembedProvider()
@@ -102,6 +174,7 @@ def test_empty_batch_returns_empty_list(provider: FastembedProvider) -> None:
     assert fresh._embedder is None  # noqa: SLF001
 
 
+@pytest.mark.integration
 def test_embed_is_deterministic(provider: FastembedProvider) -> None:
     """Two calls with the same input produce identical vectors.
 
@@ -115,6 +188,7 @@ def test_embed_is_deterministic(provider: FastembedProvider) -> None:
     assert v1 == v2
 
 
+@pytest.mark.integration
 def test_batch_matches_singletons(provider: FastembedProvider) -> None:
     """Batching does not change the output: embed_batch == [embed, embed, ...].
 
@@ -128,6 +202,7 @@ def test_batch_matches_singletons(provider: FastembedProvider) -> None:
     assert batched == singletons
 
 
+@pytest.mark.integration
 def test_model_name_property(provider: FastembedProvider) -> None:
     """``model_name`` exposes the resolved HuggingFace identifier."""
     assert provider.model_name == DEFAULT_MODEL

--- a/tests/test_fastembed_provider.py
+++ b/tests/test_fastembed_provider.py
@@ -130,6 +130,7 @@ def test_concurrent_load_constructs_single_embedder(monkeypatch: pytest.MonkeyPa
     proceed.set()
     for t in threads:
         t.join(timeout=5.0)
+    assert all(not t.is_alive() for t in threads), "Worker thread hung during lazy-load race test"
 
     assert errors == []
     assert call_count == 1, f"Expected single TextEmbedding construction, got {call_count}"


### PR DESCRIPTION
## Summary

Wave-1 slice **W1-fastembed** of the LongMemEval bench plan
(`~/.claude/plans/look-at-mempalace-hook-dynamic-mccarthy.md`).

- New `FastembedProvider` (`src/distillery/embedding/fastembed.py`) implements the existing `EmbeddingProvider` protocol on top of `fastembed.TextEmbedding`. Default model `BAAI/bge-small-en-v1.5` (384-dim, ~67 MB on-device); optional aliases `bge-base`, `bge-large`, `nomic`, `mxbai`. Lazy-loads the ONNX session on first `embed`/`embed_batch` call.
- New `[fastembed]` optional dep group in `pyproject.toml` with `fastembed==0.8.0` **pinned exactly**. Plus a mypy `ignore_missing_imports` override so strict typing still passes when the optional dep is absent.
- New unit test `tests/eval/test_session_id_round_trip.py` pins `metadata.session_id` round-trip through both `store.search()` and `store.get()`.
- New unit test `tests/test_fastembed_provider.py` covers shape (384-dim), batch consistency, determinism, alias resolution, and lazy loading. Skipped via `pytest.importorskip` when the optional dep isn't installed.

## Why fastembed (not Jina / OpenAI)

- **Reproducibility (primary).** Pinning the fastembed version + model name yields byte-identical embeddings across runs. Hosted APIs can update a model under the same name silently, which poisons longitudinal benchmark numbers.
- **Cost (secondary).** No per-token billing for benchmark loops or CI; everything runs offline on CPU.

## Why the round-trip test exists

The bench stores haystack sessions as entries with `metadata={"session_id": "<id>"}` and maps each `SearchResult.entry.metadata["session_id"]` back to the gold answer set. If `DuckDBStore` ever drops or renames that key during JSON serialisation, **the bench silently reports 0% recall** — every result's session_id key is missing and nothing matches. This test catches that regression locally before it can poison published numbers.

## Test plan

- [x] `pytest -m unit -k "embedding or session_id"` passes locally (109 tests pass)
- [x] `pytest tests/test_fastembed_provider.py tests/eval/test_session_id_round_trip.py -v` — 13/13 pass
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` on touched files — clean
- [x] `mypy --strict src/distillery/` — clean (63 source files)
- [x] Smoke test: `pip install -e ".[fastembed]"` then `from distillery.embedding.fastembed import FastembedProvider; p = FastembedProvider(); v = p.embed("hello"); assert len(v) == 384` — works
- [ ] CI matrix (Python 3.11, 3.12, 3.13, 3.14)

## Constraints / scope

This slice is pure construction — no public-surface changes, no CI changes, no external state. Touches only the four files listed in the plan plus the new `[fastembed]` dep group in `pyproject.toml`. Mergeable independently of other Wave 1 worktrees per the plan's conflict-surface analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local/offline text embeddings via a new embedding provider with model alias resolution and lazy loading.

* **Tests**
  * Added unit and integration tests for the provider (concurrency/lazy-load, deterministic outputs, batch/empty behavior) and tests ensuring session_id metadata survives storage round-trips.

* **Chores**
  * Added an optional fastembed dependency group and suppressed missing-import type-check noise when it's not installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->