### PR TITLE
[bench] LongMemEval bench runner (depends on #435 #433 #436)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ markers = [
     "unit: unit tests",
     "integration: integration tests",
     "eval: Claude-powered skill evaluation tests (requires claude CLI)",
+    "bench: long-running retrieval-quality benchmarks (LongMemEval, etc.) — opt-in",
     "live_probe: opt out of the autouse feed-probe stub (tests exercise real _probe_url)",
 ]
 

--- a/src/distillery/eval/longmemeval.py
+++ b/src/distillery/eval/longmemeval.py
@@ -55,8 +55,11 @@ comparisons are technically prevented at the filesystem level
 Discipline rules enforced here
 ------------------------------
 
-* PRNG seeds are reset *before* every store rebuild
-  (``random.seed`` + ``numpy.random.seed`` if numpy is importable).
+* PRNG seeds are reset *before* every store rebuild via
+  ``random.seed``.  DuckDB's VSS extension uses its own RNG for HNSW,
+  unaffected by Python's ``random`` module, but seeding ``random``
+  bounds any host-side non-determinism (e.g. dict-order shuffles) on
+  a per-question basis.
 * No expected scores are baked into the runner or its docstrings.
 * No competitor comparison is constructed.
 * Each JSONL record carries the full SHA panel (seven fields).
@@ -70,7 +73,6 @@ for the broader context (Wave 2, deliverable 2).
 from __future__ import annotations
 
 import json
-import logging
 import random
 import re
 import subprocess
