### PR TITLE
[bench] SHA-pinned LongMemEval dataset loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ dev = [
     "types-PyYAML>=6.0",
     "types-defusedxml>=0.7.0",
     "pytest-httpx>=0.30.0",
+    # Bench tooling: SHA-pinned dataset downloads from HuggingFace.
+    # Dev-only — never required by the runtime install.
+    "huggingface_hub>=0.24,<1.0",
 ]
 docs = [
     "mkdocs-material>=9.5",

--- a/src/distillery/eval/longmemeval_dataset.py
+++ b/src/distillery/eval/longmemeval_dataset.py
@@ -1,0 +1,211 @@
+"""SHA-pinned LongMemEval dataset loader.
+
+Downloads the cleaned LongMemEval-S split from HuggingFace (repo
+``xiaowu0162/longmemeval-cleaned``) at a frozen commit revision, verifies the
+SHA-256 digest of the JSON file, and returns the parsed list of question dicts.
+
+The pinning + verification pipeline is the dataset half of publication
+discipline rule (5) in the LongMemEval bench plan: code, dataset, embed model,
+and Python version SHAs accompany every JSONL receipt. No SHAs ⇒ no claim.
+
+Workaround for the upstream ``FeaturesError``
+---------------------------------------------
+
+The HuggingFace ``datasets`` config in this repo trips ``FeaturesError`` when
+the loader tries to infer a schema for the ``answer`` column (it is a free-form
+string but feature inference treats it as a list of dicts in some rows of the
+sibling oracle split). We sidestep the loader entirely: ``snapshot_download``
+fetches the raw JSON, which we parse directly. See the dataset viewer error
+banner on https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned for
+the upstream symptom.
+
+Resolution provenance
+---------------------
+
+The constants below were resolved on **2026-05-02** by the bench-author agent:
+
+* ``DATASET_REVISION_SHA`` — current ``main`` HEAD of
+  ``xiaowu0162/longmemeval-cleaned`` queried via ``HfApi.list_repo_refs``.
+* ``DATASET_FILE_SHA256`` — SHA-256 of the downloaded
+  ``longmemeval_s_cleaned.json`` blob (264 MB, 500 questions).
+
+Bumping either constant is an intentional bench-result-invalidating change and
+must ship under its own ADR.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+# Resolved 2026-05-02. Do not edit without an ADR — bumping these constants
+# invalidates every published bench number.
+DATASET_REPO_ID = "xiaowu0162/longmemeval-cleaned"
+DATASET_REVISION_SHA = "98d7416c24c778c2fee6e6f3006e7a073259d48f"
+DATASET_FILE_SHA256 = "d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442"
+DATASET_FILENAME = "longmemeval_s_cleaned.json"
+
+# Question-dict keys we contract on. Validated by the loader on every call so a
+# silent upstream schema drift (within the same revision) is caught loudly.
+REQUIRED_QUESTION_KEYS: frozenset[str] = frozenset(
+    {
+        "question",
+        "question_date",
+        "haystack_sessions",
+        "haystack_session_ids",
+        "haystack_dates",
+        "answer_session_ids",
+    }
+)
+
+
+class DatasetIntegrityError(RuntimeError):
+    """Raised when the cached dataset file fails SHA-256 verification.
+
+    The downloaded blob does not match :data:`DATASET_FILE_SHA256`. Either the
+    cache was tampered with, the upstream revision was force-pushed (it
+    shouldn't be — HF revisions are immutable), or the constant in this module
+    is stale.
+    """
+
+
+class DatasetSchemaError(RuntimeError):
+    """Raised when a parsed question dict is missing one of the required keys.
+
+    Indicates upstream schema drift within the pinned revision, which is
+    unexpected; report and investigate before trusting bench numbers from this
+    run.
+    """
+
+
+def _default_cache_dir() -> Path:
+    """Return ``$XDG_CACHE_HOME/distillery/longmemeval`` (or HOME fallback)."""
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        return Path(xdg) / "distillery" / "longmemeval"
+    return Path.home() / ".cache" / "distillery" / "longmemeval"
+
+
+def _sha256_file(path: Path) -> str:
+    """Stream the file through SHA-256 in 1 MB chunks (264 MB JSON = 264 reads)."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _verify_sha256(path: Path, expected: str) -> None:
+    """Raise :class:`DatasetIntegrityError` unless ``path``'s SHA-256 matches."""
+    actual = _sha256_file(path)
+    if actual != expected:
+        raise DatasetIntegrityError(
+            f"SHA-256 mismatch for {path.name}.\n"
+            f"  expected: {expected}\n"
+            f"  actual:   {actual}\n"
+            f"Refusing to load — re-download by removing the cache directory "
+            f"({path.parent}) and re-running, or update DATASET_FILE_SHA256 "
+            f"under an ADR if this is an intentional revision bump."
+        )
+
+
+def _validate_schema(questions: list[dict[str, Any]]) -> None:
+    """Spot-check the first question for the contracted key set."""
+    if not questions:
+        raise DatasetSchemaError("Dataset is empty — expected 500 questions.")
+    first = questions[0]
+    if not isinstance(first, dict):
+        raise DatasetSchemaError(f"Top-level entries must be dicts, got {type(first).__name__}.")
+    missing = REQUIRED_QUESTION_KEYS - set(first.keys())
+    if missing:
+        raise DatasetSchemaError(
+            f"Dataset schema drift: question 0 missing required keys "
+            f"{sorted(missing)}. Pinned revision {DATASET_REVISION_SHA} should "
+            f"contain {sorted(REQUIRED_QUESTION_KEYS)}."
+        )
+
+
+def _load_and_verify(json_path: Path) -> list[dict[str, Any]]:
+    """Verify SHA-256, parse, validate schema; return parsed question list."""
+    _verify_sha256(json_path, DATASET_FILE_SHA256)
+    with json_path.open("rb") as f:
+        parsed = json.load(f)
+    if not isinstance(parsed, list):
+        raise DatasetSchemaError(f"Top-level JSON must be a list, got {type(parsed).__name__}.")
+    _validate_schema(parsed)
+    return parsed
+
+
+def load_longmemeval(cache_dir: Path | None = None) -> list[dict[str, Any]]:
+    """Download (if needed), verify, and return the LongMemEval-S question list.
+
+    Parameters
+    ----------
+    cache_dir:
+        Directory used for the HuggingFace blob cache. Defaults to
+        ``$XDG_CACHE_HOME/distillery/longmemeval`` (or
+        ``~/.cache/distillery/longmemeval`` if XDG is unset). After the first
+        successful run, subsequent calls are offline.
+
+    Returns
+    -------
+    list[dict]
+        Parsed question dicts. Each dict has at least ``question``,
+        ``question_date``, ``haystack_sessions``, ``haystack_session_ids``,
+        ``haystack_dates``, and ``answer_session_ids``.
+
+    Raises
+    ------
+    DatasetIntegrityError
+        If the downloaded JSON's SHA-256 does not match
+        :data:`DATASET_FILE_SHA256`.
+    DatasetSchemaError
+        If the parsed JSON is empty, not a list, or the first question is
+        missing one of :data:`REQUIRED_QUESTION_KEYS`.
+    ImportError
+        If ``huggingface_hub`` is not installed (it lives in the ``[dev]``
+        optional group).
+    """
+    target_cache = cache_dir if cache_dir is not None else _default_cache_dir()
+    target_cache.mkdir(parents=True, exist_ok=True)
+
+    # huggingface_hub is a dev-only dep; surface a clear error if missing.
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:  # pragma: no cover - import guard
+        raise ImportError(
+            "load_longmemeval requires huggingface_hub. Install the dev extras: "
+            "pip install -e '.[dev]'"
+        ) from exc
+
+    snapshot_dir_str = snapshot_download(
+        repo_id=DATASET_REPO_ID,
+        revision=DATASET_REVISION_SHA,
+        repo_type="dataset",
+        cache_dir=str(target_cache),
+        allow_patterns=[DATASET_FILENAME],
+    )
+    snapshot_dir = Path(snapshot_dir_str)
+    json_path = snapshot_dir / DATASET_FILENAME
+    if not json_path.exists():
+        raise DatasetIntegrityError(
+            f"snapshot_download succeeded but {DATASET_FILENAME} is missing "
+            f"from {snapshot_dir}. The pinned revision may not contain this "
+            f"file (revision={DATASET_REVISION_SHA})."
+        )
+    return _load_and_verify(json_path)
+
+
+__all__ = [
+    "DATASET_FILE_SHA256",
+    "DATASET_FILENAME",
+    "DATASET_REPO_ID",
+    "DATASET_REVISION_SHA",
+    "REQUIRED_QUESTION_KEYS",
+    "DatasetIntegrityError",
+    "DatasetSchemaError",
+    "load_longmemeval",
+]

--- a/src/distillery/eval/longmemeval_dataset.py
+++ b/src/distillery/eval/longmemeval_dataset.py
@@ -35,6 +35,7 @@ must ship under its own ADR.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
@@ -113,19 +114,21 @@ def _verify_sha256(path: Path, expected: str) -> None:
 
 
 def _validate_schema(questions: list[dict[str, Any]]) -> None:
-    """Spot-check the first question for the contracted key set."""
+    """Validate each question for the contracted key set."""
     if not questions:
         raise DatasetSchemaError("Dataset is empty — expected 500 questions.")
-    first = questions[0]
-    if not isinstance(first, dict):
-        raise DatasetSchemaError(f"Top-level entries must be dicts, got {type(first).__name__}.")
-    missing = REQUIRED_QUESTION_KEYS - set(first.keys())
-    if missing:
-        raise DatasetSchemaError(
-            f"Dataset schema drift: question 0 missing required keys "
-            f"{sorted(missing)}. Pinned revision {DATASET_REVISION_SHA} should "
-            f"contain {sorted(REQUIRED_QUESTION_KEYS)}."
-        )
+    for idx, question in enumerate(questions):
+        if not isinstance(question, dict):
+            raise DatasetSchemaError(
+                f"Top-level entries must be dicts, got {type(question).__name__} at index {idx}."
+            )
+        missing = REQUIRED_QUESTION_KEYS - set(question.keys())
+        if missing:
+            raise DatasetSchemaError(
+                f"Dataset schema drift: question {idx} missing required keys "
+                f"{sorted(missing)}. Pinned revision {DATASET_REVISION_SHA} should "
+                f"contain {sorted(REQUIRED_QUESTION_KEYS)}."
+            )
 
 
 def _load_and_verify(json_path: Path) -> list[dict[str, Any]]:
@@ -139,8 +142,18 @@ def _load_and_verify(json_path: Path) -> list[dict[str, Any]]:
     return parsed
 
 
-def load_longmemeval(cache_dir: Path | None = None) -> list[dict[str, Any]]:
+async def load_longmemeval(cache_dir: Path | None = None) -> list[dict[str, Any]]:
     """Download (if needed), verify, and return the LongMemEval-S question list.
+
+    This is the public entry point and is ``async`` per the repository
+    storage-async convention (see ``CLAUDE.md``: *all storage operations must
+    be async using async/await patterns*). The blocking calls
+    (``snapshot_download``, SHA-256 streaming, JSON parse) are dispatched via
+    :func:`asyncio.to_thread` so the event loop is never blocked. Internal
+    helpers (``_default_cache_dir``, ``_sha256_file``, ``_load_and_verify``,
+    ``_validate_schema``) remain sync — they are single-call, short, and
+    making them async would force every caller-of-caller chain to be async
+    without benefit.
 
     Parameters
     ----------
@@ -163,8 +176,8 @@ def load_longmemeval(cache_dir: Path | None = None) -> list[dict[str, Any]]:
         If the downloaded JSON's SHA-256 does not match
         :data:`DATASET_FILE_SHA256`.
     DatasetSchemaError
-        If the parsed JSON is empty, not a list, or the first question is
-        missing one of :data:`REQUIRED_QUESTION_KEYS`.
+        If the parsed JSON is empty, not a list, or any question is missing
+        one of :data:`REQUIRED_QUESTION_KEYS`.
     ImportError
         If ``huggingface_hub`` is not installed (it lives in the ``[dev]``
         optional group).
@@ -181,7 +194,8 @@ def load_longmemeval(cache_dir: Path | None = None) -> list[dict[str, Any]]:
             "pip install -e '.[dev]'"
         ) from exc
 
-    snapshot_dir_str = snapshot_download(
+    snapshot_dir_str = await asyncio.to_thread(
+        snapshot_download,
         repo_id=DATASET_REPO_ID,
         revision=DATASET_REVISION_SHA,
         repo_type="dataset",
@@ -196,7 +210,7 @@ def load_longmemeval(cache_dir: Path | None = None) -> list[dict[str, Any]]:
             f"from {snapshot_dir}. The pinned revision may not contain this "
             f"file (revision={DATASET_REVISION_SHA})."
         )
-    return _load_and_verify(json_path)
+    return await asyncio.to_thread(_load_and_verify, json_path)
 
 
 __all__ = [

--- a/tests/eval/test_dataset_loader.py
+++ b/tests/eval/test_dataset_loader.py
@@ -1,0 +1,268 @@
+"""Tests for the SHA-pinned LongMemEval dataset loader.
+
+Two tiers:
+
+* ``@pytest.mark.unit`` — exercise SHA verification and schema validation
+  against a hand-crafted fixture in ``tests/fixtures/longmemeval_mini.json``.
+  No network, no HF SDK invocation. Designed for the regular CI unit suite.
+
+* ``@pytest.mark.integration`` — hits the real HuggingFace API on the first
+  run, downloads ~265 MB into the user-supplied cache, and verifies the file
+  SHA against :data:`DATASET_FILE_SHA256`. The second call exercises the
+  warm-cache offline path. Skipped under ``pytest -m unit``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from distillery.eval.longmemeval_dataset import (
+    DATASET_FILE_SHA256,
+    DATASET_FILENAME,
+    DATASET_REVISION_SHA,
+    REQUIRED_QUESTION_KEYS,
+    DatasetIntegrityError,
+    DatasetSchemaError,
+    _load_and_verify,
+    _validate_schema,
+    _verify_sha256,
+    load_longmemeval,
+)
+
+# ---------------------------------------------------------------------------
+# Constants — fixture path + its known-good digest (re-computed on disk).
+# ---------------------------------------------------------------------------
+
+FIXTURE_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "longmemeval_mini.json"
+
+
+def _sha256_bytes(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — fixture-driven, no network, no HF SDK
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fixture_exists() -> None:
+    """The hand-crafted fixture must ship with the test file."""
+    assert FIXTURE_PATH.exists(), f"Missing fixture at {FIXTURE_PATH}"
+
+
+@pytest.mark.unit
+def test_verify_sha256_accepts_matching_digest(tmp_path: Path) -> None:
+    """``_verify_sha256`` is a no-op when the digest matches."""
+    target = tmp_path / "data.json"
+    target.write_bytes(b'{"hello": "world"}')
+    expected = _sha256_bytes(target.read_bytes())
+    _verify_sha256(target, expected)  # must not raise
+
+
+@pytest.mark.unit
+def test_verify_sha256_rejects_mismatch(tmp_path: Path) -> None:
+    """A wrong digest raises :class:`DatasetIntegrityError` with both hashes."""
+    target = tmp_path / "data.json"
+    target.write_bytes(b'{"hello": "world"}')
+    bogus = "0" * 64
+    with pytest.raises(DatasetIntegrityError) as excinfo:
+        _verify_sha256(target, bogus)
+    msg = str(excinfo.value)
+    assert "expected" in msg and bogus in msg
+    assert "actual" in msg
+    assert "data.json" in msg
+
+
+@pytest.mark.unit
+def test_load_and_verify_corrupt_file_raises(tmp_path: Path) -> None:
+    """Corrupting the cached fixture must trip SHA verification."""
+    cached = tmp_path / DATASET_FILENAME
+    shutil.copy(FIXTURE_PATH, cached)
+    fixture_sha = _sha256_bytes(cached.read_bytes())
+
+    # Sanity check: fixture matches itself.
+    _verify_sha256(cached, fixture_sha)
+
+    # Now corrupt the file — write garbage of identical-ish length.
+    cached.write_bytes(b"this is not the dataset you are looking for\n" * 100)
+
+    with pytest.raises(DatasetIntegrityError) as excinfo:
+        _verify_sha256(cached, fixture_sha)
+    assert "SHA-256 mismatch" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_load_and_verify_returns_questions(tmp_path: Path) -> None:
+    """End-to-end ``_load_and_verify`` returns the parsed list."""
+    cached = tmp_path / DATASET_FILENAME
+    shutil.copy(FIXTURE_PATH, cached)
+    fixture_sha = _sha256_bytes(cached.read_bytes())
+
+    # Monkey-patch the module-level constant for one call by routing through
+    # the lower-level helper directly. ``_load_and_verify`` always uses
+    # ``DATASET_FILE_SHA256`` — so we bypass it here by calling _verify + json
+    # ourselves with the fixture's own SHA. This keeps the unit test honest
+    # about what each helper does.
+    _verify_sha256(cached, fixture_sha)
+    parsed = json.loads(cached.read_bytes())
+    _validate_schema(parsed)
+
+    assert isinstance(parsed, list)
+    assert len(parsed) >= 1
+    assert REQUIRED_QUESTION_KEYS.issubset(parsed[0].keys())
+
+
+@pytest.mark.unit
+def test_validate_schema_accepts_fixture() -> None:
+    """The shipped fixture conforms to the contracted question schema."""
+    parsed = json.loads(FIXTURE_PATH.read_bytes())
+    _validate_schema(parsed)  # must not raise
+
+    first = parsed[0]
+    for key in REQUIRED_QUESTION_KEYS:
+        assert key in first, f"Fixture is missing required key: {key}"
+
+    # haystack arrays must be parallel.
+    assert len(first["haystack_sessions"]) == len(first["haystack_session_ids"])
+    assert len(first["haystack_sessions"]) == len(first["haystack_dates"])
+
+
+@pytest.mark.unit
+def test_validate_schema_rejects_empty() -> None:
+    with pytest.raises(DatasetSchemaError, match="empty"):
+        _validate_schema([])
+
+
+@pytest.mark.unit
+def test_validate_schema_rejects_non_dict() -> None:
+    with pytest.raises(DatasetSchemaError, match="must be dicts"):
+        _validate_schema(["not-a-dict"])  # type: ignore[list-item]
+
+
+@pytest.mark.unit
+def test_validate_schema_rejects_missing_keys() -> None:
+    bad = [{"question": "only one key"}]
+    with pytest.raises(DatasetSchemaError, match="missing required keys"):
+        _validate_schema(bad)
+
+
+@pytest.mark.unit
+def test_load_and_verify_full_path_with_fixture_digest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive ``_load_and_verify`` end-to-end by patching the expected SHA."""
+    cached = tmp_path / DATASET_FILENAME
+    shutil.copy(FIXTURE_PATH, cached)
+    fixture_sha = _sha256_bytes(cached.read_bytes())
+
+    monkeypatch.setattr(
+        "distillery.eval.longmemeval_dataset.DATASET_FILE_SHA256",
+        fixture_sha,
+    )
+    result = _load_and_verify(cached)
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    assert REQUIRED_QUESTION_KEYS.issubset(result[0].keys())
+
+
+@pytest.mark.unit
+def test_load_and_verify_corrupt_file_e2e(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Garbage bytes at the fixture path must raise ``DatasetIntegrityError``."""
+    cached = tmp_path / DATASET_FILENAME
+    cached.write_bytes(b"GARBAGE GARBAGE GARBAGE")
+
+    # Use the fixture's real digest as the "expected" so the corruption is
+    # visible (otherwise both garbage and expected would be the same hash).
+    monkeypatch.setattr(
+        "distillery.eval.longmemeval_dataset.DATASET_FILE_SHA256",
+        _sha256_bytes(FIXTURE_PATH.read_bytes()),
+    )
+    with pytest.raises(DatasetIntegrityError, match="SHA-256 mismatch"):
+        _load_and_verify(cached)
+
+
+@pytest.mark.unit
+def test_pinned_constants_are_concrete() -> None:
+    """Guard against shipping placeholder SHAs (rule 5)."""
+    assert len(DATASET_REVISION_SHA) == 40, "Revision SHA must be a full 40-char hex"
+    assert len(DATASET_FILE_SHA256) == 64, "File SHA-256 must be 64 hex chars"
+    int(DATASET_REVISION_SHA, 16)  # must parse as hex
+    int(DATASET_FILE_SHA256, 16)
+    # No "TODO"/"PLACEHOLDER"/"resolved" sentinel strings allowed.
+    for sha in (DATASET_REVISION_SHA, DATASET_FILE_SHA256):
+        assert sha.lower() == sha, "SHA constants must be lowercase hex"
+        assert all(c in "0123456789abcdef" for c in sha)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — first call hits the network (~265 MB), second is offline.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_load_longmemeval_downloads_and_verifies(tmp_path: Path) -> None:
+    """First call: downloads the SHA-pinned dataset and verifies its hash.
+
+    Note: the real ``longmemeval_s_cleaned.json`` is ~265 MB. Plan for a
+    ~30-60 s run on a warm pip cache and proportional disk in ``tmp_path``.
+    """
+    questions = load_longmemeval(cache_dir=tmp_path)
+    assert isinstance(questions, list)
+    assert len(questions) == 500, "LongMemEval-S contains exactly 500 questions"
+
+    first = questions[0]
+    for key in REQUIRED_QUESTION_KEYS:
+        assert key in first, f"Live dataset is missing key {key!r}"
+
+    # haystack arrays must be parallel — bench scoring relies on this.
+    assert len(first["haystack_sessions"]) == len(first["haystack_session_ids"])
+    assert len(first["haystack_sessions"]) == len(first["haystack_dates"])
+    assert len(first["answer_session_ids"]) >= 1
+
+
+@pytest.mark.integration
+def test_load_longmemeval_warm_cache_offline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second call from the same cache must succeed with HF offline mode set."""
+    # Warm the cache.
+    load_longmemeval(cache_dir=tmp_path)
+
+    # Force HF to refuse network access; the warm cache must satisfy the call.
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    questions = load_longmemeval(cache_dir=tmp_path)
+    assert len(questions) == 500
+
+
+@pytest.mark.integration
+def test_load_longmemeval_corrupt_cache_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the cached blob is tampered with, the loader must refuse to return it."""
+    load_longmemeval(cache_dir=tmp_path)
+
+    # Locate the cached snapshot entry. snapshot_download uses HF's canonical
+    # cache layout: <cache>/datasets--<owner>--<repo>/snapshots/<sha>/<file>.
+    # The snapshot path is a symlink into the blobs/ directory; corrupt the
+    # underlying blob so verification fails on the next load.
+    canonical = (
+        tmp_path
+        / "datasets--xiaowu0162--longmemeval-cleaned"
+        / "snapshots"
+        / DATASET_REVISION_SHA
+        / DATASET_FILENAME
+    )
+    assert canonical.exists(), f"Expected cached file at {canonical}"
+    blob_target = canonical.resolve()
+    blob_target.write_bytes(b"corrupted contents\n")
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    with pytest.raises(DatasetIntegrityError, match="SHA-256 mismatch"):
+        load_longmemeval(cache_dir=tmp_path)

--- a/tests/eval/test_dataset_loader.py
+++ b/tests/eval/test_dataset_loader.py
@@ -18,6 +18,7 @@ import hashlib
 import json
 import shutil
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -153,6 +154,35 @@ def test_validate_schema_rejects_missing_keys() -> None:
 
 
 @pytest.mark.unit
+def test_validate_schema_rejects_malformed_later_question() -> None:
+    """Schema drift in non-first rows must trip validation (not just questions[0]).
+
+    Regression for CodeRabbit comment on PR #436: the original implementation
+    only spot-checked ``questions[0]``, so a bad row at index >= 1 silently
+    passed loader checks and exploded later at runtime.
+    """
+    good = dict.fromkeys(REQUIRED_QUESTION_KEYS, "x")
+    questions = [
+        good,
+        {"question": "missing the rest"},  # idx=1 — this is the bad row
+        good,
+    ]
+    with pytest.raises(DatasetSchemaError, match="missing required keys") as excinfo:
+        _validate_schema(questions)
+    assert "question 1" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_validate_schema_rejects_non_dict_at_later_index() -> None:
+    """Non-dict entries at index > 0 must also raise (regression for PR #436)."""
+    good = dict.fromkeys(REQUIRED_QUESTION_KEYS, "x")
+    questions: list[Any] = [good, "not-a-dict", good]
+    with pytest.raises(DatasetSchemaError, match="must be dicts") as excinfo:
+        _validate_schema(questions)
+    assert "at index 1" in str(excinfo.value)
+
+
+@pytest.mark.unit
 def test_load_and_verify_full_path_with_fixture_digest(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -206,13 +236,13 @@ def test_pinned_constants_are_concrete() -> None:
 
 
 @pytest.mark.integration
-def test_load_longmemeval_downloads_and_verifies(tmp_path: Path) -> None:
+async def test_load_longmemeval_downloads_and_verifies(tmp_path: Path) -> None:
     """First call: downloads the SHA-pinned dataset and verifies its hash.
 
     Note: the real ``longmemeval_s_cleaned.json`` is ~265 MB. Plan for a
     ~30-60 s run on a warm pip cache and proportional disk in ``tmp_path``.
     """
-    questions = load_longmemeval(cache_dir=tmp_path)
+    questions = await load_longmemeval(cache_dir=tmp_path)
     assert isinstance(questions, list)
     assert len(questions) == 500, "LongMemEval-S contains exactly 500 questions"
 
@@ -227,26 +257,26 @@ def test_load_longmemeval_downloads_and_verifies(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
-def test_load_longmemeval_warm_cache_offline(
+async def test_load_longmemeval_warm_cache_offline(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Second call from the same cache must succeed with HF offline mode set."""
     # Warm the cache.
-    load_longmemeval(cache_dir=tmp_path)
+    await load_longmemeval(cache_dir=tmp_path)
 
     # Force HF to refuse network access; the warm cache must satisfy the call.
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
     monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
-    questions = load_longmemeval(cache_dir=tmp_path)
+    questions = await load_longmemeval(cache_dir=tmp_path)
     assert len(questions) == 500
 
 
 @pytest.mark.integration
-def test_load_longmemeval_corrupt_cache_raises(
+async def test_load_longmemeval_corrupt_cache_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """If the cached blob is tampered with, the loader must refuse to return it."""
-    load_longmemeval(cache_dir=tmp_path)
+    await load_longmemeval(cache_dir=tmp_path)
 
     # Locate the cached snapshot entry. snapshot_download uses HF's canonical
     # cache layout: <cache>/datasets--<owner>--<repo>/snapshots/<sha>/<file>.
@@ -265,4 +295,4 @@ def test_load_longmemeval_corrupt_cache_raises(
 
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
     with pytest.raises(DatasetIntegrityError, match="SHA-256 mismatch"):
-        load_longmemeval(cache_dir=tmp_path)
+        await load_longmemeval(cache_dir=tmp_path)

--- a/tests/fixtures/longmemeval_mini.json
+++ b/tests/fixtures/longmemeval_mini.json
@@ -1,0 +1,60 @@
+[
+  {
+    "question_id": "fixture_q1",
+    "question_type": "single-session-user",
+    "question": "What city did the user mention they were moving to?",
+    "question_date": "2024/06/15 (Sat) 10:00",
+    "answer": "Lisbon",
+    "answer_session_ids": ["answer_session_alpha"],
+    "haystack_dates": [
+      "2024/06/01 (Sat) 09:00",
+      "2024/06/05 (Wed) 14:30",
+      "2024/06/10 (Mon) 18:00"
+    ],
+    "haystack_session_ids": [
+      "session_alpha_001",
+      "answer_session_alpha",
+      "session_alpha_003"
+    ],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "Hi, I'm planning a vacation."},
+        {"role": "assistant", "content": "Where are you thinking of going?"}
+      ],
+      [
+        {"role": "user", "content": "Actually, I'm moving to Lisbon next month for work."},
+        {"role": "assistant", "content": "That sounds exciting! What kind of work?"}
+      ],
+      [
+        {"role": "user", "content": "I just need help with my packing list."},
+        {"role": "assistant", "content": "Happy to help — what items are you considering?"}
+      ]
+    ]
+  },
+  {
+    "question_id": "fixture_q2",
+    "question_type": "multi-session",
+    "question": "How many cats does the user own?",
+    "question_date": "2024/07/20 (Sat) 09:00",
+    "answer": "Three",
+    "answer_session_ids": ["answer_session_beta_1", "answer_session_beta_2"],
+    "haystack_dates": [
+      "2024/07/01 (Mon) 08:00",
+      "2024/07/05 (Fri) 11:00"
+    ],
+    "haystack_session_ids": [
+      "answer_session_beta_1",
+      "answer_session_beta_2"
+    ],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "I just adopted two cats — Mochi and Yuzu."},
+        {"role": "assistant", "content": "Congrats! Two cats is great company."}
+      ],
+      [
+        {"role": "user", "content": "I added a third cat today, named Soba."},
+        {"role": "assistant", "content": "Three is a lovely number for a feline household."}
+      ]
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Implements the **W1-dataset-loader** slice of the LongMemEval bench plan: a SHA-pinned, integrity-verified loader for `xiaowu0162/longmemeval-cleaned`. This is the dataset half of publication discipline rule (5) — *no SHAs ⇒ no claim* — every JSONL receipt the bench produces will carry these SHAs.

- New module `src/distillery/eval/longmemeval_dataset.py` with `load_longmemeval(cache_dir=...)` returning the parsed 500-question list.
- Pinned constants resolved against the real HuggingFace API (see "Resolved values" below).
- Unit tests use a hand-crafted 2-question fixture (`tests/fixtures/longmemeval_mini.json`) — no HF SDK mocking, no network in `pytest -m unit`.
- Integration tests (`pytest -m integration`) drive the full network path, including warm-cache offline replay and corrupt-cache rejection.

## Resolved values

| Constant | Value | Resolution date |
|---|---|---|
| `DATASET_REPO_ID` | `xiaowu0162/longmemeval-cleaned` | n/a |
| `DATASET_REVISION_SHA` | `98d7416c24c778c2fee6e6f3006e7a073259d48f` | 2026-05-02 |
| `DATASET_FILE_SHA256` | `d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442` | 2026-05-02 |
| `DATASET_FILENAME` | `longmemeval_s_cleaned.json` (264.5 MB, 500 questions) | n/a |

Resolved by querying `HfApi.list_repo_refs(...)` for the current `main` HEAD of the dataset repo, then downloading the file at that revision via `snapshot_download` and computing SHA-256 of the downloaded blob.

## Rationale (discipline rule 5)

> Code + dataset + model SHAs in every JSONL line. … No SHAs ⇒ no claim.

The loader is the dataset enforcement point for that rule. Anyone running `distillery bench longmemeval` after this lands gets the *exact same bytes* as the published numbers, or the loader refuses to return them — `DatasetIntegrityError` is raised on any SHA mismatch with both expected and actual hashes in the message. Bumping either pinned constant invalidates every published bench number and is gated on a future ADR.

## FeaturesError workaround

The HuggingFace `datasets` config in this repo trips `FeaturesError` on the `answer` column during feature inference. We sidestep `datasets.load_dataset` entirely and read the raw JSON file via `snapshot_download`. Documented in the module docstring with a pointer to the upstream dataset viewer banner.

## Files touched

- `src/distillery/eval/longmemeval_dataset.py` (new) — loader + verification
- `tests/eval/test_dataset_loader.py` (new) — 12 unit + 3 integration tests
- `tests/fixtures/longmemeval_mini.json` (new) — 2-question hand-crafted schema fixture
- `pyproject.toml` — `huggingface_hub>=0.24,<1.0` added to `[dev]` only

## Test plan

- [x] `pytest tests/eval/test_dataset_loader.py -m unit -v` — **12 passed** (no network)
- [x] `pytest tests/eval/test_dataset_loader.py -m integration -v` — **3 passed** (downloads ~265 MB; warm cache; corrupt-cache rejection)
- [x] `mypy --strict src/distillery/eval/longmemeval_dataset.py` — clean
- [x] `ruff check` + `ruff format --check` — clean

## Out of scope

- Bench runner, scoring, fastembed provider — separate Wave 1 / Wave 2 worktrees.
- The 1.5M-token `longmemeval_m_cleaned.json` split — `[bench plan §"Out of scope"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a LongMemEval-S dataset loader that downloads a pinned dataset, verifies SHA-256 integrity, and enforces schema/required fields before use.

* **Tests**
  * Added comprehensive unit and integration tests covering integrity checks, schema validation, cache/offline behavior, and a mini dataset fixture.

* **Chores**
  * Added Hugging Face Hub as a dev-only dependency for bench/dataset tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->