### PR TITLE
feat(skills): /radar issues all top-5 queries and raises default limit to 35 (#461)

### DIFF
--- a/docs/skills/radar.md
+++ b/docs/skills/radar.md
@@ -5,7 +5,7 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 ## Usage
 
 ```text
-/radar                                  # Default: last 7 days, up to 20 entries
+/radar                                  # Default: last 7 days, up to 35 entries
 /radar --days 3                         # Last 3 days
 /radar --limit 10                       # Limit to 10 entries
 /radar --topic "build hermeticity"      # Use an explicit topic instead of mining tags
@@ -23,7 +23,7 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--days <n>` | Look back period in days (overrides `feeds.digest.window_days`) | `feeds.digest.window_days` (7 if unset) |
-| `--limit <n>` | Maximum entries to include | 20 |
+| `--limit <n>` | Maximum entries to include (overrides `feeds.digest.candidate_limit`) | `feeds.digest.candidate_limit` (35 if unset) |
 | `--topic <query>` | Use the literal string as the semantic-search query instead of mining tags. Repeatable. | Off (auto-mine) |
 | `--suggest` | Include new source suggestions | Off |
 | `--store` | Store the digest as an entry | Off (display-only) |
@@ -75,7 +75,7 @@ Digest stored: m3n4o5p6
 
 1. Determines the query set:
    - If one or more `--topic` flags are supplied, the literal strings become the queries (deduplicated, preserving order).
-   - Otherwise the skill mines curated entries (`session`, `reference`, `bookmark`, `idea`, `note`, `minutes`) for a tag profile, then picks **3 namespace-diverse tags** rather than the raw top-3 by count. A tag's namespace is its hierarchical path with the leaf removed, capped at two segments (e.g., `domain/build/hermeticity` → `domain/build`; `tech/duckdb` → `tech`). One leader per namespace prevents one dominant cluster from crowding out distinct topics.
+   - Otherwise the skill mines curated entries (`session`, `reference`, `bookmark`, `idea`, `note`, `minutes`) for a tag profile, then picks **5 namespace-diverse tags** rather than the raw top-5 by count. A tag's namespace is its hierarchical path with the leaf removed, capped at two segments (e.g., `domain/build/hermeticity` → `domain/build`; `tech/duckdb` → `tech`). One leader per namespace prevents one dominant cluster from crowding out distinct topics.
 2. Runs one `distillery_search` per query against feed entries, deduplicating results by entry ID.
 3. Groups entries by source tag or topic.
 4. Synthesizes 2-4 sentence summaries per group with bullet points.

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -35,7 +35,7 @@ See CONVENTIONS.md — skip if already confirmed this conversation.
 | Flag | Description |
 |------|-------------|
 | `--days N` | Look back N days for recent feed entries (overrides `feeds.digest.window_days`, default 7) |
-| `--limit N` | Maximum number of feed entries to include (default: 20) |
+| `--limit N` | Maximum number of feed entries to include (overrides `feeds.digest.candidate_limit`, default 35) |
 | `--project <name>` | Scope feed entries to a specific project |
 | `--topic <query>` | Use the literal string as a semantic-search query instead of mining tags. Repeatable; each `--topic` is one query. When set, use Path 1 in Step 3a and skip Path 2 (tag mining). |
 | `--suggest` | Include source suggestions at end of digest |
@@ -82,7 +82,7 @@ Build an interest profile that excludes feed-ingested content. Make separate
 types: `session`, `reference`, `bookmark`, `idea`, `note`, and `minutes`.
 Merge the group counts across all responses to obtain a combined count map.
 
-Then select **3 namespace-diverse tags**, *not* the raw top-3 by count. A
+Then select **5 namespace-diverse tags**, *not* the raw top-5 by count. A
 tag's namespace is its hierarchical path with the leaf segment removed,
 capped at two segments (e.g., `domain/build/hermeticity` → namespace
 `domain/build`; `tech/duckdb` → namespace `tech`; single-segment `release`
@@ -93,12 +93,12 @@ namespaces to itself). The selection rule:
    the *namespace leader*.
 3. Rank namespaces by *aggregate population* (sum of counts across all
    tags in the namespace), then by leader count, then alphabetically.
-4. Return the namespace leaders of the top 3 namespaces.
+4. Return the namespace leaders of the top 5 namespaces.
 
-This guarantees the query set spans up to three distinct conceptual
+This guarantees the query set spans up to five distinct conceptual
 clusters. The reference implementation lives in
 `distillery.feeds.radar_selection.select_namespace_diverse_tags` — call it
-mentally as `select_namespace_diverse_tags(merged_counts, top_n=3)`.
+mentally as `select_namespace_diverse_tags(merged_counts, top_n=5)`.
 
 Convert each chosen tag path to a natural-language query by taking the leaf
 segment and replacing hyphens with spaces (e.g.,
@@ -108,13 +108,19 @@ segment and replacing hyphens with spaces (e.g.,
 
 Compute `published_after = (now - <days>).isoformat()` where `<days>` is the
 `--days` flag if provided, otherwise the configured `feeds.digest.window_days`
-(default 7). For each query in the query set from 3a (whether `--topic`-supplied
-or namespace-derived), call:
+(default 7). Resolve `<limit>` from the `--limit` flag if provided, otherwise
+from the configured `feeds.digest.candidate_limit` (default 35). For each
+query in the query set from 3a (whether `--topic`-supplied or
+namespace-derived), call:
 
 `distillery_search(query="<query>", entry_type="feed", limit=<ceil(limit/N)>, published_after=<iso>, include_evergreen=<bool>)`
 
-Where N is the number of queries. Pass `include_evergreen=true` only when the
-user supplied `--include-evergreen`. If `--project` was specified, also pass
+Where N is the number of queries in the set. With the default `<limit>` of 35
+and N=5 (the namespace-diverse default), this yields 5 × ceil(35/5)=7 → 35
+raw → ~30 unique candidates after dedup. If fewer than 5 namespace-diverse
+tags are available, issue one query per tag returned and size each query as
+`ceil(limit/N)` accordingly. Pass `include_evergreen=true` only when the user
+supplied `--include-evergreen`. If `--project` was specified, also pass
 `project=<name>`.
 
 Deduplicate results across queries by entry ID, keeping the highest similarity score.
@@ -254,7 +260,7 @@ Tags: digest, radar, ambient
 
 - NEVER use Bash, Python, or any tool not listed in allowed-tools
 - If an MCP tool call fails, report the error to the user and STOP. Do not attempt workarounds.
-- Default lookback is `feeds.digest.window_days` (7 days); default limit is 20 — respect overrides
+- Default lookback is `feeds.digest.window_days` (7 days); default candidate limit is `feeds.digest.candidate_limit` (35 entries) — respect `--days` and `--limit` overrides
 - Filter on `published_after` (publication time), not `date_from` (ingest time) — older items polled today are not new intelligence
 - First-poll backfill items (`metadata.backfill = true`) are excluded by default; surface them with `--include-evergreen`
 - Group entries by source tag when available; fall back to topic grouping

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -102,24 +102,32 @@ mentally as `select_namespace_diverse_tags(merged_counts, top_n=5)`.
 
 Convert each chosen tag path to a natural-language query by taking the leaf
 segment and replacing hyphens with spaces (e.g.,
-`domain/build/hermeticity` → query `"hermeticity"`).
+`domain/build/hermeticity` → query `"hermeticity"`). De-duplicate the
+normalized query strings (case- and whitespace-insensitive), preserving the
+highest-ranked occurrence; if a collision drops a tag, substitute the
+next-ranked namespace leader from the merged counts so the query set still
+spans up to 5 distinct queries.
 
 **3b. Search by interests (primary path):**
 
 Compute `published_after = (now - <days>).isoformat()` where `<days>` is the
 `--days` flag if provided, otherwise the configured `feeds.digest.window_days`
 (default 7). Resolve `<limit>` from the `--limit` flag if provided, otherwise
-from the configured `feeds.digest.candidate_limit` (default 35). For each
-query in the query set from 3a (whether `--topic`-supplied or
-namespace-derived), call:
+from the configured `feeds.digest.candidate_limit` (default 35). Let
+`Q = min(number_of_distinct_queries_from_3a, 5, <limit>)` — that is, the
+number of queries in the set from Step 3a (whether `--topic`-supplied or
+namespace-derived), capped at 5 and at `<limit>`. Distribute the `<limit>`
+budget exactly so the sum of per-query limits never exceeds `<limit>`: let
+`base = <limit> // Q` and `rem = <limit> % Q`, then assign `base + 1` to the
+first `rem` queries and `base` to the rest (skipping any zero-budget
+queries). For each query, call:
 
-`distillery_search(query="<query>", entry_type="feed", limit=<ceil(limit/N)>, published_after=<iso>, include_evergreen=<bool>)`
+`distillery_search(query="<query>", entry_type="feed", limit=<per-query budget>, published_after=<iso>, include_evergreen=<bool>)`
 
-Where N is the number of queries in the set. With the default `<limit>` of 35
-and N=5 (the namespace-diverse default), this yields 5 × ceil(35/5)=7 → 35
-raw → ~30 unique candidates after dedup. If fewer than 5 namespace-diverse
-tags are available, issue one query per tag returned and size each query as
-`ceil(limit/N)` accordingly. Pass `include_evergreen=true` only when the user
+With the default `<limit>` of 35 and Q=5, this yields 5 queries of 7 results
+each → 35 raw → ~30 unique candidates after dedup. For small limits (e.g.,
+`--limit 3` with 5 queries), Q=3 and only 3 queries are issued so the
+override is honored exactly. Pass `include_evergreen=true` only when the user
 supplied `--include-evergreen`. If `--project` was specified, also pass
 `project=<name>`.
 
@@ -135,7 +143,11 @@ skipped.
 
 If none of the curated-type `group_by="tags"` calls return any tags, fall back to:
 
-`distillery_list(entry_type="feed", limit=<limit>, output_mode="summary", published_after=<iso>, include_evergreen=<bool>)`
+`distillery_list(entry_type="feed", limit=<limit>, output_mode="summary", published_after=<iso>, include_evergreen=<bool>, project=<name?>)`
+
+Apply the same project-scoping rule as Step 3b: only include `project=<name>`
+when `--project` was supplied, so the fallback never synthesizes entries from
+other projects when the user explicitly scoped the request.
 
 Report: `Retrieved <total> entries via recent listing (fallback, window=<days>d).`
 

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -113,14 +113,16 @@ spans up to 5 distinct queries.
 Compute `published_after = (now - <days>).isoformat()` where `<days>` is the
 `--days` flag if provided, otherwise the configured `feeds.digest.window_days`
 (default 7). Resolve `<limit>` from the `--limit` flag if provided, otherwise
-from the configured `feeds.digest.candidate_limit` (default 35). Let
-`Q = min(number_of_distinct_queries_from_3a, 5, <limit>)` — that is, the
-number of queries in the set from Step 3a (whether `--topic`-supplied or
-namespace-derived), capped at 5 and at `<limit>`. Distribute the `<limit>`
-budget exactly so the sum of per-query limits never exceeds `<limit>`: let
-`base = <limit> // Q` and `rem = <limit> % Q`, then assign `base + 1` to the
-first `rem` queries and `base` to the rest (skipping any zero-budget
-queries). For each query, call:
+from the configured `feeds.digest.candidate_limit` (default 35). Compute `Q`
+(the number of queries to issue):
+
+- If explicit `--topic` flags were provided (Path 1): `Q = min(number_of_distinct_explicit_topics, <limit>)` — honor every user-supplied topic up to the limit; do *not* apply the 5-query cap.
+- Otherwise (Path 2, namespace-derived): `Q = min(number_of_distinct_namespace_queries, 5, <limit>)` — namespace-derived queries are capped at 5.
+
+Distribute the `<limit>` budget exactly so the sum of per-query limits never
+exceeds `<limit>`: let `base = <limit> // Q` and `rem = <limit> % Q`, then
+assign `base + 1` to the first `rem` queries and `base` to the rest
+(skipping any zero-budget queries). For each query, call:
 
 `distillery_search(query="<query>", entry_type="feed", limit=<per-query budget>, published_after=<iso>, include_evergreen=<bool>)`
 

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -119,10 +119,13 @@ from the configured `feeds.digest.candidate_limit` (default 35). Compute `Q`
 - If explicit `--topic` flags were provided (Path 1): `Q = min(number_of_distinct_explicit_topics, <limit>)` — honor every user-supplied topic up to the limit; do *not* apply the 5-query cap.
 - Otherwise (Path 2, namespace-derived): `Q = min(number_of_distinct_namespace_queries, 5, <limit>)` — namespace-derived queries are capped at 5.
 
-Distribute the `<limit>` budget exactly so the sum of per-query limits never
-exceeds `<limit>`: let `base = <limit> // Q` and `rem = <limit> % Q`, then
-assign `base + 1` to the first `rem` queries and `base` to the rest
-(skipping any zero-budget queries). For each query, call:
+If `Q == 0` (no queries — e.g. `<limit>` is 0 or both paths produced an
+empty set), short-circuit: skip Step 3b entirely and proceed to Step 3c
+(fallback). Otherwise distribute the `<limit>` budget exactly so the sum
+of per-query limits never exceeds `<limit>`: let `base = <limit> // Q`
+and `rem = <limit> % Q`, then assign `base + 1` to the first `rem`
+queries and `base` to the rest (skipping any zero-budget queries). For
+each query, call:
 
 `distillery_search(query="<query>", entry_type="feed", limit=<per-query budget>, published_after=<iso>, include_evergreen=<bool>)`
 

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -833,19 +833,29 @@ def _parse_feeds(raw: dict[str, Any]) -> FeedsConfig:
     )
 
 
+_CANDIDATE_LIMIT_MAX = 1000
+"""Upper bound for ``feeds.digest.candidate_limit``.
+
+Mirrors the range enforced by the ``distillery_configure`` MCP tool
+(see ``src/distillery/mcp/tools/configure.py``) so the YAML and runtime
+configuration paths accept the same set of values.
+"""
+
+
 def _parse_digest(raw: dict[str, Any]) -> DigestConfig:
     """Parse the ``feeds.digest`` section from a raw YAML mapping.
 
     Args:
         raw: Mapping with optional keys ``window_days`` (positive int,
-            default 7) and ``candidate_limit`` (positive int, default 35).
+            default 7) and ``candidate_limit`` (int in ``[1, 1000]``,
+            default 35).
 
     Returns:
         A populated :class:`DigestConfig` instance.
 
     Raises:
-        ValueError: If ``window_days`` or ``candidate_limit`` is not a
-            positive integer.
+        ValueError: If ``window_days`` is not a positive integer, or
+            ``candidate_limit`` is outside ``[1, 1000]``.
     """
     window_days = _parse_strict_int(raw.get("window_days", 7), "feeds.digest.window_days")
     if window_days <= 0:
@@ -853,9 +863,10 @@ def _parse_digest(raw: dict[str, Any]) -> DigestConfig:
     candidate_limit = _parse_strict_int(
         raw.get("candidate_limit", 35), "feeds.digest.candidate_limit"
     )
-    if candidate_limit <= 0:
+    if candidate_limit <= 0 or candidate_limit > _CANDIDATE_LIMIT_MAX:
         raise ValueError(
-            f"feeds.digest.candidate_limit must be a positive integer, got: {candidate_limit}"
+            "feeds.digest.candidate_limit must be a positive integer in "
+            f"[1, {_CANDIDATE_LIMIT_MAX}], got: {candidate_limit}"
         )
     return DigestConfig(window_days=window_days, candidate_limit=candidate_limit)
 

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -254,9 +254,19 @@ class DigestConfig:
             ``published_after`` / ``include_evergreen`` arguments on
             :func:`distillery_search` and :func:`distillery_list`.
             Default ``7``.
+        candidate_limit: Default maximum number of feed entries the
+            ``/radar`` skill retrieves into its candidate set before
+            synthesis.  The skill issues one semantic-search query per
+            top-5 interest tag and divides this budget evenly across
+            queries (``ceil(candidate_limit / N)`` per query).  Callers
+            can override per-call via the ``--limit`` flag on ``/radar``.
+            Default ``35`` (5 queries × 7 results → ~30 unique after
+            dedup, providing enough breadth to surface rank-4/5 tag
+            namespaces alongside dominant sources).
     """
 
     window_days: int = 7
+    candidate_limit: int = 35
 
 
 @dataclass
@@ -827,18 +837,27 @@ def _parse_digest(raw: dict[str, Any]) -> DigestConfig:
     """Parse the ``feeds.digest`` section from a raw YAML mapping.
 
     Args:
-        raw: Mapping with optional key ``window_days`` (positive int, default 7).
+        raw: Mapping with optional keys ``window_days`` (positive int,
+            default 7) and ``candidate_limit`` (positive int, default 35).
 
     Returns:
         A populated :class:`DigestConfig` instance.
 
     Raises:
-        ValueError: If ``window_days`` is not a positive integer.
+        ValueError: If ``window_days`` or ``candidate_limit`` is not a
+            positive integer.
     """
     window_days = _parse_strict_int(raw.get("window_days", 7), "feeds.digest.window_days")
     if window_days <= 0:
         raise ValueError(f"feeds.digest.window_days must be a positive integer, got: {window_days}")
-    return DigestConfig(window_days=window_days)
+    candidate_limit = _parse_strict_int(
+        raw.get("candidate_limit", 35), "feeds.digest.candidate_limit"
+    )
+    if candidate_limit <= 0:
+        raise ValueError(
+            f"feeds.digest.candidate_limit must be a positive integer, got: {candidate_limit}"
+        )
+    return DigestConfig(window_days=window_days, candidate_limit=candidate_limit)
 
 
 def _parse_reader(raw: dict[str, Any]) -> ReaderConfig:

--- a/src/distillery/mcp/tools/configure.py
+++ b/src/distillery/mcp/tools/configure.py
@@ -92,6 +92,10 @@ _ALLOWED_KEYS: dict[tuple[str, str], dict[str, Any]] = {
         "type": int,
         "range": (1, 3650),
     },
+    ("feeds.digest", "candidate_limit"): {
+        "type": int,
+        "range": (1, 1000),
+    },
 }
 
 

--- a/src/distillery/mcp/tools/configure.py
+++ b/src/distillery/mcp/tools/configure.py
@@ -101,6 +101,11 @@ _ALLOWED_KEYS: dict[tuple[str, str], dict[str, Any]] = {
 
 def _coerce_value(raw_value: str | int | float, target_type: type) -> Any:
     """Coerce *raw_value* to *target_type*, raising ValueError on failure."""
+    # Reject bools for numeric types: bool is a subclass of int in Python so
+    # int(True) == 1 / int(False) == 0 silently coerce, which diverges from
+    # YAML's _parse_strict_int() rejection.  Match that behavior here.
+    if target_type in (int, float) and isinstance(raw_value, bool):
+        raise ValueError(f"Expected {target_type.__name__}, got bool")
     if target_type is float:
         return float(raw_value)
     if target_type is int:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -236,6 +236,27 @@ class TestYAMLLoading:
         assert cfg.defaults.dedup_limit == 3
         assert cfg.defaults.stale_days == 30
 
+    def test_feeds_digest_defaults(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """``feeds.digest`` falls back to defaults (window_days=7, candidate_limit=35)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+        cfg = load_config()
+        assert cfg.feeds.digest.window_days == 7
+        assert cfg.feeds.digest.candidate_limit == 35
+
+    def test_feeds_digest_overrides(self, tmp_path: Path) -> None:
+        """``feeds.digest.window_days`` and ``candidate_limit`` are overridable via YAML."""
+        yaml_content = """\
+            feeds:
+              digest:
+                window_days: 14
+                candidate_limit: 50
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.feeds.digest.window_days == 14
+        assert cfg.feeds.digest.candidate_limit == 50
+
 
 # ---------------------------------------------------------------------------
 # Validation errors
@@ -366,6 +387,16 @@ class TestValidationErrors:
         """
         p = write_yaml(tmp_path, yaml_content)
         with pytest.raises(ValueError):
+            load_config(str(p))
+
+    def test_feeds_digest_candidate_limit_zero_raises_value_error(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            feeds:
+              digest:
+                candidate_limit: 0
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="candidate_limit"):
             load_config(str(p))
 
     def test_explicit_missing_path_raises_file_not_found(self, tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -399,6 +399,19 @@ class TestValidationErrors:
         with pytest.raises(ValueError, match="candidate_limit"):
             load_config(str(p))
 
+    def test_feeds_digest_candidate_limit_non_integer_raises_value_error(
+        self, tmp_path: Path
+    ) -> None:
+        """YAML validation rejects non-integer values (mirrors ``distillery_configure``)."""
+        yaml_content = """\
+            feeds:
+              digest:
+                candidate_limit: 12.5
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="candidate_limit"):
+            load_config(str(p))
+
     def test_feeds_digest_candidate_limit_above_max_raises_value_error(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -399,6 +399,19 @@ class TestValidationErrors:
         with pytest.raises(ValueError, match="candidate_limit"):
             load_config(str(p))
 
+    def test_feeds_digest_candidate_limit_above_max_raises_value_error(
+        self, tmp_path: Path
+    ) -> None:
+        """YAML validation mirrors the ``distillery_configure`` upper bound (1000)."""
+        yaml_content = """\
+            feeds:
+              digest:
+                candidate_limit: 1001
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="candidate_limit"):
+            load_config(str(p))
+
     def test_explicit_missing_path_raises_file_not_found(self, tmp_path: Path) -> None:
         missing = str(tmp_path / "no_such_file.yaml")
         with pytest.raises(FileNotFoundError):

--- a/tests/test_radar_published_at_floor.py
+++ b/tests/test_radar_published_at_floor.py
@@ -432,6 +432,58 @@ class TestConfigureDigestWindowDays:
 
 
 # ---------------------------------------------------------------------------
+# distillery_configure: feeds.digest.candidate_limit knob (Issue #461)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureDigestCandidateLimit:
+    @pytest.mark.asyncio
+    async def test_read_default_value(self) -> None:
+        cfg = _make_configure_cfg()
+        # DigestConfig.candidate_limit defaults to 35.
+        assert cfg.feeds.digest.candidate_limit == 35
+        result = await _handle_configure(cfg, {"section": "feeds.digest", "key": "candidate_limit"})
+        data = json.loads(result[0].text)
+        assert data.get("error") is not True
+        assert data["value"] == 35
+
+    @pytest.mark.asyncio
+    async def test_set_new_value(self) -> None:
+        cfg = _make_configure_cfg()
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds.digest", "key": "candidate_limit", "value": 50},
+        )
+        data = json.loads(result[0].text)
+        assert data.get("error") is not True
+        assert data["changed"] is True
+        assert data["new_value"] == 50
+        assert cfg.feeds.digest.candidate_limit == 50
+
+    @pytest.mark.asyncio
+    async def test_reject_zero(self) -> None:
+        cfg = _make_configure_cfg()
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds.digest", "key": "candidate_limit", "value": 0},
+        )
+        data = json.loads(result[0].text)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
+    @pytest.mark.asyncio
+    async def test_reject_non_integer(self) -> None:
+        cfg = _make_configure_cfg()
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds.digest", "key": "candidate_limit", "value": 12.5},
+        )
+        data = json.loads(result[0].text)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
+
+# ---------------------------------------------------------------------------
 # Integration: skill-shaped /radar candidate-set query
 # ---------------------------------------------------------------------------
 