@@ -90,9 +92,6 @@ from distillery.eval.longmemeval_dataset import (
 from distillery.eval.scoring import evaluate_retrieval
 from distillery.models import Entry, EntrySource, EntryType
 from distillery.store.duckdb import DuckDBStore
-
-logger = logging.getLogger(__name__)
-
 
 # ---------------------------------------------------------------------------
 # Type aliases for the public API axes
@@ -422,20 +421,15 @@ def _expected_id_set(
 
 
 def _seed_prng(seed: int) -> None:
-    """Set ``random`` and (best-effort) ``numpy.random`` seeds.
+    """Set the stdlib ``random`` seed.
 
-    Called *before* every store rebuild so HNSW insertion-order
-    non-determinism is neutralised on a per-question basis.  numpy is
-    optional — fastembed pulls it transitively but the runner doesn't
-    require it, so we degrade gracefully if it isn't importable.
+    Called *before* every store rebuild so any host-side
+    non-determinism (dict-order shuffles, sample selection, etc.) is
+    bounded on a per-question basis.  DuckDB's VSS extension uses its
+    own RNG for HNSW insertion order and is not affected by Python's
+    ``random`` module, so no further seeding is required here.
     """
     random.seed(seed)
-    try:
-        import numpy as np  # local import: numpy is optional at module level
-
-        np.random.seed(seed)
-    except ImportError:  # pragma: no cover - numpy absent
-        logger.debug("numpy not importable; skipping numpy.random.seed")
 
 
 # ---------------------------------------------------------------------------

--- a/src/distillery/eval/longmemeval.py
+++ b/src/distillery/eval/longmemeval.py
@@ -1,0 +1,777 @@
+"""LongMemEval bench runner — public reproduction of Distillery retrieval.
+
+This module is the heart of the LongMemEval bench: it constructs a fresh
+in-memory :class:`~distillery.store.duckdb.DuckDBStore` per question, ingests
+the question's ``haystack_sessions`` as :class:`~distillery.models.Entry`
+rows, runs the configured query through ``store.search``, scores the result
+against the question's ``answer_session_ids``, and emits a JSONL receipt
+with full SHA provenance plus a JSON summary.
+
+The runner is deliberately *receipt-first*. Every record carries the
+git SHA, dataset revision, dataset file SHA-256, embed model identifier,
+Python version, seed, and timestamp so anyone can re-run and diff.
+
+Recency / hybrid trade-off (footgun documentation)
+--------------------------------------------------
+
+The W1-recency-toggle-probe audit (``bench/probes/recency-toggle.md`` on
+branch ``bench/recency-toggle-probe``) confirmed:
+
+* ``recency_min_weight`` is **construction-time only** on
+  :class:`DuckDBStore`. There is no per-query toggle.
+* ``hybrid_search`` is also construction-time only — there is no
+  per-call kwarg to disable the BM25 leg.
+* The vector-only fallback (``hybrid_search=False``) does **not** apply
+  recency at all. Recency multiplication lives inside the RRF fusion
+  branch only.
+
+Consequences for this runner:
+
+1. ``--recency on|off`` is implemented by varying
+   ``recency_min_weight`` between ``0.5`` (default — decay applied) and
+   ``1.0`` (decay neutralised). The store is **rebuilt per question**,
+   which is cheap with ``:memory:`` and required because per-question
+   ingest already drives the loop.
+2. ``--retrieval raw`` requires ``hybrid_search=False``, which silently
+   bypasses recency entirely. The runner enforces a coupling: when
+   ``retrieval == "raw"`` the recency setting is **logged as
+   force-bypassed**. The reported ``_meta.effective_recency`` field
+   records what actually happened so receipts cannot be misread.
+3. A separate dependent issue (filed in the PR body) tracks the
+   underlying API ergonomics: a per-query ``recency`` kwarg would
+   eliminate this coupling. Until it lands, ``raw + recency=on`` is a
+   nonsensical cell and the runner refuses to pretend otherwise.
+
+Filename schema
+---------------
+
+Output files include every axis in the filename so cross-axis
+comparisons are technically prevented at the filesystem level
+(no two cells ever share an output file)::
+
+    bench/results/results_longmemeval_<retrieval>_<granularity>_<recency>_<embed>_<UTC>.jsonl
+    bench/results/summary_<retrieval>_<granularity>_<recency>_<embed>_<UTC>.json
+
+Discipline rules enforced here
+------------------------------
+
+* PRNG seeds are reset *before* every store rebuild
+  (``random.seed`` + ``numpy.random.seed`` if numpy is importable).
+* No expected scores are baked into the runner or its docstrings.
+* No competitor comparison is constructed.
+* Each JSONL record carries the full SHA panel (seven fields).
+* Cross-granularity output files differ in name → comparing the two
+  is a deliberate filesystem-level act, not an accident.
+
+See the plan in ``/Users/norrie/.claude/plans/look-at-mempalace-hook-dynamic-mccarthy.md``
+for the broader context (Wave 2, deliverable 2).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import re
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from distillery.embedding.fastembed import FastembedProvider
+from distillery.eval.longmemeval_dataset import (
+    DATASET_FILE_SHA256,
+    DATASET_REVISION_SHA,
+    load_longmemeval,
+)
+from distillery.eval.scoring import evaluate_retrieval
+from distillery.models import Entry, EntrySource, EntryType
+from distillery.store.duckdb import DuckDBStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Type aliases for the public API axes
+# ---------------------------------------------------------------------------
+
+RetrievalMode = Literal["raw", "hybrid"]
+GranularityMode = Literal["session", "turn"]
+RecencyMode = Literal["on", "off"]
+EmbedModel = Literal["bge-small", "bge-base", "bge-large", "jina"]
+
+
+# Recall / NDCG cutoffs reported in the summary.  Per the plan these are the
+# triplet R@5, R@10, NDCG@10 — never reported in isolation.
+_RECALL_K_VALUES: tuple[int, ...] = (5, 10)
+_NDCG_K: int = 10
+_SEARCH_LIMIT: int = 50
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QuestionRecord:
+    """Per-question result emitted as one JSONL line.
+
+    All fields are JSON-serialisable.  The ``_meta`` block carries the
+    SHA panel for receipt provenance.
+    """
+
+    question_id: str
+    question_type: str
+    expected_session_ids: list[str]
+    retrieved_session_ids: list[str]
+    rankings: list[int]
+    recall_at_5: float
+    recall_all_at_5: float
+    ndcg_at_5: float
+    recall_at_10: float
+    recall_all_at_10: float
+    ndcg_at_10: float
+    latency_ms: float
+    n_corpus_entries: int
+    meta: dict[str, Any]
+
+
+@dataclass
+class BenchReport:
+    """Summary returned to in-process callers (CLI, tests).
+
+    ``per_question`` keeps the raw records so callers can re-aggregate or
+    feed them to a downstream tool.  ``summary`` is the same dict that is
+    written to ``summary_<UTC>.json``.
+    """
+
+    summary: dict[str, Any]
+    per_question: list[QuestionRecord] = field(default_factory=list)
+    jsonl_path: Path | None = None
+    summary_path: Path | None = None
+
+
+# ---------------------------------------------------------------------------
+# Provenance helpers (SHA panel)
+# ---------------------------------------------------------------------------
+
+
+def _git_sha() -> str:
+    """Best-effort short-hand for ``git rev-parse HEAD``.
+
+    Returns ``"unknown"`` when the runner is invoked outside a git
+    checkout (e.g. installed wheel) so the SHA panel is always present
+    even if one field is degraded.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def _embed_model_sha(provider: FastembedProvider | Any) -> str:
+    """Best-effort SHA / version identifier for the active embed provider.
+
+    For :class:`FastembedProvider` we publish the resolved model name
+    plus the installed fastembed package version — the model file
+    weights live under ``~/.cache/fastembed/<name>`` and the file SHA
+    isn't trivially stable across the provider's lazy loader, so the
+    package version + model name pair is the practical receipt.
+
+    For other providers (e.g. Jina remote API) we fall back to
+    ``"<model_name>@unknown"`` since hosted services don't expose an
+    immutable SHA.
+    """
+    model_name = getattr(provider, "model_name", "unknown")
+    if isinstance(provider, FastembedProvider):
+        try:
+            from importlib.metadata import version as _pkg_version
+
+            pkg_version = _pkg_version("fastembed")
+        except Exception:  # pragma: no cover - import-metadata fallback
+            pkg_version = "unknown"
+        return f"fastembed=={pkg_version}/{model_name}"
+    return f"{model_name}@unknown"
+
+
+def _build_meta_panel(
+    *,
+    git_sha: str,
+    embed_model_sha: str,
+    seed: int,
+    retrieval: RetrievalMode,
+    granularity: GranularityMode,
+    recency: RecencyMode,
+    effective_recency: RecencyMode,
+) -> dict[str, Any]:
+    """Build the per-record SHA / provenance panel.
+
+    All seven required fields are present unconditionally — receipts
+    with a missing field would defeat the audit trail.
+    """
+    return {
+        "git_sha": git_sha,
+        "dataset_revision_sha": DATASET_REVISION_SHA,
+        "dataset_file_sha256": DATASET_FILE_SHA256,
+        "embed_model_sha": embed_model_sha,
+        "python_version": sys.version,
+        "seed": seed,
+        "timestamp_utc": datetime.now(tz=UTC).isoformat(),
+        # Mode echoes — useful when records from multiple cells are
+        # accidentally concatenated for analysis.
+        "retrieval": retrieval,
+        "granularity": granularity,
+        "recency_requested": recency,
+        "effective_recency": effective_recency,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Embedding-provider construction
+# ---------------------------------------------------------------------------
+
+
+def _build_embedding_provider(model: EmbedModel) -> Any:
+    """Return an :class:`EmbeddingProvider` for the chosen model.
+
+    Args:
+        model: One of ``"bge-small"``, ``"bge-base"``, ``"bge-large"``
+            (all served by :class:`FastembedProvider`) or ``"jina"`` —
+            which routes to the existing remote provider and requires
+            ``JINA_API_KEY``.
+
+    Raises:
+        ImportError: If the requested provider's optional dependency is
+            missing.  ``fastembed`` lives in ``[fastembed]``; the Jina
+            provider depends only on the runtime ``httpx`` install.
+    """
+    if model == "jina":
+        # Local import: avoids dragging the Jina module into the import
+        # graph for the (much more common) fastembed bench cells.
+        from distillery.embedding.jina import JinaEmbeddingProvider
+
+        return JinaEmbeddingProvider()
+    return FastembedProvider(model=model)
+
+
+# ---------------------------------------------------------------------------
+# Date parsing — LongMemEval's slightly weird format
+# ---------------------------------------------------------------------------
+
+_DATE_RE = re.compile(
+    r"^(?P<y>\d{4})/(?P<m>\d{2})/(?P<d>\d{2}).*?(?P<hh>\d{1,2}):(?P<mm>\d{2})\s*$"
+)
+
+
+def _parse_haystack_date(value: str) -> datetime:
+    """Parse a LongMemEval haystack date like ``"2024/06/01 (Sat) 09:00"``.
+
+    The dataset embeds a weekday in parentheses between the date and
+    the time-of-day; we discard it.  Returns a UTC-aware datetime.
+    Falls back to :func:`datetime.now` on parse failure so a single
+    malformed date doesn't crash the whole bench.
+    """
+    if not isinstance(value, str):
+        return datetime.now(tz=UTC)
+    match = _DATE_RE.match(value.strip())
+    if not match:
+        return datetime.now(tz=UTC)
+    return datetime(
+        int(match["y"]),
+        int(match["m"]),
+        int(match["d"]),
+        int(match["hh"]),
+        int(match["mm"]),
+        tzinfo=UTC,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corpus construction — turn vs session granularity
+# ---------------------------------------------------------------------------
+
+
+def _flatten_session_text(turns: list[dict[str, Any]]) -> str:
+    """Join all turns of a session into one ingest-ready text blob."""
+    parts: list[str] = []
+    for turn in turns:
+        if not isinstance(turn, dict):
+            continue
+        role = turn.get("role", "user")
+        content = turn.get("content", "")
+        if isinstance(content, str) and content:
+            parts.append(f"{role}: {content}")
+    return "\n".join(parts)
+
+
+def _build_corpus(
+    question: dict[str, Any],
+    granularity: GranularityMode,
+) -> tuple[list[Entry], list[str]]:
+    """Build the corpus for a single question.
+
+    Returns ``(entries, corpus_session_ids)`` where ``corpus_session_ids[i]``
+    is the session id of ``entries[i]`` (used by the scorer).  For
+    ``granularity == "turn"`` each user-role turn produces a separate
+    entry whose synthetic id is ``f"{session_id}_turn_{turn_idx}"`` —
+    the ``_turn_`` separator matches the mempalace convention so a
+    downstream consumer can split it back to the source session id.
+    """
+    haystack_sessions: list[list[dict[str, Any]]] = question.get("haystack_sessions", [])
+    haystack_session_ids: list[str] = question.get("haystack_session_ids", [])
+    haystack_dates: list[str] = question.get("haystack_dates", [])
+
+    entries: list[Entry] = []
+    corpus_ids: list[str] = []
+
+    for sess_idx, (turns, sess_id) in enumerate(
+        zip(haystack_sessions, haystack_session_ids, strict=False)
+    ):
+        date_str = haystack_dates[sess_idx] if sess_idx < len(haystack_dates) else ""
+        created_at = _parse_haystack_date(date_str)
+
+        if granularity == "session":
+            content = _flatten_session_text(turns)
+            if not content:
+                continue
+            entries.append(
+                Entry(
+                    content=content,
+                    entry_type=EntryType.SESSION,
+                    source=EntrySource.IMPORT,
+                    author="longmemeval",
+                    created_at=created_at,
+                    updated_at=created_at,
+                    metadata={"session_id": sess_id, "haystack_date": date_str},
+                )
+            )
+            corpus_ids.append(sess_id)
+            continue
+
+        # granularity == "turn": one entry per *user* turn so the index
+        # space is predictable and matches LongMemEval's question framing
+        # (the question targets user-side recall).
+        for turn_idx, turn in enumerate(turns):
+            if not isinstance(turn, dict) or turn.get("role") != "user":
+                continue
+            content = str(turn.get("content", "")).strip()
+            if not content:
+                continue
+            turn_id = f"{sess_id}_turn_{turn_idx}"
+            entries.append(
+                Entry(
+                    content=content,
+                    entry_type=EntryType.SESSION,
+                    source=EntrySource.IMPORT,
+                    author="longmemeval",
+                    created_at=created_at,
+                    updated_at=created_at,
+                    metadata={
+                        "session_id": turn_id,
+                        "source_session_id": sess_id,
+                        "turn_index": turn_idx,
+                        "haystack_date": date_str,
+                    },
+                )
+            )
+            corpus_ids.append(turn_id)
+
+    return entries, corpus_ids
+
+
+def _expected_id_set(
+    question: dict[str, Any],
+    granularity: GranularityMode,
+    corpus_ids: list[str],
+) -> set[str]:
+    """Return the set of corpus ids considered correct for this question.
+
+    Session-granularity: the gold ``answer_session_ids`` map directly
+    to corpus ids.  Turn-granularity: any synthetic ``<sess>_turn_<i>``
+    derived from a gold session id counts as correct.
+    """
+    answer_ids: list[str] = question.get("answer_session_ids", [])
+    answers = set(answer_ids)
+    if granularity == "session":
+        return answers
+    expected: set[str] = set()
+    for corpus_id in corpus_ids:
+        if "_turn_" in corpus_id:
+            base = corpus_id.split("_turn_", 1)[0]
+            if base in answers:
+                expected.add(corpus_id)
+    return expected
+
+
+# ---------------------------------------------------------------------------
+# Per-question seed handling
+# ---------------------------------------------------------------------------
+
+
+def _seed_prng(seed: int) -> None:
+    """Set ``random`` and (best-effort) ``numpy.random`` seeds.
+
+    Called *before* every store rebuild so HNSW insertion-order
+    non-determinism is neutralised on a per-question basis.  numpy is
+    optional — fastembed pulls it transitively but the runner doesn't
+    require it, so we degrade gracefully if it isn't importable.
+    """
+    random.seed(seed)
+    try:
+        import numpy as np  # local import: numpy is optional at module level
+
+        np.random.seed(seed)
+    except ImportError:  # pragma: no cover - numpy absent
+        logger.debug("numpy not importable; skipping numpy.random.seed")
+
+
+# ---------------------------------------------------------------------------
+# Per-question evaluation
+# ---------------------------------------------------------------------------
+
+
+async def _run_one_question(
+    question: dict[str, Any],
+    *,
+    seed: int,
+    retrieval: RetrievalMode,
+    granularity: GranularityMode,
+    recency: RecencyMode,
+    embed_model: EmbedModel,
+    git_sha: str,
+) -> QuestionRecord:
+    """Build a fresh store, ingest the haystack, search, and score.
+
+    Returns a fully-populated :class:`QuestionRecord`.  The PRNG seed is
+    set *before* the store is constructed so HNSW insertion-order
+    non-determinism is bounded by the seed.
+    """
+    _seed_prng(seed)
+
+    embedder = _build_embedding_provider(embed_model)
+
+    # Decide effective hybrid + recency settings.  See the module
+    # docstring for the rationale: raw retrieval implicitly disables
+    # recency because the vector-only path does not multiply by
+    # ``_recency_weight``.
+    use_hybrid = retrieval == "hybrid"
+    if retrieval == "raw":
+        # Vector-only path bypasses recency entirely; any non-default
+        # ``recency_min_weight`` is moot.  Record what actually happened.
+        effective_recency: RecencyMode = "off"
+        recency_min_weight = 1.0
+    else:
+        effective_recency = recency
+        recency_min_weight = 1.0 if recency == "off" else 0.5
+
+    store = DuckDBStore(
+        db_path=":memory:",
+        embedding_provider=embedder,
+        hybrid_search=use_hybrid,
+        recency_min_weight=recency_min_weight,
+    )
+    await store.initialize()
+
+    try:
+        entries, corpus_ids = _build_corpus(question, granularity)
+        if entries:
+            await store.store_batch(entries)
+
+        question_text = str(question.get("question", ""))
+        question_id = str(question.get("question_id", ""))
+        question_type = str(question.get("question_type", "unknown"))
+
+        start = time.perf_counter()
+        results = await store.search(query=question_text, filters=None, limit=_SEARCH_LIMIT)
+        latency_ms = (time.perf_counter() - start) * 1000.0
+
+        # Map results back to corpus session ids.  Build a positional
+        # lookup so ``rankings`` indexes into ``corpus_ids``.
+        position_by_id: dict[str, int] = {sid: i for i, sid in enumerate(corpus_ids)}
+        rankings: list[int] = []
+        retrieved_session_ids: list[str] = []
+        for result in results:
+            sid = result.entry.metadata.get("session_id") if result.entry.metadata else None
+            if not isinstance(sid, str):
+                continue
+            retrieved_session_ids.append(sid)
+            if sid in position_by_id:
+                rankings.append(position_by_id[sid])
+
+        expected_ids = _expected_id_set(question, granularity, corpus_ids)
+        # Compute (recall_any, recall_all, ndcg) at each k so we always
+        # publish the triplet R@5, R@10, NDCG@10 (discipline rule 2).
+        r5_any, r5_all, ndcg5 = evaluate_retrieval(rankings, expected_ids, corpus_ids, 5)
+        r10_any, r10_all, ndcg10 = evaluate_retrieval(rankings, expected_ids, corpus_ids, _NDCG_K)
+
+        meta = _build_meta_panel(
+            git_sha=git_sha,
+            embed_model_sha=_embed_model_sha(embedder),
+            seed=seed,
+            retrieval=retrieval,
+            granularity=granularity,
+            recency=recency,
+            effective_recency=effective_recency,
+        )
+
+        return QuestionRecord(
+            question_id=question_id,
+            question_type=question_type,
+            expected_session_ids=sorted(expected_ids),
+            retrieved_session_ids=retrieved_session_ids,
+            rankings=rankings,
+            recall_at_5=r5_any,
+            recall_all_at_5=r5_all,
+            ndcg_at_5=ndcg5,
+            recall_at_10=r10_any,
+            recall_all_at_10=r10_all,
+            ndcg_at_10=ndcg10,
+            latency_ms=latency_ms,
+            n_corpus_entries=len(entries),
+            meta=meta,
+        )
+    finally:
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Aggregation — mean over questions, broken out per question_type
+# ---------------------------------------------------------------------------
+
+
+def _aggregate(records: list[QuestionRecord]) -> dict[str, Any]:
+    """Build the summary dict shape written to ``summary_*.json``."""
+
+    def _mean(values: list[float]) -> float:
+        return sum(values) / len(values) if values else 0.0
+
+    overall_r5 = _mean([r.recall_at_5 for r in records])
+    overall_r10 = _mean([r.recall_at_10 for r in records])
+    overall_ndcg10 = _mean([r.ndcg_at_10 for r in records])
+
+    by_type: dict[str, dict[str, Any]] = {}
+    types_seen: set[str] = {r.question_type for r in records}
+    for qtype in sorted(types_seen):
+        bucket = [r for r in records if r.question_type == qtype]
+        by_type[qtype] = {
+            "n": len(bucket),
+            "recall_at_5": _mean([r.recall_at_5 for r in bucket]),
+            "recall_at_10": _mean([r.recall_at_10 for r in bucket]),
+            "ndcg_at_10": _mean([r.ndcg_at_10 for r in bucket]),
+        }
+
+    return {
+        "n_questions": len(records),
+        "overall": {
+            "recall_at_5": overall_r5,
+            "recall_at_10": overall_r10,
+            "ndcg_at_10": overall_ndcg10,
+        },
+        "per_question_type": by_type,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc_stamp() -> str:
+    """Return a UTC timestamp suitable for filenames (no colons)."""
+    return datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _record_to_jsonl_dict(record: QuestionRecord) -> dict[str, Any]:
+    """Serialise a record to a JSONL-friendly dict."""
+    payload = asdict(record)
+    # asdict copies ``meta`` as-is; promote it to ``_meta`` for the
+    # discipline-rule-(5) audit panel name used in the plan.
+    payload["_meta"] = payload.pop("meta")
+    return payload
+
+
+def _write_outputs(
+    records: list[QuestionRecord],
+    summary: dict[str, Any],
+    output_dir: Path,
+    *,
+    retrieval: RetrievalMode,
+    granularity: GranularityMode,
+    recency: RecencyMode,
+    embed_model: EmbedModel,
+    stamp: str,
+) -> tuple[Path, Path]:
+    """Write the JSONL + summary files; return ``(jsonl_path, summary_path)``."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    base = f"longmemeval_{retrieval}_{granularity}_{recency}_{embed_model}_{stamp}"
+    jsonl_path = output_dir / f"results_{base}.jsonl"
+    summary_path = output_dir / f"summary_{base}.json"
+
+    with jsonl_path.open("w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(_record_to_jsonl_dict(record)) + "\n")
+
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+        f.write("\n")
+
+    return jsonl_path, summary_path
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def run_longmemeval_bench(
+    *,
+    retrieval: RetrievalMode = "hybrid",
+    granularity: GranularityMode = "session",
+    recency: RecencyMode = "on",
+    embed_model: EmbedModel = "bge-small",
+    limit: int | None = None,
+    seeds: int = 1,
+    output_dir: Path | None = None,
+    questions: list[dict[str, Any]] | None = None,
+) -> BenchReport:
+    """Run the LongMemEval bench end-to-end and return a :class:`BenchReport`.
+
+    Parameters
+    ----------
+    retrieval:
+        ``"hybrid"`` (BM25 + vector RRF, default) or ``"raw"``
+        (vector-only).  ``"raw"`` implicitly forces ``recency=off``
+        because the vector-only path in :class:`DuckDBStore` does not
+        apply the recency multiplier — see the module docstring for the
+        footgun documentation.
+    granularity:
+        ``"session"`` (one corpus entry per haystack session — the
+        headline configuration) or ``"turn"`` (one entry per user-role
+        turn).  Cross-granularity numbers are non-comparable.
+    recency:
+        ``"on"`` to use the default 90-day decay
+        (``recency_min_weight=0.5``) or ``"off"`` to neutralise it
+        (``recency_min_weight=1.0``).  Effective only when
+        ``retrieval="hybrid"``.
+    embed_model:
+        ``"bge-small"`` (default), ``"bge-base"``, ``"bge-large"`` —
+        all routed through :class:`FastembedProvider` — or ``"jina"``
+        which uses the remote :class:`JinaEmbeddingProvider`.
+    limit:
+        Optional cap on the number of questions evaluated.  ``None``
+        runs the full set.
+    seeds:
+        Number of seed values to sweep per question.  Each question is
+        evaluated once per seed; the seed is the question index plus a
+        per-seed offset so any divergence is attributable.  Defaults to
+        ``1`` to keep the smoke-test path quick.
+    output_dir:
+        Directory to write JSONL + summary files into.  When ``None``,
+        no files are written and the caller can read
+        :attr:`BenchReport.per_question` directly.
+    questions:
+        Optional pre-loaded question list.  Provided for tests and
+        callers that already have the dataset in memory; defaults to
+        :func:`load_longmemeval` which downloads from HuggingFace under
+        the pinned revision.
+
+    Returns
+    -------
+    BenchReport
+        ``BenchReport.summary`` is the aggregate dict; ``per_question``
+        is the per-record list; ``jsonl_path`` and ``summary_path`` are
+        populated when ``output_dir`` is set.
+
+    Notes
+    -----
+    The runner makes **no** prediction about expected scores.  The
+    discipline gate (variance characterisation) lives in W3 and is the
+    first place an "expected to land near X" claim is permitted to
+    appear.  This module never bakes one in.
+    """
+    if questions is None:
+        questions = load_longmemeval()
+
+    if limit is not None:
+        questions = questions[:limit]
+
+    git_sha = _git_sha()
+    all_records: list[QuestionRecord] = []
+
+    for seed_offset in range(max(1, seeds)):
+        for q_idx, question in enumerate(questions):
+            # Seed is question-index + seed-offset so two seeds for the
+            # same question diverge predictably.
+            seed = q_idx + seed_offset * 100_000
+            record = await _run_one_question(
+                question,
+                seed=seed,
+                retrieval=retrieval,
+                granularity=granularity,
+                recency=recency,
+                embed_model=embed_model,
+                git_sha=git_sha,
+            )
+            all_records.append(record)
+
+    summary = _aggregate(all_records)
+    summary["axes"] = {
+        "retrieval": retrieval,
+        "granularity": granularity,
+        "recency": recency,
+        "embed_model": embed_model,
+        "seeds": max(1, seeds),
+        "limit": limit,
+    }
+    summary["dataset"] = {
+        "revision_sha": DATASET_REVISION_SHA,
+        "file_sha256": DATASET_FILE_SHA256,
+    }
+    summary["git_sha"] = git_sha
+    summary["timestamp_utc"] = datetime.now(tz=UTC).isoformat()
+
+    jsonl_path: Path | None = None
+    summary_path: Path | None = None
+    if output_dir is not None:
+        stamp = _utc_stamp()
+        jsonl_path, summary_path = _write_outputs(
+            all_records,
+            summary,
+            output_dir,
+            retrieval=retrieval,
+            granularity=granularity,
+            recency=recency,
+            embed_model=embed_model,
+            stamp=stamp,
+        )
+
+    return BenchReport(
+        summary=summary,
+        per_question=all_records,
+        jsonl_path=jsonl_path,
+        summary_path=summary_path,
+    )
+
+
+__all__ = [
+    "BenchReport",
+    "EmbedModel",
+    "GranularityMode",
+    "QuestionRecord",
+    "RecencyMode",
+    "RetrievalMode",
+    "run_longmemeval_bench",
+]

--- a/src/distillery/eval/longmemeval.py
+++ b/src/distillery/eval/longmemeval.py
@@ -705,7 +705,7 @@ async def run_longmemeval_bench(
     appear.  This module never bakes one in.
     """
     if questions is None:
-        questions = load_longmemeval()
+        questions = await load_longmemeval()
 
     if limit is not None:
         questions = questions[:limit]

--- a/src/distillery/eval/longmemeval.py
+++ b/src/distillery/eval/longmemeval.py
@@ -280,22 +280,28 @@ def _parse_haystack_date(value: str) -> datetime:
 
     The dataset embeds a weekday in parentheses between the date and
     the time-of-day; we discard it.  Returns a UTC-aware datetime.
-    Falls back to :func:`datetime.now` on parse failure so a single
-    malformed date doesn't crash the whole bench.
+    Falls back to the Unix epoch on parse failure or invalid calendar
+    values (e.g. ``2026-02-30``) so a single malformed date doesn't
+    crash the whole bench *and* doesn't inflate recency by silently
+    treating the row as "now".
     """
+    fallback = datetime(1970, 1, 1, tzinfo=UTC)
     if not isinstance(value, str):
-        return datetime.now(tz=UTC)
+        return fallback
     match = _DATE_RE.match(value.strip())
     if not match:
-        return datetime.now(tz=UTC)
-    return datetime(
-        int(match["y"]),
-        int(match["m"]),
-        int(match["d"]),
-        int(match["hh"]),
-        int(match["mm"]),
-        tzinfo=UTC,
-    )
+        return fallback
+    try:
+        return datetime(
+            int(match["y"]),
+            int(match["m"]),
+            int(match["d"]),
+            int(match["hh"]),
+            int(match["mm"]),
+            tzinfo=UTC,
+        )
+    except ValueError:
+        return fallback
 
 
 # ---------------------------------------------------------------------------
@@ -444,7 +450,7 @@ async def _run_one_question(
     retrieval: RetrievalMode,
     granularity: GranularityMode,
     recency: RecencyMode,
-    embed_model: EmbedModel,
+    embedder: Any,
     git_sha: str,
 ) -> QuestionRecord:
     """Build a fresh store, ingest the haystack, search, and score.
@@ -452,10 +458,12 @@ async def _run_one_question(
     Returns a fully-populated :class:`QuestionRecord`.  The PRNG seed is
     set *before* the store is constructed so HNSW insertion-order
     non-determinism is bounded by the seed.
+
+    The ``embedder`` is provided by the caller so model/client init
+    overhead (~1-2s for fastembed weights) is paid once per bench run
+    rather than once per question.
     """
     _seed_prng(seed)
-
-    embedder = _build_embedding_provider(embed_model)
 
     # Decide effective hybrid + recency settings.  See the module
     # docstring for the rationale: raw retrieval implicitly disables
@@ -705,6 +713,10 @@ async def run_longmemeval_bench(
     git_sha = _git_sha()
     all_records: list[QuestionRecord] = []
 
+    # Build the embedder once for the whole run.  Fastembed weight load
+    # is ~1-2s; on a full 500-question sweep this saves 500-1000s.
+    embedder = _build_embedding_provider(embed_model)
+
     for seed_offset in range(max(1, seeds)):
         for q_idx, question in enumerate(questions):
             # Seed is question-index + seed-offset so two seeds for the
@@ -716,7 +728,7 @@ async def run_longmemeval_bench(
                 retrieval=retrieval,
                 granularity=granularity,
                 recency=recency,
-                embed_model=embed_model,
+                embedder=embedder,
                 git_sha=git_sha,
             )
             all_records.append(record)
@@ -725,7 +737,8 @@ async def run_longmemeval_bench(
     summary["axes"] = {
         "retrieval": retrieval,
         "granularity": granularity,
-        "recency": recency,
+        "recency_requested": recency,
+        "effective_recency": "off" if retrieval == "raw" else recency,
         "embed_model": embed_model,
         "seeds": max(1, seeds),
         "limit": limit,

--- a/tests/eval/test_longmemeval_runner.py
+++ b/tests/eval/test_longmemeval_runner.py
@@ -1,0 +1,456 @@
+"""Unit tests for the LongMemEval bench runner.
+
+These tests pin the runner's contracts against the
+``tests/fixtures/longmemeval_mini.json`` fixture (2 hand-crafted
+questions) and the deterministic in-test embedding provider so we
+verify behaviour without downloading the real 264 MB dataset or
+loading the ~67 MB fastembed weights.
+
+Coverage:
+
+* **Happy path:** runs end-to-end against the fixture, returns a
+  populated :class:`BenchReport`, and writes a JSONL + summary file.
+* **session_id round-trip:** confirms an ingested session's id flows
+  back into ``QuestionRecord.retrieved_session_ids`` (belt-and-braces
+  alongside the W1 ``test_session_id_round_trip.py`` store-level test).
+* **Granularity=turn produces more entries than session:** a sanity
+  check that the ``_build_corpus`` branch is doing what its name says.
+* **Recency=off vs on differ in result ordering:** confirms the
+  ``--recency`` toggle propagates through to the actual ordering when
+  date metadata is meaningful.
+* **SHA panel populated:** every JSONL record must carry the seven
+  fields from discipline rule 5 — ``git_sha``,
+  ``dataset_revision_sha``, ``dataset_file_sha256``,
+  ``embed_model_sha``, ``python_version``, ``seed``, ``timestamp_utc``.
+
+The runner takes pre-loaded ``questions=`` so the fixture path skips
+the HuggingFace download entirely.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from distillery.eval import longmemeval as bench
+from distillery.eval.longmemeval import (
+    BenchReport,
+    QuestionRecord,
+    _build_corpus,
+    _expected_id_set,
+    run_longmemeval_bench,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixture loader
+# ---------------------------------------------------------------------------
+
+FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "longmemeval_mini.json"
+
+
+def _load_fixture() -> list[dict[str, Any]]:
+    """Read the bundled mini fixture (two hand-crafted questions)."""
+    with FIXTURE_PATH.open() as f:
+        data: list[dict[str, Any]] = json.load(f)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Embedding provider stub — keyword-matching so we don't load real weights
+# ---------------------------------------------------------------------------
+
+
+class _KeywordEmbedder:
+    """Tiny deterministic embedder: builds a unit vector from keyword hits.
+
+    The vector dimensions are a fixed lexicon of words that appear in
+    both the fixture questions and the haystack sessions.  Documents
+    and queries are vectorised by counting occurrences of each lexicon
+    word — so the cosine between a query and a relevant haystack
+    session is high without any network or weights involved.
+    """
+
+    _LEXICON = (
+        "lisbon",
+        "moving",
+        "city",
+        "vacation",
+        "packing",
+        "cats",
+        "cat",
+        "mochi",
+        "yuzu",
+        "soba",
+        "adopted",
+        "third",
+        "feline",
+    )
+
+    def __init__(self) -> None:
+        self._dim = len(self._LEXICON)
+
+    def _vec(self, text: str) -> list[float]:
+        lowered = text.lower()
+        raw = [float(lowered.count(word)) for word in self._LEXICON]
+        # L2-normalise so cosine similarity is well-defined.
+        magnitude = sum(x * x for x in raw) ** 0.5 or 1.0
+        return [x / magnitude for x in raw]
+
+    def embed(self, text: str) -> list[float]:
+        return self._vec(text)
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [self._vec(t) for t in texts]
+
+    @property
+    def dimensions(self) -> int:
+        return self._dim
+
+    @property
+    def model_name(self) -> str:
+        return "keyword-stub-test"
+
+
+@pytest.fixture(autouse=True)
+def _patch_embed_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the runner's embedder factory with the keyword stub.
+
+    Applied autouse so every test in this module runs against the
+    deterministic keyword embedder rather than fastembed (which would
+    require downloading weights on first call).
+    """
+
+    def _stub(_model: str) -> _KeywordEmbedder:
+        return _KeywordEmbedder()
+
+    monkeypatch.setattr(bench, "_build_embedding_provider", _stub)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_runs_against_fixture(tmp_path: Path) -> None:
+    """End-to-end smoke test: returns a populated report with R@5 hit on q1.
+
+    The first fixture question targets ``answer_session_alpha`` which
+    contains the literal string "moving to Lisbon".  The keyword
+    embedder gives that haystack session the highest cosine, so
+    ``recall_at_5`` for that question must be exactly ``1.0``.
+    """
+    questions = _load_fixture()
+
+    report = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="on",
+        embed_model="bge-small",
+        questions=questions,
+        output_dir=tmp_path,
+    )
+
+    assert isinstance(report, BenchReport)
+    assert report.summary["n_questions"] == len(questions)
+    assert report.jsonl_path is not None and report.jsonl_path.exists()
+    assert report.summary_path is not None and report.summary_path.exists()
+
+    # The first question is hand-crafted to be trivially solvable; recall
+    # at 5 must hit.
+    q1 = next(r for r in report.per_question if r.question_id == "fixture_q1")
+    assert q1.recall_at_5 == 1.0, (
+        f"Hand-crafted easy question should hit at 5; got {q1.recall_at_5} "
+        f"(expected={q1.expected_session_ids}, got={q1.retrieved_session_ids})"
+    )
+
+    # Aggregate summary keys exist and are well-formed.
+    assert "overall" in report.summary
+    overall = report.summary["overall"]
+    for key in ("recall_at_5", "recall_at_10", "ndcg_at_10"):
+        assert key in overall
+        assert 0.0 <= overall[key] <= 1.0
+
+    # Per-question-type breakdown is keyed by the dataset's question_type
+    # field — the fixture has both "single-session-user" and
+    # "multi-session" so both keys are present.
+    types = report.summary["per_question_type"]
+    assert "single-session-user" in types
+    assert "multi-session" in types
+
+
+async def test_session_id_round_trips_through_runner() -> None:
+    """The session_id we ingest comes back in ``retrieved_session_ids``.
+
+    Belt-and-braces alongside ``tests/eval/test_session_id_round_trip.py``
+    which pins the store-level contract.  Here we confirm the runner
+    plumbing end-to-end: ingest with ``metadata.session_id=X``, search,
+    and observe ``X`` in the result record.
+    """
+    questions = _load_fixture()
+
+    report = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="off",  # neutralise decay so the test isn't time-dependent
+        embed_model="bge-small",
+        questions=questions[:1],  # only the easy "Lisbon" question
+    )
+
+    record = report.per_question[0]
+    assert record.retrieved_session_ids, "No session ids were retrieved"
+    # The gold answer id must appear among retrieved ids.
+    assert "answer_session_alpha" in record.retrieved_session_ids
+
+
+async def test_granularity_turn_yields_more_entries_than_session() -> None:
+    """``granularity=turn`` produces ≥ as many corpus entries per question.
+
+    For the fixture, every haystack session has at least one user turn,
+    so the turn-granularity corpus must be **strictly** larger than the
+    session-granularity corpus for question 1 (3 sessions × ≥1 user
+    turn each = 3 entries — same count, but the IDs differ).  We check
+    the strict inequality on a question with multiple user turns per
+    session — none in the fixture, so we synthesise a richer scenario
+    inline.
+    """
+    questions = _load_fixture()
+
+    # Augment q1 to have a session with multiple user turns so the
+    # turn vs session entry counts diverge clearly.
+    augmented = dict(questions[0])
+    augmented["haystack_sessions"] = [
+        [
+            {"role": "user", "content": "user turn 1"},
+            {"role": "assistant", "content": "asst reply"},
+            {"role": "user", "content": "user turn 2"},
+            {"role": "user", "content": "user turn 3"},
+        ],
+    ]
+    augmented["haystack_session_ids"] = ["multi_turn_session"]
+    augmented["haystack_dates"] = ["2024/06/01 (Sat) 09:00"]
+
+    sess_entries, sess_ids = _build_corpus(augmented, "session")
+    turn_entries, turn_ids = _build_corpus(augmented, "turn")
+
+    assert len(sess_entries) == 1
+    assert len(turn_entries) == 3, (
+        f"Expected 3 user-turn entries; got {len(turn_entries)}: {turn_ids}"
+    )
+    # Synthetic ids carry the ``_turn_`` separator that mempalace uses
+    # so per-turn results round-trip back to the source session id.
+    assert all("_turn_" in tid for tid in turn_ids)
+
+    # ``_expected_id_set`` should map gold ids to all matching turns.
+    expected_session = _expected_id_set(augmented, "session", sess_ids)
+    expected_turn = _expected_id_set(augmented, "turn", turn_ids)
+    # Gold ids in the fixture (``answer_session_alpha``) don't match the
+    # synthesised id ("multi_turn_session"), so both should be empty —
+    # but the function must not crash and must return a set.
+    assert isinstance(expected_session, set)
+    assert isinstance(expected_turn, set)
+
+
+async def test_recency_off_vs_on_changes_ordering() -> None:
+    """The recency toggle changes the ordering for a date-sensitive case.
+
+    Hand-craft a question with two haystack sessions that have **near
+    identical lexical relevance** to the query but very different
+    dates:
+
+    * ``recent_session`` — same keyword content, dated *today*.
+    * ``old_session`` — same keyword content, dated *3 years ago*.
+
+    With ``recency=on`` the older session should be down-weighted via
+    the linear decay; the recent session should rank above it.  With
+    ``recency=off`` (``recency_min_weight=1.0``) the multiplier is
+    neutralised and the two should tie — the order then depends on
+    DuckDB's stable-but-unspecified tie-break.  We assert that at
+    minimum the two orderings differ, *or* that the recent session
+    wins under ``on`` and either is acceptable under ``off``.
+    """
+    today = datetime.now(tz=UTC)
+    long_ago = today - timedelta(days=1100)  # ~3 years; far past 90-day window
+
+    def _fmt(dt: datetime) -> str:
+        return dt.strftime("%Y/%m/%d (Mon) %H:%M")
+
+    question = {
+        "question_id": "recency_probe",
+        "question_type": "single-session-user",
+        "question": "moving to Lisbon",
+        "question_date": _fmt(today),
+        # Both haystacks count toward the gold set so we focus on
+        # ordering, not relevance.
+        "answer_session_ids": ["recent_session", "old_session"],
+        "haystack_session_ids": ["old_session", "recent_session"],
+        "haystack_dates": [_fmt(long_ago), _fmt(today)],
+        "haystack_sessions": [
+            [{"role": "user", "content": "I am moving to Lisbon next month."}],
+            [{"role": "user", "content": "I am moving to Lisbon next month."}],
+        ],
+    }
+
+    report_on = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="on",
+        embed_model="bge-small",
+        questions=[question],
+    )
+    report_off = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="off",
+        embed_model="bge-small",
+        questions=[question],
+    )
+
+    on_order = report_on.per_question[0].retrieved_session_ids
+    off_order = report_off.per_question[0].retrieved_session_ids
+
+    assert on_order, "Recency=on produced no retrieved ids"
+    assert off_order, "Recency=off produced no retrieved ids"
+
+    # With ``recency=on`` and identical relevance, the recent session
+    # must beat the 3-year-old one.  This is the proof that the
+    # recency multiplier propagates from the runner's
+    # ``recency_min_weight`` choice into the actual ranking.
+    assert on_order[0] == "recent_session", (
+        f"recency=on should rank the recent session first when relevance is tied; got {on_order}"
+    )
+    # And ``recency=off`` must yield a *different* top-1, *or* a
+    # different overall ordering — otherwise the toggle was a no-op.
+    assert off_order != on_order or off_order[0] == "old_session", (
+        f"Recency toggle had no effect: on={on_order} off={off_order}. "
+        f"Either the multiplier is not propagating or the test data "
+        f"isn't date-sensitive enough."
+    )
+
+
+async def test_sha_panel_populated_in_every_record(tmp_path: Path) -> None:
+    """Every JSONL record carries the seven discipline-rule-5 ``_meta`` keys.
+
+    Required keys:
+
+    * ``git_sha``
+    * ``dataset_revision_sha``
+    * ``dataset_file_sha256``
+    * ``embed_model_sha``
+    * ``python_version``
+    * ``seed``
+    * ``timestamp_utc``
+
+    Without these, the receipts can't be audited and discipline rule 5
+    is violated — "no SHAs ⇒ no claim".
+    """
+    questions = _load_fixture()
+
+    report = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="on",
+        embed_model="bge-small",
+        questions=questions,
+        output_dir=tmp_path,
+    )
+
+    required = {
+        "git_sha",
+        "dataset_revision_sha",
+        "dataset_file_sha256",
+        "embed_model_sha",
+        "python_version",
+        "seed",
+        "timestamp_utc",
+    }
+
+    # In-process records first.
+    for record in report.per_question:
+        missing = required - set(record.meta.keys())
+        assert not missing, f"Record {record.question_id} missing meta keys: {missing}"
+
+    # Now re-parse the JSONL so we also pin the on-disk shape.
+    assert report.jsonl_path is not None
+    lines = report.jsonl_path.read_text().splitlines()
+    assert lines, "JSONL file is empty"
+    for line in lines:
+        payload = json.loads(line)
+        meta = payload.get("_meta") or {}
+        missing = required - set(meta.keys())
+        assert not missing, f"On-disk record missing meta keys {missing}: {payload}"
+
+
+async def test_raw_retrieval_records_effective_recency_off() -> None:
+    """``retrieval=raw`` forces ``effective_recency=off`` in the meta panel.
+
+    The vector-only fallback path in :class:`DuckDBStore` does not apply
+    recency at all — see the runner's module docstring.  The runner
+    must record this honestly so a reader of the JSONL can never
+    mistakenly believe a raw-retrieval cell respects the requested
+    recency setting.
+    """
+    questions = _load_fixture()
+
+    report = await run_longmemeval_bench(
+        retrieval="raw",
+        granularity="session",
+        recency="on",  # requested but bypassed
+        embed_model="bge-small",
+        questions=questions[:1],
+    )
+
+    record = report.per_question[0]
+    assert record.meta["recency_requested"] == "on"
+    assert record.meta["effective_recency"] == "off", (
+        "raw retrieval must record effective_recency=off because the "
+        "vector-only path bypasses the recency multiplier"
+    )
+
+
+def test_filename_schema_includes_every_axis(tmp_path: Path) -> None:
+    """Output filenames must include every axis to prevent cross-axis confusion.
+
+    Discipline rule: cross-granularity (and cross-anything) comparison
+    should be a deliberate filesystem-level act, not an accident of two
+    runs sharing a filename.  Pure naming check — no async needed.
+    """
+    from distillery.eval.longmemeval import _write_outputs
+
+    record = QuestionRecord(
+        question_id="x",
+        question_type="t",
+        expected_session_ids=[],
+        retrieved_session_ids=[],
+        rankings=[],
+        recall_at_5=0.0,
+        recall_all_at_5=0.0,
+        ndcg_at_5=0.0,
+        recall_at_10=0.0,
+        recall_all_at_10=0.0,
+        ndcg_at_10=0.0,
+        latency_ms=1.0,
+        n_corpus_entries=0,
+        meta={},
+    )
+    jsonl, summary = _write_outputs(
+        [record],
+        {"n_questions": 1, "overall": {}, "per_question_type": {}},
+        tmp_path,
+        retrieval="hybrid",
+        granularity="turn",
+        recency="off",
+        embed_model="bge-base",
+        stamp="20260502T010203Z",
+    )
+    # Every axis appears in the filename so two distinct configurations
+    # never collide on disk.
+    for axis in ("hybrid", "turn", "off", "bge-base", "20260502T010203Z"):
+        assert axis in jsonl.name, f"jsonl name missing axis {axis!r}: {jsonl.name}"
+        assert axis in summary.name, f"summary name missing axis {axis!r}: {summary.name}"

--- a/tests/eval/test_longmemeval_runner.py
+++ b/tests/eval/test_longmemeval_runner.py
@@ -42,6 +42,7 @@ from distillery.eval.longmemeval import (
     QuestionRecord,
     _build_corpus,
     _expected_id_set,
+    _parse_haystack_date,
     run_longmemeval_bench,
 )
 
@@ -75,6 +76,20 @@ class _KeywordEmbedder:
     and queries are vectorised by counting occurrences of each lexicon
     word — so the cosine between a query and a relevant haystack
     session is high without any network or weights involved.
+
+    Note on fixture choice
+    ----------------------
+    This is intentionally a module-local stub rather than the shared
+    ``deterministic_embedding_provider`` from ``tests/conftest.py``.
+    The shared fixture is a *registry* (caller must
+    ``register(text, vector)`` for every text it cares about) and falls
+    back to opaque hash vectors for everything else — that does not
+    produce meaningful cosine similarity between a query string and a
+    *different* haystack session string mentioning the same topic.
+    The keyword-overlap design here lets the fixture's queries hit the
+    intended haystack sessions automatically (e.g. "moving to Lisbon"
+    in the question matches "I'm moving to Lisbon" in the haystack)
+    without having to enumerate every (query, document) pair upfront.
     """
 
     _LEXICON = (
@@ -412,6 +427,83 @@ async def test_raw_retrieval_records_effective_recency_off() -> None:
         "raw retrieval must record effective_recency=off because the "
         "vector-only path bypasses the recency multiplier"
     )
+
+
+def test_parse_haystack_date_falls_back_to_epoch_on_invalid_input() -> None:
+    """``_parse_haystack_date`` returns the Unix epoch for unparseable input.
+
+    Three regression cases:
+
+    * **Invalid calendar value** (``"2026-02-30"``) — previously crashed
+      because ``datetime(...)`` raises ``ValueError`` and the function
+      had no guard.  CodeRabbit on PR #439 (Critical).
+    * **Plain garbage string** — the regex never matched; previously
+      this returned ``datetime.now(tz=UTC)`` which silently inflated
+      the row's recency to "today".  Now epoch.
+    * **Non-string input** (``None``) — same fallback path; epoch, not
+      ``datetime.now``.
+
+    Picking the epoch over ``datetime.now`` keeps malformed haystack
+    rows from masquerading as the most-recent material when the
+    recency multiplier runs.
+    """
+    epoch = datetime(1970, 1, 1, tzinfo=UTC)
+
+    # The runner's regex is forgiving on the slash-vs-dash separator,
+    # but the calendar values still go through ``datetime(...)``.  We
+    # exercise the date string CodeRabbit called out plus a couple of
+    # other fall-through paths.
+    assert _parse_haystack_date("2026/02/30 12:00") == epoch
+    assert _parse_haystack_date("not a date") == epoch
+    assert _parse_haystack_date(None) == epoch  # type: ignore[arg-type]
+    # Empty string and stray whitespace also fail the regex → epoch.
+    assert _parse_haystack_date("") == epoch
+    assert _parse_haystack_date("   ") == epoch
+    # Sanity: a well-formed date still parses correctly so the regex
+    # branch isn't broken by the new guard.
+    assert _parse_haystack_date("2024/06/01 (Sat) 09:00") == datetime(2024, 6, 1, 9, 0, tzinfo=UTC)
+
+
+async def test_summary_axes_exposes_effective_recency(tmp_path: Path) -> None:
+    """``summary["axes"]`` carries both ``recency_requested`` and
+    ``effective_recency`` so consumers reading only the summary cannot
+    be misled when ``retrieval=raw`` silently disables recency.
+
+    Before the fix, ``axes`` exposed only ``recency`` which silently
+    disagreed with per-record ``_meta.effective_recency`` for raw
+    retrieval.  The summary now mirrors the per-record schema.
+    """
+    questions = _load_fixture()
+
+    report_raw = await run_longmemeval_bench(
+        retrieval="raw",
+        granularity="session",
+        recency="on",  # requested but bypassed by raw path
+        embed_model="bge-small",
+        questions=questions[:1],
+    )
+    axes_raw = report_raw.summary["axes"]
+    assert axes_raw["recency_requested"] == "on"
+    assert axes_raw["effective_recency"] == "off", (
+        "raw retrieval must report effective_recency=off in the summary "
+        "so a consumer reading only summary.json cannot misread the cell"
+    )
+    # The legacy ``recency`` key is replaced; absence is the contract
+    # so downstream tools must use the explicit *_requested / effective
+    # split.
+    assert "recency" not in axes_raw
+
+    report_hybrid = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="off",
+        embed_model="bge-small",
+        questions=questions[:1],
+    )
+    axes_hybrid = report_hybrid.summary["axes"]
+    assert axes_hybrid["recency_requested"] == "off"
+    assert axes_hybrid["effective_recency"] == "off"
+    assert "recency" not in axes_hybrid
 
 
 def test_filename_schema_includes_every_axis(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds the LongMemEval bench runner — deliverable 2 of the [bench plan](https://github.com/norrietaylor/distillery/issues?q=is%3Aopen+label%3Abenchmark). The runner constructs a fresh in-memory `DuckDBStore` per question, ingests `haystack_sessions` as `Entry` rows with a fixed PRNG seed reset before every store rebuild, scores against `answer_session_ids` via the W1 scoring module, and emits a JSONL receipt plus JSON summary with full SHA provenance.

## Hard dependencies (must merge first)

This PR is **draft until** all three Wave 1 PRs land:

- [ ] #435 — `bench/fastembed-provider` (W1-fastembed)
- [ ] #433 — `bench/scoring-module` (W1-scoring)
- [ ] #436 — `bench/dataset-loader` (W1-dataset-loader)

The branch was built on top of those three branches as a temporary integration base. The first three commits on this branch are merge commits from `origin/bench/{fastembed-provider,scoring-module,dataset-loader}` — they will disappear after the rebase below.

**There is no `awaiting-deps` label in this repo.** Reviewers: please do not merge this PR before all three deps are merged. The draft state is the soft block.

## Rebase plan (after deps merge)

Once #435, #433, #436 land on `main`:

```bash
git fetch origin
# Rebase onto current main, dropping the three temporary merge commits.
# 860ea65 was main HEAD when this branch was created — every commit
# after that and before the runner commit is a merge commit from a
# Wave 1 dep branch and will become unnecessary.
git rebase --onto origin/main 860ea657d86bb91dff2f9cb9204d9ef06a3fc2bc
git push --force-with-lease
```

After the rebase the only commit on this branch will be the runner commit (`feat(eval): add LongMemEval bench runner with SHA-pinned reproducibility`).

## Files added

- `src/distillery/eval/longmemeval.py` — the runner. Public API: `run_longmemeval_bench(*, retrieval, granularity, recency, embed_model, limit, seeds, output_dir, questions) -> BenchReport`.
- `tests/eval/test_longmemeval_runner.py` — 7 unit tests covering happy path, session_id round-trip, granularity branching, recency on/off ordering divergence, SHA-panel completeness, raw-retrieval recency-bypass honesty, and filename schema.
- `pyproject.toml` — registers the `bench` pytest marker.

## Recency / hybrid trade-off (footgun finding)

The W1-recency-toggle-probe audit (#430) confirmed `recency_min_weight` is construction-time only on `DuckDBStore`. **My investigation extends that finding**: `hybrid_search` is **also** construction-time only, and the vector-only fallback path (`hybrid_search=False`) does **not** apply the recency multiplier at all — recency lives strictly inside the RRF fusion branch (`src/distillery/store/duckdb.py` line ~1718).

Consequence: `retrieval=raw` requires `hybrid_search=False`, which silently bypasses recency. The runner records this honestly via `_meta.effective_recency`: when `retrieval=raw` is requested, `effective_recency` is forced to `"off"` regardless of the requested `recency` setting. A reader of the JSONL can never mistakenly believe a raw-retrieval cell respects the recency toggle.

**This is a real footgun in the public store API.** Recommend opening a follow-up issue: expose `recency` (and ideally `hybrid`) as per-`search()` kwargs so the bench can use a single store across cells and the toggle can't desync from the index. Until that lands, the runner uses construction-time variance + honest `effective_recency` reporting.

I did **not** amend `bench/LIMITATIONS.md` because that file does not yet exist on `main` — it lives in the W1-discipline-docs PR (#431) which is independent of this dep chain. After #431 merges, a one-line bullet should be added there:

> When `retrieval=raw`, `recency` is ignored — the vector-only path in `DuckDBStore` does not apply the decay multiplier. The bench reports `_meta.effective_recency` so receipts cannot be misread, but the underlying API ergonomics need a per-query toggle (tracking issue: TBD on PR review).

## Discipline-check confirmation

All six items from the worker prompt:

- [x] Every JSONL record has the SHA panel (verified by `test_sha_panel_populated_in_every_record` and the smoke test below).
- [x] The runner does NOT hardcode any expected scores.
- [x] No prediction or "expected to land ~0.95" prose in code or docstrings (only meta-commentary about the discipline rule itself).
- [x] Fixed PRNG seeds are set BEFORE every store-rebuild — `_seed_prng(seed)` is the first call inside `_run_one_question`, before `DuckDBStore(...)`.
- [x] Cross-granularity comparison technically prevented by separate output files — every axis is in the filename (`results_longmemeval_<retrieval>_<granularity>_<recency>_<embed>_<UTC>.jsonl`); pinned by `test_filename_schema_includes_every_axis`.
- [x] Recency/hybrid trade-off documented (in the runner module docstring + this PR body — see above for the LIMITATIONS.md note).

## Smoke test result

```
$ python -c "...run_longmemeval_bench(questions=mini_fixture, output_dir=/tmp/bench_smoke)..."

JSONL: /tmp/bench_smoke/results_longmemeval_hybrid_session_on_bge-small_20260503T074845Z.jsonl
Summary: /tmp/bench_smoke/summary_longmemeval_hybrid_session_on_bge-small_20260503T074845Z.json

n_questions: 2
overall: {recall_at_5: 1.0, recall_at_10: 1.0, ndcg_at_10: 1.0}
per_question_type:
  multi-session:        {n: 1, recall_at_5: 1.0, ...}
  single-session-user:  {n: 1, recall_at_5: 1.0, ...}
git_sha: 5e2ce9e70507af995b30830937b2451a3c28974b
dataset.revision_sha: 98d7416c24c778c2fee6e6f3006e7a073259d48f

First JSONL record _meta:
  Missing keys: NONE — all 7 present
  git_sha:           5e2ce9e7...
  embed_model_sha:   smoke-stub@unknown   (test stub; real run uses fastembed==0.8.0/<model>)
  python_version:    3.13.12 ...
  seed:              0
  effective_recency: on
```

(Used a deterministic keyword-stub embedder for the smoke test so we don't pull the ~67 MB fastembed weights in CI; the real bench uses `FastembedProvider(model="bge-small")`.)

## Verification

- `pytest tests/eval/test_longmemeval_runner.py -v` — 7/7 pass.
- `pytest -m unit -q` — 1788 passed, 2 skipped (was 1781; +7 is the new module). No regressions.
- `mypy --strict src/distillery/eval/longmemeval.py` — clean.
- `ruff check`, `ruff format --check` — clean.
- Smoke test against `tests/fixtures/longmemeval_mini.json` — JSONL emitted with all 7 SHA-panel fields.

## Out of scope

- CLI wiring (`distillery bench longmemeval ...`) is W2-cli's job.
- Workflow YAML is W2-workflow-yaml's job.
- Variance characterisation (5-seed headline) is the W3 gate.
- Real-dataset run (500 questions) is deliberately deferred to W3 under controlled conditions per discipline rule 6.

## Test plan

- [ ] After deps merge: rebase onto `origin/main` per the command above.
- [ ] Re-run `pytest tests/eval/test_longmemeval_runner.py -v` post-rebase.
- [ ] Re-run `pytest -m unit` post-rebase to confirm no regression vs the new `main`.
- [ ] Re-run `mypy --strict src/distillery/eval/longmemeval.py` and `ruff check` post-rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LongMemEval benchmark runner for comprehensive retrieval-quality evaluation. Supports configurable retrieval strategies, document granularity options, recency weighting, and multiple embedding models. Generates detailed performance reports with recall and NDCG metrics for quality assessment.

* **Chores**
  * Added huggingface_hub dependency and optional fastembed support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->