### PR TITLE
ci: publish multi-arch (linux/arm64) container image (#447)

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -168,6 +168,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: linux/arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -200,6 +205,7 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha,scope=${{ matrix.target }}
           build-args: |


### PR DESCRIPTION
## Summary

Adds `linux/arm64` to the GHCR publish step in `.github/workflows/supply-chain.yml` so Apple Silicon devs (the team) can `docker pull ghcr.io/norrietaylor/distillery:latest` without `--platform linux/amd64`.

Closes #447.

## Changes

Two surgical edits to `.github/workflows/supply-chain.yml` (publish job only):

**1. Add QEMU setup before Buildx** (enables arm64 emulation on the amd64 runner):

```yaml
      - name: Set up QEMU
        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
        with:
          platforms: linux/arm64
```

**2. Add `platforms:` to `docker/build-push-action`**:

```yaml
      - name: Push image to GHCR
        id: push
        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
        with:
          context: ${{ matrix.context }}
          file: ${{ matrix.dockerfile }}
          push: true
          platforms: linux/amd64,linux/arm64
          tags: ${{ steps.tags.outputs.tags }}
          cache-from: type=gha,scope=${{ matrix.target }}
          build-args: |
            BUILD_SHA=${{ github.sha }}
```

Diff stats: `1 file changed, 6 insertions(+)`.

## Cosign + SBOM + attestations: unchanged

`docker/build-push-action` with multiple `platforms` produces a manifest list. `${{ steps.push.outputs.digest }}` is the manifest list digest, which is exactly what the existing cosign sign / attest steps already consume:

- `cosign sign` signs the manifest list digest -> covers both platform manifests automatically.
- `cosign attest --type cyclonedx` attaches the SBOM to the manifest list digest -> applies to both arches.
- `cosign attest --type vuln` attaches the Grype report to the manifest list digest -> applies to both arches.
- `actions/attest-build-provenance` uses the same digest -> SLSA attestation covers both arches.

The Grype scan in the `scan` job continues to scan a locally-loaded amd64 image (the dev/PR loop is unchanged); the published manifest list adds the arm64 variant on top.

## Cost

QEMU emulation of arm64 on the amd64 runner adds ~3-5 min to the publish wall-clock time. Acceptable per the cost analysis in #447.

## Verification

- [x] `actionlint .github/workflows/supply-chain.yml` -> exit 0
- [x] `git diff` shows only the two intended additions in `supply-chain.yml` (no other workflow changes)
- [x] All action SHAs pinned (no floating tags); `docker/setup-qemu-action` pinned to `c7c53464625b32c7a7e944ae62b3e17d2b600130` (v3.7.0, published 2025-11-05)
- [ ] After merge: next `Supply Chain Security` run on `main` should produce a manifest list with both `linux/amd64` and `linux/arm64` entries
- [ ] After merge: `docker pull ghcr.io/norrietaylor/distillery:latest` succeeds on Apple Silicon without `--platform`
- [ ] After merge: `cosign verify ghcr.io/norrietaylor/distillery@<digest>` and `cosign verify-attestation` continue to pass against the manifest list digest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for ARM64 architecture in the build pipeline, enabling multi-platform deployments alongside existing x86_64 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->