### PR TITLE
[bench] fix: clean up artifacts/ dir before verify-paths gate

### DIFF
--- a/.github/workflows/bench-longmemeval.yml
+++ b/.github/workflows/bench-longmemeval.yml
@@ -283,6 +283,9 @@ jobs:
           # Flatten the per-cell artifact directories into one tree.
           find artifacts/ -type f \( -name '*.jsonl' -o -name '*.json' \) -print0 \
             | xargs -0 -I{} cp {} bench/results/
+          # Remove the download dir so it doesn't trip the verify-paths
+          # allowlist (which uses `git add -A` to stage everything).
+          rm -rf artifacts/
           ls -la bench/results/
 
       # Day-of-week guard: full per-question JSONL is committed only on


### PR DESCRIPTION
## Summary

The aggregator job in `.github/workflows/bench-longmemeval.yml` has been failing every nightly run at the `Verify paths (allowlist enforcement)` step because the `artifacts/` download directory is left in the worktree after `actions/download-artifact@v4` runs. The verify-paths step uses `git add -A` to stage everything that would land in the auto-PR diff, so the leftover `artifacts/...` paths get staged and tripped the allowlist regex `^(bench/results/|bench/badge_(r5|r10|ndcg10)\.json$)`.

Run [25329394717](https://github.com/norrietaylor/distillery/actions/runs/25329394717) (yesterday's verification with the VSS preinstall fix) had **8/8 bench cells succeed** but the aggregator failed with:

```
ERROR: changes outside allowlist (bench/results/**, bench/badge_*.json):
artifacts/bench-results-hybrid-session-recency-off-bge-small-25329394717/results_longmemeval_hybrid_session_off_bge-small_*.jsonl
... (16 files in total under artifacts/...) ...
```

## Root cause

`actions/download-artifact@v4` is configured with `path: artifacts/` (line 278). The `Stage artifacts into bench/results` step copies them into `bench/results/` via `find ... | xargs cp`, but never cleans up the original `artifacts/` directory. When the later `verify-paths` step runs `git add -A`, every file under `artifacts/` gets staged and fails the allowlist check.

## Fix

Three-line addition at the end of the staging step — remove the download dir after the copy, so only allowlisted paths exist in the worktree when `verify-paths` runs:

```diff
       - name: Stage artifacts into bench/results
         run: |
           mkdir -p bench/results
           # Flatten the per-cell artifact directories into one tree.
           find artifacts/ -type f \( -name '*.jsonl' -o -name '*.json' \) -print0 \
             | xargs -0 -I{} cp {} bench/results/
+          # Remove the download dir so it doesn't trip the verify-paths
+          # allowlist (which uses `git add -A` to stage everything).
+          rm -rf artifacts/
           ls -la bench/results/
```

The original artifacts are still preserved as workflow artifacts (uploaded by per-cell jobs upstream), so removing the download copy in the worktree is safe.

## Impact

- Unblocks the nightly auto-PR cadence — verify-paths will now see only the allowlisted `bench/results/**` and `bench/badge_*.json` paths.
- Cosmetic CI-only change; no runtime / library / test impact.
- `actionlint .github/workflows/bench-longmemeval.yml` passes locally.

## Test plan

- [x] `actionlint` clean
- [ ] Next nightly aggregator run (or re-run of 25329394717) opens auto-PR successfully with only allowlisted paths in the diff
- [ ] Pre-commit hooks pass on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed GitHub Actions workflow to properly clean up temporary files during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->