### PR TITLE
fix(feeds): default User-Agent for async poller (#443)

### DIFF
--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -249,11 +249,19 @@ class FeedsConfig:
         sources: Ordered list of feed sources to monitor.
         thresholds: Relevance score thresholds for alert vs. digest inclusion.
         reader: Jina Reader API enrichment settings for the RSS poller.
+        user_agent: Optional override for the User-Agent header sent by the
+            RSS / Reader poller HTTP clients.  When empty (the default),
+            :data:`~distillery.feeds.rss.DEFAULT_USER_AGENT` is used —
+            ``f"distillery/{__version__} (+<repo url>)"`` — which Reddit
+            and other contact-required hosts accept.  Reddit-specific
+            override in :func:`~distillery.feeds.rss._normalise_feed_url`
+            still wins for ``reddit.com`` hosts.
     """
 
     sources: list[FeedSourceConfig] = field(default_factory=list)
     thresholds: FeedsThresholdsConfig = field(default_factory=FeedsThresholdsConfig)
     reader: ReaderConfig = field(default_factory=ReaderConfig)
+    user_agent: str = ""
 
 
 @dataclass
@@ -774,10 +782,18 @@ def _parse_feeds(raw: dict[str, Any]) -> FeedsConfig:
         raise ValueError(f"feeds.reader must be a YAML mapping, got: {type(reader_raw).__name__}")
     reader = _parse_reader(reader_raw)
 
+    user_agent_raw = raw.get("user_agent", "")
+    if user_agent_raw is None:
+        user_agent_raw = ""
+    if not isinstance(user_agent_raw, str):
+        raise ValueError(f"feeds.user_agent must be a string, got: {type(user_agent_raw).__name__}")
+    user_agent = user_agent_raw.strip()
+
     return FeedsConfig(
         sources=sources,
         thresholds=FeedsThresholdsConfig(alert=alert, digest=digest),
         reader=reader,
+        user_agent=user_agent,
     )
 
 

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -161,7 +161,7 @@ def _enriched_item_text(item: FeedItem, enriched_content: str | None) -> str:
     return truncate_content("\n".join(parts))
 
 
-def _build_adapter(source: FeedSourceConfig) -> Any:
+def _build_adapter(source: FeedSourceConfig, *, user_agent: str | None = None) -> Any:
     """Instantiate the correct adapter for *source*.
 
     For GitHub sources the ``GITHUB_TOKEN`` environment variable is read and
@@ -170,6 +170,9 @@ def _build_adapter(source: FeedSourceConfig) -> Any:
 
     Args:
         source: The configured feed source.
+        user_agent: Optional User-Agent override forwarded to RSS adapters.
+            ``None`` / empty string lets the adapter pick its default
+            (project name + version + contact URL).
 
     Returns:
         An adapter instance with a ``.fetch()`` method.
@@ -195,7 +198,7 @@ def _build_adapter(source: FeedSourceConfig) -> Any:
     elif source.source_type == "rss":
         from distillery.feeds.rss import RSSAdapter
 
-        return RSSAdapter(url=source.url)
+        return RSSAdapter(url=source.url, user_agent=user_agent)
     else:
         raise ValueError(
             f"Unsupported source_type {source.source_type!r} for url {source.url!r}. "
@@ -755,7 +758,7 @@ class FeedPoller:
         """
         # Build adapter
         try:
-            adapter = _build_adapter(source)
+            adapter = _build_adapter(source, user_agent=self._config.feeds.user_agent or None)
         except ValueError as exc:
             result.errors.append(f"Failed to build adapter: {exc}")
             logger.warning("FeedPoller: %s", exc)

--- a/src/distillery/feeds/reader.py
+++ b/src/distillery/feeds/reader.py
@@ -30,6 +30,7 @@ from urllib.parse import quote
 import httpx
 
 from distillery.embedding.errors import extract_retry_after
+from distillery.feeds.rss import DEFAULT_USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ def build_reader_client(
     timeout_seconds: float = 30.0,
     max_retries: int = _MAX_RETRIES,
     concurrency: int = 5,
+    user_agent: str | None = None,
 ) -> JinaReaderClient | None:
     """Build a :class:`JinaReaderClient` if the API key is present.
 
@@ -62,6 +64,9 @@ def build_reader_client(
         timeout_seconds: Per-request timeout in seconds.
         max_retries: Maximum number of retry attempts on retryable errors.
         concurrency: Maximum number of concurrent requests.
+        user_agent: Optional User-Agent header to send on every request.
+            When ``None`` or empty, falls back to
+            :data:`~distillery.feeds.rss.DEFAULT_USER_AGENT`.
 
     Returns:
         A configured :class:`JinaReaderClient`, or ``None`` if the API key
@@ -84,6 +89,7 @@ def build_reader_client(
         timeout_seconds=timeout_seconds,
         max_retries=max_retries,
         concurrency=concurrency,
+        user_agent=user_agent,
     )
 
 
@@ -124,6 +130,7 @@ class JinaReaderClient:
         timeout_seconds: float = 30.0,
         max_retries: int = _MAX_RETRIES,
         concurrency: int = 5,
+        user_agent: str | None = None,
     ) -> None:
         if not api_key:
             raise ValueError("JinaReaderClient requires a non-empty api_key")
@@ -138,6 +145,10 @@ class JinaReaderClient:
         self._timeout = timeout_seconds
         self._max_retries = max_retries
         self._semaphore = asyncio.Semaphore(concurrency)
+        # Empty / whitespace-only strings fall back to the project default so
+        # misconfiguration cannot send blank UA headers (issue #443).
+        ua = (user_agent or "").strip()
+        self._user_agent = ua or DEFAULT_USER_AGENT
 
     async def fetch(self, url: str) -> str | None:
         """Fetch markdown for *url* via the Jina Reader API.
@@ -168,6 +179,7 @@ class JinaReaderClient:
         headers = {
             "Authorization": f"Bearer {self._api_key}",
             "Accept": "text/plain",
+            "User-Agent": self._user_agent,
         }
         backoff = _INITIAL_BACKOFF
 

--- a/src/distillery/feeds/rss.py
+++ b/src/distillery/feeds/rss.py
@@ -22,6 +22,7 @@ from xml.etree.ElementTree import Element
 import defusedxml.ElementTree as DefusedElementTree
 import httpx
 
+from distillery import __version__
 from distillery.feeds.models import FeedItem
 
 logger = logging.getLogger(__name__)
@@ -41,8 +42,18 @@ _REDDIT_SUBREDDIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Default poller User-Agent.  Includes project name + version + a contact URL
+# so upstream operators can identify and reach us; required by Reddit and
+# other hosts that block generic / unidentified bots (issue #443).
+DEFAULT_USER_AGENT = f"distillery/{__version__} (+https://github.com/norrietaylor/distillery)"
+
 # User-Agent that Reddit will accept (requires a descriptive bot string).
-_REDDIT_USER_AGENT = "Distillery/0.1 (RSS feed reader; https://github.com/norrietaylor/distillery)"
+# Kept distinct from ``DEFAULT_USER_AGENT`` so the Reddit-specific override
+# below continues to win for reddit.com hosts even when callers configure
+# ``feeds.user_agent`` to something else.
+_REDDIT_USER_AGENT = (
+    f"distillery/{__version__} (RSS feed reader; +https://github.com/norrietaylor/distillery)"
+)
 
 
 def _normalise_feed_url(url: str) -> tuple[str, dict[str, str]]:
@@ -368,7 +379,7 @@ class RSSAdapter:
         If *url* is empty.
     """
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, *, user_agent: str | None = None) -> None:
         if not url.strip():
             raise ValueError("RSSAdapter requires a non-empty feed URL.")
         raw = url.strip()
@@ -376,6 +387,10 @@ class RSSAdapter:
         self._source_url = raw  # original URL — used as identity / source_url in FeedItems
         self._fetch_url = normalised  # possibly rewritten URL — used for HTTP requests only
         self._extra_headers = extra_headers
+        # When the caller supplies an empty / whitespace string treat it as
+        # "use the default" so misconfigured deployments still send a sane UA.
+        ua = (user_agent or "").strip()
+        self._user_agent = ua or DEFAULT_USER_AGENT
         self.last_polled_at: datetime | None = None
 
     # ------------------------------------------------------------------
@@ -405,7 +420,10 @@ class RSSAdapter:
         """
         logger.debug("RSSAdapter: fetching %s", self._fetch_url)
 
-        headers = {"User-Agent": "Distillery/0.1 (RSS adapter)"}
+        # Extra headers (e.g. the Reddit-specific override from
+        # ``_normalise_feed_url``) win over the default / configured UA so
+        # reddit.com hosts always get the descriptive bot string they require.
+        headers = {"User-Agent": self._user_agent}
         headers.update(self._extra_headers)
 
         with httpx.Client(timeout=_REQUEST_TIMEOUT, verify=True) as client:

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1159,9 +1159,10 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
 
         PARAMS:
           - section (str, required): Config section path (dotted notation).
-            Valid: [feeds.thresholds, defaults, classification].
+            Valid: [feeds, feeds.thresholds, defaults, classification].
           - key (str, required): Config key within the section.
-            Valid keys by section: feeds.thresholds: [alert, digest];
+            Valid keys by section: feeds: [user_agent];
+            feeds.thresholds: [alert, digest];
             defaults: [dedup_threshold, dedup_limit, stale_days];
             classification: [confidence_threshold, mode].
           - value (str | int | float | None, optional): New value. Omit to read

--- a/src/distillery/mcp/tools/configure.py
+++ b/src/distillery/mcp/tools/configure.py
@@ -100,6 +100,10 @@ def _coerce_value(raw_value: str | int | float, target_type: type) -> Any:
         if isinstance(raw_value, float) and raw_value != int_val:
             raise ValueError(f"Cannot losslessly convert {raw_value} to int")
         return int_val
+    if target_type is str:
+        if not isinstance(raw_value, str):
+            raise ValueError(f"Expected str, got {type(raw_value).__name__}")
+        return raw_value
     return raw_value  # pragma: no cover
 
 

--- a/src/distillery/mcp/tools/configure.py
+++ b/src/distillery/mcp/tools/configure.py
@@ -79,6 +79,15 @@ _ALLOWED_KEYS: dict[tuple[str, str], dict[str, Any]] = {
             else None
         ),
     },
+    # Issue #443: deployments hosting the poller behind a shared egress IP
+    # may need a different UA than the project default (e.g. to add their
+    # own contact address).  Empty string resets to the built-in default.
+    ("feeds", "user_agent"): {
+        "type": str,
+        "constraint": lambda _cfg, val: (
+            "feeds.user_agent must be <= 255 characters" if len(val) > 255 else None
+        ),
+    },
 }
 
 

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -543,6 +543,7 @@ async def _handle_poll(
                 timeout_seconds=reader_cfg.timeout_seconds,
                 max_retries=reader_cfg.max_retries,
                 concurrency=reader_cfg.concurrency,
+                user_agent=config.feeds.user_agent or None,
             )
             if reader_cfg.enabled
             else None

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -59,6 +59,7 @@ def _build_reader(config: DistilleryConfig) -> JinaReaderClient | None:
         timeout_seconds=reader_cfg.timeout_seconds,
         max_retries=reader_cfg.max_retries,
         concurrency=reader_cfg.concurrency,
+        user_agent=config.feeds.user_agent or None,
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -732,6 +732,26 @@ class TestFeedsConfigYAML:
         with pytest.raises(ValueError, match="feeds.user_agent must be a string"):
             load_config(str(p))
 
+    def test_user_agent_null_becomes_empty_string(self, tmp_path: Path) -> None:
+        """Explicit YAML null normalises to empty string (issue #443 follow-up)."""
+        yaml_content = """\
+            feeds:
+              user_agent:
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.feeds.user_agent == ""
+
+    def test_user_agent_whitespace_is_trimmed_to_empty(self, tmp_path: Path) -> None:
+        """Whitespace-only value is stripped, falling back to default UA at request time."""
+        yaml_content = """\
+            feeds:
+              user_agent: "   "
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.feeds.user_agent == ""
+
     def test_reader_config_loaded(self, tmp_path: Path) -> None:
         yaml_content = """\
             feeds:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -704,6 +704,34 @@ class TestFeedsConfigYAML:
         assert cfg.feeds.reader.max_retries == 2
         assert cfg.feeds.reader.concurrency == 5
 
+    def test_user_agent_default_is_empty_string(self, tmp_path: Path) -> None:
+        """``feeds.user_agent`` defaults to empty so adapters pick the
+        project default at request time (issue #443)."""
+        yaml_content = """\
+            feeds: {}
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.feeds.user_agent == ""
+
+    def test_user_agent_loaded_from_yaml(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            feeds:
+              user_agent: "acme-bot/2.0 (+https://acme.example.com/contact)"
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.feeds.user_agent == "acme-bot/2.0 (+https://acme.example.com/contact)"
+
+    def test_user_agent_non_string_raises(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            feeds:
+              user_agent: 12345
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="feeds.user_agent must be a string"):
+            load_config(str(p))
+
     def test_reader_config_loaded(self, tmp_path: Path) -> None:
         yaml_content = """\
             feeds:

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -614,6 +614,97 @@ class TestRSSAdapter:
 
 
 # ---------------------------------------------------------------------------
+# RSSAdapter User-Agent (issue #443)
+# ---------------------------------------------------------------------------
+
+
+class TestRSSAdapterUserAgent:
+    """Issue #443: poller must send a descriptive User-Agent so Reddit
+    and other contact-required hosts accept the request."""
+
+    def _fetch_and_capture_headers(
+        self, *, url: str, user_agent: str | None = None
+    ) -> dict[str, str]:
+        from distillery.feeds.rss import RSSAdapter
+
+        mock_response = MagicMock()
+        mock_response.content = _RSS_XML
+        mock_response.raise_for_status.return_value = None
+
+        with patch("distillery.feeds.rss.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            if user_agent is None:
+                adapter = RSSAdapter(url)
+            else:
+                adapter = RSSAdapter(url, user_agent=user_agent)
+            adapter.fetch()
+
+            assert mock_client.get.call_count == 1
+            _, kwargs = mock_client.get.call_args
+            headers = kwargs.get("headers", {})
+            assert isinstance(headers, dict)
+            return headers
+
+    def test_default_user_agent_includes_project_version_and_contact(self) -> None:
+        """Default UA carries project name, version, and the GitHub contact URL."""
+        from distillery import __version__
+        from distillery.feeds.rss import DEFAULT_USER_AGENT
+
+        headers = self._fetch_and_capture_headers(url="https://example.com/rss")
+
+        ua = headers["User-Agent"]
+        assert ua == DEFAULT_USER_AGENT
+        assert "distillery" in ua.lower()
+        assert __version__ in ua
+        assert "github.com/norrietaylor/distillery" in ua
+
+    def test_configured_user_agent_overrides_default(self) -> None:
+        """Caller-supplied ``user_agent`` wins for non-Reddit hosts."""
+        custom = "acme-bot/2.0 (+https://acme.example.com/contact)"
+        headers = self._fetch_and_capture_headers(
+            url="https://example.com/rss",
+            user_agent=custom,
+        )
+        assert headers["User-Agent"] == custom
+
+    def test_empty_configured_user_agent_falls_back_to_default(self) -> None:
+        """Whitespace-only / empty overrides do not regress to a blank UA."""
+        from distillery.feeds.rss import DEFAULT_USER_AGENT
+
+        for blank in ("", "   "):
+            headers = self._fetch_and_capture_headers(
+                url="https://example.com/rss",
+                user_agent=blank,
+            )
+            assert headers["User-Agent"] == DEFAULT_USER_AGENT
+
+    def test_reddit_override_still_wins_when_configured_ua_is_set(self) -> None:
+        """Reddit hosts must always receive the descriptive bot UA, even when
+        ``user_agent`` is explicitly configured to something else."""
+        from distillery.feeds.rss import _REDDIT_USER_AGENT
+
+        headers = self._fetch_and_capture_headers(
+            url="https://www.reddit.com/r/python/.rss",
+            user_agent="acme-bot/2.0",
+        )
+        assert headers["User-Agent"] == _REDDIT_USER_AGENT
+
+    def test_reddit_override_applied_with_default_user_agent(self) -> None:
+        """Reddit hosts get the Reddit-specific UA out of the box."""
+        from distillery.feeds.rss import _REDDIT_USER_AGENT
+
+        headers = self._fetch_and_capture_headers(
+            url="https://www.reddit.com/r/python/",
+        )
+        assert headers["User-Agent"] == _REDDIT_USER_AGENT
+
+
+# ---------------------------------------------------------------------------
 # _derive_source_tags
 # ---------------------------------------------------------------------------
 

--- a/tests/test_feeds_reader.py
+++ b/tests/test_feeds_reader.py
@@ -255,3 +255,73 @@ class TestJinaReaderClientFetch:
             result = await client.fetch("https://example.com/post")
         assert result is None
         assert len(transport.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# User-Agent (issue #443)
+# ---------------------------------------------------------------------------
+
+
+class TestJinaReaderClientUserAgent:
+    """The async poller must send a descriptive User-Agent so Reddit and
+    other contact-required upstreams accept the request (issue #443)."""
+
+    async def test_default_user_agent_contains_project_version_and_contact(self) -> None:
+        from distillery import __version__
+        from distillery.feeds.rss import DEFAULT_USER_AGENT
+
+        transport = _RecordingTransport([httpx.Response(200, text="body")])
+        client = _make_client(max_retries=0)
+        with _patched_async_client(transport):
+            await client.fetch("https://example.com/post")
+
+        assert len(transport.calls) == 1
+        ua = transport.calls[0].headers["User-Agent"]
+        assert ua == DEFAULT_USER_AGENT
+        assert "distillery" in ua.lower()
+        assert __version__ in ua
+        assert "github.com/norrietaylor/distillery" in ua
+
+    async def test_configured_user_agent_overrides_default(self) -> None:
+        custom = "acme-bot/2.0 (+https://acme.example.com/contact)"
+        transport = _RecordingTransport([httpx.Response(200, text="body")])
+        client = JinaReaderClient(
+            api_key="k",
+            max_retries=0,
+            user_agent=custom,
+        )
+        with _patched_async_client(transport):
+            await client.fetch("https://example.com/post")
+
+        assert transport.calls[0].headers["User-Agent"] == custom
+
+    async def test_empty_configured_user_agent_falls_back_to_default(self) -> None:
+        from distillery.feeds.rss import DEFAULT_USER_AGENT
+
+        for blank in ("", "   "):
+            transport = _RecordingTransport([httpx.Response(200, text="body")])
+            client = JinaReaderClient(
+                api_key="k",
+                max_retries=0,
+                user_agent=blank,
+            )
+            with _patched_async_client(transport):
+                await client.fetch("https://example.com/post")
+            assert transport.calls[0].headers["User-Agent"] == DEFAULT_USER_AGENT
+
+    def test_build_reader_client_forwards_user_agent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JINA_API_KEY", "real-key")
+        custom = "acme-bot/2.0"
+        client = build_reader_client(user_agent=custom)
+        assert isinstance(client, JinaReaderClient)
+        assert client._user_agent == custom
+
+    def test_build_reader_client_default_user_agent_when_unspecified(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from distillery.feeds.rss import DEFAULT_USER_AGENT
+
+        monkeypatch.setenv("JINA_API_KEY", "real-key")
+        client = build_reader_client()
+        assert isinstance(client, JinaReaderClient)
+        assert client._user_agent == DEFAULT_USER_AGENT

--- a/tests/test_mcp_configure.py
+++ b/tests/test_mcp_configure.py
@@ -552,3 +552,22 @@ class TestFeedsUserAgent:
         assert data["code"] == "INVALID_PARAMS"
         # Original value untouched.
         assert cfg.feeds.user_agent == ""
+
+    @pytest.mark.asyncio
+    async def test_user_agent_non_string_value_rejected_with_invalid_params(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Non-string values must surface a structured INVALID_PARAMS error
+        rather than raising TypeError inside the constraint lambda."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DISTILLERY_CONFIG", raising=False)
+        cfg = make_config()
+        # Pass an int — must be rejected before it reaches len(val).
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds", "key": "user_agent", "value": 12345},
+        )
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert cfg.feeds.user_agent == ""

--- a/tests/test_mcp_configure.py
+++ b/tests/test_mcp_configure.py
@@ -496,3 +496,59 @@ class TestReadOnlyMode:
         data = parse(result)
         assert data.get("error") is None or data.get("error") is False
         assert data["value"] == 0.85
+
+
+# ---------------------------------------------------------------------------
+# feeds.user_agent (issue #443)
+# ---------------------------------------------------------------------------
+
+
+class TestFeedsUserAgent:
+    """``feeds.user_agent`` is exposed as a runtime-configurable string so
+    deployments can override the poller UA without editing the config
+    file by hand (issue #443)."""
+
+    @pytest.mark.asyncio
+    async def test_read_default_user_agent(self) -> None:
+        cfg = make_config()
+        result = await _handle_configure(cfg, {"section": "feeds", "key": "user_agent"})
+        data = parse(result)
+        assert data.get("error") is None or data.get("error") is False
+        assert data["value"] == ""
+
+    @pytest.mark.asyncio
+    async def test_update_user_agent_in_memory(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # No config file on disk → in-memory only path.
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DISTILLERY_CONFIG", raising=False)
+        cfg = make_config()
+        custom = "acme-bot/2.0 (+https://acme.example.com/contact)"
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds", "key": "user_agent", "value": custom},
+        )
+        data = parse(result)
+        assert data.get("error") is None or data.get("error") is False
+        assert data["changed"] is True
+        assert data["new_value"] == custom
+        assert cfg.feeds.user_agent == custom
+
+    @pytest.mark.asyncio
+    async def test_user_agent_too_long_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DISTILLERY_CONFIG", raising=False)
+        cfg = make_config()
+        too_long = "x" * 256
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds", "key": "user_agent", "value": too_long},
+        )
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        # Original value untouched.
+        assert cfg.feeds.user_agent == ""

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -450,7 +450,7 @@ class TestFeedPollerMultipleSources:
         }
         cfg = _make_config(sources=sources, digest_threshold=0.0)
 
-        def _build_adapter_side_effect(source: FeedSourceConfig) -> MagicMock:
+        def _build_adapter_side_effect(source: FeedSourceConfig, **_kwargs: object) -> MagicMock:
             mock = MagicMock()
             mock.fetch.return_value = source_items_map[source.url]
             return mock
@@ -497,7 +497,7 @@ class TestFeedPollerParallel:
         }
         cfg = _make_config(sources=sources, digest_threshold=0.0)
 
-        def _build_adapter_side_effect(source: FeedSourceConfig) -> MagicMock:
+        def _build_adapter_side_effect(source: FeedSourceConfig, **_kwargs: object) -> MagicMock:
             mock = MagicMock()
             mock.fetch.return_value = source_items_map[source.url]
             return mock
@@ -527,7 +527,7 @@ class TestFeedPollerParallel:
 
         cfg = _make_config(sources=sources, digest_threshold=0.0)
 
-        def _build_adapter_side_effect(source: FeedSourceConfig) -> MagicMock:
+        def _build_adapter_side_effect(source: FeedSourceConfig, **_kwargs: object) -> MagicMock:
             mock = MagicMock()
             if source.url == "https://bad.com/rss":
                 mock.fetch.side_effect = RuntimeError("network error")
@@ -1080,6 +1080,8 @@ class TestLastPolledAtAdvancesPerSource:
             assert sources[0]["next_poll_at"] is not None
         finally:
             await store.close()
+
+
 # ---------------------------------------------------------------------------
 # Reader enrichment integration (#403)
 # ---------------------------------------------------------------------------

--- a/tests/test_radar_published_at_floor.py
+++ b/tests/test_radar_published_at_floor.py
@@ -215,7 +215,7 @@ class TestPollerBackfillFlag:
             ],
         }
 
