### PR TITLE
[bench] results aggregator (depends on #439)

### DIFF
--- a/scripts/bench/__init__.py
+++ b/scripts/bench/__init__.py
@@ -1,0 +1,6 @@
+"""Bench tooling — scripts that operate on bench/results/ artefacts.
+
+This package is intentionally tiny: it exists so the aggregator can be
+imported as ``scripts.bench.aggregate_results`` from tests, while still
+being runnable as a standalone CLI (``python scripts/bench/aggregate_results.py``).
+"""

--- a/scripts/bench/aggregate_results.py
+++ b/scripts/bench/aggregate_results.py
@@ -1,0 +1,701 @@
+"""Aggregate LongMemEval bench results into badge JSON + SUMMARY.md.
+
+This script is the publication step in the bench pipeline. It scans
+``bench/results/`` for ``summary_longmemeval_<retrieval>_<granularity>_<recency>_<embed>_<UTC>.json``
+files emitted by :mod:`distillery.eval.longmemeval`, identifies the
+*headline* cell (pre-registered in ``bench/HEADLINE.md`` —
+``retrieval=hybrid, granularity=session, recency=on, embed=bge-small``),
+and writes:
+
+* ``bench/badge_r5.json``, ``bench/badge_r10.json``,
+  ``bench/badge_ndcg10.json`` — Shields.io endpoint-format files. The
+  README points each badge URL at one of these files. Three files (not
+  one composite) keeps the URL parametrisation simple.
+
+* ``bench/results/SUMMARY.md`` — auto-updated table with the headline
+  triplet, a Distillery-only matrix of recent runs, the per-question-type
+  breakdown for the headline cell, and a 7-day history of headline R@5.
+
+Honesty constraint
+------------------
+
+If no headline run is present in ``results_dir``, the badges are written
+with ``message="unknown"`` and ``color="lightgrey"`` rather than falling
+back to a non-headline cell. Surfacing that the headline didn't run is
+strictly better than silently substituting a different configuration —
+the latter is the publication failure mode mempalace's #875 was about.
+
+CLI
+---
+
+    python scripts/bench/aggregate_results.py \\
+        --results-dir bench/results/ \\
+        --output-dir bench/
+
+The ``--output-dir`` controls where the three badge files land.
+``SUMMARY.md`` is always written into ``<results_dir>/SUMMARY.md``
+because it documents the runs in that directory.
+
+See the plan in ``/Users/norrie/.claude/plans/look-at-mempalace-hook-dynamic-mccarthy.md``
+(Wave 2, deliverable 3 — "Nightly automation" — and deliverable 4 —
+"Publication") for the broader publication discipline this script
+enforces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Headline configuration — pinned to bench/HEADLINE.md
+# ---------------------------------------------------------------------------
+
+# These four axis values define "the" headline cell. Anything else is an
+# auxiliary matrix cell. The runner (`src/distillery/eval/longmemeval.py`)
+# emits these same axis values into ``summary["axes"]``, so equality
+# matching is exact.
+DEFAULT_HEADLINE_CONFIG: dict[str, str] = {
+    "retrieval": "hybrid",
+    "granularity": "session",
+    "recency": "on",
+    "embed_model": "bge-small",
+}
+
+# The summary.json filename convention from longmemeval.py is:
+#   summary_longmemeval_<retrieval>_<granularity>_<recency>_<embed>_<UTC>.json
+_SUMMARY_FILENAME_RE = re.compile(
+    r"^summary_longmemeval_"
+    r"(?P<retrieval>[^_]+)_"
+    r"(?P<granularity>[^_]+)_"
+    r"(?P<recency>[^_]+)_"
+    r"(?P<embed>[^_]+(?:-[^_]+)*)_"  # embed names contain hyphens (bge-small etc.)
+    r"(?P<stamp>\d{8}T\d{6}Z)\.json$"
+)
+
+
+# ---------------------------------------------------------------------------
+# Badge colour bands (subjective; documented inline)
+# ---------------------------------------------------------------------------
+#
+# These thresholds are *not* claims about "good" or "bad" retrieval — they
+# are a colour-coding choice for the badge so a reader can spot regressions
+# at a glance. They sit within the sensible Shields.io palette and do not
+# imply leaderboard ordering. Update only with an ADR.
+_COLOUR_BANDS: tuple[tuple[float, str], ...] = (
+    (0.90, "brightgreen"),
+    (0.80, "yellowgreen"),
+    (0.70, "yellow"),
+    (0.0, "orange"),
+)
+
+
+def _colour_for(score: float) -> str:
+    """Pick a Shields.io colour name for ``score`` in ``[0, 1]``.
+
+    Scores above 0.90 → ``brightgreen``; 0.80–0.90 → ``yellowgreen``;
+    0.70–0.80 → ``yellow``; below 0.70 → ``orange``. The bands are
+    intentionally coarse — fine-grained colour shifts would imply more
+    precision than the underlying noise band warrants (see W3 variance
+    characterisation).
+    """
+    for threshold, colour in _COLOUR_BANDS:
+        if score >= threshold:
+            return colour
+    return "orange"
+
+
+# ---------------------------------------------------------------------------
+# Loading helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SummaryRecord:
+    """One parsed ``summary_*.json`` file plus its filesystem provenance.
+
+    ``axes`` is the four-key dict that identifies the cell. ``data`` is
+    the full parsed JSON (so callers can read overall metrics, per-type
+    breakdowns, and the SHA panel without re-reading the file).
+    ``timestamp`` is the parsed UTC timestamp from the filename
+    (preferred over the in-file ``timestamp_utc`` because filename order
+    is what the writer guarantees uniqueness on).
+    """
+
+    path: Path
+    axes: dict[str, str]
+    data: dict[str, Any]
+    timestamp: datetime
+
+
+def _parse_filename_timestamp(stamp: str) -> datetime:
+    """Parse the ``YYYYMMDDTHHMMSSZ`` filename stamp to a UTC datetime."""
+    return datetime.strptime(stamp, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
+
+
+def _load_summaries(results_dir: Path) -> list[SummaryRecord]:
+    """Load every ``summary_longmemeval_*.json`` in ``results_dir``.
+
+    Files that fail to parse (corrupt JSON, unreadable, filename pattern
+    mismatch) are skipped with a warning rather than aborting the whole
+    aggregation. The discipline rule is "no headline ⇒ unknown badges",
+    which only triggers if *zero* matching headline summaries are
+    findable; one corrupt file shouldn't kill the run.
+    """
+    if not results_dir.exists():
+        return []
+
+    records: list[SummaryRecord] = []
+    for path in sorted(results_dir.glob("summary_longmemeval_*.json")):
+        match = _SUMMARY_FILENAME_RE.match(path.name)
+        if match is None:
+            logger.warning("Skipping summary with non-matching filename: %s", path.name)
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to read %s: %s", path.name, exc)
+            continue
+
+        # Prefer the in-file ``axes`` dict (it's authoritative — the
+        # filename was derived from it) but fall back to filename parsing
+        # if the file lacks the axes block.
+        axes_payload = data.get("axes") if isinstance(data, dict) else None
+        if isinstance(axes_payload, dict):
+            axes = {
+                "retrieval": str(axes_payload.get("retrieval", match["retrieval"])),
+                "granularity": str(axes_payload.get("granularity", match["granularity"])),
+                "recency": str(axes_payload.get("recency", match["recency"])),
+                "embed_model": str(axes_payload.get("embed_model", match["embed"])),
+            }
+        else:
+            axes = {
+                "retrieval": match["retrieval"],
+                "granularity": match["granularity"],
+                "recency": match["recency"],
+                "embed_model": match["embed"],
+            }
+
+        records.append(
+            SummaryRecord(
+                path=path,
+                axes=axes,
+                data=data if isinstance(data, dict) else {},
+                timestamp=_parse_filename_timestamp(match["stamp"]),
+            )
+        )
+    return records
+
+
+def _matches_headline(axes: dict[str, str], headline: dict[str, str]) -> bool:
+    """Return True iff every axis in ``headline`` matches ``axes``."""
+    return all(axes.get(key) == value for key, value in headline.items())
+
+
+# ---------------------------------------------------------------------------
+# Badge emission (Shields.io endpoint format)
+# ---------------------------------------------------------------------------
+
+
+def _badge_payload(label: str, score: float | None) -> dict[str, Any]:
+    """Return a Shields.io endpoint-schema dict for one metric.
+
+    ``score=None`` → ``message="unknown"``, ``color="lightgrey"`` (the
+    honesty fallback). Otherwise the score is rendered to three decimal
+    places — matches the precision the runner reports without implying
+    bench precision beyond the noise band.
+    """
+    if score is None:
+        return {
+            "schemaVersion": 1,
+            "label": label,
+            "message": "unknown",
+            "color": "lightgrey",
+        }
+    return {
+        "schemaVersion": 1,
+        "label": label,
+        "message": f"{score:.3f}",
+        "color": _colour_for(score),
+    }
+
+
+def _write_badges(
+    output_dir: Path,
+    *,
+    r5: float | None,
+    r10: float | None,
+    ndcg10: float | None,
+) -> dict[str, Path]:
+    """Write the three Shields.io badge JSON files. Returns the paths."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    badges: dict[str, tuple[str, float | None]] = {
+        "badge_r5.json": ("LongMemEval R@5", r5),
+        "badge_r10.json": ("LongMemEval R@10", r10),
+        "badge_ndcg10.json": ("LongMemEval NDCG@10", ndcg10),
+    }
+    written: dict[str, Path] = {}
+    for filename, (label, score) in badges.items():
+        path = output_dir / filename
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(_badge_payload(label, score), f, indent=2)
+            f.write("\n")
+        written[filename] = path
+    return written
+
+
+# ---------------------------------------------------------------------------
+# SUMMARY.md generation
+# ---------------------------------------------------------------------------
+
+
+def _format_score(value: Any) -> str:
+    """Render a metric value to three decimals; ``"—"`` if missing."""
+    if not isinstance(value, int | float):
+        return "—"
+    return f"{float(value):.3f}"
+
+
+def _format_stamp(ts: datetime) -> str:
+    """Render a UTC timestamp as ``YYYY-MM-DDTHH:MM:SSZ`` for tables."""
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _format_axes(axes: dict[str, str]) -> str:
+    """Render an axes dict as ``retrieval/granularity/recency/embed``."""
+    return "/".join(
+        [
+            axes.get("retrieval", "?"),
+            axes.get("granularity", "?"),
+            axes.get("recency", "?"),
+            axes.get("embed_model", "?"),
+        ]
+    )
+
+
+def _latest_per_cell(records: list[SummaryRecord]) -> list[SummaryRecord]:
+    """Reduce ``records`` to one entry per ``(axes...)`` tuple — the latest.
+
+    Sorted ascending by axes string then by timestamp descending so the
+    output table reads stably across runs.
+    """
+    by_cell: dict[tuple[str, str, str, str], SummaryRecord] = {}
+    for rec in records:
+        key = (
+            rec.axes["retrieval"],
+            rec.axes["granularity"],
+            rec.axes["recency"],
+            rec.axes["embed_model"],
+        )
+        existing = by_cell.get(key)
+        if existing is None or rec.timestamp > existing.timestamp:
+            by_cell[key] = rec
+    return sorted(by_cell.values(), key=lambda r: (_format_axes(r.axes), -r.timestamp.timestamp()))
+
+
+def _headline_history(
+    records: list[SummaryRecord],
+    headline: dict[str, str],
+    *,
+    days: int = 7,
+    now: datetime | None = None,
+) -> list[SummaryRecord]:
+    """Return headline runs in the last ``days`` days, newest first."""
+    reference = now if now is not None else datetime.now(tz=UTC)
+    cutoff = reference - timedelta(days=days)
+    matched = [
+        rec for rec in records if _matches_headline(rec.axes, headline) and rec.timestamp >= cutoff
+    ]
+    return sorted(matched, key=lambda r: r.timestamp, reverse=True)
+
+
+def _render_summary_md(
+    *,
+    headline: SummaryRecord | None,
+    headline_config: dict[str, str],
+    matrix: list[SummaryRecord],
+    history: list[SummaryRecord],
+) -> str:
+    """Render the full SUMMARY.md body as a string.
+
+    Section order matches the plan:
+      1. Latest headline run
+      2. Latest matrix (Distillery configurations only)
+      3. Per-question-type breakdown for the headline cell only
+      4. History (last 7 days)
+      5. Footer with pointers to bench/HEADLINE.md and bench/LIMITATIONS.md
+    """
+    lines: list[str] = []
+    lines.append("# LongMemEval bench results")
+    lines.append("")
+    lines.append("_This file is auto-generated by `scripts/bench/aggregate_results.py`._")
+    lines.append("_Do not edit by hand — your changes will be overwritten._")
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Section 1 — Latest headline run
+    # ------------------------------------------------------------------
+    lines.append("## Latest headline run")
+    lines.append("")
+    headline_axes_str = _format_axes(_normalise_headline_keys(headline_config))
+    lines.append(f"Headline cell: `{headline_axes_str}` (pre-registered in `bench/HEADLINE.md`).")
+    lines.append("")
+    if headline is None:
+        lines.append(
+            "**No headline run found in this results directory.** Badges are reporting "
+            "`unknown` until the next nightly produces a headline cell."
+        )
+        lines.append("")
+    else:
+        overall = headline.data.get("overall", {}) if isinstance(headline.data, dict) else {}
+        lines.append("| Date (UTC) | git_sha | dataset_revision_sha | R@5 | R@10 | NDCG@10 |")
+        lines.append("| --- | --- | --- | ---: | ---: | ---: |")
+        dataset_sha = (
+            headline.data.get("dataset", {}).get("revision_sha", "—")
+            if isinstance(headline.data, dict)
+            else "—"
+        )
+        git_sha_value = (
+            headline.data.get("git_sha", "—") if isinstance(headline.data, dict) else "—"
+        )
+        lines.append(
+            "| {date} | `{git}` | `{ds}` | {r5} | {r10} | {nd} |".format(
+                date=_format_stamp(headline.timestamp),
+                git=str(git_sha_value)[:12],
+                ds=str(dataset_sha)[:12],
+                r5=_format_score(overall.get("recall_at_5")),
+                r10=_format_score(overall.get("recall_at_10")),
+                nd=_format_score(overall.get("ndcg_at_10")),
+            )
+        )
+        lines.append("")
+
+    # ------------------------------------------------------------------
+    # Section 2 — Latest matrix (Distillery configurations only)
+    # ------------------------------------------------------------------
+    lines.append("## Latest matrix")
+    lines.append("")
+    lines.append(
+        "Distillery configurations only. Cross-system comparisons are forbidden by "
+        "discipline rule (3) — see `bench/LIMITATIONS.md`."
+    )
+    lines.append("")
+    if not matrix:
+        lines.append("_No bench runs found._")
+        lines.append("")
+    else:
+        lines.append("| Cell | R@5 | R@10 | NDCG@10 | UTC |")
+        lines.append("| --- | ---: | ---: | ---: | --- |")
+        for rec in matrix:
+            overall = rec.data.get("overall", {}) if isinstance(rec.data, dict) else {}
+            lines.append(
+                "| `{cell}` | {r5} | {r10} | {nd} | {ts} |".format(
+                    cell=_format_axes(rec.axes),
+                    r5=_format_score(overall.get("recall_at_5")),
+                    r10=_format_score(overall.get("recall_at_10")),
+                    nd=_format_score(overall.get("ndcg_at_10")),
+                    ts=_format_stamp(rec.timestamp),
+                )
+            )
+        lines.append("")
+
+    # ------------------------------------------------------------------
+    # Section 3 — Per-question-type breakdown (headline cell only)
+    # ------------------------------------------------------------------
+    lines.append("## Per-question-type breakdown (headline cell)")
+    lines.append("")
+    if headline is None:
+        lines.append("_No headline run available._")
+        lines.append("")
+    else:
+        per_type = (
+            headline.data.get("per_question_type", {}) if isinstance(headline.data, dict) else {}
+        )
+        if not per_type:
+            lines.append("_No per-question-type data in headline summary._")
+            lines.append("")
+        else:
+            lines.append("| Question type | n | R@5 | R@10 | NDCG@10 |")
+            lines.append("| --- | ---: | ---: | ---: | ---: |")
+            for qtype in sorted(per_type.keys()):
+                bucket = per_type[qtype] if isinstance(per_type[qtype], dict) else {}
+                lines.append(
+                    "| `{q}` | {n} | {r5} | {r10} | {nd} |".format(
+                        q=qtype,
+                        n=bucket.get("n", "—"),
+                        r5=_format_score(bucket.get("recall_at_5")),
+                        r10=_format_score(bucket.get("recall_at_10")),
+                        nd=_format_score(bucket.get("ndcg_at_10")),
+                    )
+                )
+            lines.append("")
+
+    # ------------------------------------------------------------------
+    # Section 4 — History (last 7 days)
+    # ------------------------------------------------------------------
+    lines.append("## History (last 7 days, headline cell)")
+    lines.append("")
+    if not history:
+        lines.append("_No headline runs in the last 7 days._")
+        lines.append("")
+    else:
+        lines.append("| UTC | R@5 |")
+        lines.append("| --- | ---: |")
+        for rec in history:
+            overall = rec.data.get("overall", {}) if isinstance(rec.data, dict) else {}
+            lines.append(
+                "| {ts} | {r5} |".format(
+                    ts=_format_stamp(rec.timestamp),
+                    r5=_format_score(overall.get("recall_at_5")),
+                )
+            )
+        lines.append("")
+
+    # ------------------------------------------------------------------
+    # Footer
+    # ------------------------------------------------------------------
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "See `bench/HEADLINE.md` for the pre-registered headline configuration and "
+        "`bench/LIMITATIONS.md` for what these numbers do and do not claim."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _normalise_headline_keys(config: dict[str, str]) -> dict[str, str]:
+    """Map a user-supplied headline config to the canonical axes dict.
+
+    The plan describes the headline keys as
+    ``{"retrieval", "granularity", "recency", "embed"}`` whereas the
+    runner emits ``embed_model``. We accept either spelling on input
+    and normalise to ``embed_model`` so axis comparison is consistent.
+    """
+    normalised = {
+        "retrieval": config.get("retrieval", "?"),
+        "granularity": config.get("granularity", "?"),
+        "recency": config.get("recency", "?"),
+    }
+    embed = config.get("embed_model", config.get("embed", "?"))
+    normalised["embed_model"] = embed
+    return normalised
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AggregateReport:
+    """Returned by :func:`aggregate` for in-process callers / tests.
+
+    ``headline`` is ``None`` when no run matches the headline config —
+    this is the trigger for the "unknown" badge fallback.
+    """
+
+    headline: SummaryRecord | None
+    matrix: list[SummaryRecord]
+    history: list[SummaryRecord] = field(default_factory=list)
+    badge_paths: dict[str, Path] = field(default_factory=dict)
+    summary_path: Path | None = None
+
+
+def aggregate(
+    results_dir: Path,
+    *,
+    headline_config: dict[str, str] | None = None,
+    output_dir: Path,
+    now: datetime | None = None,
+) -> AggregateReport:
+    """Aggregate bench results, write badges and SUMMARY.md.
+
+    Parameters
+    ----------
+    results_dir:
+        Directory containing ``summary_longmemeval_*.json`` files.
+    headline_config:
+        Override for the pre-registered headline cell. ``None`` →
+        :data:`DEFAULT_HEADLINE_CONFIG`. Keys may be ``embed`` or
+        ``embed_model`` — both are normalised internally.
+    output_dir:
+        Where the three ``badge_*.json`` files are written. The
+        ``SUMMARY.md`` always lands in ``results_dir`` because it
+        documents the runs there.
+    now:
+        Optional override for "current time" — used by tests so the
+        7-day history window is deterministic.
+
+    Returns
+    -------
+    AggregateReport
+        Structured handle for tests and callers; the same data is
+        written to disk.
+    """
+    headline_axes = _normalise_headline_keys(headline_config or DEFAULT_HEADLINE_CONFIG)
+    records = _load_summaries(results_dir)
+
+    headline_runs = [r for r in records if _matches_headline(r.axes, headline_axes)]
+    headline = max(headline_runs, key=lambda r: r.timestamp) if headline_runs else None
+
+    matrix = _latest_per_cell(records)
+    history = _headline_history(records, headline_axes, now=now)
+
+    if headline is None:
+        badge_paths = _write_badges(output_dir, r5=None, r10=None, ndcg10=None)
+    else:
+        overall = headline.data.get("overall", {}) if isinstance(headline.data, dict) else {}
+        badge_paths = _write_badges(
+            output_dir,
+            r5=_safe_float(overall.get("recall_at_5")),
+            r10=_safe_float(overall.get("recall_at_10")),
+            ndcg10=_safe_float(overall.get("ndcg_at_10")),
+        )
+
+    summary_md = _render_summary_md(
+        headline=headline,
+        headline_config=headline_axes,
+        matrix=matrix,
+        history=history,
+    )
+    results_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = results_dir / "SUMMARY.md"
+    with summary_path.open("w", encoding="utf-8") as f:
+        f.write(summary_md)
+
+    return AggregateReport(
+        headline=headline,
+        matrix=matrix,
+        history=history,
+        badge_paths=badge_paths,
+        summary_path=summary_path,
+    )
+
+
+def _safe_float(value: Any) -> float | None:
+    """Convert ``value`` to a float if numeric; ``None`` otherwise."""
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="aggregate_results",
+        description=(
+            "Aggregate LongMemEval bench summaries into Shields.io badge JSON "
+            "files and a SUMMARY.md table."
+        ),
+    )
+    parser.add_argument(
+        "--results-dir",
+        type=Path,
+        default=Path("bench/results"),
+        help="Directory containing summary_longmemeval_*.json files (default: bench/results).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("bench"),
+        help="Directory to write badge_*.json into (default: bench).",
+    )
+    parser.add_argument(
+        "--headline-retrieval",
+        default=DEFAULT_HEADLINE_CONFIG["retrieval"],
+        help="Override headline retrieval axis.",
+    )
+    parser.add_argument(
+        "--headline-granularity",
+        default=DEFAULT_HEADLINE_CONFIG["granularity"],
+        help="Override headline granularity axis.",
+    )
+    parser.add_argument(
+        "--headline-recency",
+        default=DEFAULT_HEADLINE_CONFIG["recency"],
+        help="Override headline recency axis.",
+    )
+    parser.add_argument(
+        "--headline-embed",
+        default=DEFAULT_HEADLINE_CONFIG["embed_model"],
+        help="Override headline embed-model axis.",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable INFO-level logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint. Returns a process exit code."""
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    headline_config = {
+        "retrieval": args.headline_retrieval,
+        "granularity": args.headline_granularity,
+        "recency": args.headline_recency,
+        "embed_model": args.headline_embed,
+    }
+
+    report = aggregate(
+        args.results_dir,
+        headline_config=headline_config,
+        output_dir=args.output_dir,
+    )
+
+    if report.headline is None:
+        logger.warning(
+            "No headline run found in %s — badges set to 'unknown'.",
+            args.results_dir,
+        )
+    else:
+        overall = (
+            report.headline.data.get("overall", {})
+            if isinstance(report.headline.data, dict)
+            else {}
+        )
+        logger.info(
+            "Headline: R@5=%s R@10=%s NDCG@10=%s (from %s)",
+            overall.get("recall_at_5"),
+            overall.get("recall_at_10"),
+            overall.get("ndcg_at_10"),
+            report.headline.path.name,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = [
+    "DEFAULT_HEADLINE_CONFIG",
+    "AggregateReport",
+    "SummaryRecord",
+    "aggregate",
+    "main",
+]

--- a/scripts/bench/aggregate_results.py
+++ b/scripts/bench/aggregate_results.py
@@ -63,8 +63,12 @@ logger = logging.getLogger(__name__)
 
 # These four axis values define "the" headline cell. Anything else is an
 # auxiliary matrix cell. The runner (`src/distillery/eval/longmemeval.py`)
-# emits these same axis values into ``summary["axes"]``, so equality
-# matching is exact.
+# emits the same retrieval/granularity/embed_model values into
+# ``summary["axes"]``; the recency axis is emitted there as
+# ``recency_requested`` (PR #439 split the axis into requested vs.
+# effective). The aggregator normalises ``recency_requested`` →
+# ``recency`` on load so headline matching stays exact against this
+# config.
 DEFAULT_HEADLINE_CONFIG: dict[str, str] = {
     "retrieval": "hybrid",
     "granularity": "session",
@@ -171,12 +175,27 @@ def _load_summaries(results_dir: Path) -> list[SummaryRecord]:
         # Prefer the in-file ``axes`` dict (it's authoritative — the
         # filename was derived from it) but fall back to filename parsing
         # if the file lacks the axes block.
+        #
+        # Schema note: PR #439 (longmemeval runner) split the old
+        # ``recency`` axis into ``recency_requested`` (what the user
+        # asked for, also encoded in the filename) and
+        # ``effective_recency`` (what actually applied — ``raw``
+        # retrieval force-bypasses recency). Match against
+        # ``recency_requested`` because that is what the filename token
+        # and the pre-registered headline config both encode. We keep
+        # the internal axis key as ``recency`` so headline matching,
+        # badge filenames, and SUMMARY.md formatting stay stable.
+        # ``recency`` is accepted as a fallback so legacy summary files
+        # produced before the schema change still load.
         axes_payload = data.get("axes") if isinstance(data, dict) else None
         if isinstance(axes_payload, dict):
+            recency_value = axes_payload.get(
+                "recency_requested", axes_payload.get("recency", match["recency"])
+            )
             axes = {
                 "retrieval": str(axes_payload.get("retrieval", match["retrieval"])),
                 "granularity": str(axes_payload.get("granularity", match["granularity"])),
-                "recency": str(axes_payload.get("recency", match["recency"])),
+                "recency": str(recency_value),
                 "embed_model": str(axes_payload.get("embed_model", match["embed"])),
             }
         else:

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,436 @@
+"""Tests for ``scripts/bench/aggregate_results.py``.
+
+These tests use hand-crafted ``summary_longmemeval_*.json`` files that
+mimic the schema emitted by :mod:`distillery.eval.longmemeval` (see the
+``_aggregate`` helper there for the canonical shape). The point is to
+pin the contract:
+
+* The headline cell is picked correctly when several cells coexist.
+* Badge JSON conforms to the Shields.io endpoint schema.
+* SUMMARY.md is generated and contains the headline row.
+* The "unknown" fallback fires when no headline run is present —
+  the non-negotiable honesty constraint from the plan.
+* Non-headline cells appear in the matrix table but do not become the
+  headline by accident.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# The aggregator lives under scripts/bench/ which isn't on the default
+# import path; insert the repo root so the module resolves cleanly under
+# pytest without requiring an install step.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.bench.aggregate_results import (  # noqa: E402  — sys.path mutated above
+    DEFAULT_HEADLINE_CONFIG,
+    aggregate,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _summary_payload(
+    *,
+    retrieval: str,
+    granularity: str,
+    recency: str,
+    embed_model: str,
+    r5: float,
+    r10: float,
+    ndcg10: float,
+    git_sha: str = "abc1234deadbeef",
+    dataset_revision_sha: str = "feedface00112233",
+) -> dict[str, Any]:
+    """Return a summary.json-shaped dict matching the runner's schema."""
+    return {
+        "n_questions": 10,
+        "overall": {
+            "recall_at_5": r5,
+            "recall_at_10": r10,
+            "ndcg_at_10": ndcg10,
+        },
+        "per_question_type": {
+            "single-session-user": {
+                "n": 5,
+                "recall_at_5": r5,
+                "recall_at_10": r10,
+                "ndcg_at_10": ndcg10,
+            },
+            "multi-session": {
+                "n": 5,
+                "recall_at_5": max(0.0, r5 - 0.1),
+                "recall_at_10": max(0.0, r10 - 0.05),
+                "ndcg_at_10": max(0.0, ndcg10 - 0.05),
+            },
+        },
+        "axes": {
+            "retrieval": retrieval,
+            "granularity": granularity,
+            "recency": recency,
+            "embed_model": embed_model,
+            "seeds": 1,
+            "limit": None,
+        },
+        "dataset": {
+            "revision_sha": dataset_revision_sha,
+            "file_sha256": "deadbeef" * 8,
+        },
+        "git_sha": git_sha,
+        "timestamp_utc": "2026-04-30T05:00:00+00:00",
+    }
+
+
+def _write_summary(
+    results_dir: Path,
+    *,
+    retrieval: str,
+    granularity: str,
+    recency: str,
+    embed_model: str,
+    stamp: str,
+    payload: dict[str, Any] | None = None,
+) -> Path:
+    """Write a summary.json with the runner's filename convention."""
+    results_dir.mkdir(parents=True, exist_ok=True)
+    name = f"summary_longmemeval_{retrieval}_{granularity}_{recency}_{embed_model}_{stamp}.json"
+    path = results_dir / name
+    if payload is None:
+        payload = _summary_payload(
+            retrieval=retrieval,
+            granularity=granularity,
+            recency=recency,
+            embed_model=embed_model,
+            r5=0.85,
+            r10=0.92,
+            ndcg10=0.88,
+        )
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHeadlineSelection:
+    """The headline must be picked unambiguously — and never substituted."""
+
+    def test_headline_picked_when_present(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+
+        # Headline cell — newer of two timestamps.
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="session",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260430T050000Z",
+        )
+        # Headline cell, earlier — should be ignored.
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="session",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260429T050000Z",
+            payload=_summary_payload(
+                retrieval="hybrid",
+                granularity="session",
+                recency="on",
+                embed_model="bge-small",
+                r5=0.50,
+                r10=0.55,
+                ndcg10=0.52,
+            ),
+        )
+        # Non-headline cell.
+        _write_summary(
+            results_dir,
+            retrieval="raw",
+            granularity="session",
+            recency="off",
+            embed_model="bge-small",
+            stamp="20260430T060000Z",
+        )
+
+        report = aggregate(results_dir, output_dir=output_dir)
+
+        assert report.headline is not None
+        # Picked the most recent headline cell, not the most recent run.
+        assert report.headline.timestamp == datetime(2026, 4, 30, 5, 0, 0, tzinfo=UTC)
+        assert report.headline.axes["retrieval"] == "hybrid"
+        assert report.headline.axes["embed_model"] == "bge-small"
+
+    def test_unknown_fallback_when_headline_missing(self, tmp_path: Path) -> None:
+        """Honesty constraint: never substitute a non-headline cell."""
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+
+        # Only a non-headline cell present.
+        _write_summary(
+            results_dir,
+            retrieval="raw",
+            granularity="session",
+            recency="off",
+            embed_model="bge-small",
+            stamp="20260430T050000Z",
+        )
+
+        report = aggregate(results_dir, output_dir=output_dir)
+        assert report.headline is None
+
+        # Each badge must be the lightgrey "unknown" payload.
+        for filename in ("badge_r5.json", "badge_r10.json", "badge_ndcg10.json"):
+            badge_path = output_dir / filename
+            assert badge_path.exists()
+            payload = json.loads(badge_path.read_text())
+            assert payload["schemaVersion"] == 1
+            assert payload["message"] == "unknown"
+            assert payload["color"] == "lightgrey"
+
+
+@pytest.mark.unit
+class TestBadgeSchema:
+    """Badge files must match the Shields.io endpoint contract exactly."""
+
+    def test_badge_files_have_endpoint_schema(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="session",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260430T050000Z",
+            payload=_summary_payload(
+                retrieval="hybrid",
+                granularity="session",
+                recency="on",
+                embed_model="bge-small",
+                r5=0.911,
+                r10=0.951,
+                ndcg10=0.842,
+            ),
+        )
+
+        report = aggregate(results_dir, output_dir=output_dir)
+        assert report.headline is not None
+
+        r5_payload = json.loads((output_dir / "badge_r5.json").read_text())
+        r10_payload = json.loads((output_dir / "badge_r10.json").read_text())
+        ndcg_payload = json.loads((output_dir / "badge_ndcg10.json").read_text())
+
+        for payload in (r5_payload, r10_payload, ndcg_payload):
+            assert set(payload.keys()) == {"schemaVersion", "label", "message", "color"}
+            assert payload["schemaVersion"] == 1
+            # Three-decimal rendering.
+            assert payload["message"].count(".") == 1
+
+        # Colour bands: 0.911 → brightgreen, 0.842 → yellowgreen.
+        assert r5_payload["color"] == "brightgreen"
+        assert r10_payload["color"] == "brightgreen"
+        assert ndcg_payload["color"] == "yellowgreen"
+
+        # Labels include the metric so a reader can tell badges apart.
+        assert "R@5" in r5_payload["label"]
+        assert "R@10" in r10_payload["label"]
+        assert "NDCG@10" in ndcg_payload["label"]
+
+
+@pytest.mark.unit
+class TestSummaryMarkdown:
+    """SUMMARY.md must contain the headline, the matrix, and the footer."""
+
+    def test_summary_contains_headline_row(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="session",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260430T050000Z",
+            payload=_summary_payload(
+                retrieval="hybrid",
+                granularity="session",
+                recency="on",
+                embed_model="bge-small",
+                r5=0.873,
+                r10=0.921,
+                ndcg10=0.892,
+            ),
+        )
+
+        report = aggregate(results_dir, output_dir=output_dir)
+        assert report.summary_path is not None
+        body = report.summary_path.read_text()
+
+        assert "# LongMemEval bench results" in body
+        assert "## Latest headline run" in body
+        # Headline triplet rendered.
+        assert "0.873" in body
+        assert "0.921" in body
+        assert "0.892" in body
+        # Matrix and per-type sections.
+        assert "## Latest matrix" in body
+        assert "## Per-question-type breakdown" in body
+        assert "single-session-user" in body
+        # Footer pointers.
+        assert "bench/HEADLINE.md" in body
+        assert "bench/LIMITATIONS.md" in body
+        # Distillery-only discipline rule restated near the matrix.
+        assert "Distillery configurations only" in body
+
+    def test_non_headline_cells_in_matrix_not_in_headline(self, tmp_path: Path) -> None:
+        """Non-headline cells must show up in the matrix but NOT as the headline."""
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="session",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260430T050000Z",
+            payload=_summary_payload(
+                retrieval="hybrid",
+                granularity="session",
+                recency="on",
+                embed_model="bge-small",
+                r5=0.871,
+                r10=0.921,
+                ndcg10=0.890,
+            ),
+        )
+        _write_summary(
+            results_dir,
+            retrieval="raw",
+            granularity="session",
+            recency="off",
+            embed_model="bge-small",
+            stamp="20260430T060000Z",
+            payload=_summary_payload(
+                retrieval="raw",
+                granularity="session",
+                recency="off",
+                embed_model="bge-small",
+                r5=0.611,
+                r10=0.711,
+                ndcg10=0.654,
+            ),
+        )
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="turn",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260430T070000Z",
+            payload=_summary_payload(
+                retrieval="hybrid",
+                granularity="turn",
+                recency="on",
+                embed_model="bge-small",
+                r5=0.512,
+                r10=0.612,
+                ndcg10=0.555,
+            ),
+        )
+
+        report = aggregate(results_dir, output_dir=output_dir)
+        assert report.headline is not None
+        # Headline must be the hybrid/session/on/bge-small cell — not the raw or turn cells.
+        assert report.headline.axes["retrieval"] == "hybrid"
+        assert report.headline.axes["granularity"] == "session"
+        assert report.headline.axes["recency"] == "on"
+
+        # Matrix should contain all three cells.
+        cell_keys = [
+            (r.axes["retrieval"], r.axes["granularity"], r.axes["recency"], r.axes["embed_model"])
+            for r in report.matrix
+        ]
+        assert ("hybrid", "session", "on", "bge-small") in cell_keys
+        assert ("raw", "session", "off", "bge-small") in cell_keys
+        assert ("hybrid", "turn", "on", "bge-small") in cell_keys
+
+        body = report.summary_path.read_text() if report.summary_path else ""
+        # All three cell signatures should appear in the matrix table.
+        assert "hybrid/session/on/bge-small" in body
+        assert "raw/session/off/bge-small" in body
+        assert "hybrid/turn/on/bge-small" in body
+
+        # The headline triplet should match the hybrid/session cell, not raw or turn.
+        # Raw cell's R@5 is 0.611 — must not appear in the headline row.
+        # Find the headline section text and check it references 0.871 not 0.611/0.512.
+        latest_section = body.split("## Latest matrix")[0]
+        assert "0.871" in latest_section
+        assert "0.611" not in latest_section
+        assert "0.512" not in latest_section
+
+
+@pytest.mark.unit
+class TestHistory:
+    """The 7-day headline history table must respect the time window."""
+
+    def test_history_window_excludes_old_runs(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+
+        # In window — 2026-04-30.
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="session",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260430T050000Z",
+        )
+        # Out of window — 2026-04-15 (15 days before "now"=2026-05-02).
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="session",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260415T050000Z",
+        )
+
+        now = datetime(2026, 5, 2, 12, 0, 0, tzinfo=UTC)
+        report = aggregate(results_dir, output_dir=output_dir, now=now)
+
+        assert len(report.history) == 1
+        assert report.history[0].timestamp == datetime(2026, 4, 30, 5, 0, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+class TestDefaultHeadlineConfig:
+    """The plan pre-registers the headline; the default must match it."""
+
+    def test_default_headline_config_matches_plan(self) -> None:
+        assert DEFAULT_HEADLINE_CONFIG == {
+            "retrieval": "hybrid",
+            "granularity": "session",
+            "recency": "on",
+            "embed_model": "bge-small",
+        }

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -75,10 +75,16 @@ def _summary_payload(
                 "ndcg_at_10": max(0.0, ndcg10 - 0.05),
             },
         },
