### PR TITLE
[bench] fix: bump cell timeout to 120m; nightly samples 100q

### DIFF
--- a/.github/workflows/bench-longmemeval.yml
+++ b/.github/workflows/bench-longmemeval.yml
@@ -4,8 +4,10 @@
 # (retrieval x granularity x recency, embed pinned to bge-small) every
 # night at 05:00 UTC, after the eval-nightly.yml workflow at 03:00 UTC.
 #
-# Cost envelope: 8 cells * ~15 min = ~120 min/night = ~730 hr/yr. Well
-# inside GitHub free-tier minutes for public repos.
+# Cost envelope: nightly cron samples 100 questions per cell (8 cells *
+# ~15 min ≈ 2 hrs/run). Full 500-question runs are workflow_dispatch only
+# (~12 hrs/run, est. 1-1.5 hrs/cell post-VSS-preinstall). Well inside
+# GitHub free-tier minutes for public repos at the daily sampling cadence.
 #
 # Path-restriction note: GitHub does not let you path-scope GITHUB_TOKEN
 # at the workflow level — `permissions:` is per-permission, not per-path.
@@ -66,7 +68,10 @@ jobs:
   bench-matrix:
     name: bench (${{ matrix.retrieval }}/${{ matrix.granularity }}/recency-${{ matrix.recency }}/${{ matrix.embed }})
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Nightly cron samples 100 questions per cell to stay within ~5 hrs/run.
+    # Full 500q runs are workflow_dispatch only. Per-cell timeout is 120 min
+    # to accommodate hybrid+turn worst case (post-VSS-preinstall ~1-1.5 hrs).
+    timeout-minutes: 120
     permissions:
       contents: read
     strategy:
@@ -167,6 +172,9 @@ jobs:
       - name: Run bench (primary embed cell)
         env:
           DISTILLERY_BENCH_GIT_SHA: ${{ github.sha }}
+          # Nightly schedule samples 100 questions per cell; workflow_dispatch
+          # honors inputs.limit (empty = full 500-question set).
+          LIMIT: ${{ inputs.limit || (github.event_name == 'schedule' && '100' || '') }}
         run: |
           # CLI presence guard: the `distillery bench longmemeval` subcommand
           # lands in a follow-up PR (#440). Until that merges to main, every
@@ -176,44 +184,60 @@ jobs:
             echo "::warning::distillery bench longmemeval CLI not yet present on main. Skipping bench cell. Merge PR #440 to enable."
             exit 0
           fi
+          LIMIT_ARGS=()
+          if [ -n "${LIMIT:-}" ]; then
+            LIMIT_ARGS=(--limit "${LIMIT}")
+          fi
           distillery bench longmemeval \
             --retrieval ${{ matrix.retrieval }} \
             --granularity ${{ matrix.granularity }} \
             --recency ${{ matrix.recency }} \
             --embed-model ${{ matrix.embed }} \
-            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
+            "${LIMIT_ARGS[@]}"
 
       - name: Run bench (bge-base extension)
         if: github.event_name == 'workflow_dispatch' && inputs.run_embed_matrix == true && matrix.embed == 'bge-small'
         env:
           DISTILLERY_BENCH_GIT_SHA: ${{ github.sha }}
+          # workflow_dispatch only: honors inputs.limit (empty = full 500).
+          LIMIT: ${{ inputs.limit || (github.event_name == 'schedule' && '100' || '') }}
         run: |
           if ! distillery bench longmemeval --help >/dev/null 2>&1; then
             echo "::warning::distillery bench longmemeval CLI not yet present on main. Skipping bench cell. Merge PR #440 to enable."
             exit 0
+          fi
+          LIMIT_ARGS=()
+          if [ -n "${LIMIT:-}" ]; then
+            LIMIT_ARGS=(--limit "${LIMIT}")
           fi
           distillery bench longmemeval \
             --retrieval ${{ matrix.retrieval }} \
             --granularity ${{ matrix.granularity }} \
             --recency ${{ matrix.recency }} \
             --embed-model bge-base \
