### PR TITLE
fix(feeds): bound /radar candidates by published_at + flag backfill (#444)

### DIFF
--- a/docs/skills/radar.md
+++ b/docs/skills/radar.md
@@ -19,7 +19,7 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--days <n>` | Look back period in days (overrides `feeds.digest.window_days`) | 7 |
+| `--days <n>` | Look back period in days (overrides `feeds.digest.window_days`) | `feeds.digest.window_days` (7 if unset) |
 | `--limit <n>` | Maximum entries to include | 20 |
 | `--suggest` | Include new source suggestions | Off |
 | `--no-store` | Don't store the digest as an entry | Stores by default |

--- a/docs/skills/radar.md
+++ b/docs/skills/radar.md
@@ -10,6 +10,7 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 /radar --limit 10              # Limit to 10 entries
 /radar --suggest               # Include source suggestions
 /radar --no-store              # Don't save the digest
+/radar --include-evergreen     # Surface older / first-poll backfill items
 ```
 
 **Trigger phrases:** "what's new", "show my digest", "ambient digest", "what have I missed", "feed digest"
@@ -18,10 +19,18 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--days <n>` | Look back period in days | 7 |
+| `--days <n>` | Look back period in days (overrides `feeds.digest.window_days`) | 7 |
 | `--limit <n>` | Maximum entries to include | 20 |
 | `--suggest` | Include new source suggestions | Off |
 | `--no-store` | Don't store the digest as an entry | Stores by default |
+| `--include-evergreen` | Include items older than the window or flagged as first-poll backfill | Off |
+
+The look-back window is bounded by `metadata.published_at` (the feed item's
+publication time), not the ingest timestamp. First-poll backfill batches —
+items pulled when a feed source is first registered — are flagged
+`metadata.backfill = true` and excluded from the default candidate set so
+they don't surface as "new intelligence". Use `--include-evergreen` to
+override.
 
 ## Output
 

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -34,11 +34,18 @@ See CONVENTIONS.md — skip if already confirmed this conversation.
 
 | Flag | Description |
 |------|-------------|
-| `--days N` | Look back N days for recent feed entries (default: 7) |
+| `--days N` | Look back N days for recent feed entries (overrides `feeds.digest.window_days`, default 7) |
 | `--limit N` | Maximum number of feed entries to include (default: 20) |
 | `--project <name>` | Scope feed entries to a specific project |
 | `--suggest` | Include source suggestions at end of digest |
 | `--store` | Store digest as a knowledge entry (default: display-only) |
+| `--include-evergreen` | Include older / first-poll backfill items in the candidate set (default: excluded) |
+
+The look-back window is bounded by `metadata.published_at` (the feed item's
+publication timestamp), not `created_at`. Items with no `published_at` are
+included unless they are flagged `metadata.backfill = true` (first-poll
+backfill batches), in which case they are hidden by default. Pass
+`--include-evergreen` to override and surface them.
 
 ### Step 3: Retrieve Recent Feed Entries
 
@@ -50,23 +57,27 @@ Build an interest profile that excludes feed-ingested content. Make separate `di
 
 **3b. Search by interests (primary path):**
 
-For each of the top interest tags (up to 3 queries), call:
+Compute `published_after = (now - <days>).isoformat()` where `<days>` is the
+`--days` flag if provided, otherwise the configured `feeds.digest.window_days`
+(default 7). For each of the top interest tags (up to 3 queries), call:
 
-`distillery_search(query="<interest>", entry_type="feed", limit=<ceil(limit/N)>, date_from=<date>)`
+`distillery_search(query="<interest>", entry_type="feed", limit=<ceil(limit/N)>, published_after=<iso>, include_evergreen=<bool>)`
 
-Where N is the number of queries. If `--project` was specified, also pass `project=<name>`.
+Where N is the number of queries. Pass `include_evergreen=true` only when the
+user supplied `--include-evergreen`. If `--project` was specified, also pass
+`project=<name>`.
 
 Deduplicate results across queries by entry ID, keeping the highest similarity score.
 
-Report: `Retrieved <total> entries via interest-based search (<N> queries).`
+Report: `Retrieved <total> entries via interest-based search (<N> queries, window=<days>d).`
 
 **3c. Fallback (if interest tags unavailable):**
 
 If none of the curated-type `group_by="tags"` calls return any tags, fall back to:
 
-`distillery_list(entry_type="feed", limit=<limit>, output_mode="summary", date_from=<date>)`
+`distillery_list(entry_type="feed", limit=<limit>, output_mode="summary", published_after=<iso>, include_evergreen=<bool>)`
 
-Report: `Retrieved <total> entries via recent listing (fallback).`
+Report: `Retrieved <total> entries via recent listing (fallback, window=<days>d).`
 
 If the curated-type `group_by="tags"` calls themselves error, treat that as an MCP error per the Rules section below — report and stop.
 
@@ -189,7 +200,9 @@ Tags: digest, radar, ambient
 
 - NEVER use Bash, Python, or any tool not listed in allowed-tools
 - If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.
-- Default lookback is 7 days; default limit is 20 — respect overrides
+- Default lookback is `feeds.digest.window_days` (7 days); default limit is 20 — respect overrides
+- Filter on `published_after` (publication time), not `date_from` (ingest time) — older items polled today are not new intelligence
+- First-poll backfill items (`metadata.backfill = true`) are excluded by default; surface them with `--include-evergreen`
 - Group entries by source tag when available; fall back to topic grouping
 - Display digest by default; store only with `--store` flag
 - Always include `digest`, `radar`, `ambient` tags when storing

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -242,6 +242,24 @@ class ReaderConfig:
 
 
 @dataclass
+class DigestConfig:
+    """Digest / ``/radar`` candidate-set configuration.
+
+    Attributes:
+        window_days: Default look-back window in days for the ``/radar``
+            digest.  Items whose ``metadata.published_at`` is older than
+            this window are excluded from the default candidate set, as are
+            items flagged ``metadata.backfill = true`` regardless of
+            published date.  Callers can override per-call via the
+            ``published_after`` / ``include_evergreen`` arguments on
+            :func:`distillery_search` and :func:`distillery_list`.
+            Default ``7``.
+    """
+
+    window_days: int = 7
+
+
+@dataclass
 class FeedsConfig:
     """Ambient feed monitoring configuration.
 
@@ -249,11 +267,13 @@ class FeedsConfig:
         sources: Ordered list of feed sources to monitor.
         thresholds: Relevance score thresholds for alert vs. digest inclusion.
         reader: Jina Reader API enrichment settings for the RSS poller.
+        digest: ``/radar`` candidate-set settings (look-back window, etc.).
     """
 
     sources: list[FeedSourceConfig] = field(default_factory=list)
     thresholds: FeedsThresholdsConfig = field(default_factory=FeedsThresholdsConfig)
     reader: ReaderConfig = field(default_factory=ReaderConfig)
+    digest: DigestConfig = field(default_factory=DigestConfig)
 
 
 @dataclass
@@ -774,11 +794,35 @@ def _parse_feeds(raw: dict[str, Any]) -> FeedsConfig:
         raise ValueError(f"feeds.reader must be a YAML mapping, got: {type(reader_raw).__name__}")
     reader = _parse_reader(reader_raw)
 
+    digest_raw = raw.get("digest", {}) or {}
+    if not isinstance(digest_raw, dict):
+        raise ValueError(f"feeds.digest must be a YAML mapping, got: {type(digest_raw).__name__}")
+    digest_cfg = _parse_digest(digest_raw)
+
     return FeedsConfig(
         sources=sources,
         thresholds=FeedsThresholdsConfig(alert=alert, digest=digest),
         reader=reader,
+        digest=digest_cfg,
     )
+
+
+def _parse_digest(raw: dict[str, Any]) -> DigestConfig:
+    """Parse the ``feeds.digest`` section from a raw YAML mapping.
+
+    Args:
+        raw: Mapping with optional key ``window_days`` (positive int, default 7).
+
+    Returns:
+        A populated :class:`DigestConfig` instance.
+
+    Raises:
+        ValueError: If ``window_days`` is not a positive integer.
+    """
+    window_days = _parse_strict_int(raw.get("window_days", 7), "feeds.digest.window_days")
+    if window_days <= 0:
+        raise ValueError(f"feeds.digest.window_days must be a positive integer, got: {window_days}")
+    return DigestConfig(window_days=window_days)
 
 
 def _parse_reader(raw: dict[str, Any]) -> ReaderConfig:

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -399,6 +399,7 @@ def _item_to_entry_kwargs(
     keyword_map: dict[str, str] | None = None,
     *,
     enriched_content: str | None = None,
+    is_backfill: bool = False,
 ) -> dict[str, Any]:
     """Convert a :class:`~distillery.feeds.models.FeedItem` to Entry constructor kwargs.
 
@@ -418,6 +419,10 @@ def _item_to_entry_kwargs(
             ``None`` only Tier-1 source tags are applied.
         enriched_content: Optional Reader-fetched markdown to use in place
             of ``item.content``.  Provenance is recorded in metadata.
+        is_backfill: When ``True``, mark this entry as part of a first-poll
+            backfill batch via ``metadata.backfill = True``.  ``/radar`` and
+            other digest surfaces use this flag to suppress historic items
+            that pre-date the source's registration.  See issue #444.
 
     Returns:
         A dict of keyword arguments for :class:`~distillery.models.Entry`.
@@ -437,6 +442,8 @@ def _item_to_entry_kwargs(
         metadata["item_url"] = item.url
     if item.published_at:
         metadata["published_at"] = item.published_at.isoformat()
+    if is_backfill:
+        metadata["backfill"] = True
 
     if enriched_content is not None:
         # Replace the body with Reader-fetched markdown but keep the title
@@ -546,11 +553,15 @@ class FeedPoller:
             db_sources = [s for s in db_sources if s["url"] == source_url]
         # list_feed_sources returns liveness fields (last_polled_at, etc.)
         # that are not part of FeedSourceConfig — filter to the constructor
-        # kwargs before instantiation.
+        # kwargs before instantiation.  Capture which sources have never been
+        # polled so the first batch can be flagged as backfill (issue #444).
         _cfg_fields = {"url", "source_type", "label", "poll_interval_minutes", "trust_weight"}
         sources = [
             FeedSourceConfig(**{k: v for k, v in s.items() if k in _cfg_fields}) for s in db_sources
         ]
+        first_poll_urls: set[str] = {
+            s["url"] for s in db_sources if s.get("last_polled_at") is None
+        }
         if not sources:
             logger.debug("FeedPoller: no sources configured — skipping poll")
             summary.finished_at = datetime.now(tz=UTC)
@@ -598,7 +609,15 @@ class FeedPoller:
         # still advances the per-source timestamps for sources that did
         # complete (issue #404).
         results = await asyncio.gather(
-            *(self._poll_source(source, scorer, keyword_map=keyword_map) for source in sources),
+            *(
+                self._poll_source(
+                    source,
+                    scorer,
+                    keyword_map=keyword_map,
+                    is_backfill=source.url in first_poll_urls,
+                )
+                for source in sources
+            ),
             return_exceptions=True,
         )
 
@@ -692,6 +711,7 @@ class FeedPoller:
         scorer: RelevanceScorer,
         *,
         keyword_map: dict[str, str] | None = None,
+        is_backfill: bool = False,
     ) -> PollResult:
         """Poll a single source and return a :class:`PollResult`.
 
@@ -722,7 +742,13 @@ class FeedPoller:
         )
 
         try:
