### PR TITLE
[bench] fix: pre-install DuckDB VSS extension in nightly workflow

### DIFF
--- a/.github/workflows/bench-longmemeval.yml
+++ b/.github/workflows/bench-longmemeval.yml
@@ -102,6 +102,32 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev,fastembed]"
 
+      # Cache the DuckDB VSS extension binary. GitHub-hosted runners do
+      # not ship with VSS on disk, and the store's `_setup_vss`
+      # (src/distillery/store/duckdb.py) deliberately skips `INSTALL vss`
+      # to avoid blocking network fetches in production — it expects VSS
+      # to be pre-installed during image build. Without this cache + the
+      # subsequent install step, every `:memory:` DuckDBStore in the
+      # bench falls back to brute-force vector search, silently
+      # invalidating the measurement.
+      - name: Cache DuckDB VSS extension
+        uses: actions/cache@v4
+        with:
+          path: ~/.duckdb/extensions
+          key: duckdb-vss-${{ runner.os }}-${{ runner.arch }}-v1
+
+      - name: Pre-install DuckDB VSS extension
+        run: |
+          python - <<'PY'
+          import duckdb
+          con = duckdb.connect(':memory:')
+          con.execute("INSTALL vss")
+          con.execute("LOAD vss")
+          row = con.execute("SELECT installed, loaded FROM duckdb_extensions() WHERE extension_name = 'vss'").fetchone()
+          print(f"VSS extension state: installed={row[0]} loaded={row[1]}")
+          assert row[0] and row[1], "VSS extension failed to install/load"
+          PY
+
       # Cache fastembed model weights. Key includes the embed model name
       # so each matrix cell gets its own cache entry. fastembed downloads
       # to ~/.cache/fastembed by default.

--- a/.github/workflows/bench-longmemeval.yml
+++ b/.github/workflows/bench-longmemeval.yml
@@ -110,11 +110,16 @@ jobs:
       # subsequent install step, every `:memory:` DuckDBStore in the
       # bench falls back to brute-force vector search, silently
       # invalidating the measurement.
+      - name: Get DuckDB version
+        id: get-duckdb-version
+        run: |
+          python -c "import duckdb; print(f'duckdb_version={duckdb.__version__}')" >> "$GITHUB_OUTPUT"
+
       - name: Cache DuckDB VSS extension
         uses: actions/cache@v4
         with:
           path: ~/.duckdb/extensions
-          key: duckdb-vss-${{ runner.os }}-${{ runner.arch }}-v1
+          key: duckdb-vss-${{ steps.get-duckdb-version.outputs.duckdb_version }}-${{ runner.os }}-${{ runner.arch }}-v1
 
       - name: Pre-install DuckDB VSS extension
         run: |


### PR DESCRIPTION
## Symptoms

Every `:memory:` `DuckDBStore` in the LongMemEval bench was hitting:

```
Extension "vss" is an existing extension.
Install it first using "INSTALL vss".
VSS extension not available — HNSW indexing disabled, falling back to brute-force vector search: IO Error: Extension "/home/runner/.duckdb/extensions/v1.5.2/linux_amd64/vss.duckdb_extension" not found.
```

The bench produced *some* number, but on the brute-force fallback — not on the hybrid + HNSW pipeline the bench claims to measure. The result was not a valid measurement.

## Root cause / design intent

`src/distillery/store/duckdb.py` (`_setup_vss`, lines 228–269) deliberately skips `INSTALL vss` and goes straight to `LOAD vss`:

> ``INSTALL vss`` downloads from the network and can block indefinitely when connectivity is unavailable. To avoid hangs we first check if the extension is already installed; if not, we attempt ``LOAD vss`` (which fails fast) so we never issue a blocking download.

This is correct for production (Lambda, Fly, Docker images that pre-install during build), but GitHub-hosted runners don't satisfy that precondition — the VSS binary isn't on disk, `LOAD` fails fast, and the store falls back to brute-force.

## Fix

Add two steps to `.github/workflows/bench-longmemeval.yml` (matrix-cell-level, replicated per cell):

1. `actions/cache@v4` over `~/.duckdb/extensions` keyed `duckdb-vss-${{ runner.os }}-${{ runner.arch }}-v1`. Placed before the existing fastembed cache step.
2. A `Pre-install DuckDB VSS extension` step that runs `INSTALL vss; LOAD vss` once and asserts both succeeded. The cache makes the second+ run a no-op (just a restore).

Touches only the workflow file — no code changes. The store keeps its production-safe `_setup_vss` semantics; CI now satisfies the pre-install precondition the store expects.

## Verification

- `actionlint .github/workflows/bench-longmemeval.yml` — passes (no output).
- Local equivalent: `python -c "import duckdb; con=duckdb.connect(':memory:'); con.execute('INSTALL vss'); con.execute('LOAD vss')"` succeeds (validated in a fresh venv with `duckdb` from PyPI).
- Once merged, the first nightly run should print `VSS extension state: installed=True loaded=True` in the new step, and the brute-force fallback warnings should disappear from the bench step output.

## Test plan

- [ ] Wait for next nightly (05:00 UTC) or trigger via `workflow_dispatch` and confirm:
  - [ ] `Pre-install DuckDB VSS extension` step prints `installed=True loaded=True`.
  - [ ] `Run bench (primary embed cell)` step no longer logs `VSS extension not available`.
  - [ ] On the second run, the cache hit shortens the install step to a near-instant no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved benchmark pipeline stability by caching DuckDB extensions per runtime and pre-installing the vector-search extension.
  * Ensured the extension is loaded and available before model and dataset caching to make performance tests more reliable and consistent across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->