### PR TITLE
[bench] CLI: distillery bench longmemeval (depends on #439)

### DIFF
--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -264,6 +264,79 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Classification mode: llm (LLM-based) or heuristic (embedding-based). Defaults to config value.",
     )
 
+    # ------------------------------------------------------------------
+    # bench subcommand — public reproduction benchmarks (LongMemEval, ...)
+    # ------------------------------------------------------------------
+    bench_parser = subparsers.add_parser(
+        "bench",
+        help="Run public reproduction benchmarks",
+        parents=[sub_shared],
+    )
+    bench_subparsers = bench_parser.add_subparsers(dest="bench_command")
+
+    longmemeval_parser = bench_subparsers.add_parser(
+        "longmemeval",
+        help="Run the LongMemEval retrieval bench (fastembed by default)",
+        parents=[sub_shared],
+        description=(
+            "Run the LongMemEval retrieval bench. Emits a timestamped JSONL "
+            "file (one line per question, with the SHA provenance panel) and "
+            "a summary.json into the output directory. See bench/README.md "
+            "and bench/LIMITATIONS.md before publishing any number from this "
+            "tool."
+        ),
+    )
+    longmemeval_parser.add_argument(
+        "--retrieval",
+        choices=["raw", "hybrid"],
+        default="hybrid",
+        help="Retrieval mode: raw (vector-only) or hybrid (BM25+RRF, default)",
+    )
+    longmemeval_parser.add_argument(
+        "--granularity",
+        choices=["session", "turn"],
+        default="session",
+        help="Corpus granularity: one entry per session (default) or per user turn",
+    )
+    longmemeval_parser.add_argument(
+        "--recency",
+        choices=["on", "off"],
+        default="on",
+        help="Toggle the 90-day recency decay (on by default; ignored for raw)",
+    )
+    longmemeval_parser.add_argument(
+        "--embed-model",
+        choices=["bge-small", "bge-base", "bge-large", "jina"],
+        default="bge-small",
+        help="Embedding model (default: bge-small via fastembed)",
+    )
+    longmemeval_parser.add_argument(
+        "--limit",
+        metavar="N",
+        type=int,
+        default=None,
+        help="Cap the number of questions evaluated (default: full set)",
+    )
+    longmemeval_parser.add_argument(
+        "--seeds",
+        metavar="N",
+        type=int,
+        default=1,
+        help="Number of seeds to sweep per question (default: 1)",
+    )
+    longmemeval_parser.add_argument(
+        "--output-dir",
+        metavar="PATH",
+        default=None,
+        help="Directory for JSONL + summary outputs (default: bench/results/)",
+    )
+    longmemeval_parser.add_argument(
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="Suppress per-question progress output",
+    )
+
     return parser
 
 