-            await self._do_poll_source(source, scorer, result, keyword_map=keyword_map)
+            await self._do_poll_source(
+                source,
+                scorer,
+                result,
+                keyword_map=keyword_map,
+                is_backfill=is_backfill,
+            )
         finally:
             # Persist liveness on every exit — success, handled error,
             # or cancellation — so a partial cycle still advances
@@ -745,6 +771,7 @@ class FeedPoller:
         result: PollResult,
         *,
         keyword_map: dict[str, str] | None = None,
+        is_backfill: bool = False,
     ) -> None:
         """Inner poll loop; mutates *result* in place.
 
@@ -840,6 +867,7 @@ class FeedPoller:
                     adjusted_score,
                     keyword_map,
                     enriched_content=enriched,
+                    is_backfill=is_backfill,
                 )
                 entry = Entry(**kwargs)
                 await self._store.store(entry)

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -659,6 +659,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         output: str | None = None,
         feed_url: str | None = None,
         include_archived: bool = False,
+        published_after: str | None = None,
+        published_before: str | None = None,
+        include_evergreen: bool = False,
     ) -> list[types.TextContent]:
         """List knowledge entries with optional filters and pagination (newest first).
 
@@ -708,6 +711,16 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             retrieve all items polled from e.g. "https://hnrss.org/frontpage".
           - include_archived (bool, optional, default=False): Include archived entries
             in the default view (same effect as status="any" when status is unset).
