### PR TITLE
[bench] MkDocs benchmarks page (placeholders, awaiting first nightly)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,152 @@
+# Benchmarks
+
+Distillery runs the [LongMemEval](https://arxiv.org/html/2410.10813v1) retrieval bench
+nightly against its own pipeline. This page surfaces the most recent headline numbers, the
+configurations Distillery ships, and — equally important — the things this number does
+*not* claim.
+
+This page is wired up before any number lands. The cells below show placeholders until the
+first stable nightly run completes and the variance gate (5-seed back-to-back execution,
+stddev ≤ 0.5pp on R@5) confirms the bench is a useful regression signal. No number is
+displayed here until that gate is green.
+
+## Headline
+
+The pre-registered headline triplet — Recall@5, Recall@10, NDCG@10 — for the headline cell
+(`retrieval=hybrid, granularity=session, recency=on, embed=bge-small`).
+
+<div class="grid cards" markdown>
+
+-   __Recall@5__
+
+    ---
+
+    <!-- TODO: populated by first nightly -->
+    `—`
+
+    Headline cell, mean across seeds.
+
+-   __Recall@10__
+
+    ---
+
+    <!-- TODO: populated by first nightly -->
+    `—`
+
+    Headline cell, mean across seeds.
+
+-   __NDCG@10__
+
+    ---
+
+    <!-- TODO: populated by first nightly -->
+    `—`
+
+    Headline cell, mean across seeds.
+
+</div>
+
+## Configuration
+
+The headline cell is pre-registered and immutable without an ADR. It does not change to
+chase a number.
+
+| Axis | Headline value |
+|---|---|
+| Retrieval | `hybrid` (BM25 + vector via Reciprocal Rank Fusion) |
+| Granularity | `session` (one document per haystack session) |
+| Recency | `on` (90-day linear decay, `recency_min_weight=0.5`) |
+| Embed model | `bge-small` (`BAAI/bge-small-en-v1.5`, 384-dim, fastembed) |
+
+Full pre-registration rationale and change-control rules live in
+[`bench/HEADLINE.md`](../bench/HEADLINE.md).
+
+## What this number does NOT claim
+
+!!! warning "Read this before citing any number on this page"
+
+    - These numbers are **retrieval metrics** (R@k, NDCG@k). They are **not comparable** to
+      LongMemEval QA-accuracy leaderboard entries — the LongMemEval paper's primary metric
+      is GPT-4o-judged QA accuracy, which requires a generator stack Distillery does not
+      ship.
+    - These numbers are **Distillery vs. Distillery only**. There are no competitor rows
+      anywhere on this page, in the README, or in the auto-generated `bench/results/`
+      summaries. Cross-system retrieval-vs-QA comparisons are a known category error.
+    - **Cross-granularity** rows (`session` vs `turn`) are non-comparable to one another —
+      the corpus_id space differs, so R@k means different things in each row.
+    - **Cross-embed-model** rows carry an HNSW-construction caveat: the index is rebuilt
+      per model, so insertion-order and seed effects are part of the score.
+    - The headline number is the **mean** of multiple seeds. The corresponding stddev lives
+      alongside it in `bench/results/variance_baseline.json`.
+
+    Read the full limitations before citing this number →
+    [bench/LIMITATIONS.md](../bench/LIMITATIONS.md)
+
+## Internal comparison table
+
+**Distillery configurations only.** No competitor rows. Each row is a single Distillery
+configuration evaluated against the same LongMemEval-S question set with the same SHA-pinned
+dataset and embedding model.
+
+| Configuration | R@5 | R@10 | NDCG@10 |
+|---|---|---|---|
+| `hybrid + recency on` (headline) | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `raw + recency on` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `hybrid + recency off` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `hybrid + granularity=turn` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+
+The `granularity=turn` row is shown for ablation interest only; it is not directly
+comparable to the session rows above (see the LIMITATIONS callout).
+
+## Per-question-type breakdown
+
+LongMemEval-S partitions questions into six types. The headline cell scores each
+type independently.
+
+| Question type | R@5 | R@10 | NDCG@10 |
+|---|---|---|---|
+| `knowledge-update` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `multi-session` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `temporal` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `single-session-user` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `single-session-preference` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `single-session-assistant` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+
+## Methodology
+
+The bench instantiates an in-memory `DuckDBStore` per question, fixes the PRNG seed before
+ingestion to neutralise HNSW insertion-order non-determinism, ingests `haystack_sessions`
+as entries with `metadata.session_id` populated, then runs `store.search(query, limit=50)`
+and maps the returned session_ids back to the gold `answer_session_ids` for scoring.
+
+Scoring is a textbook `dcg`/`ndcg`/`evaluate_retrieval` reimplementation in
+`src/distillery/eval/scoring.py`, adapted to the existing `RetrievalMetrics` shape from
+`src/distillery/eval/retrieval_scorer.py`. Every JSONL line carries a SHA panel
+(`git_sha`, `dataset_revision_sha`, `embed_model_sha`, `python_version`) so any number on
+this page can be reproduced bit-for-bit.
+
+Full methodology and dataset citation:
+[`bench/METHODOLOGY.md`](../bench/METHODOLOGY.md).
+
+Dataset citation: Wu et al., *LongMemEval: Benchmarking Chat Assistants on Long-Term
+Interactive Memory*, ICLR 2025 — [arxiv:2410.10813](https://arxiv.org/html/2410.10813v1).
+
+## Reproduction
+
+The bench runs offline. fastembed downloads model weights once, the dataset loader pins the
+HuggingFace revision, and there is no API call in the hot loop.
+
+```bash
+pip install -e ".[dev,fastembed]"
+
+distillery bench longmemeval \
+    --retrieval hybrid \
+    --granularity session \
+    --recency on \
+    --embed-model bge-small \
+    --seeds 1
+```
+
+Outputs land in `bench/results/results_longmemeval_<mode>_<embed>_<UTC>.jsonl` plus a
+`summary.json` next to it. The canonical reproduction guide — including the 5-seed variance
+characterisation procedure — is in [`bench/README.md`](../bench/README.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - Team Member Guide: team/team-setup.md
     - Operator Deployment: team/deployment.md
   - Architecture: architecture.md
+  - Benchmarks: benchmarks.md
   - Contributing: contributing.md
   - Blog:
     - "Full-Proof: Distillery 0.4.0 and the Agent Memory Problem": blog/distillery-0-4-0-full-proof.md


### PR DESCRIPTION
## Summary

Adds `docs/benchmarks.md` and wires it into `mkdocs.yml` nav (as a sibling to
Architecture). The page is part of the LongMemEval bench rollout (Wave 2 slice
**W2-docs-page**) — see the master plan for context.

**This page ships with placeholders deliberately.** No number is claimed until
the W3-variance-gate slice runs the headline cell across 5 seeds and confirms
stddev on R@5 is ≤ 0.5pp. Until then, every numeric cell renders as `—` with
either a `<!-- TODO: populated by first nightly -->` or `<!-- placeholder -->`
marker so the W3-public-surfaces slice can grep for them and substitute the
real numbers / Shields.io badges.

The page sections, in order, mirror the spec in the plan:

- **Headline** — three placeholder cards (R@5, R@10, NDCG@10) using the MkDocs
  Material `grid cards` block.
- **Configuration** — restates the pre-registered headline cell
  (`retrieval=hybrid, granularity=session, recency=on, embed=bge-small`) and
  links to `bench/HEADLINE.md`.
- **What this number does NOT claim** — `!!! warning` admonition with five
  bullets summarising LIMITATIONS.md, plus a prominent link to the full file.
- **Internal comparison table** — explicitly headed "Distillery configurations
  only", four rows (`hybrid + recency on (headline)`, `raw + recency on`,
  `hybrid + recency off`, `hybrid + granularity=turn`), all numeric cells
  placeholder. **No competitor rows anywhere on the page** (verified by
  inspection).
- **Per-question-type breakdown** — six-row placeholder table for the
  LongMemEval question types.
- **Methodology** — short prose pointing to `bench/METHODOLOGY.md` and citing
  the LongMemEval paper (Wu et al., ICLR 2025, arxiv:2410.10813).
- **Reproduction** — `pip install -e ".[dev,fastembed]"` + `distillery bench
  longmemeval ...` command stub, link to `bench/README.md`.

## Rebase status — Option A (forward-references)

This PR uses **Option A** from the slice spec: cross-links to `../bench/*.md`
are forward-references that resolve once PR #431 (`bench/discipline-scaffold`)
merges to `main`. Local verification:

- `mkdocs build` — passes cleanly.
- `mkdocs build --strict` — fails with exactly four warnings, all
  "target is not found" for the four `bench/*.md` files that PR #431 introduces.

Once PR #431 merges, `mkdocs build --strict` will pass on this branch with no
further changes. **No rebase is required before merge** — the warnings only
surface in `--strict` mode, and the GitHub Pages workflow will succeed (or
fail loudly) once #431 is on `main`. If reviewers prefer the strict-clean
ordering, this branch can be merged *after* #431 with no rebase needed.

## Prerequisite

- Cross-links to `bench/HEADLINE.md`, `bench/LIMITATIONS.md`,
  `bench/METHODOLOGY.md`, `bench/README.md` resolve only after PR #431
  (`bench/discipline-scaffold`) merges. This PR does **not** introduce or
  modify any `bench/*.md` files.

## Constraints honoured

- Touches only `docs/benchmarks.md` (new) and `mkdocs.yml` (one nav line added).
- No bench numbers pre-populated.
- No competitor comparison tables (verified — only Distillery-vs-Distillery
  rows; the only "competitor" mentions are explicit disclaimers in the
  LIMITATIONS callout).
- No modifications to `bench/*.md` (those are PR #431's territory).

## Test plan

- [x] `mkdocs build` succeeds locally (with mkdocs-material installed).
- [x] `mkdocs build --strict` fails with exactly four expected warnings (the
      four forward-references), and no other issues.
- [x] Page reads as Distillery-vs-Distillery in framing — verified by
      `grep -i "(mempalace|competitor|vs\.|versus)"` returning only the two
      intentional disclaimer lines.
- [x] Only `docs/benchmarks.md` and `mkdocs.yml` touched (`git diff --stat`).
- [ ] Reviewer: visually confirm rendered page once GitHub Pages publishes
      (or `make docs-serve` locally with PR #431 merged in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive benchmarks documentation detailing the Distillery LongMemEval benchmark setup, including key performance metrics (Recall@5, Recall@10, NDCG@10), system configurations, and complete reproduction methodology with CLI examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->