### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "distillery",
       "source": "./",
       "description": "Knowledge base skills — capture, search, and synthesize project knowledge",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings"],
       "category": "knowledge-management"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '[Distillery v0.4.1] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+            "command": "echo '[Distillery] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
           }
         ]
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "distillery",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Knowledge base skills for Claude Code — capture, search, and synthesize project knowledge",
   "author": {
     "name": "norrietaylor",
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '[Distillery v0.4.0] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+            "command": "echo '[Distillery v0.4.1] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.4.1] - 2026-05-05
+## [0.4.1] - 2026-05-06
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-05
+
+### Bug Fixes
+
+- `/radar` no longer surfaces stale backfill items. Candidates are now bounded by `metadata.published_at` instead of `created_at`, and first-poll backfill batches are excluded by default. Pass `include_evergreen=true` to opt back in. (#444, #446) *(feeds,skills)*
+- Async feed poller sends a descriptive default User-Agent. Reddit and other UA-enforcing sources no longer 403. (#443, #445) *(feeds)*
+- Poller dedup is fail-closed; FTS rebuild failures roll back instead of poisoning the index. (#414) *(feeds,store)*
+- Serialize DuckDB connection access with `asyncio.Lock` to eliminate connection-lock races. (#416) *(store)*
+
 ### Changed
 
-- **BREAKING (default behavior):** `claude plugin install distillery` now configures a **local stdio** MCP server (`uvx distillery-mcp`) instead of the hosted demo at `distillery-mcp.fly.dev`. The hosted demo becomes explicit opt-in. (#381) *(skills)*
+- **BREAKING (default behavior):** `claude plugin install distillery` now configures a **local stdio** MCP server (`uvx distillery-mcp`) instead of the hosted demo at `distillery-mcp.fly.dev`. The hosted demo becomes explicit opt-in. (#381, #408) *(skills)*
+- Container image migrated to Chainguard distroless Python. (#419) *(image)*
+- Container image now publishes multi-arch (`linux/amd64` + `linux/arm64`). (#447, #450) *(ci)*
 
 ### Migration
 
@@ -17,6 +28,10 @@ claude mcp add distillery --scope user --transport http --url https://distillery
 ```
 
 The hosted demo is intended for evaluation only — do not store sensitive data on it.
+
+### Bench (internal)
+
+LongMemEval nightly benchmark scaffolding: dataset loader (#436), runner (#439), results aggregator (#441), CLI entrypoint (#440), nightly workflow (#438), MkDocs benchmarks page (#437), variance-gate workflow + `--seed-offset` (#455), nightly workflow timeout/cadence fix (#453). No runtime impact.
 
 ## [0.4.0] - 2026-04-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distillery-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "Persistent shared memory for Claude Code — MCP server with DuckDB vector search, semantic dedup, and ambient intelligence for team knowledge"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.norrietaylor/distillery-mcp",
   "title": "Distillery",
   "description": "Knowledge base for Claude Code with semantic search, feed intelligence, and teams",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "repository": {
     "url": "https://github.com/norrietaylor/distillery",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": {
         "type": "streamable-http",
         "url": "https://distillery-mcp.fly.dev/mcp"

--- a/src/distillery/__init__.py
+++ b/src/distillery/__init__.py
@@ -2,5 +2,5 @@
 
 import os
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __build_sha__ = os.environ.get("DISTILLERY_BUILD_SHA", "dev")


### PR DESCRIPTION
Cuts patch release **v0.4.1** to ship the user-visible fixes stranded on `main` since v0.4.0 (closes #452).

## Why

The MCP server has been running fixes from #443 and #444 for ~2 weeks, but the Claude Code plugin marketplace serves the v0.4.0 SKILL.md, so end users running `/radar` still see backfill items and the poller still 403s on Reddit. Tagging cuts a new release tag, which the plugin cache will pull on next update.

## Scope (patch only)

- #444, #446 — `/radar` bounded by `metadata.published_at`; first-poll backfill excluded by default (`include_evergreen=true` to opt back in)
- #443, #445 — async poller default User-Agent
- #414 — poller dedup fail-closed + FTS rollback on rebuild failure
- #416 — DuckDB connection serialized with `asyncio.Lock`
- #381, #408 — plugin install defaults to local stdio MCP (hosted demo opt-in)
- #419 — Chainguard distroless Python image
- #447, #450 — multi-arch image (`linux/amd64` + `linux/arm64`)
- Bench scaffolding (#436–#441, #455, #453) — internal, no runtime impact

**Not included**: graph PRs (#422–#429). Those land in 0.5.0.

## Bumps

- `pyproject.toml`
- `src/distillery/__init__.py`
- `.claude-plugin/plugin.json` (version + SessionStart echo)
- `.claude-plugin/marketplace.json`
- `server.json` (top-level + both package entries)
- `CHANGELOG.md` ([Unreleased] → [0.4.1])

## Release steps after merge

1. `git tag v0.4.1` on `main`, push
2. `gh release create v0.4.1` — triggers `pypi-publish.yml` and `publish-mcp-registry`

## Acceptance (from #452)

- [x] `.claude-plugin/plugin.json` version bumped to 0.4.1
- [ ] `git tag v0.4.1` on main, push (after merge)
- [ ] GitHub release published with changelog (after merge)
- [ ] Fresh Claude Code install pulls v0.4.1 and `/radar` no longer surfaces backfill (post-release verification)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional opt-in for evergreen backfill mode

* **Bug Fixes**
  * Backfill capping by publication metadata
  * Improved descriptive User-Agent handling
  * Fixed dedup and full-text search behavior
  * DuckDB connection locking improvements

* **Changed**
  * ⚠️ BREAKING: Default deployment now uses local model context protocol server instead of hosted demo.
  * Container image updated to Chainguard distroless Python with multi-architecture support
  * Package and plugin released as version 0.4.1; plugin startup message simplified
<!-- end of auto-generated comment: release notes by coderabbit.ai -->