+          - published_after (str, optional): ISO 8601 inclusive lower bound on
+            metadata.published_at (the feed-item publication timestamp written by the
+            poller). Use this to bound the /radar candidate set by the digest window.
+          - published_before (str, optional): ISO 8601 inclusive upper bound on
+            metadata.published_at.
+          - include_evergreen (bool, optional, default=False): When False (default) and
+            published_after/published_before is set, also drops entries flagged
+            metadata.backfill=true so first-poll backfill items don't surface as
+            "new intelligence". Set to True to surface older / evergreen items
+            explicitly. See issue #444.
 
         RETURNS (success): { entries: list, count: int, total_count: int, limit: int, offset: int }
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
@@ -721,6 +734,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             offset=offset,
             output_mode=output_mode,
             include_archived=include_archived,
+            include_evergreen=include_evergreen,
             **_omit_none(
                 entry_type=entry_type,
                 author=author,
@@ -738,6 +752,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 group_by=group_by,
                 output=output,
                 feed_url=feed_url,
+                published_after=published_after,
+                published_before=published_before,
             ),
         )
         return await _handle_list(store=c["store"], arguments=args)
@@ -758,6 +774,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         limit: int = 10,
         tag_prefix: str | None = None,
         include_archived: bool = False,
+        published_after: str | None = None,
+        published_before: str | None = None,
+        include_evergreen: bool = False,
     ) -> list[types.TextContent]:
         """Search knowledge entries using semantic similarity (cosine distance, ranked descending).
 
@@ -785,6 +804,16 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - tag_prefix (str, optional): Filter tags by namespace prefix.
           - include_archived (bool, optional, default=False): Include archived entries
             in the candidate set.
+          - published_after (str, optional): ISO 8601 inclusive lower bound on
+            metadata.published_at (poller-recorded publication timestamp). Used by
+            /radar to bound the candidate set by the configured digest window.
+          - published_before (str, optional): ISO 8601 inclusive upper bound on
+            metadata.published_at.
+          - include_evergreen (bool, optional, default=False): When False (default) and
+            published_after/published_before is set, also drops entries flagged
+            metadata.backfill=true so first-poll backfill items don't surface as
+            "new intelligence". Set to True to surface older / evergreen items
+            explicitly. See issue #444.
 
         RETURNS (success): { results: [{ score: float, entry: {...} }], count: int }
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
@@ -797,6 +826,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             query=query,
             limit=limit,
             include_archived=include_archived,
+            include_evergreen=include_evergreen,
             **_omit_none(
                 entry_type=entry_type,
                 author=author,
@@ -808,6 +838,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 date_from=date_from,
                 date_to=date_to,
                 tag_prefix=tag_prefix,
+                published_after=published_after,
+                published_before=published_before,
             ),
         )
         return await _handle_search(store=c["store"], arguments=args, cfg=c["config"])

--- a/src/distillery/mcp/tools/configure.py
+++ b/src/distillery/mcp/tools/configure.py
@@ -79,6 +79,10 @@ _ALLOWED_KEYS: dict[tuple[str, str], dict[str, Any]] = {
             else None
         ),
     },
+    ("feeds.digest", "window_days"): {
+        "type": int,
+        "range": (1, 3650),
+    },
 }
 
 

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -1618,7 +1618,8 @@ def _build_filters_from_arguments(arguments: dict[str, Any]) -> dict[str, Any] |
 
     Keys extracted: ``entry_type``, ``author``, ``project``, ``tags``,
     ``status``, ``verification``, ``source``, ``date_from``, ``date_to``,
-    ``tag_prefix``, ``session_id``, ``feed_url``.
+    ``tag_prefix``, ``session_id``, ``feed_url``, ``published_after``,
+    ``published_before``.
 
     The ``feed_url`` key is translated to a ``metadata.source_url`` filter so
     callers can retrieve entries ingested from a registered feed source
@@ -1626,6 +1627,12 @@ def _build_filters_from_arguments(arguments: dict[str, Any]) -> dict[str, Any] |
     the entry's ``source`` column is set to ``import``).  URL-shaped
     ``source`` values are routed to ``feed_url`` upstream by
     :func:`_alias_source_url_to_feed_url`.
+
+    The ``published_after`` / ``published_before`` keys filter on
+    ``metadata.published_at`` (the feed-item publication timestamp recorded by
+    the poller) and ``include_evergreen=False`` adds an ``exclude_backfill``
+    flag so first-poll backfill items are dropped from the candidate set.
+    Together these implement the ``/radar`` published-at floor for issue #444.
 
     Args:
         arguments: The tool argument dict.
@@ -1645,6 +1652,8 @@ def _build_filters_from_arguments(arguments: dict[str, Any]) -> dict[str, Any] |
         "date_to",
         "tag_prefix",
         "session_id",
+        "published_after",
+        "published_before",
     )
     filters: dict[str, Any] = {}
     for key in filter_keys:
@@ -1655,6 +1664,30 @@ def _build_filters_from_arguments(arguments: dict[str, Any]) -> dict[str, Any] |
     feed_url = arguments.get("feed_url")
     if feed_url is not None:
         filters["metadata.source_url"] = feed_url
+
+    # /radar published-at floor (issue #444).  ``include_evergreen`` defaults
+    # to False at the skill layer; when explicitly True the caller wants
+    # evergreen / backfilled material surfaced regardless of age.  When False
+    # (or absent) we add ``exclude_backfill`` so first-poll backfill batches
+    # are hidden from default digest queries.  The ``published_after`` clause
+    # is supplied by the caller (typically the skill computes
+    # ``now - digest.window_days``).
+    include_evergreen_raw = arguments.get("include_evergreen")
+    if include_evergreen_raw is not None and not isinstance(include_evergreen_raw, bool):
+        # Defer error reporting to the handler; coerce truthy strings here
+        # so callers can pass either bool or canonical string.
+        if isinstance(include_evergreen_raw, str):
+            include_evergreen = include_evergreen_raw.strip().lower() in {"true", "1", "yes"}
+        else:
+            include_evergreen = bool(include_evergreen_raw)
+    else:
+        include_evergreen = bool(include_evergreen_raw) if include_evergreen_raw else False
+
+    if not include_evergreen and ("published_after" in filters or "published_before" in filters):
+        # Only attach exclude_backfill when a published-at bound is in play —
+        # otherwise generic list/search calls without time-window semantics
+        # would silently lose backfill material.
+        filters["exclude_backfill"] = True
 
     return filters if filters else None
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1380,6 +1380,12 @@ class DuckDBStore:
         - ``source`` (str) -- entry origin (e.g. "claude-code", "manual", "inference", etc.)
         - ``date_from`` (datetime | str) -- inclusive lower bound on ``created_at``
         - ``date_to`` (datetime | str) -- inclusive upper bound on ``created_at``
+        - ``published_after`` (datetime | str) -- inclusive lower bound on
+          ``metadata.published_at`` (ISO 8601 string compare)
+        - ``published_before`` (datetime | str) -- inclusive upper bound on
+          ``metadata.published_at`` (ISO 8601 string compare)
+        - ``exclude_backfill`` (bool) -- when True, drop rows where
+          ``metadata.backfill`` is the string ``"true"``
         """
         if not filters:
             return [], []
