### PR TITLE
feat(skills): /radar --topic flag and namespace-aware tag selection (#460)

### DIFF
--- a/docs/skills/radar.md
+++ b/docs/skills/radar.md
@@ -12,7 +12,7 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 /radar --topic agentic-eval --days 14   # Topic + custom window
 /radar --topic build --topic wheels     # Multiple topics; one search query each
 /radar --suggest                        # Include source suggestions
-/radar --no-store                       # Don't save the digest
+/radar --store                          # Store the digest as an entry (default: display-only)
 /radar --include-evergreen              # Surface older / first-poll backfill items
 ```
 
@@ -26,7 +26,7 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 | `--limit <n>` | Maximum entries to include | 20 |
 | `--topic <query>` | Use the literal string as the semantic-search query instead of mining tags. Repeatable. | Off (auto-mine) |
 | `--suggest` | Include new source suggestions | Off |
-| `--no-store` | Don't store the digest as an entry | Stores by default |
+| `--store` | Store the digest as an entry | Off (display-only) |
 | `--include-evergreen` | Include items older than the window or flagged as first-poll backfill | Off |
 
 The look-back window is bounded by `metadata.published_at` (the feed item's
@@ -81,11 +81,11 @@ Digest stored: m3n4o5p6
 4. Synthesizes 2-4 sentence summaries per group with bullet points.
 5. Generates a cross-group overall summary.
 6. If `--suggest` is enabled, the feed scorer mines the knowledge base for an interest profile and emits source recommendations inline (the former `distillery_interests` tool was folded into `/radar`'s internal pipeline).
-7. Stores the digest as an entry (type `digest`) unless `--no-store` is specified.
+7. Stores the digest as an entry (type `digest`) only when `--store` is specified.
 
 ## Tips
 
-- The digest is stored by default with tags `digest/radar/ambient` for future retrieval
+- Digests are display-only by default; pass `--store` to persist with tags `digest/radar/ambient` for future retrieval
 - Source suggestions are based on your interest profile (mined from existing entries)
 - Use `/watch add` to subscribe to suggested sources
 - Groups are organized by source when available, falling back to topic clustering

--- a/docs/skills/radar.md
+++ b/docs/skills/radar.md
@@ -5,12 +5,15 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 ## Usage
 
 ```text
-/radar                         # Default: last 7 days, up to 20 entries
-/radar --days 3                # Last 3 days
-/radar --limit 10              # Limit to 10 entries
-/radar --suggest               # Include source suggestions
-/radar --no-store              # Don't save the digest
-/radar --include-evergreen     # Surface older / first-poll backfill items
+/radar                                  # Default: last 7 days, up to 20 entries
+/radar --days 3                         # Last 3 days
+/radar --limit 10                       # Limit to 10 entries
+/radar --topic "build hermeticity"      # Use an explicit topic instead of mining tags
+/radar --topic agentic-eval --days 14   # Topic + custom window
+/radar --topic build --topic wheels     # Multiple topics; one search query each
+/radar --suggest                        # Include source suggestions
+/radar --no-store                       # Don't save the digest
+/radar --include-evergreen              # Surface older / first-poll backfill items
 ```
 
 **Trigger phrases:** "what's new", "show my digest", "ambient digest", "what have I missed", "feed digest"
@@ -21,6 +24,7 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 |--------|-------------|---------|
 | `--days <n>` | Look back period in days (overrides `feeds.digest.window_days`) | `feeds.digest.window_days` (7 if unset) |
 | `--limit <n>` | Maximum entries to include | 20 |
+| `--topic <query>` | Use the literal string as the semantic-search query instead of mining tags. Repeatable. | Off (auto-mine) |
 | `--suggest` | Include new source suggestions | Off |
 | `--no-store` | Don't store the digest as an entry | Stores by default |
 | `--include-evergreen` | Include items older than the window or flagged as first-poll backfill | Off |
@@ -69,12 +73,15 @@ Digest stored: m3n4o5p6
 
 ## How It Works
 
-1. Retrieves recent feed entries from the knowledge base (type `feed`)
-2. Groups entries by source tag or topic
-3. Synthesizes 2-4 sentence summaries per group with bullet points
-4. Generates a cross-group overall summary
-5. If `--suggest` is enabled, the feed scorer mines the knowledge base for an interest profile and emits source recommendations inline (the former `distillery_interests` tool was folded into `/radar`'s internal pipeline)
-6. Stores the digest as an entry (type `digest`) unless `--no-store` is specified
+1. Determines the query set:
+   - If one or more `--topic` flags are supplied, the literal strings become the queries (deduplicated, preserving order).
+   - Otherwise the skill mines curated entries (`session`, `reference`, `bookmark`, `idea`, `note`, `minutes`) for a tag profile, then picks **3 namespace-diverse tags** rather than the raw top-3 by count. A tag's namespace is its hierarchical path with the leaf removed, capped at two segments (e.g., `domain/build/hermeticity` → `domain/build`; `tech/duckdb` → `tech`). One leader per namespace prevents one dominant cluster from crowding out distinct topics.
+2. Runs one `distillery_search` per query against feed entries, deduplicating results by entry ID.
+3. Groups entries by source tag or topic.
+4. Synthesizes 2-4 sentence summaries per group with bullet points.
+5. Generates a cross-group overall summary.
+6. If `--suggest` is enabled, the feed scorer mines the knowledge base for an interest profile and emits source recommendations inline (the former `distillery_interests` tool was folded into `/radar`'s internal pipeline).
+7. Stores the digest as an entry (type `digest`) unless `--no-store` is specified.
 
 ## Tips
 

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -37,9 +37,22 @@ See CONVENTIONS.md — skip if already confirmed this conversation.
 | `--days N` | Look back N days for recent feed entries (overrides `feeds.digest.window_days`, default 7) |
 | `--limit N` | Maximum number of feed entries to include (default: 20) |
 | `--project <name>` | Scope feed entries to a specific project |
+| `--topic <query>` | Use the literal string as a semantic-search query instead of mining tags. Repeatable; each `--topic` is one query. When set, Step 3a is skipped. |
 | `--suggest` | Include source suggestions at end of digest |
 | `--store` | Store digest as a knowledge entry (default: display-only) |
 | `--include-evergreen` | Include older / first-poll backfill items in the candidate set (default: excluded) |
+
+**`--topic` examples:**
+
+```
+/radar --topic "build hermeticity"
+/radar --topic agentic-eval --days 14
+/radar --topic "build hermeticity" --topic "wheels caching"
+```
+
+Multiple `--topic` flags may be passed; each becomes a separate
+`distillery_search` query. Deduplicate the literal query strings (case- and
+whitespace-insensitive) before issuing.
 
 The look-back window is bounded by `metadata.published_at` (the feed item's
 publication timestamp), not `created_at`. Items with no `published_at` are
@@ -51,17 +64,52 @@ backfill batches), in which case they are hidden by default. Pass
 
 Use tag-driven semantic search to surface the most relevant feed entries, not just the newest.
 
-**3a. Get interest profile from curated entries:**
+**3a. Determine the query set:**
 
-Build an interest profile that excludes feed-ingested content. Make separate `distillery_list(group_by="tags", entry_type=<type>)` calls for curated types: `session`, `reference`, `bookmark`, `idea`, `note`, and `minutes`. Merge the group counts across all responses, take the top 5 tags by combined count. Convert tag paths to natural language by taking the leaf segment and replacing hyphens with spaces (e.g., `domain/authentication` → query `"authentication"`).
+Two paths — explicit override or auto-derived from interests.
+
+*Path 1 — `--topic` override (skip tag mining):*
+
+If one or more `--topic <query>` flags were supplied, use the supplied
+strings directly as the query set. Deduplicate (case-insensitive, trim
+whitespace), preserving the user's order. Skip the rest of Step 3a and
+proceed to 3b. Report: `Using <N> user-supplied topic(s): <comma-separated>.`
+
+*Path 2 — Namespace-diverse interest profile (default):*
+
+Build an interest profile that excludes feed-ingested content. Make separate
+`distillery_list(group_by="tags", entry_type=<type>)` calls for curated
+types: `session`, `reference`, `bookmark`, `idea`, `note`, and `minutes`.
+Merge the group counts across all responses to obtain a combined count map.
+
+Then select **3 namespace-diverse tags**, *not* the raw top-3 by count. A
+tag's namespace is its hierarchical path with the leaf segment removed,
+capped at two segments (e.g., `domain/build/hermeticity` → namespace
+`domain/build`; `tech/duckdb` → namespace `tech`; single-segment `release`
+namespaces to itself). The selection rule:
+
+1. Group all tags by namespace.
+2. Pick the highest-count tag in each namespace (alphabetical tie-break) —
+   the *namespace leader*.
+3. Rank namespace leaders by their count and take the top 3 leaders.
+
+This guarantees the query set spans up to three distinct conceptual
+clusters. The reference implementation lives in
+`distillery.feeds.radar_selection.select_namespace_diverse_tags` — call it
+mentally as `select_namespace_diverse_tags(merged_counts, top_n=3)`.
+
+Convert each chosen tag path to a natural-language query by taking the leaf
+segment and replacing hyphens with spaces (e.g.,
+`domain/build/hermeticity` → query `"hermeticity"`).
 
 **3b. Search by interests (primary path):**
 
 Compute `published_after = (now - <days>).isoformat()` where `<days>` is the
 `--days` flag if provided, otherwise the configured `feeds.digest.window_days`
-(default 7). For each of the top interest tags (up to 3 queries), call:
+(default 7). For each query in the query set from 3a (whether `--topic`-supplied
+or namespace-derived), call:
 
-`distillery_search(query="<interest>", entry_type="feed", limit=<ceil(limit/N)>, published_after=<iso>, include_evergreen=<bool>)`
+`distillery_search(query="<query>", entry_type="feed", limit=<ceil(limit/N)>, published_after=<iso>, include_evergreen=<bool>)`
 
 Where N is the number of queries. Pass `include_evergreen=true` only when the
 user supplied `--include-evergreen`. If `--project` was specified, also pass
@@ -72,6 +120,10 @@ Deduplicate results across queries by entry ID, keeping the highest similarity s
 Report: `Retrieved <total> entries via interest-based search (<N> queries, window=<days>d).`
 
 **3c. Fallback (if interest tags unavailable):**
+
+This fallback applies only to Path 2 (auto-derived interest profile). If
+`--topic` was supplied, Step 3b always has at least one query and 3c is
+skipped.
 
 If none of the curated-type `group_by="tags"` calls return any tags, fall back to:
 
@@ -111,7 +163,7 @@ You (the executing Claude instance) produce the synthesis — do not dump raw en
 
 ### Step 5: Suggest Sources
 
-When `--suggest` is specified, use the interest tags identified in Step 3a to suggest new sources. Based on the top interest topics, recommend 3–5 relevant RSS feeds or GitHub repos the user might want to add via `/watch add <url>`. Omit this section silently if Step 3a returned no tags or if `--suggest` was not specified.
+When `--suggest` is specified, use the query set from Step 3a — namespace-diverse interest tags from Path 2, or the user-supplied `--topic` strings from Path 1 — to suggest new sources. Based on those topics, recommend 3–5 relevant RSS feeds or GitHub repos the user might want to add via `/watch add <url>`. Omit this section silently if Step 3a produced no queries or if `--suggest` was not specified.
 
 ### Step 6: Check for Duplicates (if --store specified)
 

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -44,7 +44,7 @@ See CONVENTIONS.md — skip if already confirmed this conversation.
 
 **`--topic` examples:**
 
-```
+```text
 /radar --topic "build hermeticity"
 /radar --topic agentic-eval --days 14
 /radar --topic "build hermeticity" --topic "wheels caching"
@@ -91,7 +91,9 @@ namespaces to itself). The selection rule:
 1. Group all tags by namespace.
 2. Pick the highest-count tag in each namespace (alphabetical tie-break) —
    the *namespace leader*.
-3. Rank namespace leaders by their count and take the top 3 leaders.
+3. Rank namespaces by *aggregate population* (sum of counts across all
+   tags in the namespace), then by leader count, then alphabetically.
+4. Return the namespace leaders of the top 3 namespaces.
 
 This guarantees the query set spans up to three distinct conceptual
 clusters. The reference implementation lives in

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -37,7 +37,7 @@ See CONVENTIONS.md — skip if already confirmed this conversation.
 | `--days N` | Look back N days for recent feed entries (overrides `feeds.digest.window_days`, default 7) |
 | `--limit N` | Maximum number of feed entries to include (default: 20) |
 | `--project <name>` | Scope feed entries to a specific project |
-| `--topic <query>` | Use the literal string as a semantic-search query instead of mining tags. Repeatable; each `--topic` is one query. When set, Step 3a is skipped. |
+| `--topic <query>` | Use the literal string as a semantic-search query instead of mining tags. Repeatable; each `--topic` is one query. When set, use Path 1 in Step 3a and skip Path 2 (tag mining). |
 | `--suggest` | Include source suggestions at end of digest |
 | `--store` | Store digest as a knowledge entry (default: display-only) |
 | `--include-evergreen` | Include older / first-poll backfill items in the candidate set (default: excluded) |

--- a/src/distillery/feeds/radar_selection.py
+++ b/src/distillery/feeds/radar_selection.py
@@ -75,9 +75,12 @@ def select_namespace_diverse_tags(
     1. Group all tags by :func:`tag_namespace`.
     2. For each namespace, pick its highest-count tag (alphabetical
        tie-break) — this is the *namespace leader*.
-    3. Rank namespace leaders by their count (alphabetical tie-break on
-       both leader name and namespace).
-    4. Return up to ``top_n`` namespace leaders.
+    3. Rank namespaces by *aggregate* population (sum of counts across the
+       namespace's tags), then by leader count, then alphabetically.  This
+       matches the issue #460 spec ("most-populated namespaces") and
+       prevents a broadly-populated namespace from losing to one with a
+       single spiky tag.
+    4. Return the namespace leaders of the top ``top_n`` namespaces.
 
     Parameters
     ----------
@@ -102,18 +105,19 @@ def select_namespace_diverse_tags(
             continue
         grouped[tag_namespace(tag)].append((tag, count))
 
-    leaders: list[tuple[str, str, int | float]] = []
+    leaders: list[tuple[str, str, int | float, int | float]] = []
     for ns, members in grouped.items():
         # Highest count first; alphabetical tag name as deterministic tie-break.
         members.sort(key=lambda item: (-item[1], item[0]))
         leader_tag, leader_count = members[0]
-        leaders.append((ns, leader_tag, leader_count))
+        namespace_total = sum(count for _tag, count in members)
+        leaders.append((ns, leader_tag, leader_count, namespace_total))
 
-    # Rank namespaces by their leader's count, then by namespace name, then
-    # by leader tag name — fully deterministic.
-    leaders.sort(key=lambda item: (-item[2], item[0], item[1]))
+    # Rank namespaces by aggregate population first, then leader count, then
+    # deterministic alphabetical tie-breaks (namespace name, then leader tag).
+    leaders.sort(key=lambda item: (-item[3], -item[2], item[0], item[1]))
 
-    return [tag for _ns, tag, _count in leaders[:top_n]]
+    return [tag for _ns, tag, _leader_count, _ns_total in leaders[:top_n]]
 
 
 __all__ = ["select_namespace_diverse_tags", "tag_namespace"]

--- a/src/distillery/feeds/radar_selection.py
+++ b/src/distillery/feeds/radar_selection.py
@@ -1,0 +1,119 @@
+"""Tag selection helpers for the ``/radar`` skill.
+
+The ``/radar`` skill builds an interest profile from curated entries and uses
+the top tags as semantic-search seeds against feed entries.  Issue #460
+documented that the original "top-N by combined count" rule consistently
+collapsed to the same dominant tags — distinct conceptual clusters ranked
+below position three were never seeded, no matter how heavily they appeared
+in the knowledge base.
+
+This module provides :func:`select_namespace_diverse_tags`, which picks the
+top tag from each of the most-populated tag *namespaces* before taking the
+overall top-N.  Tag namespaces are derived from the second segment of a
+hierarchical tag path (``domain/build/hermeticity`` → namespace
+``domain/build``).  Single-segment tags (``release``, ``feed``) namespace to
+themselves.
+
+The function is deterministic given a count map: ties on count are broken
+alphabetically, both within namespaces (which tag wins the namespace) and
+across namespaces (which namespace wins a slot).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping
+
+
+def tag_namespace(tag: str) -> str:
+    """Return the namespace portion of a hierarchical tag path.
+
+    The namespace is *everything except the leaf segment*, capped at the
+    first two segments.  That keeps the partition aligned with how
+    Distillery's curated tags fan out:
+
+    - ``domain/agents/eval`` → ``domain/agents`` (the ``domain/`` prefix is
+      too coarse on its own — different sub-domains are different topics)
+    - ``domain/build/hermeticity`` → ``domain/build``
+    - ``tech/duckdb`` → ``tech`` (only one prefix segment present, so all
+      ``tech/*`` tags share a single namespace)
+    - ``release`` → ``release`` (single-segment tags namespace to
+      themselves so they still compete for a slot)
+    - ``a/b/c/d`` → ``a/b`` (cap at two segments)
+
+    Examples
+    --------
+    >>> tag_namespace("domain/build/hermeticity")
+    'domain/build'
+    >>> tag_namespace("tech/duckdb")
+    'tech'
+    >>> tag_namespace("release")
+    'release'
+    """
+    if not tag:
+        return tag
+    parts = tag.split("/")
+    if len(parts) == 1:
+        return parts[0]
+    if len(parts) == 2:
+        # ``prefix/leaf`` — namespace is the prefix.
+        return parts[0]
+    # Three or more segments: namespace is the first two; everything from
+    # the third segment onward is treated as leaf detail.
+    return f"{parts[0]}/{parts[1]}"
+
+
+def select_namespace_diverse_tags(
+    tag_counts: Mapping[str, int | float],
+    *,
+    top_n: int = 3,
+) -> list[str]:
+    """Select up to ``top_n`` tags drawn from distinct namespaces.
+
+    The selection rule:
+
+    1. Group all tags by :func:`tag_namespace`.
+    2. For each namespace, pick its highest-count tag (alphabetical
+       tie-break) — this is the *namespace leader*.
+    3. Rank namespace leaders by their count (alphabetical tie-break on
+       both leader name and namespace).
+    4. Return up to ``top_n`` namespace leaders.
+
+    Parameters
+    ----------
+    tag_counts:
+        Mapping of fully-qualified tag path to occurrence count (or any
+        comparable numeric weight).
+    top_n:
+        Maximum number of namespace leaders to return.  Default ``3``.
+
+    Returns
+    -------
+    list[str]
+        Tag paths in descending namespace-rank order.  Empty if
+        ``tag_counts`` is empty or ``top_n <= 0``.
+    """
+    if top_n <= 0 or not tag_counts:
+        return []
+
+    grouped: dict[str, list[tuple[str, int | float]]] = defaultdict(list)
+    for tag, count in tag_counts.items():
+        if not tag:
+            continue
+        grouped[tag_namespace(tag)].append((tag, count))
+
+    leaders: list[tuple[str, str, int | float]] = []
+    for ns, members in grouped.items():
+        # Highest count first; alphabetical tag name as deterministic tie-break.
+        members.sort(key=lambda item: (-item[1], item[0]))
+        leader_tag, leader_count = members[0]
+        leaders.append((ns, leader_tag, leader_count))
+
+    # Rank namespaces by their leader's count, then by namespace name, then
+    # by leader tag name — fully deterministic.
+    leaders.sort(key=lambda item: (-item[2], item[0], item[1]))
+
+    return [tag for _ns, tag, _count in leaders[:top_n]]
+
+
+__all__ = ["select_namespace_diverse_tags", "tag_namespace"]

--- a/tests/test_radar_selection.py
+++ b/tests/test_radar_selection.py
@@ -1,0 +1,151 @@
+"""Tests for :mod:`distillery.feeds.radar_selection`.
+
+Exercises the namespace-aware tag picker the ``/radar`` skill uses to seed
+its interest-driven feed search.  Issue #460: the previous top-N-by-count
+rule always crowded out lower-ranked but conceptually-distinct tag clusters.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.feeds.radar_selection import (
+    select_namespace_diverse_tags,
+    tag_namespace,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestTagNamespace:
+    def test_two_segment_tag_uses_first_segment(self) -> None:
+        # ``tech/duckdb`` is prefix + leaf; the namespace is just ``tech``.
+        assert tag_namespace("tech/duckdb") == "tech"
+
+    def test_three_segment_tag_truncates_to_first_two_segments(self) -> None:
+        assert tag_namespace("domain/build/hermeticity") == "domain/build"
+
+    def test_four_segment_tag_caps_at_two_segments(self) -> None:
+        assert tag_namespace("a/b/c/d") == "a/b"
+
+    def test_single_segment_tag_namespaces_to_itself(self) -> None:
+        assert tag_namespace("release") == "release"
+
+    def test_empty_tag_returns_empty(self) -> None:
+        assert tag_namespace("") == ""
+
+
+class TestSelectNamespaceDiverseTags:
+    def test_returns_empty_for_empty_counts(self) -> None:
+        assert select_namespace_diverse_tags({}, top_n=3) == []
+
+    def test_returns_empty_for_zero_top_n(self) -> None:
+        assert select_namespace_diverse_tags({"foo/bar": 5}, top_n=0) == []
+
+    def test_picks_highest_count_within_namespace(self) -> None:
+        counts = {
+            "domain/build/hermeticity": 4,
+            "domain/build/cache": 7,
+            "domain/build/wheels": 2,
+        }
+        # Only one namespace, so we get exactly one leader.
+        assert select_namespace_diverse_tags(counts, top_n=3) == ["domain/build/cache"]
+
+    def test_diversifies_across_namespaces(self) -> None:
+        counts = {
+            # domain/agents namespace dominates by total count, but other
+            # namespaces still earn a slot under the new rule.
+            "domain/agents/eval": 30,
+            "domain/agents/orchestration": 25,
+            "domain/agents/memory": 20,
+            "tech/duckdb": 12,
+            "tech/jina": 8,
+            "domain/build/hermeticity": 6,
+        }
+        result = select_namespace_diverse_tags(counts, top_n=3)
+        assert result == [
+            "domain/agents/eval",
+            "tech/duckdb",
+            "domain/build/hermeticity",
+        ]
+        # Sanity: each chosen tag belongs to a distinct namespace.
+        assert len({tag_namespace(t) for t in result}) == 3
+
+    def test_acceptance_low_rank_namespace_still_wins_slot(self) -> None:
+        """Issue #460 acceptance: a rank-<=5 tag in domain/build/* must
+        appear in the default selection even though several higher-count
+        tags share another namespace.
+        """
+        counts = {
+            # Top-3 by raw count are all domain/agents/* — under the old
+            # rule, domain/build/* tags (rank 4-5 by raw count) never got a
+            # query slot.
+            "domain/agents/eval": 30,
+            "domain/agents/orchestration": 25,
+            "domain/agents/memory": 20,
+            "domain/build/hermeticity": 8,  # rank 4 by raw count
+            "tech/duckdb": 6,  # rank 5 by raw count
+            "domain/agents/tools": 5,
+        }
+        result = select_namespace_diverse_tags(counts, top_n=3)
+        # At least one selected tag must come from domain/build/*.
+        assert any(tag_namespace(t) == "domain/build" for t in result), result
+        # And the namespaces must be distinct.
+        assert len({tag_namespace(t) for t in result}) == 3
+
+    def test_top_n_caps_returned_count(self) -> None:
+        counts = {
+            "domain/agents/eval": 10,
+            "domain/build/hermeticity": 9,
+            "tech/duckdb": 8,
+            "source/github": 7,
+        }
+        result = select_namespace_diverse_tags(counts, top_n=2)
+        assert len(result) == 2
+        assert result[0] == "domain/agents/eval"
+
+    def test_alphabetical_tiebreak_within_namespace(self) -> None:
+        counts = {
+            "domain/build/cache": 5,
+            "domain/build/wheels": 5,
+        }
+        # Same count → alphabetical tag name wins.
+        assert select_namespace_diverse_tags(counts, top_n=1) == ["domain/build/cache"]
+
+    def test_alphabetical_tiebreak_across_namespaces(self) -> None:
+        counts = {
+            "tech/duckdb": 10,
+            "domain/agents/eval": 10,
+        }
+        result = select_namespace_diverse_tags(counts, top_n=2)
+        # Both leaders have the same count.  Namespace-name alphabetical
+        # tie-break: "domain/agents" < "tech".
+        assert result == ["domain/agents/eval", "tech/duckdb"]
+
+    def test_single_segment_tags_namespace_independently(self) -> None:
+        counts = {
+            "release": 6,
+            "feed": 4,
+            "domain/agents/eval": 5,
+        }
+        result = select_namespace_diverse_tags(counts, top_n=3)
+        # Three distinct namespaces: "release", "domain/agents", "feed".
+        assert set(result) == {"release", "domain/agents/eval", "feed"}
+
+    def test_float_counts_supported(self) -> None:
+        counts: dict[str, int | float] = {
+            "domain/agents/eval": 0.92,
+            "domain/build/hermeticity": 0.87,
+            "tech/duckdb": 0.81,
+        }
+        result = select_namespace_diverse_tags(counts, top_n=3)
+        assert result == [
+            "domain/agents/eval",
+            "domain/build/hermeticity",
+            "tech/duckdb",
+        ]
+
+    def test_skips_empty_tag_strings(self) -> None:
+        counts = {"": 100, "domain/agents/eval": 5}
+        result = select_namespace_diverse_tags(counts, top_n=3)
+        assert result == ["domain/agents/eval"]

--- a/tests/test_radar_selection.py
+++ b/tests/test_radar_selection.py
@@ -145,6 +145,34 @@ class TestSelectNamespaceDiverseTags:
             "tech/duckdb",
         ]
 
+    def test_namespace_aggregate_outranks_spiky_leader(self) -> None:
+        """A broadly-populated namespace must outrank a namespace whose
+        single spiky tag has a higher individual count.  This is the
+        spec interpretation of "most-populated namespaces" from #460
+        and prevents thin namespaces from monopolizing query slots.
+        """
+        counts = {
+            # tech namespace: one spiky tag.
+            "tech/rust": 20,
+            # domain/build namespace: many smaller tags, aggregate dominates.
+            "domain/build/hermeticity": 9,
+            "domain/build/cache": 8,
+            "domain/build/wheels": 7,
+            "domain/build/reproducibility": 6,
+            # domain/agents namespace: medium aggregate.
+            "domain/agents/eval": 12,
+            "domain/agents/orchestration": 5,
+        }
+        result = select_namespace_diverse_tags(counts, top_n=3)
+        # Aggregate ranking: domain/build (30) > domain/agents (17) > tech (20).
+        # Wait: tech is 20, domain/agents is 17 — so order is
+        # domain/build (30), tech (20), domain/agents (17).
+        assert result == [
+            "domain/build/hermeticity",
+            "tech/rust",
+            "domain/agents/eval",
+        ]
+
     def test_skips_empty_tag_strings(self) -> None:
         counts = {"": 100, "domain/agents/eval": 5}
         result = select_namespace_diverse_tags(counts, top_n=3)


### PR DESCRIPTION
## Summary

Closes #460. Two fixes for `/radar` interest selection so that diverse conceptual clusters are not crowded out by one dominant tag group:

- **A. `--topic <query>` flag (repeatable).** When set, skips tag mining entirely and uses the literal string(s) as `distillery_search` queries. Examples:
  ```
  /radar --topic "build hermeticity"
  /radar --topic agentic-eval --days 14
  /radar --topic "build hermeticity" --topic "wheels caching"
  ```
- **B. Namespace-aware default selection.** Default behaviour now picks the top tag from each of the 3 most-populated namespaces (one leader per namespace) instead of the raw top-3 by count. A tag's namespace is its hierarchical path with the leaf segment removed, capped at two segments (`domain/build/hermeticity` → `domain/build`; `tech/duckdb` → `tech`; single-segment `release` namespaces to itself).

The selection logic lives in a new `distillery.feeds.radar_selection.select_namespace_diverse_tags` helper so it can be unit-tested deterministically. `skills/radar/SKILL.md` and `docs/skills/radar.md` are updated with both behaviours and examples.

## Files changed

- `skills/radar/SKILL.md` — `--topic` row in the flag table; Step 3a split into Path 1 (override) and Path 2 (namespace-diverse mining); Step 3c clarified to apply only to Path 2; Step 5 updated to use the unified query set.
- `docs/skills/radar.md` — `--topic` documented; "How It Works" rewritten to describe namespace selection.
- `src/distillery/feeds/radar_selection.py` (new) — `tag_namespace`, `select_namespace_diverse_tags`.
- `tests/test_radar_selection.py` (new) — 16 unit tests including the issue #460 acceptance test where a rank-<=5 `domain/build/*` tag must still earn a slot.

## Test plan

- [x] `pytest -m unit` — 1857 passed, 3 skipped
- [x] `ruff check src/ tests/` — passes; new files also format-clean
- [x] `mypy --strict src/distillery/` — 67 source files clean
- [x] `mkdocs build --strict` — only pre-existing `benchmarks.md` warnings (unchanged on `main`)
- [ ] Manual: invoke `/radar --topic build` and confirm a single search query is issued from the literal string

## Acceptance criteria mapping

- `--topic <query>` flag accepted; can be passed multiple times — Step 2 table + Path 1 in Step 3a.
- When `--topic` is set, skip tag profile derivation; use provided string(s) directly — Path 1 explicitly says "Skip the rest of Step 3a".
- Default behaviour selects top 3 namespace-distinct tags rather than top 3 raw — Path 2 + reference helper.
- SKILL.md documents both behaviours with examples — Step 2 examples block + Step 3a Path 1/Path 2.
- Test: fixture KB where `domain/build/*` has a rank-≤5 tag → default selection includes it — `test_acceptance_low_rank_namespace_still_wins_slot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Radar docs and in-skill guide with new --topic usage examples, revised step-by-step workflow, and clarified digest storage behavior (digests display-only unless persisted with --store).

* **New Features**
  * Added CLI options: --topic, --suggest, --store, --include-evergreen; improved query-selection flow with explicit topic overrides and namespace-diverse tag selection (deterministic tie-breaking).

* **Tests**
  * Added tests covering tag namespace handling and diverse-selection behaviors, edge cases, and ranking rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->