### PR TITLE
[bench] feat: variance-gate workflow + --seed-offset CLI

### DIFF
--- a/.github/workflows/bench-variance-gate.yml
+++ b/.github/workflows/bench-variance-gate.yml
@@ -179,20 +179,30 @@ jobs:
 
           # Each matrix cell uploaded its bench/results/ tree under
           # artifacts/variance-seed-<N>/. Collect every summary_*.json.
+          # The runner writes ``seed_offset`` in axes (added in this same
+          # PR). A summary missing ``seed_offset`` would mean the bench
+          # was produced by an older runner whose seed-offset axis is
+          # not recoverable from the summary alone — silently grouping
+          # such records would corrupt the variance baseline, so we
+          # fail loudly instead.
           summaries = []
           for path in sorted(glob.glob("artifacts/variance-seed-*/summary_*.json")):
               with open(path) as f:
                   payload = json.load(f)
               axes = payload.get("axes", {}) or {}
-              # The runner writes ``seed_offset`` in axes; tolerate older
-              # records that only set ``seeds`` (the bucket count).
               seed_offset = axes.get("seed_offset")
               if seed_offset is None:
-                  seed_offset = axes.get("seeds")
+                  print(
+                      f"::error::summary {path} is missing ``axes.seed_offset``; "
+                      "cannot group records for variance baseline. Re-run after "
+                      "the runner emits seed_offset in axes (post-#455).",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
               overall = payload.get("overall", {}) or {}
               summaries.append(
                   {
-                      "seed_offset": seed_offset,
+                      "seed_offset": int(seed_offset),
                       "r5": float(overall.get("recall_at_5", 0.0)),
                       "r10": float(overall.get("recall_at_10", 0.0)),
                       "ndcg10": float(overall.get("ndcg_at_10", 0.0)),
@@ -201,7 +211,7 @@ jobs:
                   }
               )
 
-          summaries.sort(key=lambda s: s["seed_offset"] if s["seed_offset"] is not None else -1)
+          summaries.sort(key=lambda s: s["seed_offset"])
 
           if len(summaries) < 5:
               print(

--- a/.github/workflows/bench-variance-gate.yml
+++ b/.github/workflows/bench-variance-gate.yml
@@ -1,0 +1,314 @@
+# Wave 3 variance-gate workflow.
+#
+# Runs the pre-registered headline cell (hybrid / session / recency-on /
+# bge-small) five times back-to-back at full 500-question scale, with
+# documented seed offsets 0..4. Aggregates the per-cell summaries and
+# emits a one-time variance baseline at
+# `bench/results/variance_baseline.json`.
+#
+# Halts (workflow exits red) if R@5 stddev across the 5 seeds is >=
+# 0.5pp (0.005). Per discipline rule 6 ("variance characterisation")
+# from the plan at `/Users/norrie/.claude/plans/look-at-mempalace-hook-
+# dynamic-mccarthy.md`, no public-surface number (README badge, blog,
+# benchmarks page headline) may reference the bench until the gate
+# passes and `variance_baseline.json` is committed.
+#
+# Each matrix cell is a single-seed full-500q run; the matrix axis is
+# the seed offset (0..4) which is plumbed through `--seed-offset N`
+# into the runner. The aggregator job downloads every cell's artifact,
+# extracts R@5 from the summary JSON, computes the mean + stddev, and
+# opens an auto-PR with the baseline file.
+#
+# Path-restriction: `verify-paths` allow-lists exactly the one file
+# this workflow is permitted to commit. Anything else fails the build
+# before the auto-PR is opened.
+#
+# Trigger: workflow_dispatch only. This is a one-time exercise (re-runs
+# are fine, but it should not be on a schedule).
+
+name: Bench — Variance Gate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Variance-gate runs are intentionally serialized so the on-disk state
+# (caches, artifacts) is never raced by two simultaneous attempts.
+concurrency:
+  group: bench-variance-gate
+  cancel-in-progress: false
+
+jobs:
+  bench-seed:
+    name: bench (seed-offset ${{ matrix.seed }})
+    runs-on: ubuntu-latest
+    # Full 500-question runs take ~1-1.5 hours per cell post-VSS-preinstall;
+    # 4 hour ceiling matches the bench-longmemeval.yml workflow_dispatch
+    # full-set ceiling and gives headroom for first-run cache misses.
+    timeout-minutes: 240
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Five seed offsets — the variance gate samples the per-question
+        # PRNG seed at offsets 0, 1, 2, 3, 4. The runner derives the
+        # per-question seed as `seed_offset + question_index` when
+        # `--seeds 1`, so each cell is a fully independent seed run.
+        seed: [0, 1, 2, 3, 4]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,fastembed]"
+
+      # Cache the DuckDB VSS extension. See bench-longmemeval.yml for
+      # the rationale (without VSS the store falls back to brute-force
+      # vector search, silently invalidating the measurement).
+      - name: Get DuckDB version
+        id: get-duckdb-version
+        run: |
+          python -c "import duckdb; print(f'duckdb_version={duckdb.__version__}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache DuckDB VSS extension
+        uses: actions/cache@v4
+        with:
+          path: ~/.duckdb/extensions
+          key: duckdb-vss-${{ steps.get-duckdb-version.outputs.duckdb_version }}-${{ runner.os }}-${{ runner.arch }}-v1
+
+      - name: Pre-install DuckDB VSS extension
+        run: |
+          python - <<'PY'
+          import duckdb
+          con = duckdb.connect(':memory:')
+          con.execute("INSTALL vss")
+          con.execute("LOAD vss")
+          row = con.execute(
+              "SELECT installed, loaded FROM duckdb_extensions() "
+              "WHERE extension_name = 'vss'"
+          ).fetchone()
+          print(f"VSS extension state: installed={row[0]} loaded={row[1]}")
+          assert row[0] and row[1], "VSS extension failed to install/load"
+          PY
+
+      # Cache fastembed model weights (bge-small only — the headline cell).
+      - name: Cache fastembed model weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/fastembed
+          key: fastembed-${{ runner.os }}-bge-small-v1
+          restore-keys: |
+            fastembed-${{ runner.os }}-bge-small-
+
+      # Cache the HuggingFace dataset (longmemeval-cleaned, 264.5 MB),
+      # pinned to the same revision SHA as bench-longmemeval.yml.
+      - name: Cache HuggingFace dataset
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-longmemeval-98d7416c24c778c2fee6e6f3006e7a073259d48f-v1
+          restore-keys: |
+            hf-longmemeval-98d7416c24c778c2fee6e6f3006e7a073259d48f-
+
+      - name: Run bench (full 500q, seed-offset ${{ matrix.seed }})
+        env:
+          DISTILLERY_BENCH_GIT_SHA: ${{ github.sha }}
+        run: |
+          distillery bench longmemeval \
+            --retrieval hybrid \
+            --granularity session \
+            --recency on \
+            --embed-model bge-small \
+            --seeds 1 \
+            --seed-offset ${{ matrix.seed }}
+
+      - name: Upload seed artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: variance-seed-${{ matrix.seed }}
+          path: bench/results/**
+          retention-days: 90
+          if-no-files-found: error
+
+  aggregate-variance:
+    name: Aggregate variance + auto-PR
+    needs: [bench-seed]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Only run if the matrix succeeded — a failed seed run would skew
+    # the variance baseline. `cancelled()` guard plus needs.result.
+    if: ${{ !cancelled() && needs.bench-seed.result == 'success' }}
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download all variance artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Compute variance + emit baseline
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import statistics
+          import sys
+          from pathlib import Path
+
+          # Each matrix cell uploaded its bench/results/ tree under
+          # artifacts/variance-seed-<N>/. Collect every summary_*.json.
+          summaries = []
+          for path in sorted(glob.glob("artifacts/variance-seed-*/summary_*.json")):
+              with open(path) as f:
+                  payload = json.load(f)
+              axes = payload.get("axes", {}) or {}
+              # The runner writes ``seed_offset`` in axes; tolerate older
+              # records that only set ``seeds`` (the bucket count).
+              seed_offset = axes.get("seed_offset")
+              if seed_offset is None:
+                  seed_offset = axes.get("seeds")
+              overall = payload.get("overall", {}) or {}
+              summaries.append(
+                  {
+                      "seed_offset": seed_offset,
+                      "r5": float(overall.get("recall_at_5", 0.0)),
+                      "r10": float(overall.get("recall_at_10", 0.0)),
+                      "ndcg10": float(overall.get("ndcg_at_10", 0.0)),
+                      "n_questions": int(payload.get("n_questions", 0)),
+                      "summary_path": path,
+                  }
+              )
+
+          summaries.sort(key=lambda s: s["seed_offset"] if s["seed_offset"] is not None else -1)
+
+          if len(summaries) < 5:
+              print(
+                  f"::error::Only {len(summaries)} seed runs found; need 5",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          r5_values = [s["r5"] for s in summaries]
+          mean_r5 = statistics.mean(r5_values)
+          stddev_r5 = statistics.stdev(r5_values)
+
+          baseline = {
+              "metric": "R@5",
+              "config": "hybrid/session/recency-on/bge-small",
+              "questions": summaries[0]["n_questions"],
+              "seeds": [
+                  {
+                      "seed_offset": s["seed_offset"],
+                      "r5": s["r5"],
+                      "r10": s["r10"],
+                      "ndcg10": s["ndcg10"],
+                  }
+                  for s in summaries
+              ],
+              "mean": mean_r5,
+              "stddev": stddev_r5,
+              "min": min(r5_values),
+              "max": max(r5_values),
+              "gate_threshold_pp": 0.5,
+              "gate_pass": stddev_r5 < 0.005,
+          }
+
+          out_path = Path("bench/results/variance_baseline.json")
+          out_path.parent.mkdir(parents=True, exist_ok=True)
+          with out_path.open("w") as f:
+              json.dump(baseline, f, indent=2)
+              f.write("\n")
+          print(json.dumps(baseline, indent=2))
+
+          if stddev_r5 >= 0.005:
+              print(
+                  f"::error::Variance gate FAILED: R@5 stddev {stddev_r5:.4f} "
+                  f">= 0.005 (0.5pp threshold)",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          print(
+              f"Variance gate PASSED: R@5 stddev {stddev_r5:.4f} "
+              f"< 0.005 (mean {mean_r5:.4f})"
+          )
+          PY
+
+      # Path-restriction enforcement. GitHub does not allow path-scoped
+      # GITHUB_TOKEN, so we verify the staged diff manually. Anything
+      # outside the variance_baseline.json allowlist fails the job.
+      - name: Verify paths (allowlist enforcement)
+        run: |
+          set -euo pipefail
+          ALLOW='^bench/results/variance_baseline\.json$'
+          # Drop the artifacts download dir so it doesn't show up in
+          # `git add -A`'s diff.
+          rm -rf artifacts/
+          git add -A
+          CHANGED=$(git diff --cached --name-only)
+          if [ -z "${CHANGED}" ]; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          echo "Changed files:"
+          echo "${CHANGED}"
+          BAD=$(echo "${CHANGED}" | grep -Ev "${ALLOW}" || true)
+          if [ -n "${BAD}" ]; then
+            echo "ERROR: changes outside allowlist (only bench/results/variance_baseline.json permitted):"
+            echo "${BAD}"
+            exit 1
+          fi
+          echo "All changes within allowlist."
+          # Reset the index so create-pull-request can re-stage cleanly.
+          git reset
+
+      - name: Open auto-PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bench/variance-baseline-${{ github.run_id }}
+          base: main
+          title: "[bench] variance baseline from gate run ${{ github.run_id }}"
+          commit-message: |
+            bench(variance): commit variance_baseline.json from variance-gate run
+
+            Run ID: ${{ github.run_id }}
+            Headline cell: hybrid / session / recency-on / bge-small
+            Seeds: 0..4 (full 500-question runs)
+          body: |
+            Variance baseline committed by `bench-variance-gate.yml` (run ${{ github.run_id }}).
+
+            See `bench/results/variance_baseline.json` for the 5-seed mean +
+            stddev across the pre-registered headline cell
+            (`hybrid/session/recency-on/bge-small`, 500 questions per seed).
+
+            If `gate_pass: true`, the bench is a useful regression signal and
+            the headline numbers can land on public surfaces (README badges,
+            `docs/benchmarks.md`, blog post). If `gate_pass: false`, the
+            workflow itself failed before this PR could open — investigate
+            HNSW determinism, RRF tie-break, fastembed batching before
+            publishing any number.
+          labels: benchmark
+          add-paths: bench/results/variance_baseline.json
+          delete-branch: true

--- a/.github/workflows/bench-variance-gate.yml
+++ b/.github/workflows/bench-variance-gate.yml
@@ -185,6 +185,11 @@ jobs:
           # not recoverable from the summary alone — silently grouping
           # such records would corrupt the variance baseline, so we
           # fail loudly instead.
+          # Required keys per summary. ``recall_at_*`` and ``ndcg_at_*``
+          # are the headline triplet; ``n_questions`` is needed so the
+          # baseline records the corpus size each seed actually saw.
+          REQUIRED_OVERALL_KEYS = ("recall_at_5", "recall_at_10", "ndcg_at_10")
+
           summaries = []
           for path in sorted(glob.glob("artifacts/variance-seed-*/summary_*.json")):
               with open(path) as f:
@@ -199,23 +204,69 @@ jobs:
                       file=sys.stderr,
                   )
                   sys.exit(1)
-              overall = payload.get("overall", {}) or {}
+              overall = payload.get("overall")
+              if not isinstance(overall, dict) or not overall:
+                  print(
+                      f"::error::summary {path} is missing or has empty ``overall`` "
+                      "block; cannot extract R@5 / R@10 / NDCG@10 for variance "
+                      "baseline.",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              missing_keys = [k for k in REQUIRED_OVERALL_KEYS if k not in overall]
+              if missing_keys:
+                  print(
+                      f"::error::summary {path} ``overall`` block is missing "
+                      f"required keys: {missing_keys}",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              if "n_questions" not in payload:
+                  print(
+                      f"::error::summary {path} is missing top-level "
+                      "``n_questions``; cannot record corpus size for baseline.",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              try:
+                  r5 = float(overall["recall_at_5"])
+                  r10 = float(overall["recall_at_10"])
+                  ndcg10 = float(overall["ndcg_at_10"])
+                  n_questions = int(payload["n_questions"])
+                  seed_offset_int = int(seed_offset)
+              except (TypeError, ValueError) as exc:
+                  print(
+                      f"::error::summary {path} has a non-numeric metric or "
+                      f"non-integer seed_offset/n_questions: {exc}",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
               summaries.append(
                   {
-                      "seed_offset": int(seed_offset),
-                      "r5": float(overall.get("recall_at_5", 0.0)),
-                      "r10": float(overall.get("recall_at_10", 0.0)),
-                      "ndcg10": float(overall.get("ndcg_at_10", 0.0)),
-                      "n_questions": int(payload.get("n_questions", 0)),
+                      "seed_offset": seed_offset_int,
+                      "r5": r5,
+                      "r10": r10,
+                      "ndcg10": ndcg10,
+                      "n_questions": n_questions,
                       "summary_path": path,
                   }
               )
 
           summaries.sort(key=lambda s: s["seed_offset"])
 
-          if len(summaries) < 5:
+          # Variance grouping is only meaningful when every matrix cell
+          # uploaded a summary AND each is a unique seed offset in 0..4.
+          # A loose length check would silently accept e.g. four cells
+          # with offsets {0, 1, 2, 3} plus a duplicate of offset 0 —
+          # that would skew the stddev. Enforce exact coverage.
+          observed_offsets = sorted(s["seed_offset"] for s in summaries)
+          expected_offsets = list(range(5))
+          if observed_offsets != expected_offsets:
               print(
-                  f"::error::Only {len(summaries)} seed runs found; need 5",
+                  f"::error::Variance gate aggregator expected one summary per "
+                  f"seed_offset in {expected_offsets}; got {observed_offsets}. "
+                  "Each matrix cell must upload exactly one summary with a "
+                  "unique seed_offset in 0..4.",
                   file=sys.stderr,
               )
               sys.exit(1)

--- a/.github/workflows/bench-variance-gate.yml
+++ b/.github/workflows/bench-variance-gate.yml
@@ -271,6 +271,21 @@ jobs:
               )
               sys.exit(1)
 
+          # All 5 cells must have evaluated the same number of
+          # questions, otherwise mean/stddev across them is comparing
+          # apples to oranges (e.g. one cell silently truncated).
+          n_questions_values = {s["n_questions"] for s in summaries}
+          if len(n_questions_values) != 1:
+              by_offset = {s["seed_offset"]: s["n_questions"] for s in summaries}
+              print(
+                  f"::error::Cells disagree on n_questions: {by_offset}. "
+                  "Variance gate requires every seed to evaluate the same "
+                  "question count; aborting before computing mean/stddev.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          n_questions = n_questions_values.pop()
+
           r5_values = [s["r5"] for s in summaries]
           mean_r5 = statistics.mean(r5_values)
           stddev_r5 = statistics.stdev(r5_values)
@@ -278,7 +293,7 @@ jobs:
           baseline = {
               "metric": "R@5",
               "config": "hybrid/session/recency-on/bge-small",
-              "questions": summaries[0]["n_questions"],
+              "questions": n_questions,
               "seeds": [
                   {
                       "seed_offset": s["seed_offset"],

--- a/.github/workflows/bench-variance-gate.yml
+++ b/.github/workflows/bench-variance-gate.yml
@@ -173,6 +173,7 @@ jobs:
           python - <<'PY'
           import glob
           import json
+          import math
           import statistics
           import sys
           from pathlib import Path
@@ -241,6 +242,18 @@ jobs:
                       file=sys.stderr,
                   )
                   sys.exit(1)
+              # ``float()`` happily accepts ``"NaN"`` / ``"Infinity"``; if a
+              # buggy upstream emitted those, ``statistics.mean`` would
+              # return ``nan`` (silently corrupting the baseline) and
+              # ``statistics.stdev`` would crash. Reject them up front.
+              for label, value in (("r5", r5), ("r10", r10), ("ndcg10", ndcg10)):
+                  if not math.isfinite(value):
+                      print(
+                          f"::error::summary {path} has non-finite {label}={value}; "
+                          "variance baseline cannot be computed from NaN/Infinity.",
+                          file=sys.stderr,
+                      )
+                      sys.exit(1)
               summaries.append(
                   {
                       "seed_offset": seed_offset_int,

--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -55,6 +55,23 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
+def _non_negative_int(value: str) -> int:
+    """argparse ``type`` callable that rejects ``< 0`` integers.
+
+    Used by ``bench longmemeval --seed-offset`` so the variance-gate
+    workflow can dispatch ``--seed-offset 0`` (the canonical baseline
+    cell) without tripping the stricter ``> 0`` guard, while still
+    rejecting nonsense like ``--seed-offset -1``.
+    """
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid int value: {value!r}") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0 (got {parsed})")
+    return parsed
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Build and return the argument parser.
 
@@ -339,6 +356,18 @@ def _build_parser() -> argparse.ArgumentParser:
         type=_positive_int,
         default=1,
         help="Number of seeds to sweep per question (default: 1)",
+    )
+    longmemeval_parser.add_argument(
+        "--seed-offset",
+        metavar="N",
+        type=_non_negative_int,
+        default=0,
+        help=(
+            "Starting offset added to the per-question PRNG seed (default: 0). "
+            "Used by the variance-gate matrix to dispatch independent single-seed "
+            "runs across offsets 0..N-1; combine with --seeds 1 for one run per "
+            "matrix cell."
+        ),
     )
     longmemeval_parser.add_argument(
         "--output-dir",
@@ -1920,6 +1949,7 @@ def _cmd_bench_longmemeval(
     embed_model: str,
     limit: int | None,
     seeds: int,
+    seed_offset: int,
     output_dir: str | None,
     quiet: bool,
     fmt: str,
@@ -1970,7 +2000,8 @@ def _cmd_bench_longmemeval(
         print(
             f"Running LongMemEval bench: retrieval={retrieval} "
             f"granularity={granularity} recency={recency} "
-            f"embed_model={embed_model} limit={limit} seeds={seeds}",
+            f"embed_model={embed_model} limit={limit} seeds={seeds} "
+            f"seed_offset={seed_offset}",
             file=sys.stderr,
         )
         print(f"Output directory: {resolved_output_dir}", file=sys.stderr)
@@ -1990,6 +2021,7 @@ def _cmd_bench_longmemeval(
             embed_model=embed_model_typed,
             limit=limit,
             seeds=seeds,
+            seed_offset=seed_offset,
             output_dir=resolved_output_dir,
         )
 
@@ -2120,6 +2152,7 @@ def main(argv: list[str] | None = None) -> None:
                 embed_model=getattr(args, "embed_model", "bge-small"),
                 limit=getattr(args, "limit", None),
                 seeds=getattr(args, "seeds", 1),
+                seed_offset=getattr(args, "seed_offset", 0),
                 output_dir=getattr(args, "output_dir", None),
                 quiet=getattr(args, "quiet", False),
                 fmt=fmt,

--- a/src/distillery/eval/longmemeval.py
+++ b/src/distillery/eval/longmemeval.py
@@ -211,6 +211,7 @@ def _build_meta_panel(
     git_sha: str,
     embed_model_sha: str,
     seed: int,
+    seed_offset: int,
     retrieval: RetrievalMode,
     granularity: GranularityMode,
     recency: RecencyMode,
@@ -220,6 +221,13 @@ def _build_meta_panel(
 
     All seven required fields are present unconditionally — receipts
     with a missing field would defeat the audit trail.
+
+    ``seed_offset`` is the run-level starting offset that produced the
+    per-question ``seed`` (``seed = seed_offset * 100_000 + q_idx`` for
+    ``--seeds N`` sweeps; ``seed = seed_offset + q_idx`` when callers
+    drive the offset directly via the variance-gate path).  Carried in
+    the panel so a downstream aggregator can group records by the run
+    that produced them without inspecting the filename.
     """
     return {
         "git_sha": git_sha,
@@ -228,6 +236,7 @@ def _build_meta_panel(
         "embed_model_sha": embed_model_sha,
         "python_version": sys.version,
         "seed": seed,
+        "seed_offset": seed_offset,
         "timestamp_utc": datetime.now(tz=UTC).isoformat(),
         # Mode echoes — useful when records from multiple cells are
         # accidentally concatenated for analysis.
@@ -447,6 +456,7 @@ async def _run_one_question(
     question: dict[str, Any],
     *,
     seed: int,
+    seed_offset: int,
     retrieval: RetrievalMode,
     granularity: GranularityMode,
     recency: RecencyMode,
@@ -523,6 +533,7 @@ async def _run_one_question(
             git_sha=git_sha,
             embed_model_sha=_embed_model_sha(embedder),
             seed=seed,
+            seed_offset=seed_offset,
             retrieval=retrieval,
             granularity=granularity,
             recency=recency,
@@ -646,6 +657,7 @@ async def run_longmemeval_bench(
     embed_model: EmbedModel = "bge-small",
     limit: int | None = None,
     seeds: int = 1,
+    seed_offset: int = 0,
     output_dir: Path | None = None,
     questions: list[dict[str, Any]] | None = None,
 ) -> BenchReport:
@@ -680,6 +692,17 @@ async def run_longmemeval_bench(
         evaluated once per seed; the seed is the question index plus a
         per-seed offset so any divergence is attributable.  Defaults to
         ``1`` to keep the smoke-test path quick.
+    seed_offset:
+        Starting offset added to the per-question seed.  When the
+        bench runs as a single seed (``seeds=1``) the per-question
+        seed becomes ``seed_offset + question_index`` directly, so a
+        CI matrix can dispatch independent single-seed runs across
+        offsets ``0..N-1`` for variance characterisation (Wave 3,
+        ``bench-variance-gate.yml``).  When ``seeds > 1`` each
+        in-process sweep step ``i`` uses
+        ``seed_offset + i * 100_000 + question_index`` so the per-run
+        and per-sweep axes don't collide.  Defaults to ``0`` so the
+        existing ``--seeds N`` semantics are unchanged.
     output_dir:
         Directory to write JSONL + summary files into.  When ``None``,
         no files are written and the caller can read
@@ -717,14 +740,21 @@ async def run_longmemeval_bench(
     # is ~1-2s; on a full 500-question sweep this saves 500-1000s.
     embedder = _build_embedding_provider(embed_model)
 
-    for seed_offset in range(max(1, seeds)):
+    # ``sweep_offset`` is the in-process per-seed bucket (``--seeds N``
+    # internal sweep), ``seed_offset`` is the run-level starting offset
+    # supplied by the caller (e.g. the variance-gate matrix axis).  The
+    # per-question PRNG seed is the sum so the two never collide:
+    # ``seed_offset + sweep_offset * 100_000 + q_idx``.  When
+    # ``seeds=1`` the sweep axis is a single bucket of zero so this
+    # collapses to ``seed_offset + q_idx`` — exactly what the variance
+    # gate needs (Wave 3, discipline rule 6).
+    for sweep_offset in range(max(1, seeds)):
         for q_idx, question in enumerate(questions):
-            # Seed is question-index + seed-offset so two seeds for the
-            # same question diverge predictably.
-            seed = q_idx + seed_offset * 100_000
+            seed = seed_offset + sweep_offset * 100_000 + q_idx
             record = await _run_one_question(
                 question,
                 seed=seed,
+                seed_offset=seed_offset,
                 retrieval=retrieval,
                 granularity=granularity,
                 recency=recency,
@@ -741,6 +771,7 @@ async def run_longmemeval_bench(
         "effective_recency": "off" if retrieval == "raw" else recency,
         "embed_model": embed_model,
         "seeds": max(1, seeds),
+        "seed_offset": seed_offset,
         "limit": limit,
     }
     summary["dataset"] = {

--- a/tests/eval/test_longmemeval_runner.py
+++ b/tests/eval/test_longmemeval_runner.py
@@ -506,6 +506,78 @@ async def test_summary_axes_exposes_effective_recency(tmp_path: Path) -> None:
     assert "recency" not in axes_hybrid
 
 
+async def test_seed_offset_changes_per_question_seed_in_meta() -> None:
+    """``seed_offset`` shifts the per-question seed by exactly its value.
+
+    Pin: with ``seeds=1``, the per-question seed is
+    ``seed_offset + question_index``.  Two runs with different
+    ``seed_offset`` values must therefore produce ``_meta.seed`` and
+    ``_meta.seed_offset`` differing by exactly the offset delta on
+    every record.
+
+    This is the contract the variance-gate workflow relies on — each
+    matrix cell dispatches a single-seed run with its own offset, and
+    the aggregator groups records by ``seed_offset`` from the SHA panel.
+    """
+    questions = _load_fixture()
+
+    report_a = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="on",
+        embed_model="bge-small",
+        questions=questions,
+        seeds=1,
+        seed_offset=0,
+    )
+    report_b = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="on",
+        embed_model="bge-small",
+        questions=questions,
+        seeds=1,
+        seed_offset=7,
+    )
+
+    assert len(report_a.per_question) == len(report_b.per_question)
+    for rec_a, rec_b in zip(report_a.per_question, report_b.per_question, strict=True):
+        # Pair-up by question id so we compare the same question.
+        assert rec_a.question_id == rec_b.question_id
+        # Per-question seed differs by exactly the seed_offset delta.
+        assert rec_b.meta["seed"] - rec_a.meta["seed"] == 7
+        assert rec_a.meta["seed_offset"] == 0
+        assert rec_b.meta["seed_offset"] == 7
+
+    # Summary axes carry the offset so a downstream consumer reading
+    # only summary.json can group runs without inspecting per-record meta.
+    assert report_a.summary["axes"]["seed_offset"] == 0
+    assert report_b.summary["axes"]["seed_offset"] == 7
+
+
+async def test_seed_offset_default_is_zero() -> None:
+    """Omitting ``seed_offset`` matches the historical ``seeds=1`` semantics.
+
+    Regression guard: the new parameter must default to ``0`` so every
+    existing caller (CLI without ``--seed-offset``, in-process tests)
+    sees the original ``seed = q_idx`` behaviour.
+    """
+    questions = _load_fixture()
+
+    report = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="on",
+        embed_model="bge-small",
+        questions=questions,
+    )
+
+    for q_idx, record in enumerate(report.per_question):
+        assert record.meta["seed_offset"] == 0
+        # With seed_offset=0 and seeds=1, per-question seed equals q_idx.
+        assert record.meta["seed"] == q_idx
+
+
 def test_filename_schema_includes_every_axis(tmp_path: Path) -> None:
     """Output filenames must include every axis to prevent cross-axis confusion.
 

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -338,3 +338,118 @@ class TestBenchLongmemevalArgValidation:
         assert exc.value.code == 2
         captured = capsys.readouterr()
         assert "must be > 0" in captured.err
+
+    @pytest.mark.parametrize("value", ["-1", "-5"])
+    def test_negative_seed_offset_rejected(
+        self,
+        value: str,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--seed-offset`` rejects negative values but accepts ``0``.
+
+        The variance-gate matrix dispatches offsets ``0..4``, so ``0``
+        must remain valid (unlike ``--seeds`` / ``--limit`` which must
+        be ``> 0``).  Only negative values are nonsense.
+        """
+        with pytest.raises(SystemExit) as exc:
+            main(["bench", "longmemeval", "--seed-offset", value])
+        assert exc.value.code == 2
+        captured = capsys.readouterr()
+        assert "must be >= 0" in captured.err
+
+    def test_zero_seed_offset_accepted(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--seed-offset 0 --help`` parses cleanly (no argparse error)."""
+        # Use --help to short-circuit before any heavy imports / network.
+        with pytest.raises(SystemExit) as exc:
+            main(["bench", "longmemeval", "--seed-offset", "0", "--help"])
+        # --help exits 0; only argparse type errors exit 2.
+        assert exc.value.code == 0
+
+
+@pytest.mark.unit
+class TestBenchLongmemevalSeedOffsetFlag:
+    """``--seed-offset`` is documented and round-trips through argparse."""
+
+    def test_seed_offset_appears_in_help(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--help`` lists ``--seed-offset`` so the variance-gate workflow
+        and any external CI matrix can discover the flag without reading
+        source.
+        """
+        with pytest.raises(SystemExit) as exc:
+            main(["bench", "longmemeval", "--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--seed-offset" in out
+
+    def test_seed_offset_round_trips_to_runner(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``--seed-offset N`` reaches ``run_longmemeval_bench`` unchanged.
+
+        We don't run the bench end-to-end here — we monkeypatch the
+        runner with a recording stub so the unit test stays fast and
+        does not depend on fastembed weights.
+        """
+        from distillery import cli as cli_module
+
+        captured_kwargs: dict[str, Any] = {}
+
+        async def _stub_runner(**kwargs: Any) -> Any:
+            captured_kwargs.update(kwargs)
+            from distillery.eval.longmemeval import BenchReport
+
+            return BenchReport(
+                summary={
+                    "n_questions": 0,
+                    "overall": {
+                        "recall_at_5": 0.0,
+                        "recall_at_10": 0.0,
+                        "ndcg_at_10": 0.0,
+                    },
+                },
+                per_question=[],
+                jsonl_path=None,
+                summary_path=None,
+            )
+
+        monkeypatch.setattr(
+            "distillery.eval.longmemeval.run_longmemeval_bench",
+            _stub_runner,
+        )
+        # The CLI's lazy import binds the symbol into a local name; force
+        # the lazy import path to re-resolve from the module so the patch
+        # is observed.
+        if hasattr(cli_module, "run_longmemeval_bench"):  # pragma: no cover - defensive
+            monkeypatch.setattr(
+                cli_module,
+                "run_longmemeval_bench",
+                _stub_runner,
+                raising=False,
+            )
+
+        out_dir = tmp_path / "results"
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    "bench",
+                    "longmemeval",
+                    "--seed-offset",
+                    "3",
+                    "--seeds",
+                    "1",
+                    "--output-dir",
+                    str(out_dir),
+                    "--quiet",
+                ]
+            )
+        assert exc.value.code == 0
+        assert captured_kwargs.get("seed_offset") == 3
+        assert captured_kwargs.get("seeds") == 1


### PR DESCRIPTION
## Summary

Implements Wave 3's variance characterisation gate per the discipline plan (`/Users/norrie/.claude/plans/look-at-mempalace-hook-dynamic-mccarthy.md` — verification step 5, discipline rule 6, Wave 3 sequencing entry).

- **New workflow** `.github/workflows/bench-variance-gate.yml` (workflow_dispatch only) runs a 5-cell matrix. Each cell does a full 500-question run of the pre-registered headline cell (`hybrid/session/recency-on/bge-small`) with `--seeds 1 --seed-offset N` for N in 0..4. The aggregator job computes mean + stddev of R@5 and writes `bench/results/variance_baseline.json`. The job exits red if stddev >= 0.005 (the 0.5pp threshold from the plan).
- **Path-restriction** `verify-paths` allow-lists exactly `bench/results/variance_baseline.json`; auto-PR uses `peter-evans/create-pull-request@v6` with `add-paths:` scoped to the same file.
- **Runner change:** new `--seed-offset N` CLI flag (default 0) on `distillery bench longmemeval`. Per-question PRNG seed becomes `seed_offset + sweep_offset * 100_000 + question_index`. With `--seeds 1` (variance-gate path) this collapses to `seed_offset + question_index`. `_meta.seed_offset` and `summary["axes"]["seed_offset"]` are added so downstream aggregators can group records by the run that produced them without parsing filenames.

Discipline note: the gate is the first place the plan permits an "expected to land near X" claim. README badges, `docs/benchmarks.md` headline, and the blog post may not reference public bench numbers until this workflow runs once and `gate_pass: true` is committed.

## Files touched

- `.github/workflows/bench-variance-gate.yml` (new)
- `src/distillery/eval/longmemeval.py` — `seed_offset` parameter + plumb through
- `src/distillery/cli.py` — `--seed-offset` argparse arg + `_non_negative_int` helper
- `tests/eval/test_longmemeval_runner.py` — 2 new tests
- `tests/test_cli_bench.py` — 4 new tests (1 negation case + 1 zero-OK case + 2 in a new flag class)

## Threshold

Gate fails if R@5 stddev across 5 seeds >= 0.005 (0.5pp). The summary JSON's `gate_pass` field reflects the boolean and the workflow exits red on failure so the auto-PR never opens with a failing baseline.

## Next step

After merge, run `gh workflow run bench-variance-gate.yml --ref main` once. Each cell takes ~1-1.5h after VSS preinstall, so the matrix wall-clock is ~1.5-2h. The auto-PR appears with `bench/results/variance_baseline.json` ready for review.

## Test plan

- [x] `actionlint .github/workflows/bench-variance-gate.yml` clean
- [x] `mypy --strict src/distillery/` clean (66 files)
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check` clean for all touched files
- [x] `pytest tests/eval/test_longmemeval_runner.py tests/test_cli_bench.py -v` — 25 passed
- [ ] CI green
- [ ] After merge: workflow_dispatch the variance-gate once, verify auto-PR opens with `gate_pass: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated benchmark variance workflow: runs multiple seeded benchmarks, aggregates per-seed metrics, enforces a stability gate (fails on high variance), and auto-commits approved baseline results.
  * Added a seed-offset CLI option to run independent/parallel benchmark seeds and include offset in run metadata.

* **Tests**
  * Added tests validating seed-offset behavior in benchmarks and CLI argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->