@@ -1459,6 +1465,35 @@ class DuckDBStore:
         if "session_id" in filters:
             clauses.append("session_id = ?")
             params.append(str(filters["session_id"]))
+
+        # Range / inequality filters on JSON metadata fields.  Used by
+        # ``/radar`` to bound the candidate set by ``metadata.published_at``
+        # (issue #444) so digests don't surface decade-old items as new
+        # intelligence.  Each value is compared as an ISO 8601 string —
+        # lexicographic order matches chronological order for that format.
+        if "published_after" in filters:
+            val = filters["published_after"]
+            if hasattr(val, "isoformat"):  # datetime
+                val = val.isoformat()
+            clauses.append("json_extract_string(metadata, '$.published_at') >= ?")
+            params.append(str(val))
+
+        if "published_before" in filters:
+            val = filters["published_before"]
+            if hasattr(val, "isoformat"):  # datetime
+                val = val.isoformat()
+            clauses.append("json_extract_string(metadata, '$.published_at') <= ?")
+            params.append(str(val))
+
+        # Exclude items flagged as first-poll backfill (issue #444).  When set
+        # to True, drops rows where ``metadata.backfill`` is the literal string
+        # ``"true"`` — DuckDB ``json_extract_string`` returns booleans as that.
+        # Existing rows without the field (NULL) are kept.
+        if filters.get("exclude_backfill"):
+            clauses.append(
+                "(json_extract_string(metadata, '$.backfill') IS NULL "
+                "OR json_extract_string(metadata, '$.backfill') != 'true')"
+            )
 
         # Support metadata path filters like "metadata.external_id".
         # DuckDB stores metadata as a JSON string; use json_extract_string