--- a/tests/test_radar_published_at_floor.py
+++ b/tests/test_radar_published_at_floor.py
@@ -482,6 +482,20 @@ class TestConfigureDigestCandidateLimit:
         assert data["error"] is True
         assert data["code"] == "INVALID_PARAMS"
 
+    @pytest.mark.asyncio
+    async def test_reject_above_upper_bound(self) -> None:
+        """``configure.py`` caps ``candidate_limit`` at 1000 — values above
+        the bound must be rejected with ``INVALID_PARAMS``.
+        """
+        cfg = _make_configure_cfg()
+        result = await _handle_configure(
+            cfg,
+            {"section": "feeds.digest", "key": "candidate_limit", "value": 1001},
+        )
+        data = json.loads(result[0].text)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
 
 # ---------------------------------------------------------------------------
 # Integration: skill-shaped /radar candidate-set query


### PR DESCRIPTION
## Summary

Closes #461.

- **Fix A — Top-5 queries (not top-3):** `skills/radar/SKILL.md` Step 3b now issues **one `distillery_search` per top-5 interest tag** (N=5). Previously the skill computed 5 tags but only used 3 — items in rank-4/5 namespaces never appeared in the candidate set.
- **Fix B — Default candidate set 20 → 35:** With N=5 × ceil(35/5)=7 → 35 raw → ~30 unique after dedup, giving enough breadth to surface rank-4/5 namespaces alongside dominant sources. New `feeds.digest.candidate_limit` config knob (default `35`) sits alongside the existing `feeds.digest.window_days`. `--limit` flag still overrides per call.
- **Config plumbing:** `DigestConfig.candidate_limit` field, `_parse_digest` parses + validates (positive int), `distillery_configure` exposes it via `_ALLOWED_KEYS` with range `[1, 1000]`.
- **Tests:** YAML parsing (default 35, override, zero rejected) and `distillery_configure` (read/set/reject zero/reject non-int) for the new knob. SKILL.md prose updated; `docs/skills/radar.md` reflects new default.

## Test plan

- [x] `_parse_digest` smoke-tested standalone (defaults, overrides, validation rejections)
- [x] `_handle_configure` smoke-tested standalone for read/set/reject zero/reject 12.5
- [x] `ruff check` + `ruff format --check` clean on modified files
- [x] `mypy --strict src/distillery/config.py src/distillery/mcp/tools/configure.py` clean
- [ ] Full `pytest -m unit` (system Python expat is broken in this sandbox; CI will run on clean image)
- [ ] `mkdocs build --strict` (4 unrelated pre-existing warnings about `bench/*.md` links exist on `main` already)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Radar/digest candidate limit now defaults to 35 (was 20), is configurable, and capped at 1000.

* **Documentation**
  * Expanded radar guidance: updated default/--limit wording, extended namespace/query behavior, clarified scheduling/budgeting, fallback and project-scoping semantics, dedup/filtering, and tagging/storage guidance.

* **Tests**
  * Added tests covering defaults, overrides, and validation/error boundaries for the candidate limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->