-            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
+            "${LIMIT_ARGS[@]}"
 
       - name: Run bench (bge-large extension)
         if: github.event_name == 'workflow_dispatch' && inputs.run_embed_matrix == true && matrix.embed == 'bge-small'
         env:
           DISTILLERY_BENCH_GIT_SHA: ${{ github.sha }}
+          # workflow_dispatch only: honors inputs.limit (empty = full 500).
+          LIMIT: ${{ inputs.limit || (github.event_name == 'schedule' && '100' || '') }}
         run: |
           if ! distillery bench longmemeval --help >/dev/null 2>&1; then
             echo "::warning::distillery bench longmemeval CLI not yet present on main. Skipping bench cell. Merge PR #440 to enable."
             exit 0
+          fi
+          LIMIT_ARGS=()
+          if [ -n "${LIMIT:-}" ]; then
+            LIMIT_ARGS=(--limit "${LIMIT}")
           fi
           distillery bench longmemeval \
             --retrieval ${{ matrix.retrieval }} \
             --granularity ${{ matrix.granularity }} \
             --recency ${{ matrix.recency }} \
             --embed-model bge-large \
-            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
+            "${LIMIT_ARGS[@]}"
 
       # Optional Jina cell. Only fires on workflow_dispatch with
       # run_jina=true AND the JINA_API_KEY secret available. Never on
@@ -223,6 +247,8 @@ jobs:
         env:
           DISTILLERY_BENCH_GIT_SHA: ${{ github.sha }}
           JINA_API_KEY: ${{ secrets.JINA_API_KEY }}
+          # workflow_dispatch only: honors inputs.limit (empty = full 500).
+          LIMIT: ${{ inputs.limit || (github.event_name == 'schedule' && '100' || '') }}
         run: |
           if [ -z "${JINA_API_KEY}" ]; then
             echo "JINA_API_KEY not set in repository secrets — skipping Jina cell"
@@ -232,12 +258,16 @@ jobs:
             echo "::warning::distillery bench longmemeval CLI not yet present on main. Skipping bench cell. Merge PR #440 to enable."
             exit 0
           fi
+          LIMIT_ARGS=()
+          if [ -n "${LIMIT:-}" ]; then
+            LIMIT_ARGS=(--limit "${LIMIT}")
+          fi
           distillery bench longmemeval \
             --retrieval ${{ matrix.retrieval }} \
             --granularity ${{ matrix.granularity }} \
             --recency ${{ matrix.recency }} \
             --embed-model jina \
-            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
+            "${LIMIT_ARGS[@]}"
 
       - name: Upload bench results artifact
         if: always()

--- a/.github/workflows/bench-longmemeval.yml
+++ b/.github/workflows/bench-longmemeval.yml
@@ -68,7 +68,7 @@ jobs:
   bench-matrix:
     name: bench (${{ matrix.retrieval }}/${{ matrix.granularity }}/recency-${{ matrix.recency }}/${{ matrix.embed }})
     runs-on: ubuntu-latest
-    # Nightly cron samples 100 questions per cell to stay within ~5 hrs/run.
+    # Nightly cron samples 100 questions per cell (~2 hrs/run total).
     # Full 500q runs are workflow_dispatch only. Per-cell timeout is 120 min
     # to accommodate hybrid+turn worst case (post-VSS-preinstall ~1-1.5 hrs).
     timeout-minutes: 120


### PR DESCRIPTION
## Summary