-        def _build(source: FeedSourceConfig) -> MagicMock:
+        def _build(source: FeedSourceConfig, **_kwargs: Any) -> MagicMock:
             mock = MagicMock()
             mock.fetch.return_value = items_by_url[source.url]
             return mock


### PR DESCRIPTION
## Summary

- Both the sync RSS adapter (``RSSAdapter``) and the async Jina Reader client (``JinaReaderClient``) now send a descriptive default User-Agent: ``f\"distillery/{__version__} (+https://github.com/norrietaylor/distillery)\"``. Reddit and other contact-required hosts blocked the previous generic UA with HTTP 403.
- Adds ``feeds.user_agent`` to the config schema and the ``distillery_configure`` allowlist so deployments can override the default without a code change. Empty / whitespace values fall back to the project default to prevent blank UA headers.
- The Reddit-specific override in ``_normalise_feed_url`` still wins for reddit.com hosts so a misconfigured ``feeds.user_agent`` cannot regress Reddit access.

Closes #443

## Test plan

- [x] ``pytest -m unit`` (1752 passed, 2 skipped)
- [x] ``ruff check src/ tests/`` clean
- [x] ``ruff format`` clean on touched files
- [x] ``mypy --strict src/distillery/`` clean
- [x] New unit coverage in ``tests/test_feeds.py::TestRSSAdapterUserAgent``, ``tests/test_feeds_reader.py::TestJinaReaderClientUserAgent``, ``tests/test_config.py`` (3 cases), ``tests/test_mcp_configure.py::TestFeedsUserAgent``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable User-Agent for feed polling and reader clients via feeds.user_agent (string, max 255 chars); default User-Agent now includes project version and contact.

* **Configuration**
  * Runtime config tooling validates feeds.user_agent type/length and treats empty/blank values as the default.

* **Tests**
  * Added extensive tests covering User-Agent defaults, overrides, normalization, validation, and host-specific overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->