+        # Mirror the runner's post-#439 schema: recency split into
+        # ``recency_requested`` (the user-asked value, also encoded in
+        # the filename) and ``effective_recency`` (what actually
+        # applied — vector-only ``raw`` retrieval force-bypasses
+        # recency).
         "axes": {
             "retrieval": retrieval,
             "granularity": granularity,
-            "recency": recency,
+            "recency_requested": recency,
+            "effective_recency": "off" if retrieval == "raw" else recency,
             "embed_model": embed_model,
             "seeds": 1,
             "limit": None,


### PR DESCRIPTION
## Summary

Adds `scripts/bench/aggregate_results.py` — the publication step in the LongMemEval bench pipeline (Wave 2, deliverables 3 + 4 of the bench plan).

The aggregator scans `bench/results/summary_longmemeval_*.json` files emitted by the runner (#439), identifies the pre-registered headline cell (`hybrid/session/on/bge-small`), and writes:

- **`bench/badge_r5.json`**, **`bench/badge_r10.json`**, **`bench/badge_ndcg10.json`** — three separate Shields.io endpoint-format files. Three files (not one composite) so the README can point one badge URL at each, with no querystring parameter gymnastics.
- **`<results_dir>/SUMMARY.md`** — auto-updated table with: latest headline run (with date / git_sha / dataset_revision_sha / R@5 / R@10 / NDCG@10), latest matrix of all cells (Distillery configurations only), per-question-type breakdown for the headline cell, and a 7-day headline R@5 history. Footer points at `bench/HEADLINE.md` and `bench/LIMITATIONS.md`.

## Honesty constraint (non-negotiable)

If no headline run is present in the results directory, the badges are written with `message="unknown"` and `color="lightgrey"` rather than silently substituting a non-headline cell. This is the publication discipline rule from the plan — surfacing that the headline didn't run is strictly better than misleading consumers.

## Dependencies

This branch was rebased from `main` and then merged with `origin/bench/longmemeval-runner` so the aggregator can be authored against the actual JSONL/summary.json schema produced by the runner. Hard deps:

- **#439** (`bench/longmemeval-runner`) — schema source
- **#436** (W1-dataset-loader) — transitive
- **#435** (W1-fastembed) — transitive
- **#433** (W1-scoring) — transitive

After #439 lands on main, rebase:
```
git fetch origin
git rebase origin/main
```

## Workflow wiring (PR #438)

The nightly workflow YAML in PR #438 currently has a TODO where the aggregator is supposed to be invoked. Per the slice constraints I did **not** edit `.github/workflows/bench-longmemeval.yml` directly — that file is owned by another worktree. Instead I left a comment on #438 with the exact invocation pattern:

```yaml
- name: Aggregate results
  run: python scripts/bench/aggregate_results.py --results-dir bench/results/ --output-dir bench/
```

## Test plan

- [x] `pytest tests/test_aggregator.py -v --noconftest` — 7 passed (conftest unrelated to this PR fails on local Python 3.14 due to pyexpat ABI; CI Python pins are unaffected).
- [x] `mypy --strict scripts/bench/aggregate_results.py` — clean.
- [x] `ruff check`, `ruff format --check` — clean.
- [x] Smoke test: hand-crafted two summary.json files (one headline, one non-headline). Verified `badge_r5.json` is a valid Shields.io endpoint payload (`schemaVersion: 1`, `label`, `message`, `color`); `SUMMARY.md` has the headline row with the headline cell's R@5/R@10/NDCG@10, the matrix shows both cells, and the per-type breakdown reflects the headline cell.
- [ ] CI on this branch (after rebase post-#439).

## Constraints honoured

- Only touches `scripts/bench/aggregate_results.py`, `scripts/bench/__init__.py`, `tests/test_aggregator.py`.
- Does **not** modify `.github/workflows/bench-longmemeval.yml`, `bench/badge.json` (the published file), `bench/HEADLINE.md`, or `bench/LIMITATIONS.md`.
- Honesty constraint enforced and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)