Run [25386226404](https://github.com/norrietaylor/distillery/actions/runs/25386226404) — the first fresh full bench after both the VSS preinstall fix (#448) and verify-paths cleanup (#451) landed in main — was cancelled at the 45-min job timeout across all 8 cells before any cell could complete 500 questions.

Two coordinated changes:

1. **Bump per-cell `timeout-minutes` from 45 to 120.** Provides headroom for the worst-case hybrid+turn cell (~1-1.5 hrs estimated post-#448). The aggregator job timeout (15 min) is unchanged.
2. **Nightly cron now samples 100 questions per cell.** Full 500q runs remain available via `workflow_dispatch` (leave `limit` blank). Cuts nightly cost from an estimated ~12 hrs to ~2 hrs of CI minutes while preserving daily signal on the headline metrics.

Per-cell timeout still bounded at 120 min so a runaway can't burn an entire matrix. Workflow_dispatch can still trigger full 500q runs at any time.

## Empirical timing (basis for the change)

From verification run [25329394717](https://github.com/norrietaylor/distillery/actions/runs/25329394717) (limit=20, no HNSW):

- ~12 min per cell for 20 questions
- Linear extrapolation to 500q (no HNSW): ~5 hrs/cell
- With HNSW (post-#448 fix): estimated 1-1.5 hrs/cell

Both exceeded the prior 45-min cell ceiling. 120 min covers the post-#448 estimate with margin.

## Diff highlights

**Timeout bump** (`bench-longmemeval.yml:69`):

```diff
-    timeout-minutes: 45
+    # Nightly cron samples 100 questions per cell to stay within ~5 hrs/run.
+    # Full 500q runs are workflow_dispatch only. Per-cell timeout is 120 min
+    # to accommodate hybrid+turn worst case (post-VSS-preinstall ~1-1.5 hrs).
+    timeout-minutes: 120
```

**Limit handling** (applied to all four bench steps: primary, bge-base, bge-large, Jina):

```diff
       - name: Run bench (primary embed cell)
         env:
           DISTILLERY_BENCH_GIT_SHA: ${{ github.sha }}
+          # Nightly schedule samples 100 questions per cell; workflow_dispatch
+          # honors inputs.limit (empty = full 500-question set).
+          LIMIT: ${{ inputs.limit || (github.event_name == 'schedule' && '100' || '') }}
         run: |
           ...
+          LIMIT_ARGS=()
+          if [ -n "${LIMIT:-}" ]; then
+            LIMIT_ARGS=(--limit "${LIMIT}")
+          fi
           distillery bench longmemeval \
             --retrieval ${{ matrix.retrieval }} \
             --granularity ${{ matrix.granularity }} \
             --recency ${{ matrix.recency }} \
             --embed-model ${{ matrix.embed }} \
-            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
+            "${LIMIT_ARGS[@]}"
```

The bash array (`LIMIT_ARGS=()` then `"${LIMIT_ARGS[@]}"`) is what passes shellcheck cleanly while still resolving to either zero args (no flag) or two args (`--limit 100`). A naive unquoted `$LIMIT_FLAG` triggered SC2086 in actionlint.

## Cost change

| trigger          | before    | after        |
|------------------|-----------|--------------|
| `schedule` cron  | ~12 hrs/run (timed out at 8 * 45 min = 6 hrs anyway) | ~2 hrs/run (limit=100) |
| `workflow_dispatch` (limit empty) | ~12 hrs/run | ~12 hrs/run |
| `workflow_dispatch` (limit=N)     | proportional | proportional |

## Test plan

- [ ] actionlint passes locally on `.github/workflows/bench-longmemeval.yml` (verified)
- [ ] On merge, next scheduled run (05:00 UTC) executes with `--limit 100` per cell and completes well under 120 min
- [ ] Manual `workflow_dispatch` with empty `limit` runs full 500q within 120-min cell ceiling
- [ ] Manual `workflow_dispatch` with `limit=20` honors the override (sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased per-job timeout for the nightly benchmark workflow (45 → 120 minutes) to improve reliability for longer runs.
  * Standardized step-level limit handling by using an environment variable (default 100 on schedule) and conditionally applying it to run steps.
  * Revised cost/sample assumptions to reflect 100-question cron sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->