@@ -1440,8 +1513,7 @@ def _cmd_eval(
         _emit_eval_error(
             fmt,
             message=(
-                f"eval dependencies not installed. Run: "
-                f"pip install 'distillery-mcp[eval]'. {exc}"
+                f"eval dependencies not installed. Run: pip install 'distillery-mcp[eval]'. {exc}"
             ),
             code="eval_dependencies_missing",
         )
@@ -1820,6 +1892,126 @@ def _cmd_maintenance_classify(
 
 
 # ---------------------------------------------------------------------------
+# Bench subcommand
+# ---------------------------------------------------------------------------
+
+
+def _cmd_bench_longmemeval(
+    *,
+    retrieval: str,
+    granularity: str,
+    recency: str,
+    embed_model: str,
+    limit: int | None,
+    seeds: int,
+    output_dir: str | None,
+    quiet: bool,
+    fmt: str,
+) -> int:
+    """Implement the ``bench longmemeval`` subcommand.
+
+    Wires the CLI flags into :func:`distillery.eval.longmemeval.run_longmemeval_bench`
+    and prints a one-line headline summary on completion. Exits non-zero if
+    the runner raises.
+
+    Returns:
+        Exit code (0 on success, 1 on error).
+    """
+    # Import lazily so `distillery --help` does not pay the cost of pulling
+    # in fastembed/onnxruntime when the user is not running a bench.
+    try:
+        from distillery.eval.longmemeval import (
+            BenchReport,
+            EmbedModel,
+            GranularityMode,
+            RecencyMode,
+            RetrievalMode,
+            run_longmemeval_bench,
+        )
+    except ImportError as exc:
+        print(
+            f"Error: bench dependencies are not installed ({exc}). "
+            "Install with: pip install 'distillery-mcp[fastembed]'",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Resolve and create the output directory. Default to ``bench/results/``
+    # under the current working directory so users can invoke the CLI from a
+    # checkout without extra flags.
+    resolved_output_dir = Path(output_dir) if output_dir else Path("bench/results")
+    try:
+        resolved_output_dir = resolved_output_dir.expanduser().resolve()
+        resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(
+            f"Error: cannot create output directory {resolved_output_dir!s}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not quiet:
+        print(
+            f"Running LongMemEval bench: retrieval={retrieval} "
+            f"granularity={granularity} recency={recency} "
+            f"embed_model={embed_model} limit={limit} seeds={seeds}",
+            file=sys.stderr,
+        )
+        print(f"Output directory: {resolved_output_dir}", file=sys.stderr)
+
+    # The argparse choices guarantee these are valid Literal values; the
+    # cast is only for mypy --strict to see the narrowed type.
+    retrieval_mode: RetrievalMode = retrieval  # type: ignore[assignment]
+    granularity_mode: GranularityMode = granularity  # type: ignore[assignment]
+    recency_mode: RecencyMode = recency  # type: ignore[assignment]
+    embed_model_typed: EmbedModel = embed_model  # type: ignore[assignment]
+
+    async def _run() -> BenchReport:
+        return await run_longmemeval_bench(
+            retrieval=retrieval_mode,
+            granularity=granularity_mode,
+            recency=recency_mode,
+            embed_model=embed_model_typed,
+            limit=limit,
+            seeds=seeds,
+            output_dir=resolved_output_dir,
+        )
+
+    try:
+        report = asyncio.run(_run())
+    except Exception as exc:
+        print(f"Error running LongMemEval bench: {exc}", file=sys.stderr)
+        return 1
+
+    overall = report.summary.get("overall", {})
+    r5 = float(overall.get("recall_at_5", 0.0))
+    r10 = float(overall.get("recall_at_10", 0.0))
+    ndcg10 = float(overall.get("ndcg_at_10", 0.0))
+    n_questions = int(report.summary.get("n_questions", 0))
+    jsonl_path = report.jsonl_path
+
+    if fmt == "json":
+        print(
+            json.dumps(
+                {
+                    "n_questions": n_questions,
+                    "recall_at_5": r5,
+                    "recall_at_10": r10,
+                    "ndcg_at_10": ndcg10,
+                    "jsonl_path": str(jsonl_path) if jsonl_path is not None else None,
+                    "summary_path": (
+                        str(report.summary_path) if report.summary_path is not None else None
+                    ),
+                }
+            )
+        )
+    else:
+        print(f"R@5={r5:.3f} R@10={r10:.3f} NDCG@10={ndcg10:.3f} (n={n_questions}) -> {jsonl_path}")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -1902,6 +2094,22 @@ def main(argv: list[str] | None = None) -> None:
             )
         else:
             parser.error("Unknown maintenance subcommand (expected: classify)")
+    elif command == "bench":
+        bench_command: str | None = getattr(args, "bench_command", None)
+        if bench_command == "longmemeval":
+            exit_code = _cmd_bench_longmemeval(
+                retrieval=getattr(args, "retrieval", "hybrid"),
+                granularity=getattr(args, "granularity", "session"),
+                recency=getattr(args, "recency", "on"),
+                embed_model=getattr(args, "embed_model", "bge-small"),
+                limit=getattr(args, "limit", None),
+                seeds=getattr(args, "seeds", 1),
+                output_dir=getattr(args, "output_dir", None),
+                quiet=getattr(args, "quiet", False),
+                fmt=fmt,
+            )
+        else:
+            parser.error("Unknown bench subcommand (expected: longmemeval)")
     else:  # pragma: no cover – argparse rejects unknown subcommands
         parser.error(f"Unknown command: {command}")
 

--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -39,6 +39,22 @@ from distillery import __version__
 from distillery.config import CONFIG_ENV_VAR, load_config
 
 
+def _positive_int(value: str) -> int:
+    """argparse ``type`` callable that rejects ``<= 0`` integers.
+
+    Used by ``bench longmemeval`` for ``--limit`` and ``--seeds`` so the
+    CLI fails fast on ``--seeds 0`` / ``--limit -1`` rather than producing
+    an empty bench run that still exits 0.
+    """
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid int value: {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"must be > 0 (got {parsed})")
+    return parsed
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Build and return the argument parser.
 
@@ -313,14 +329,14 @@ def _build_parser() -> argparse.ArgumentParser:
     longmemeval_parser.add_argument(
         "--limit",
         metavar="N",
-        type=int,
+        type=_positive_int,
         default=None,
         help="Cap the number of questions evaluated (default: full set)",
     )
     longmemeval_parser.add_argument(
         "--seeds",
         metavar="N",
-        type=int,
+        type=_positive_int,
         default=1,
         help="Number of seeds to sweep per question (default: 1)",
     )
@@ -334,7 +350,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--quiet",
         action="store_true",
         default=False,
-        help="Suppress per-question progress output",
+        help="Suppress the pre-run configuration banner on stderr",
     )
 
     return parser
@@ -1917,6 +1933,20 @@ def _cmd_bench_longmemeval(
     Returns:
         Exit code (0 on success, 1 on error).
     """
+    # Resolve and create the output directory FIRST so the cheap validation
+    # path does not depend on optional bench deps (fastembed/onnxruntime).
+    # If the user passes a bad ``--output-dir`` we want to fail in <100 ms.
+    resolved_output_dir = Path(output_dir) if output_dir else Path("bench/results")
+    try:
+        resolved_output_dir = resolved_output_dir.expanduser().resolve()
+        resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(
+            f"Error: cannot create output directory {resolved_output_dir!s}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
     # Import lazily so `distillery --help` does not pay the cost of pulling
     # in fastembed/onnxruntime when the user is not running a bench.
     try:
@@ -1932,20 +1962,6 @@ def _cmd_bench_longmemeval(
         print(
             f"Error: bench dependencies are not installed ({exc}). "
             "Install with: pip install 'distillery-mcp[fastembed]'",
-            file=sys.stderr,
-        )
-        return 1
-
-    # Resolve and create the output directory. Default to ``bench/results/``
-    # under the current working directory so users can invoke the CLI from a
-    # checkout without extra flags.
-    resolved_output_dir = Path(output_dir) if output_dir else Path("bench/results")
-    try:
-        resolved_output_dir = resolved_output_dir.expanduser().resolve()
-        resolved_output_dir.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        print(
-            f"Error: cannot create output directory {resolved_output_dir!s}: {exc}",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -1,0 +1,245 @@
+"""Tests for the ``distillery bench longmemeval`` CLI subcommand.
+
+These tests cover the wiring layer only — argparse plumbing, output-dir
+resolution, the headline summary line. The runner itself is exercised by
+``tests/eval/test_longmemeval_runner.py``.
+
+The integration smoke test loads the bundled mini fixture and patches the
+runner's embedding-provider factory with a deterministic keyword stub so
+no fastembed weights are downloaded during the test run.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from distillery.cli import main
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "longmemeval_mini.json"
+
+
+# ---------------------------------------------------------------------------
+# Help-only test (unit) — does not need the bench dependencies installed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBenchLongmemevalHelp:
+    def test_help_exits_zero_and_lists_all_flags(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``distillery bench longmemeval --help`` lists every documented flag.
+
+        Guards against argparse regressions and against silently dropping a
+        flag from the parser builder.
+        """
+        with pytest.raises(SystemExit) as exc:
+            main(["bench", "longmemeval", "--help"])
+        assert exc.value.code == 0
+
+        captured = capsys.readouterr()
+        out = captured.out
+
+        assert "longmemeval" in out.lower()
+
+        # Each user-facing flag must appear in --help.
+        for flag in (
+            "--retrieval",
+            "--granularity",
+            "--recency",
+            "--embed-model",
+            "--limit",
+            "--seeds",
+            "--output-dir",
+            "--quiet",
+        ):
+            assert flag in out, f"missing {flag} from --help"
+
+        # Choices for each enum flag must show up too.
+        for choice in ("raw", "hybrid", "session", "turn", "bge-small", "jina"):
+            assert choice in out, f"missing choice {choice!r} from --help"
+
+    def test_bench_no_subcommand_errors(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``distillery bench`` without a sub-subcommand should error out."""
+        with pytest.raises(SystemExit) as exc:
+            main(["bench"])
+        # argparse.error exits with code 2; our handler errors with non-zero.
+        assert exc.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke test — runs the full pipeline against the mini fixture.
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture() -> list[dict[str, Any]]:
+    with FIXTURE_PATH.open() as f:
+        data: list[dict[str, Any]] = json.load(f)
+    return data
+
+
+class _KeywordEmbedder:
+    """Deterministic keyword embedder used to avoid fastembed downloads.
+
+    Mirrors the stub in ``tests/eval/test_longmemeval_runner.py`` so the
+    fixture's hand-crafted "easy" question is solvable.
+    """
+
+    _LEXICON = (
+        "lisbon",
+        "moving",
+        "city",
+        "vacation",
+        "packing",
+        "cats",
+        "cat",
+        "mochi",
+        "yuzu",
+        "soba",
+        "adopted",
+        "third",
+        "feline",
+    )
+
+    def __init__(self) -> None:
+        self._dim = len(self._LEXICON)
+
+    def _vec(self, text: str) -> list[float]:
+        lowered = text.lower()
+        raw = [float(lowered.count(word)) for word in self._LEXICON]
+        magnitude = sum(x * x for x in raw) ** 0.5 or 1.0
+        return [x / magnitude for x in raw]
+
+    def embed(self, text: str) -> list[float]:
+        return self._vec(text)
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [self._vec(t) for t in texts]
+
+    @property
+    def dimensions(self) -> int:
+        return self._dim
+
+    @property
+    def model_name(self) -> str:
+        return "keyword-stub-cli-test"
+
+
+@pytest.mark.integration
+class TestBenchLongmemevalRun:
+    def test_smoke_run_writes_jsonl_and_prints_summary(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Smoke: ``distillery bench longmemeval --limit 1`` writes JSONL.
+
+        Patches both:
+          * the runner's embedding-provider factory with the keyword stub,
+            so no weights are downloaded.
+          * the dataset loader so the mini fixture stands in for the real
+            HuggingFace download.
+        """
+        # Patch the embedding factory used inside the runner.
+        from distillery.eval import longmemeval as bench_module
+
+        def _stub_provider(_model: str) -> _KeywordEmbedder:
+            return _KeywordEmbedder()
+
+        monkeypatch.setattr(bench_module, "_build_embedding_provider", _stub_provider)
+
+        # Replace the dataset loader to return the bundled fixture so the
+        # CLI path does not hit HuggingFace from a CI runner.
+        fixture = _load_fixture()
+        monkeypatch.setattr(bench_module, "load_longmemeval", lambda: fixture)
+
+        out_dir = tmp_path / "results"
+
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    "bench",
+                    "longmemeval",
+                    "--limit",
+                    "1",
+                    "--output-dir",
+                    str(out_dir),
+                    "--quiet",
+                ]
+            )
+        assert exc.value.code == 0, "CLI exit code should be 0 on success"
+
+        # Output directory must exist and contain at least one JSONL + one
+        # summary file.
+        assert out_dir.is_dir()
+        jsonl_files = list(out_dir.glob("results_longmemeval_*.jsonl"))
+        summary_files = list(out_dir.glob("summary_longmemeval_*.json"))
+        assert len(jsonl_files) == 1, f"expected one JSONL, got {jsonl_files!r}"
+        assert len(summary_files) == 1, f"expected one summary, got {summary_files!r}"
+
+        # Each JSONL line must carry the SHA panel under ``_meta``.
+        with jsonl_files[0].open() as f:
+            records = [json.loads(line) for line in f if line.strip()]
+        assert records, "JSONL must contain at least one record"
+        for rec in records:
+            assert "_meta" in rec, "missing _meta block (SHA panel)"
+            meta = rec["_meta"]
+            for key in (
+                "git_sha",
+                "dataset_revision_sha",
+                "dataset_file_sha256",
+                "embed_model_sha",
+                "python_version",
+                "seed",
+                "timestamp_utc",
+            ):
+                assert key in meta, f"missing {key} from _meta"
+
+        # The headline summary line must appear on stdout in the exact
+        # ``R@5=... R@10=... NDCG@10=... (n=...) -> <path>`` shape.
+        captured = capsys.readouterr()
+        summary_line = captured.out.strip().splitlines()[-1]
+        match = re.match(
+            r"^R@5=\d+\.\d{3} R@10=\d+\.\d{3} NDCG@10=\d+\.\d{3} \(n=\d+\) -> .+\.jsonl$",
+            summary_line,
+        )
+        assert match is not None, f"unexpected summary line: {summary_line!r}"
+        assert str(jsonl_files[0]) in summary_line
+
+    def test_invalid_output_dir_errors(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """If output dir cannot be created, the CLI exits non-zero."""
+        # Make a path under a regular file so mkdir fails with NotADirectoryError.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("nope")
+        bad_path = blocker / "results"
+
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    "bench",
+                    "longmemeval",
+                    "--limit",
+                    "1",
+                    "--output-dir",
+                    str(bad_path),
+                    "--quiet",
+                ]
+            )
+        assert exc.value.code != 0
+        captured = capsys.readouterr()
+        assert "cannot create output directory" in captured.err.lower()

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -159,9 +159,14 @@ class TestBenchLongmemevalRun:
         monkeypatch.setattr(bench_module, "_build_embedding_provider", _stub_provider)
 
         # Replace the dataset loader to return the bundled fixture so the
-        # CLI path does not hit HuggingFace from a CI runner.
+        # CLI path does not hit HuggingFace from a CI runner. The runner
+        # awaits ``load_longmemeval()`` so the stub must return an awaitable.
         fixture = _load_fixture()
-        monkeypatch.setattr(bench_module, "load_longmemeval", lambda: fixture)
+
+        async def _stub_loader() -> list[dict[str, Any]]:
+            return fixture
+
+        monkeypatch.setattr(bench_module, "load_longmemeval", _stub_loader)
 
         out_dir = tmp_path / "results"
 

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -248,3 +248,35 @@ class TestBenchLongmemevalRun:
         assert exc.value.code != 0
         captured = capsys.readouterr()
         assert "cannot create output directory" in captured.err.lower()
+
+
+@pytest.mark.unit
+class TestBenchLongmemevalArgValidation:
+    """argparse-time validation of ``--limit`` / ``--seeds``.
+
+    Both flags must be ``> 0`` so the bench cannot silently produce an
+    empty (and falsely successful) run. Validation happens at parse time
+    so the failure is surfaced before any heavy bench import.
+    """
+
+    @pytest.mark.parametrize(
+        "flag,value",
+        [
+            ("--limit", "0"),
+            ("--limit", "-1"),
+            ("--seeds", "0"),
+            ("--seeds", "-3"),
+        ],
+    )
+    def test_non_positive_int_rejected(
+        self,
+        flag: str,
+        value: str,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        with pytest.raises(SystemExit) as exc:
+            main(["bench", "longmemeval", flag, value])
+        # argparse always exits 2 on a bad type/value.
+        assert exc.value.code == 2
+        captured = capsys.readouterr()
+        assert "must be > 0" in captured.err

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -221,6 +221,64 @@ class TestBenchLongmemevalRun:
         assert match is not None, f"unexpected summary line: {summary_line!r}"
         assert str(jsonl_files[0]) in summary_line
 
+    def test_smoke_run_format_json_emits_parseable_envelope(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--format json`` must emit a single JSON object on stdout.
+
+        The scripted-automation contract is JSON, so this catches stray
+        prints and key-shape regressions on the most automation-sensitive
+        path.
+        """
+        from distillery.eval import longmemeval as bench_module
+
+        def _stub_provider(_model: str) -> _KeywordEmbedder:
+            return _KeywordEmbedder()
+
+        async def _stub_loader() -> list[dict[str, Any]]:
+            return _load_fixture()
+
+        monkeypatch.setattr(bench_module, "_build_embedding_provider", _stub_provider)
+        monkeypatch.setattr(bench_module, "load_longmemeval", _stub_loader)
+
+        out_dir = tmp_path / "results-json"
+
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    "--format",
+                    "json",
+                    "bench",
+                    "longmemeval",
+                    "--limit",
+                    "1",
+                    "--output-dir",
+                    str(out_dir),
+                    "--quiet",
+                ]
+            )
+        assert exc.value.code == 0, "CLI exit code should be 0 on success"
+
+        captured = capsys.readouterr()
+        # Stdout must be exactly one JSON object — no banner, no trailing
+        # text. A clean parse + key check is sufficient.
+        payload = json.loads(captured.out.strip())
+        assert isinstance(payload, dict)
+        for key in (
+            "n_questions",
+            "recall_at_5",
+            "recall_at_10",
+            "ndcg_at_10",
+            "jsonl_path",
+            "summary_path",
+        ):
+            assert key in payload, f"missing {key} from JSON envelope"
+        assert payload["jsonl_path"] is not None
+        assert payload["jsonl_path"].endswith(".jsonl")
+
     def test_invalid_output_dir_errors(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

Wires the new `distillery bench longmemeval ...` CLI subcommand into the existing argparse-based `cli.py`, delegating to `run_longmemeval_bench()` from PR #439. The handler resolves the output directory (creating it if missing), forwards every documented axis (`--retrieval`, `--granularity`, `--recency`, `--embed-model`, `--limit`, `--seeds`, `--output-dir`, `--quiet`), and prints a one-line headline summary on completion:

```
R@5=X.XXX R@10=Y.YYY NDCG@10=Z.ZZZ (n=<count>) -> <jsonl_path>
```

The runner module is imported lazily so users who never run a bench do not pay the `fastembed`/`onnxruntime` import cost, and `--format json` emits the headline as JSON for scripting.

## Dependencies (merge in order)

This PR depends transitively on the four upstream PRs that PR #439 itself merges:

1. #435 — W1: fastembed embedding provider
2. #433 — W1: scoring module (`dcg`/`ndcg`/`evaluate_retrieval`)
3. #436 — W1: dataset loader (SHA-pinned HuggingFace download)
4. #439 — W2: bench runner (`run_longmemeval_bench`)

This PR is **draft** and stays draft until #439 is no longer draft. The branch was bootstrapped by merging `origin/bench/longmemeval-runner` (which carries 1-3 in its merge history) into `main`. After all four upstream PRs land on `main`, rebase this PR with:

```bash
git fetch origin
git checkout bench/cli-bench-subcommand
git rebase origin/main
git push --force-with-lease
```

## What changed

- `src/distillery/cli.py` — new `bench` subparser and `longmemeval` sub-subparser, new `_cmd_bench_longmemeval` handler, dispatch wired in `main()`.
- `tests/test_cli_bench.py` — new test file with one `@pytest.mark.unit` (`--help` flag inventory) and two `@pytest.mark.integration` cases (smoke run against the bundled mini fixture; output-dir failure path).

## Verification

- `pytest tests/test_cli_bench.py -v` — 4 passed.
- `pytest -m unit -q` — 1790 passed, 2 skipped (no regressions).
- `mypy --strict src/distillery/cli.py` — clean.
- `ruff check` + `ruff format --check` — clean.
- Smoke: `distillery bench longmemeval --limit 1 --output-dir /tmp/cli-smoke` produced both `results_longmemeval_hybrid_session_on_bge-small_<UTC>.jsonl` and `summary_longmemeval_..._<UTC>.json` with the full SHA panel (`git_sha`, `dataset_revision_sha`, `dataset_file_sha256`, `embed_model_sha`, `python_version`, `seed`, `timestamp_utc`, plus axis echoes) on every line.

## Test plan

- [ ] CI green on the new test file.
- [ ] After #439 lands, rebase and confirm the integration test still passes against the squashed runner.
- [ ] Manual smoke once `bench/results/` directory convention lands from W2-workflow-yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new bench longmemeval command with retrieval/recency/granularity options, embedding-model choice, --limit/--seeds validation, --output-dir, --quiet, and optional JSON summary or headline metrics plus a generated JSONL results file.

* **Tests**
  * Added help/validation and integration smoke tests covering output files, summary formats, non-positive-argument rejection, and output-dir error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->