--- a/tests/test_radar_published_at_floor.py
+++ b/tests/test_radar_published_at_floor.py
@@ -1,0 +1,494 @@
+"""Tests for the /radar published-at floor and first-poll backfill flag.
+
+Issue #444: ``/radar`` was surfacing decade-old items as new intelligence
+because:
+  1. Newly registered feed sources backfill historical items on the first
+     poll, but those items were not flagged.
+  2. The candidate-set query bounded results by ``created_at`` (ingest time)
+     instead of ``metadata.published_at`` (publication time), so an item
+     published in 2009 but polled today fell inside any "last N days" window.
+
+This module exercises the fix end-to-end:
+  - ``_item_to_entry_kwargs(is_backfill=True)`` writes ``metadata.backfill``.
+  - ``FeedPoller`` flags only the first batch per source as backfill, never
+    subsequent polls.
+  - The DuckDB store filters on ``published_after`` / ``published_before`` /
+    ``exclude_backfill``.
+  - The MCP filter builder attaches ``exclude_backfill`` automatically when
+    ``published_after`` is set and ``include_evergreen`` is False, and skips
+    it otherwise.
+  - ``distillery_configure`` accepts the ``feeds.digest.window_days`` knob.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from distillery.config import (
+    ClassificationConfig,
+    DefaultsConfig,
+    DigestConfig,
+    DistilleryConfig,
+    EmbeddingConfig,
+    FeedsConfig,
+    FeedSourceConfig,
+    FeedsThresholdsConfig,
+    StorageConfig,
+)
+from distillery.feeds.models import FeedItem
+from distillery.feeds.poller import FeedPoller, _item_to_entry_kwargs
+from distillery.mcp.tools.configure import _handle_configure
+from distillery.mcp.tools.crud import _build_filters_from_arguments
+from distillery.models import Entry, EntrySource, EntryType
+from distillery.store.duckdb import DuckDBStore
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# _item_to_entry_kwargs: backfill flag
+# ---------------------------------------------------------------------------
+
+
+class TestItemToEntryKwargsBackfillFlag:
+    def _make_item(self) -> FeedItem:
+        return FeedItem(
+            source_url="https://example.com/rss",
+            source_type="rss",
+            item_id="item-1",
+            title="Title",
+            content="Body",
+        )
+
+    def test_default_no_backfill_flag(self) -> None:
+        item = self._make_item()
+        kwargs = _item_to_entry_kwargs(item, relevance_score=0.5)
+        assert "backfill" not in kwargs["metadata"]
+
+    def test_explicit_false_no_backfill_flag(self) -> None:
+        item = self._make_item()
+        kwargs = _item_to_entry_kwargs(item, relevance_score=0.5, is_backfill=False)
+        assert "backfill" not in kwargs["metadata"]
+
+    def test_is_backfill_true_sets_metadata(self) -> None:
+        item = self._make_item()
+        kwargs = _item_to_entry_kwargs(item, relevance_score=0.5, is_backfill=True)
+        assert kwargs["metadata"]["backfill"] is True
+
+
+# ---------------------------------------------------------------------------
+# FeedPoller: first poll vs. subsequent polls
+# ---------------------------------------------------------------------------
+
+
+def _source_dict(
+    url: str = "https://example.com/rss",
+    *,
+    last_polled_at: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "url": url,
+        "source_type": "rss",
+        "label": "",
+        "poll_interval_minutes": 60,
+        "trust_weight": 1.0,
+        "last_polled_at": last_polled_at,
+        "last_item_count": 0,
+        "last_error": None,
+        "next_poll_at": None,
+    }
+
+
+def _make_feed_item(item_id: str = "id1") -> FeedItem:
+    return FeedItem(
+        source_url="https://example.com/rss",
+        source_type="rss",
+        item_id=item_id,
+        title="Title",
+        content="Body",
+    )
+
+
+def _make_store_for_poller(
+    feed_sources: list[dict[str, Any]],
+    stored_entries: list[Entry] | None = None,
+) -> AsyncMock:
+    """Build a mock store that captures every Entry passed to ``store()``."""
+    store = AsyncMock()
+    captured: list[Entry] = stored_entries if stored_entries is not None else []
+
+    async def _capture_store(entry: Entry) -> str:
+        captured.append(entry)
+        return str(entry.id)
+
+    store.store.side_effect = _capture_store
+    store.find_similar.return_value = []
+    store.list_entries.return_value = []  # no external_id matches
+    store.get_tag_vocabulary.return_value = {}
+    store.list_feed_sources = AsyncMock(return_value=feed_sources)
+    return store
+
+
+def _make_poller_config() -> DistilleryConfig:
+    cfg = DistilleryConfig()
+    cfg.feeds = FeedsConfig(
+        thresholds=FeedsThresholdsConfig(alert=0.85, digest=0.0),
+    )
+    return cfg
+
+
+class TestPollerBackfillFlag:
+    async def test_first_poll_marks_items_as_backfill(self) -> None:
+        """Source with last_polled_at=None gets metadata.backfill=true."""
+        items = [_make_feed_item("a1")]
+        captured: list[Entry] = []
+        store = _make_store_for_poller([_source_dict(last_polled_at=None)], stored_entries=captured)
+        cfg = _make_poller_config()
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 1
+        assert len(captured) == 1
+        assert captured[0].metadata.get("backfill") is True
+
+    async def test_subsequent_poll_does_not_mark_backfill(self) -> None:
+        """Source with last_polled_at != None must NOT mark items as backfill."""
+        items = [_make_feed_item("a2")]
+        captured: list[Entry] = []
+        store = _make_store_for_poller(
+            [_source_dict(last_polled_at="2026-01-01T00:00:00+00:00")],
+            stored_entries=captured,
+        )
+        cfg = _make_poller_config()
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 1
+        assert len(captured) == 1
+        assert "backfill" not in captured[0].metadata
+
+    async def test_backfill_flag_is_per_source(self) -> None:
+        """One never-polled source plus one previously-polled source: only first batch is flagged."""
+        captured: list[Entry] = []
+        sources = [
+            _source_dict(url="https://new.com/rss", last_polled_at=None),
+            _source_dict(url="https://old.com/rss", last_polled_at="2026-01-01T00:00:00+00:00"),
+        ]
+        store = _make_store_for_poller(sources, stored_entries=captured)
+        cfg = _make_poller_config()
+
+        items_by_url = {
+            "https://new.com/rss": [
+                FeedItem(
+                    source_url="https://new.com/rss",
+                    source_type="rss",
+                    item_id="new1",
+                    title="N",
+                    content="C",
+                )
+            ],
+            "https://old.com/rss": [
+                FeedItem(
+                    source_url="https://old.com/rss",
+                    source_type="rss",
+                    item_id="old1",
+                    title="O",
+                    content="C",
+                )
+            ],
+        }
+
+        def _build(source: FeedSourceConfig) -> MagicMock:
+            mock = MagicMock()
+            mock.fetch.return_value = items_by_url[source.url]
+            return mock
+
+        with patch("distillery.feeds.poller._build_adapter", side_effect=_build):
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 2
+        by_url = {e.metadata["source_url"]: e for e in captured}
+        assert by_url["https://new.com/rss"].metadata.get("backfill") is True
+        assert "backfill" not in by_url["https://old.com/rss"].metadata
+
+
+# ---------------------------------------------------------------------------
+# DuckDBStore: published_after / published_before / exclude_backfill filters
+# ---------------------------------------------------------------------------
+
+
+def _make_feed_entry(
+    *,
+    content: str,
+    published_at: str | None,
+    backfill: bool = False,
+) -> Entry:
+    metadata: dict[str, Any] = {
+        "source_url": "https://example.com/rss",
+        "source_type": "rss",
+        "external_id": content,  # unique per entry
+    }
+    if published_at is not None:
+        metadata["published_at"] = published_at
+    if backfill:
+        metadata["backfill"] = True
+    return Entry(
+        content=content,
+        entry_type=EntryType.FEED,
+        source=EntrySource.IMPORT,
+        author="poller",
+        metadata=metadata,
+    )
+
+
+class TestDuckDBPublishedAtFilters:
+    async def test_published_after_excludes_old_items(self, store: DuckDBStore) -> None:
+        old = _make_feed_entry(content="old", published_at="2009-01-01T00:00:00+00:00")
+        new = _make_feed_entry(content="new", published_at="2026-05-01T00:00:00+00:00")
+        await store.store(old)
+        await store.store(new)
+
+        results = await store.list_entries(
+            filters={"published_after": "2026-04-01T00:00:00+00:00"},
+            limit=10,
+            offset=0,
+        )
+        contents = [e.content for e in results]
+        assert "new" in contents
+        assert "old" not in contents
+
+    async def test_exclude_backfill_drops_flagged_items(self, store: DuckDBStore) -> None:
+        bf = _make_feed_entry(content="bf", published_at="2026-04-30T00:00:00+00:00", backfill=True)
+        live = _make_feed_entry(
+            content="live", published_at="2026-04-30T00:00:00+00:00", backfill=False
+        )
+        await store.store(bf)
+        await store.store(live)
+
+        results = await store.list_entries(
+            filters={"exclude_backfill": True},
+            limit=10,
+            offset=0,
+        )
+        contents = [e.content for e in results]
+        assert "live" in contents
+        assert "bf" not in contents
+
+    async def test_exclude_backfill_keeps_unflagged_legacy_rows(self, store: DuckDBStore) -> None:
+        """Existing rows without metadata.backfill must NOT be hidden."""
+        legacy = _make_feed_entry(content="legacy", published_at="2026-04-30T00:00:00+00:00")
+        await store.store(legacy)
+
+        results = await store.list_entries(
+            filters={"exclude_backfill": True},
+            limit=10,
+            offset=0,
+        )
+        contents = [e.content for e in results]
+        assert "legacy" in contents
+
+    async def test_combined_published_after_and_exclude_backfill(self, store: DuckDBStore) -> None:
+        old_bf = _make_feed_entry(
+            content="old_bf", published_at="2009-01-01T00:00:00+00:00", backfill=True
+        )
+        new_bf = _make_feed_entry(
+            content="new_bf", published_at="2026-05-01T00:00:00+00:00", backfill=True
+        )
+        new_live = _make_feed_entry(
+            content="new_live", published_at="2026-05-01T00:00:00+00:00", backfill=False
+        )
+        for e in (old_bf, new_bf, new_live):
+            await store.store(e)
+
+        results = await store.list_entries(
+            filters={
+                "published_after": "2026-04-01T00:00:00+00:00",
+                "exclude_backfill": True,
+            },
+            limit=10,
+            offset=0,
+        )
+        contents = [e.content for e in results]
+        assert contents == ["new_live"]
+
+
+# ---------------------------------------------------------------------------
+# MCP filter builder: published_after + include_evergreen interaction
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFiltersFromArguments:
+    def test_published_after_attaches_exclude_backfill_by_default(self) -> None:
+        args = {"published_after": "2026-04-26T00:00:00+00:00"}
+        filters = _build_filters_from_arguments(args)
+        assert filters is not None
+        assert filters.get("published_after") == "2026-04-26T00:00:00+00:00"
+        assert filters.get("exclude_backfill") is True
+
+    def test_published_after_with_include_evergreen_skips_exclude_backfill(
+        self,
+    ) -> None:
+        args = {
+            "published_after": "2026-04-26T00:00:00+00:00",
+            "include_evergreen": True,
+        }
+        filters = _build_filters_from_arguments(args)
+        assert filters is not None
+        assert "exclude_backfill" not in filters
+
+    def test_no_published_window_skips_exclude_backfill(self) -> None:
+        """Generic list/search calls without time-window semantics keep backfill rows."""
+        args = {"entry_type": "feed"}
+        filters = _build_filters_from_arguments(args)
+        assert filters is not None
+        assert "exclude_backfill" not in filters
+
+    def test_include_evergreen_string_true_is_honoured(self) -> None:
+        args = {
+            "published_after": "2026-04-26T00:00:00+00:00",
+            "include_evergreen": "true",
+        }
+        filters = _build_filters_from_arguments(args)
+        assert filters is not None
+        assert "exclude_backfill" not in filters
+
+
+# ---------------------------------------------------------------------------
+# distillery_configure: feeds.digest.window_days knob
+# ---------------------------------------------------------------------------
+
+
+def _make_configure_cfg(window_days: int = 7) -> DistilleryConfig:
+    return DistilleryConfig(
+        storage=StorageConfig(database_path=":memory:"),
+        embedding=EmbeddingConfig(provider="", model="stub", dimensions=4),
+        defaults=DefaultsConfig(),
+        classification=ClassificationConfig(),
+        feeds=FeedsConfig(digest=DigestConfig(window_days=window_days)),
+    )
+
+
+class TestConfigureDigestWindowDays:
+    @pytest.mark.asyncio
+    async def test_read_default_value(self) -> None:
+        cfg = _make_configure_cfg(window_days=7)
+        result = await _handle_configure(cfg, {"section": "feeds.digest", "key": "window_days"})
+        data = json.loads(result[0].text)
+        assert data.get("error") is not True
+        assert data["value"] == 7
+
+    @pytest.mark.asyncio
+    async def test_set_new_value(self) -> None:
+        cfg = _make_configure_cfg(window_days=7)
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds.digest", "key": "window_days", "value": 14},
+        )
+        data = json.loads(result[0].text)
+        assert data.get("error") is not True
+        assert data["changed"] is True
+        assert data["new_value"] == 14
+        assert cfg.feeds.digest.window_days == 14
+
+    @pytest.mark.asyncio
+    async def test_reject_zero(self) -> None:
+        cfg = _make_configure_cfg()
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds.digest", "key": "window_days", "value": 0},
+        )
+        data = json.loads(result[0].text)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
+    @pytest.mark.asyncio
+    async def test_reject_non_integer(self) -> None:
+        cfg = _make_configure_cfg()
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds.digest", "key": "window_days", "value": 3.5},
+        )
+        data = json.loads(result[0].text)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
+
+# ---------------------------------------------------------------------------
+# Integration: skill-shaped /radar candidate-set query
+# ---------------------------------------------------------------------------
+
+
+class TestRadarCandidateSetIntegration:
+    """Exercise the full DB path the /radar skill uses to retrieve candidates."""
+
+    async def test_default_query_excludes_old_published_and_backfill(
+        self, store: DuckDBStore
+    ) -> None:
+        # An item published 30 days ago, freshly polled today (no backfill).
+        published_recent_iso = (datetime.now(tz=UTC) - timedelta(days=2)).isoformat()
+        published_old_iso = (datetime.now(tz=UTC) - timedelta(days=30)).isoformat()
+        await store.store(_make_feed_entry(content="recent", published_at=published_recent_iso))
+        await store.store(_make_feed_entry(content="old_live", published_at=published_old_iso))
+        await store.store(
+            _make_feed_entry(
+                content="old_backfill",
+                published_at=published_recent_iso,  # recent date but flagged
+                backfill=True,
+            )
+        )
+
+        window_floor = (datetime.now(tz=UTC) - timedelta(days=7)).isoformat()
+        # Default candidate set: published_after + exclude_backfill (the
+        # MCP layer attaches exclude_backfill automatically when
+        # include_evergreen is False).
+        results = await store.list_entries(
+            filters={
+                "published_after": window_floor,
+                "exclude_backfill": True,
+            },
+            limit=10,
+            offset=0,
+        )
+        contents = {e.content for e in results}
+        assert contents == {"recent"}
+
+    async def test_include_evergreen_restores_backfill_rows(self, store: DuckDBStore) -> None:
+        published_recent_iso = (datetime.now(tz=UTC) - timedelta(days=2)).isoformat()
+        await store.store(_make_feed_entry(content="recent", published_at=published_recent_iso))
+        await store.store(
+            _make_feed_entry(
+                content="recent_backfill",
+                published_at=published_recent_iso,
+                backfill=True,
+            )
+        )
+
+        window_floor = (datetime.now(tz=UTC) - timedelta(days=7)).isoformat()
+        # include_evergreen=True at the MCP layer means exclude_backfill is
+        # not attached — exercise the store with only the published_after
+        # bound (the skill's --include-evergreen path).
+        results = await store.list_entries(
+            filters={"published_after": window_floor},
+            limit=10,
+            offset=0,
+        )
+        contents = {e.content for e in results}
+        assert contents == {"recent", "recent_backfill"}


### PR DESCRIPTION
## Summary

- Poller flags first-poll batches with `metadata.backfill=true`; subsequent polls never set the flag.
- DuckDB filter builder gains `published_after` / `published_before` / `exclude_backfill` clauses (ISO 8601 string compare on `metadata.published_at`).
- `distillery_search` and `distillery_list` expose `published_after`, `published_before`, and `include_evergreen`. When `include_evergreen=False` (default) and a published-at bound is set, `exclude_backfill` is attached automatically; legacy rows without `metadata.backfill` are kept (no retroactive hiding).
- New `feeds.digest.window_days` config knob (default 7), settable via `distillery_configure`.
- `/radar` skill documents `--include-evergreen` and uses `published_after` derived from the digest window instead of `date_from`.

## Why

`/radar` was surfacing decade-old items as new intelligence because newly registered sources backfill historical material on the first poll, and the candidate-set query bounded results by `created_at` (ingest time) instead of `metadata.published_at` (publication time). An item published in 2009 but polled today fell inside any "last N days" window.

Two layers of defence: bound the candidate set by publication time, and tag the first-poll backfill batch so it stays out of the digest until the user explicitly asks for it.

## Test plan

- [x] `pytest tests/test_radar_published_at_floor.py` (20 new tests, all passing)
- [x] `pytest -m unit` (1756 passed)
- [x] `pytest -m integration` (769 passed)
- [x] `ruff check src/ tests/` (clean)
- [x] `mypy --strict src/distillery/` (clean)
- [ ] Manual: register a new GitHub source via `/watch add`, run `/hooks/poll`, then `/radar` — backfilled historic issues should not appear; rerun with `--include-evergreen` and they should.

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--include-evergreen` to surface older/backfill feed items
  * Feed filtering now uses item publication timestamps (`published_at`)
  * Configurable digest window duration (default 7 days)
  * New date-range query options: `published_after`, `published_before`

* **Documentation**
  * Updated radar docs and CLI examples to explain published-vs-ingest semantics and evergreen behavior

* **Tests**
  * Added end-to-end tests for published-at filtering and backfill handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->