### PR TITLE
feat(bench): +graph regression cell (Cell A); defer value-add to fit-for-purpose eval

### DIFF
--- a/.github/workflows/bench-graph-regression-cell.yml
+++ b/.github/workflows/bench-graph-regression-cell.yml
@@ -1,7 +1,7 @@
 # Issue #458 — Cell A: graph-enabled regression gate.
 #
 # Runs the same headline cell config as bench-variance-gate.yml
-# (hybrid / session / recency-on / bge-small, full 500q × 5 seeds) with
+# (hybrid / session / recency-on / bge-small, 500q × 5 seeds) with
 # the retrieval-time graph expansion flag enabled (``--expand-graph``).
 # The point of this cell is to catch *regressions* on the graph-enabled
 # retrieval path — it is NOT a value-add measurement (LongMemEval is
@@ -9,14 +9,27 @@
 # hypothesis; see ``bench/LIMITATIONS.md`` §(f) and the Cell B deferral
 # in ``docs/benchmarks.md``).
 #
-# Pass criterion: Cell A's mean R@5 must be within
-# ``GRAPH_REGRESSION_DELTA_PP`` (default 0.5pp) of the committed
+# Status (until graph PRs land). PRs #422–#429 are still open at the
+# time this workflow ships. Until they merge, ``--expand-graph`` is
+# metadata and output-routing only in the LongMemEval runner — the flag
+# records the ``expand_graph`` axis on every receipt and routes outputs
+# into a separate subdirectory, but the underlying retrieval call site
+# is unchanged. Cell A is therefore forward-compatible scaffolding for
+# the regression gate, not yet an active measurement of the graph-
+# enabled path. The gate becomes live as soon as the graph PRs merge
+# (no further workflow changes needed).
+#
+# Pass criterion (when sample sizes match): Cell A's mean R@5 must be
+# within ``DELTA_THRESHOLD_PP`` (default 0.5pp) of the committed
 # HEADLINE mean (``bench/results/variance_baseline.json``). A larger
 # negative delta indicates that the graph-enabled path silently
 # regressed the baseline; a positive delta is *not* a value-add claim
 # (graph value-add is deferred to a fit-for-purpose eval — multi-hop
 # QA, synthetic team-knowledge eval, /investigate /pour synthesis eval
-# — never to LongMemEval).
+# — never to LongMemEval). The gate is skipped (with a workflow
+# warning) when the Cell A run's ``n_questions`` does not match the
+# baseline's ``questions`` field — a 100q nightly cannot meaningfully
+# trip a 500q-calibrated regression gate.
 #
 # Filing: outputs land under ``bench/results/graph_regression_cell_a/``
 # (per-seed receipts) and ``bench/results/graph_regression_cell_a.json``
@@ -338,12 +351,27 @@ jobs:
           # (e.g. variance gate hasn't been run yet on this branch) we
           # emit the Cell A mean alone and skip the gate — but log a
           # warning so CI surfaces the gap.
+          #
+          # Sample-size guard (CR feedback on PR #464): the baseline is
+          # produced by bench-variance-gate.yml at the full 500-question
+          # set, but this Cell A workflow runs 100q on schedule and full-
+          # 500q only on workflow_dispatch. Comparing a 100q mean against
+          # a 500q baseline mean is statistically meaningless even when
+          # both are bench means — the noise band scales with √n and the
+          # variance-gate threshold was characterised at n=500. Refuse to
+          # compute the gate when sample sizes diverge so a noisier
+          # 100-question run cannot trip a regression gate calibrated
+          # against a less-noisy 500-question baseline (or vice versa).
           headline_mean = None
+          headline_questions = None
           headline_path = Path("bench/results/variance_baseline.json")
           if headline_path.exists():
               with headline_path.open() as f:
                   headline_payload = json.load(f)
               headline_mean = headline_payload.get("mean")
+              # variance_baseline.json carries the sample size as
+              # ``"questions"`` (see bench-variance-gate.yml line ~310).
+              headline_questions = headline_payload.get("questions")
           else:
               print(
                   f"::warning::HEADLINE baseline {headline_path} not found; "
@@ -365,13 +393,58 @@ jobs:
 
           delta = None
           gate_pass = None
+          sample_size_match = None
           if headline_mean is not None:
-              delta = mean_r5 - float(headline_mean)
-              # Cell A is a regression gate, not a value-add eval. Only a
-              # *negative* drift larger than the threshold trips the gate
-              # — a positive delta is permitted but explicitly NOT
-              # claimed as a value-add (see bench/LIMITATIONS.md §(f)).
-              gate_pass = delta >= -delta_threshold
+              # CR feedback (#464): the regression gate is statistically
+              # meaningful only when Cell A and the HEADLINE baseline are
+              # measured at the same sample size. The noise band scales
+              # with sqrt(n) and the variance-gate threshold (default
+              # 0.5pp) was calibrated against the full 500-question set.
+              # When the sizes diverge — e.g. nightly 100q vs baseline
+              # 500q — we still emit the Cell A mean and a transparent
+              # aggregate (so trending data is preserved), but skip the
+              # gate computation and surface a workflow warning. The
+              # gate IS evaluated (fail-closed) when the sizes match.
+              if headline_questions is None:
+                  print(
+                      f"::warning::HEADLINE baseline {headline_path} is missing "
+                      "the 'questions' field; cannot validate sample-size match. "
+                      "Cell A aggregate emitted without a delta or gate. "
+                      "Re-run bench-variance-gate.yml so the baseline carries "
+                      "its sample size."
+                  )
+              else:
+                  try:
+                      headline_questions_int = int(headline_questions)
+                  except (TypeError, ValueError) as exc:
+                      print(
+                          f"::error::HEADLINE baseline 'questions'={headline_questions!r} "
+                          f"is not an integer: {exc}",
+                          file=sys.stderr,
+                      )
+                      sys.exit(1)
+                  sample_size_match = headline_questions_int == n_questions
+                  if not sample_size_match:
+                      # Trend data (mean_r5) is still useful for spotting
+                      # drift over time; skip the gate but don't fail the
+                      # workflow — a noisier 100q nightly should not
+                      # silently trip a 500q-calibrated regression gate
+                      # (or vice versa).
+                      print(
+                          f"::warning::Cell A sample size ({n_questions} questions) does "
+                          f"not match HEADLINE baseline sample size ({headline_questions_int} "
+                          "questions); regression gate skipped. Cell A aggregate "
+                          "still includes mean_r5 for trending; dispatch this "
+                          "workflow with an empty 'limit' input (full 500q) for a "
+                          "gate-relevant comparison."
+                      )
+                  else:
+                      delta = mean_r5 - float(headline_mean)
+                      # Cell A is a regression gate, not a value-add eval. Only a
+                      # *negative* drift larger than the threshold trips the gate
+                      # — a positive delta is permitted but explicitly NOT
+                      # claimed as a value-add (see bench/LIMITATIONS.md §(f)).
+                      gate_pass = delta >= -delta_threshold
 
           aggregate = {
               "cell": "graph_regression_cell_a",
@@ -391,6 +464,8 @@ jobs:
               "min_r5": min(r5_values),
               "max_r5": max(r5_values),
               "headline_mean_r5": headline_mean,
+              "headline_questions": headline_questions,
+              "sample_size_match": sample_size_match,
               "delta_r5_pp": delta * 100.0 if delta is not None else None,
               "delta_threshold_pp": delta_threshold_pp,
               "gate_pass": gate_pass,

--- a/.github/workflows/bench-graph-regression-cell.yml
+++ b/.github/workflows/bench-graph-regression-cell.yml
@@ -1,0 +1,478 @@
+# Issue #458 — Cell A: graph-enabled regression gate.
+#
+# Runs the same headline cell config as bench-variance-gate.yml
+# (hybrid / session / recency-on / bge-small, full 500q × 5 seeds) with
+# the retrieval-time graph expansion flag enabled (``--expand-graph``).
+# The point of this cell is to catch *regressions* on the graph-enabled
+# retrieval path — it is NOT a value-add measurement (LongMemEval is
+# single-user / single-session and does not exercise the graph
+# hypothesis; see ``bench/LIMITATIONS.md`` §(f) and the Cell B deferral
+# in ``docs/benchmarks.md``).
+#
+# Pass criterion: Cell A's mean R@5 must be within
+# ``GRAPH_REGRESSION_DELTA_PP`` (default 0.5pp) of the committed
+# HEADLINE mean (``bench/results/variance_baseline.json``). A larger
+# negative delta indicates that the graph-enabled path silently
+# regressed the baseline; a positive delta is *not* a value-add claim
+# (graph value-add is deferred to a fit-for-purpose eval — multi-hop
+# QA, synthetic team-knowledge eval, /investigate /pour synthesis eval
+# — never to LongMemEval).
+#
+# Filing: outputs land under ``bench/results/graph_regression_cell_a/``
+# (per-seed receipts) and ``bench/results/graph_regression_cell_a.json``
+# (aggregated mean + delta). The default-off behaviour of graph
+# features is unchanged; the public HEADLINE remains the existing
+# ``bench/results/variance_baseline.json`` cell.
+#
+# Trigger: workflow_dispatch + nightly schedule (06:00 UTC, sequenced
+# AFTER bench-longmemeval.yml at 05:00 UTC so the two never compete
+# for runner capacity).
+#
+# Path-restriction: ``verify-paths`` allow-lists exactly the Cell A
+# directory and aggregate file. Anything outside fails the build before
+# the auto-PR is opened. GitHub does not support path-scoped tokens; the
+# manual verification step is the path discipline.
+
+name: Bench — Graph Regression (Cell A)
+
+on:
+  schedule:
+    # 06:00 UTC nightly — sequenced after bench-longmemeval.yml (05:00
+    # UTC) so the two nightly bench jobs never overlap on the runner
+    # pool.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Per-cell question limit (empty = full 500-question set)"
+        required: false
+        type: string
+        default: ""
+      delta_threshold_pp:
+        description: "Max allowed mean R@5 regression vs HEADLINE (in pp; default 0.5)"
+        required: false
+        type: string
+        default: "0.5"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Cell A is intentionally serialized — two simultaneous attempts would
+# race on the same auto-PR branch and waste runner minutes.
+concurrency:
+  group: bench-graph-regression-cell
+  cancel-in-progress: false
+
+jobs:
+  bench-cell-a:
+    name: cell-a (seed-offset ${{ matrix.seed }})
+    runs-on: ubuntu-latest
+    # Full 500q runs take ~1-1.5 hrs/cell post-VSS-preinstall; 4 hr
+    # ceiling matches bench-variance-gate.yml for the same shape of
+    # work and gives headroom for first-run cache misses.
+    timeout-minutes: 240
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Same 5 seed offsets as bench-variance-gate.yml so Cell A's
+        # mean is computed from the same shape of measurement as
+        # HEADLINE's mean — the delta is meaningful only when the two
+        # samples are constructed identically.
+        seed: [0, 1, 2, 3, 4]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,fastembed]"
+
+      - name: Get DuckDB version
+        id: get-duckdb-version
+        run: |
+          python -c "import duckdb; print(f'duckdb_version={duckdb.__version__}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache DuckDB VSS extension
+        uses: actions/cache@v4
+        with:
+          path: ~/.duckdb/extensions
+          key: duckdb-vss-${{ steps.get-duckdb-version.outputs.duckdb_version }}-${{ runner.os }}-${{ runner.arch }}-v1
+
+      - name: Pre-install DuckDB VSS extension
+        run: |
+          python - <<'PY'
+          import duckdb
+          con = duckdb.connect(':memory:')
+          con.execute("INSTALL vss")
+          con.execute("LOAD vss")
+          row = con.execute(
+              "SELECT installed, loaded FROM duckdb_extensions() "
+              "WHERE extension_name = 'vss'"
+          ).fetchone()
+          print(f"VSS extension state: installed={row[0]} loaded={row[1]}")
+          assert row[0] and row[1], "VSS extension failed to install/load"
+          PY
+
+      - name: Cache fastembed model weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/fastembed
+          key: fastembed-${{ runner.os }}-bge-small-v1
+          restore-keys: |
+            fastembed-${{ runner.os }}-bge-small-
+
+      - name: Cache HuggingFace dataset
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-longmemeval-98d7416c24c778c2fee6e6f3006e7a073259d48f-v1
+          restore-keys: |
+            hf-longmemeval-98d7416c24c778c2fee6e6f3006e7a073259d48f-
+
+      - name: Run bench (Cell A — graph-enabled, full 500q, seed-offset ${{ matrix.seed }})
+        env:
+          DISTILLERY_BENCH_GIT_SHA: ${{ github.sha }}
+          # Nightly schedule samples 100 questions per cell to stay inside the
+          # nightly cost envelope; workflow_dispatch honours inputs.limit.
+          # The 5-seed mean / delta computation is still meaningful at 100q —
+          # the noise band scales with √n_questions but the regression gate
+          # tolerance is set against HEADLINE's own variance which is sampled
+          # at the same n.
+          LIMIT: ${{ inputs.limit || (github.event_name == 'schedule' && '100' || '') }}
+        run: |
+          # CLI presence guard: ``--expand-graph`` was added by issue #458
+          # alongside this workflow. If a future revert silently strips the
+          # flag we want to skip cleanly rather than poison the auto-PR; the
+          # aggregate step will then complain that no Cell A summary exists.
+          if ! distillery bench longmemeval --help 2>&1 | grep -q -- '--expand-graph'; then
+            echo "::warning::distillery bench longmemeval --expand-graph not present on this revision; skipping Cell A."
+            exit 0
+          fi
+          LIMIT_ARGS=()
+          if [ -n "${LIMIT:-}" ]; then
+            LIMIT_ARGS=(--limit "${LIMIT}")
+          fi
+          distillery bench longmemeval \
+            --retrieval hybrid \
+            --granularity session \
+            --recency on \
+            --embed-model bge-small \
+            --seeds 1 \
+            --seed-offset ${{ matrix.seed }} \
+            --expand-graph \
+            "${LIMIT_ARGS[@]}"
+
+      - name: Upload Cell A seed artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cell-a-seed-${{ matrix.seed }}
+          path: bench/results/graph_regression_cell_a/**
+          retention-days: 90
+          if-no-files-found: warn
+
+  aggregate-cell-a:
+    name: Aggregate Cell A + delta vs HEADLINE
+    needs: [bench-cell-a]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ !cancelled() && needs.bench-cell-a.result == 'success' }}
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download all Cell A artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Compute Cell A mean + delta vs HEADLINE
+        env:
+          # Default 0.5pp matches the variance-gate threshold from
+          # bench-variance-gate.yml; the graph-enabled path is permitted
+          # to drift up to one variance-gate band before the gate fails.
+          DELTA_THRESHOLD_PP: ${{ inputs.delta_threshold_pp || '0.5' }}
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import math
+          import os
+          import statistics
+          import sys
+          from pathlib import Path
+
+          # Cell A artifacts land at
+          # ``artifacts/cell-a-seed-<N>/summary_longmemeval_*.json``
+          # because the runner writes Cell A summaries inside a
+          # ``graph_regression_cell_a/`` subdirectory of bench/results/
+          # (see ``_write_outputs`` in
+          # ``src/distillery/eval/longmemeval.py``).
+          REQUIRED_OVERALL_KEYS = ("recall_at_5", "recall_at_10", "ndcg_at_10")
+
+          summaries = []
+          paths = sorted(
+              glob.glob("artifacts/cell-a-seed-*/summary_longmemeval_*.json")
+          )
+          for path in paths:
+              with open(path) as f:
+                  payload = json.load(f)
+              axes = payload.get("axes", {}) or {}
+              if not axes.get("expand_graph"):
+                  print(
+                      f"::error::Cell A summary {path} has axes.expand_graph={axes.get('expand_graph')!r}; "
+                      "expected True. Refusing to aggregate — a non-graph receipt was uploaded into the Cell A artifact path.",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              seed_offset = axes.get("seed_offset")
+              if seed_offset is None:
+                  print(
+                      f"::error::Cell A summary {path} missing axes.seed_offset; "
+                      "cannot group seed runs.",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              overall = payload.get("overall")
+              if not isinstance(overall, dict) or not overall:
+                  print(
+                      f"::error::Cell A summary {path} missing or empty 'overall' block.",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              missing = [k for k in REQUIRED_OVERALL_KEYS if k not in overall]
+              if missing:
+                  print(
+                      f"::error::Cell A summary {path} 'overall' missing keys: {missing}",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              if "n_questions" not in payload:
+                  print(
+                      f"::error::Cell A summary {path} missing top-level 'n_questions'.",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              try:
+                  r5 = float(overall["recall_at_5"])
+                  r10 = float(overall["recall_at_10"])
+                  ndcg10 = float(overall["ndcg_at_10"])
+                  n_questions = int(payload["n_questions"])
+                  seed_offset_int = int(seed_offset)
+              except (TypeError, ValueError) as exc:
+                  print(
+                      f"::error::Cell A summary {path} non-numeric metric or seed_offset: {exc}",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+              # Reject NaN/Infinity (mirrors variance-gate aggregator).
+              for label, value in (("r5", r5), ("r10", r10), ("ndcg10", ndcg10)):
+                  if not math.isfinite(value):
+                      print(
+                          f"::error::Cell A summary {path} non-finite {label}={value}.",
+                          file=sys.stderr,
+                      )
+                      sys.exit(1)
+              summaries.append(
+                  {
+                      "seed_offset": seed_offset_int,
+                      "r5": r5,
+                      "r10": r10,
+                      "ndcg10": ndcg10,
+                      "n_questions": n_questions,
+                  }
+              )
+
+          if not summaries:
+              print(
+                  "::warning::No Cell A summaries found — skipping aggregate step. "
+                  "Bench cells likely skipped on the CLI presence guard.",
+              )
+              sys.exit(0)
+
+          summaries.sort(key=lambda s: s["seed_offset"])
+          observed_offsets = sorted(s["seed_offset"] for s in summaries)
+          expected_offsets = list(range(5))
+          if observed_offsets != expected_offsets:
+              print(
+                  f"::error::Cell A aggregator expected one summary per seed_offset in "
+                  f"{expected_offsets}; got {observed_offsets}.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          n_questions_values = {s["n_questions"] for s in summaries}
+          if len(n_questions_values) != 1:
+              by_offset = {s["seed_offset"]: s["n_questions"] for s in summaries}
+              print(
+                  f"::error::Cell A seeds disagree on n_questions: {by_offset}.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          n_questions = n_questions_values.pop()
+
+          r5_values = [s["r5"] for s in summaries]
+          mean_r5 = statistics.mean(r5_values)
+          stddev_r5 = statistics.stdev(r5_values)
+
+          # Compare against HEADLINE mean from the committed variance
+          # baseline. Loading is best-effort: if the file isn't present
+          # (e.g. variance gate hasn't been run yet on this branch) we
+          # emit the Cell A mean alone and skip the gate — but log a
+          # warning so CI surfaces the gap.
+          headline_mean = None
+          headline_path = Path("bench/results/variance_baseline.json")
+          if headline_path.exists():
+              with headline_path.open() as f:
+                  headline_payload = json.load(f)
+              headline_mean = headline_payload.get("mean")
+          else:
+              print(
+                  f"::warning::HEADLINE baseline {headline_path} not found; "
+                  "Cell A aggregate emitted without a delta. Run "
+                  "bench-variance-gate.yml first to produce the HEADLINE mean.",
+              )
+
+          delta_threshold_pp_str = os.environ.get("DELTA_THRESHOLD_PP", "0.5")
+          try:
+              delta_threshold_pp = float(delta_threshold_pp_str)
+          except ValueError:
+              print(
+                  f"::error::DELTA_THRESHOLD_PP={delta_threshold_pp_str!r} is not a "
+                  "float — refusing to compute the gate.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          delta_threshold = delta_threshold_pp / 100.0
+
+          delta = None
+          gate_pass = None
+          if headline_mean is not None:
+              delta = mean_r5 - float(headline_mean)
+              # Cell A is a regression gate, not a value-add eval. Only a
+              # *negative* drift larger than the threshold trips the gate
+              # — a positive delta is permitted but explicitly NOT
+              # claimed as a value-add (see bench/LIMITATIONS.md §(f)).
+              gate_pass = delta >= -delta_threshold
+
+          aggregate = {
+              "cell": "graph_regression_cell_a",
+              "config": "hybrid/session/recency-on/bge-small/expand_graph=true",
+              "questions": n_questions,
+              "seeds": [
+                  {
+                      "seed_offset": s["seed_offset"],
+                      "r5": s["r5"],
+                      "r10": s["r10"],
+                      "ndcg10": s["ndcg10"],
+                  }
+                  for s in summaries
+              ],
+              "mean_r5": mean_r5,
+              "stddev_r5": stddev_r5,
+              "min_r5": min(r5_values),
+              "max_r5": max(r5_values),
+              "headline_mean_r5": headline_mean,
+              "delta_r5_pp": delta * 100.0 if delta is not None else None,
+              "delta_threshold_pp": delta_threshold_pp,
+              "gate_pass": gate_pass,
+          }
+
+          out_path = Path("bench/results/graph_regression_cell_a.json")
+          out_path.parent.mkdir(parents=True, exist_ok=True)
+          with out_path.open("w") as f:
+              json.dump(aggregate, f, indent=2)
+              f.write("\n")
+          print(json.dumps(aggregate, indent=2))
+
+          if gate_pass is False:
+              print(
+                  f"::error::Cell A FAILED: mean R@5 {mean_r5:.4f} drifted "
+                  f"{delta * 100.0:.3f}pp below HEADLINE mean {headline_mean}; "
+                  f"threshold is -{delta_threshold_pp}pp.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          if gate_pass is True:
+              print(
+                  f"Cell A PASSED: mean R@5 {mean_r5:.4f} delta "
+                  f"{delta * 100.0:+.3f}pp vs HEADLINE {headline_mean}."
+              )
+          PY
+
+      - name: Verify paths (allowlist enforcement)
+        run: |
+          set -euo pipefail
+          # Only the Cell A aggregate file may be committed by this workflow.
+          # The per-seed receipts under bench/results/graph_regression_cell_a/
+          # are NOT committed by this workflow — they live as workflow
+          # artifacts only (90-day retention) so the repo never accumulates
+          # a graph-receipt history that could be silently mis-republished.
+          ALLOW='^bench/results/graph_regression_cell_a\.json$'
+          rm -rf artifacts/
+          # Also drop the per-seed receipts so they don't show up in the
+          # diff — see comment above; receipts live as workflow artifacts.
+          rm -rf bench/results/graph_regression_cell_a/
+          git add -A
+          CHANGED=$(git diff --cached --name-only)
+          if [ -z "${CHANGED}" ]; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          echo "Changed files:"
+          echo "${CHANGED}"
+          BAD=$(echo "${CHANGED}" | grep -Ev "${ALLOW}" || true)
+          if [ -n "${BAD}" ]; then
+            echo "ERROR: changes outside allowlist (only bench/results/graph_regression_cell_a.json permitted):"
+            echo "${BAD}"
+            exit 1
+          fi
+          echo "All changes within allowlist."
+          git reset
+
+      - name: Open auto-PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bench/graph-regression-cell-a-${{ github.run_id }}
+          base: main
+          title: "[bench] Cell A graph regression update from run ${{ github.run_id }}"
+          commit-message: |
+            bench(graph): update Cell A regression aggregate from run
+
+            Run ID: ${{ github.run_id }}
+            Cell: graph_regression_cell_a (hybrid / session / recency-on / bge-small)
+            Variant: --expand-graph (issue #458)
+          body: |
+            Cell A graph-regression update from `bench-graph-regression-cell.yml`
+            (run ${{ github.run_id }}).
+
+            See `bench/results/graph_regression_cell_a.json` for the 5-seed
+            mean R@5 + delta against the HEADLINE mean. Cell A is a
+            **regression gate** on the graph-enabled retrieval path; a
+            positive delta is **not** a value-add claim (see
+            `bench/LIMITATIONS.md` §(f) and the Cell B deferral in
+            `docs/benchmarks.md`). Default-off behaviour of graph features
+            is unchanged — the public HEADLINE remains the existing
+            variance-gate cell.
+          labels: benchmark
+          add-paths: bench/results/graph_regression_cell_a.json
+          delete-branch: true

--- a/.github/workflows/bench-graph-regression-cell.yml
+++ b/.github/workflows/bench-graph-regression-cell.yml
@@ -155,11 +155,14 @@ jobs:
         env:
           DISTILLERY_BENCH_GIT_SHA: ${{ github.sha }}
           # Nightly schedule samples 100 questions per cell to stay inside the
-          # nightly cost envelope; workflow_dispatch honours inputs.limit.
-          # The 5-seed mean / delta computation is still meaningful at 100q —
-          # the noise band scales with √n_questions but the regression gate
-          # tolerance is set against HEADLINE's own variance which is sampled
-          # at the same n.
+          # nightly cost envelope (5 cells × 500q would be ~6 hrs/night).
+          # workflow_dispatch honours inputs.limit (empty = full 500q). The
+          # 100q nightly produces useful trending data (mean_r5 over time)
+          # but the regression GATE is computed only when n_questions
+          # matches the HEADLINE baseline's sample size — see the
+          # sample-size-match guard in the aggregator step. So the nightly
+          # records the mean for trending; the gate-relevant comparison is
+          # workflow_dispatch with empty 'limit' (full 500q).
           LIMIT: ${{ inputs.limit || (github.event_name == 'schedule' && '100' || '') }}
         run: |
           # CLI presence guard: ``--expand-graph`` was added by issue #458

--- a/bench/LIMITATIONS.md
+++ b/bench/LIMITATIONS.md
@@ -90,6 +90,41 @@ A number without all four is not a Distillery claim. Reviewers, blog readers,
 and downstream tooling should treat any LongMemEval-shaped number that does not
 carry this panel as folklore until the panel is reconstructed.
 
+### (f) No graph value-add claim on LongMemEval (Cell A is a regression gate, Cell B is deferred)
+
+LongMemEval is a **single-user, single-session** benchmark. Each question is
+scored against a haystack of sessions belonging to one user; nothing in the
+dataset exercises the graph hypothesis (cross-user / cross-session entry
+relations) that motivates Distillery's graph features (PRs #422–#429, epic
+#147).
+
+The bench's coverage of the graph-enabled retrieval path is therefore split
+into two cells, **only one of which produces a publishable number**:
+
+- **Cell A — graph regression gate (DO).** The same headline cell config
+  (`hybrid / session / recency-on / bge-small`, 500q × 5 seeds) re-run with
+  `--expand-graph` enabled. Pass criterion: Cell A's mean R@5 must be within
+  the variance-gate threshold (default 0.5pp) of the HEADLINE mean. This
+  catches *accidental regressions* on the graph-enabled path. It is
+  filed under HEADLINE-shaped infrastructure (`bench-graph-regression-cell.yml`,
+  `bench/results/graph_regression_cell_a.json`) and the 0.5.0 release notes
+  may say "no regression with graph enabled" if the gate passes.
+
+- **Cell B — graph value-add (DEFER).** A claim of the form "graph features
+  improve LongMemEval" is **not supported** because LongMemEval doesn't
+  contain the structure graph features are designed to exploit. Such a
+  claim is deferred to a fit-for-purpose eval — multi-hop QA, a synthetic
+  team-knowledge eval, or a `/investigate` / `/pour` synthesis eval — once
+  one exists. Until then, no public surface (README, blog, slide, this
+  page) may claim that graph features improve LongMemEval scores.
+
+Concretely, this means: a Cell A run with mean R@5 *higher* than HEADLINE
+is **not a value-add result** — it is within the noise band the variance
+gate already characterises (`bench/results/variance_baseline.json`), and
+LongMemEval is the wrong measurement instrument for the value-add question
+regardless. The 0.5.0 release notes claim "no regression with graph
+enabled" — never "graph improves LongMemEval."
+
 ---
 
 ## What this means in practice
@@ -106,7 +141,7 @@ carry this panel as folklore until the panel is reconstructed.
 > **If any limitation in this file becomes unsupportable, the LongMemEval
 > dataset is dropped from the project, not weakened in framing.**
 
-Concretely, that means: if discipline (a)–(e) cannot all be honoured — for
+Concretely, that means: if discipline (a)–(f) cannot all be honoured — for
 example, if the project is pressured to publish a single QA-accuracy-shaped
 number, or to compare against another system on a shared axis, or to drop SHA
 provenance for convenience — the correct response is to remove the LongMemEval

--- a/bench/LIMITATIONS.md
+++ b/bench/LIMITATIONS.md
@@ -110,6 +110,18 @@ into two cells, **only one of which produces a publishable number**:
   `bench/results/graph_regression_cell_a.json`) and the 0.5.0 release notes
   may say "no regression with graph enabled" if the gate passes.
 
+  **Status (until graph PRs land).** PRs #422–#429 are still open at the
+  time this discipline note ships. Until they merge, `--expand-graph` is
+  *metadata and output-routing only* in the LongMemEval runner: the flag
+  records the `expand_graph` axis on every receipt and routes Cell A
+  outputs into a separate subdirectory so receipts cannot be confused with
+  HEADLINE, but the underlying `store.search` call site is unchanged.
+  Cell A is therefore a forward-compatible scaffold for the regression
+  gate, not yet an active measurement of the graph-enabled path. Once
+  the graph PRs merge, the runner is wired to invoke graph-enabled
+  retrieval at the same call site and the gate becomes live without
+  further workflow or docs changes.
+
 - **Cell B — graph value-add (DEFER).** A claim of the form "graph features
   improve LongMemEval" is **not supported** because LongMemEval doesn't
   contain the structure graph features are designed to exploit. Such a

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -112,6 +112,55 @@ type independently.
 | `single-session-preference` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
 | `single-session-assistant` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
 
+## Graph features — Cell A regression gate, Cell B deferred
+
+Issue [#458](https://github.com/norrietaylor/distillery/issues/458) splits the bench's
+coverage of the graph-enabled retrieval path (PRs [#422](https://github.com/norrietaylor/distillery/pull/422)–[#429](https://github.com/norrietaylor/distillery/pull/429),
+epic [#147](https://github.com/norrietaylor/distillery/issues/147)) into two cells. Only
+one produces a publishable number.
+
+### Cell A — graph regression gate (DO)
+
+Same config as the HEADLINE cell (`hybrid / session / recency-on / bge-small`, 500q × 5
+seeds), re-run with `--expand-graph` enabled. Cell A asks: **does enabling graph
+features regress baseline recall when the entry graph is sparse?** The pass criterion
+is that Cell A's mean R@5 stays within the variance-gate threshold (default 0.5pp) of
+the HEADLINE mean.
+
+- **Workflow.** [`.github/workflows/bench-graph-regression-cell.yml`](https://github.com/norrietaylor/distillery/blob/main/.github/workflows/bench-graph-regression-cell.yml)
+  runs nightly at 06:00 UTC, sequenced after the HEADLINE workflow at 05:00 UTC.
+- **Aggregate.** Cell A's 5-seed mean + delta vs HEADLINE lands at
+  `bench/results/graph_regression_cell_a.json`. Per-seed receipts live as workflow
+  artifacts only (90-day retention) and are deliberately not committed — the repo
+  must never accumulate a graph-receipt history that could be silently
+  re-published as a HEADLINE claim.
+- **Default-off.** Graph features remain default-off in production (the existing
+  HEADLINE cell does not set `expand_graph`); Cell A exists as a separate axis
+  and does not displace the public number.
+
+### Cell B — graph value-add (DEFER)
+
+A claim of the form "graph features improve LongMemEval" is deferred to a
+fit-for-purpose eval. LongMemEval is a **single-user, single-session** benchmark
+— each question is scored against one user's haystack — and does not exercise the
+graph hypothesis (cross-user / cross-session entry relations) that motivates
+Distillery's graph features. Measuring graph value-add on LongMemEval would be a
+category error analogous to (a) above.
+
+The deferred eval will be one of:
+
+- a multi-hop QA dataset (questions whose answer requires traversing entry
+  relations);
+- a synthetic team-knowledge eval (multiple authors, cross-author lookups);
+- an in-house `/investigate` or `/pour` synthesis eval that scores the value
+  the graph adds to multi-document narrative answers.
+
+Until that eval exists, **no public surface** (this page, the README, the blog,
+the 0.5.0 release notes) may claim that graph features improve LongMemEval
+scores. The 0.5.0 release notes claim "no regression with graph enabled" —
+never "graph improves LongMemEval." Full discipline rationale is in
+[`bench/LIMITATIONS.md`](../bench/LIMITATIONS.md) §(f).
+
 ## Methodology
 
 The bench instantiates an in-memory `DuckDBStore` per question, fixes the PRNG seed before

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -127,8 +127,26 @@ features regress baseline recall when the entry graph is sparse?** The pass crit
 is that Cell A's mean R@5 stays within the variance-gate threshold (default 0.5pp) of
 the HEADLINE mean.
 
+!!! note "Status: forward-compatible plumbing until graph PRs land"
+
+    Until the graph retrieval PRs ([#422](https://github.com/norrietaylor/distillery/pull/422)–[#429](https://github.com/norrietaylor/distillery/pull/429))
+    merge, `--expand-graph` is **metadata and output-routing only** in the
+    LongMemEval bench runner (`src/distillery/eval/longmemeval.py`). The flag
+    records the `expand_graph` axis on every receipt and routes outputs into a
+    separate subdirectory so Cell A receipts can never be confused with
+    HEADLINE receipts, but the underlying `store.search` call site is
+    unchanged — Cell A is currently measuring the same retrieval path as
+    HEADLINE. Once the graph PRs merge, the runner will be wired to invoke
+    graph-enabled retrieval without further workflow or docs changes, and
+    Cell A's regression-gate semantics become live. Until then, treat any
+    Cell A delta as a sanity check on the receipt-isolation infrastructure,
+    not a measurement of the graph-enabled path.
+
 - **Workflow.** [`.github/workflows/bench-graph-regression-cell.yml`](https://github.com/norrietaylor/distillery/blob/main/.github/workflows/bench-graph-regression-cell.yml)
   runs nightly at 06:00 UTC, sequenced after the HEADLINE workflow at 05:00 UTC.
+  Nightly samples 100q for trending; full-500q runs (gate-relevant) are
+  `workflow_dispatch` only and require a sample-size match against the
+  committed `variance_baseline.json` before the gate is computed.
 - **Aggregate.** Cell A's 5-seed mean + delta vs HEADLINE lands at
   `bench/results/graph_regression_cell_a.json`. Per-seed receipts live as workflow
   artifacts only (90-day retention) and are deliberately not committed — the repo

--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -370,6 +370,20 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     longmemeval_parser.add_argument(
+        "--expand-graph",
+        action="store_true",
+        default=False,
+        help=(
+            "Issue #458, Cell A: enable the retrieval-time graph expansion path "
+            "(default off — HEADLINE behaviour). When set, outputs land in a "
+            "graph_regression_cell_a/ subdirectory of --output-dir so the "
+            "HEADLINE aggregator cannot confuse Cell A receipts with the public "
+            "headline. Used by .github/workflows/bench-graph-regression-cell.yml "
+            "as a regression gate against accidental recall regressions on the "
+            "graph-enabled path. See docs/benchmarks.md and bench/LIMITATIONS.md."
+        ),
+    )
+    longmemeval_parser.add_argument(
         "--output-dir",
         metavar="PATH",
         default=None,
@@ -1950,6 +1964,7 @@ def _cmd_bench_longmemeval(
     limit: int | None,
     seeds: int,
     seed_offset: int,
+    expand_graph: bool,
     output_dir: str | None,
     quiet: bool,
     fmt: str,
@@ -2001,7 +2016,7 @@ def _cmd_bench_longmemeval(
             f"Running LongMemEval bench: retrieval={retrieval} "
             f"granularity={granularity} recency={recency} "
             f"embed_model={embed_model} limit={limit} seeds={seeds} "
-            f"seed_offset={seed_offset}",
+            f"seed_offset={seed_offset} expand_graph={expand_graph}",
             file=sys.stderr,
         )
         print(f"Output directory: {resolved_output_dir}", file=sys.stderr)
@@ -2022,6 +2037,7 @@ def _cmd_bench_longmemeval(
             limit=limit,
             seeds=seeds,
             seed_offset=seed_offset,
+            expand_graph=expand_graph,
             output_dir=resolved_output_dir,
         )
 
@@ -2153,6 +2169,7 @@ def main(argv: list[str] | None = None) -> None:
                 limit=getattr(args, "limit", None),
                 seeds=getattr(args, "seeds", 1),
                 seed_offset=getattr(args, "seed_offset", 0),
+                expand_graph=getattr(args, "expand_graph", False),
                 output_dir=getattr(args, "output_dir", None),
                 quiet=getattr(args, "quiet", False),
                 fmt=fmt,

--- a/src/distillery/eval/longmemeval.py
+++ b/src/distillery/eval/longmemeval.py
@@ -216,6 +216,7 @@ def _build_meta_panel(
     granularity: GranularityMode,
     recency: RecencyMode,
     effective_recency: RecencyMode,
+    expand_graph: bool = False,
 ) -> dict[str, Any]:
     """Build the per-record SHA / provenance panel.
 
@@ -228,6 +229,13 @@ def _build_meta_panel(
     drive the offset directly via the variance-gate path).  Carried in
     the panel so a downstream aggregator can group records by the run
     that produced them without inspecting the filename.
+
+    ``expand_graph`` is the retrieval-time graph expansion axis (issue
+    #458, Cell A).  When ``True``, the bench is exercising the
+    graph-enabled retrieval path (default-off in production).  When
+    ``False`` (default) the panel reads as before.  Recorded on every
+    record so a downstream consumer can never confuse Cell A receipts
+    with HEADLINE receipts.
     """
     return {
         "git_sha": git_sha,
@@ -244,6 +252,7 @@ def _build_meta_panel(
         "granularity": granularity,
         "recency_requested": recency,
         "effective_recency": effective_recency,
+        "expand_graph": expand_graph,
     }
 
 
@@ -462,6 +471,7 @@ async def _run_one_question(
     recency: RecencyMode,
     embedder: Any,
     git_sha: str,
+    expand_graph: bool = False,
 ) -> QuestionRecord:
     """Build a fresh store, ingest the haystack, search, and score.
 
@@ -538,6 +548,7 @@ async def _run_one_question(
             granularity=granularity,
             recency=recency,
             effective_recency=effective_recency,
+            expand_graph=expand_graph,
         )
 
         return QuestionRecord(
@@ -626,8 +637,19 @@ def _write_outputs(
     recency: RecencyMode,
     embed_model: EmbedModel,
     stamp: str,
+    expand_graph: bool = False,
 ) -> tuple[Path, Path]:
-    """Write the JSONL + summary files; return ``(jsonl_path, summary_path)``."""
+    """Write the JSONL + summary files; return ``(jsonl_path, summary_path)``.
+
+    Issue #458 / Cell A: when ``expand_graph=True`` the outputs land in a
+    ``graph_regression_cell_a/`` subdirectory of ``output_dir`` so the
+    existing nightly aggregator (``scripts/bench/aggregate_results.py``)
+    — which globs ``output_dir`` non-recursively — never sees them and
+    cannot mistake a graph-enabled receipt for a HEADLINE receipt.  The
+    Cell A workflow has its own aggregator step.
+    """
+    if expand_graph:
+        output_dir = output_dir / "graph_regression_cell_a"
     output_dir.mkdir(parents=True, exist_ok=True)
     base = f"longmemeval_{retrieval}_{granularity}_{recency}_{embed_model}_{stamp}"
     jsonl_path = output_dir / f"results_{base}.jsonl"
@@ -658,6 +680,7 @@ async def run_longmemeval_bench(
     limit: int | None = None,
     seeds: int = 1,
     seed_offset: int = 0,
+    expand_graph: bool = False,
     output_dir: Path | None = None,
     questions: list[dict[str, Any]] | None = None,
 ) -> BenchReport:
@@ -703,6 +726,20 @@ async def run_longmemeval_bench(
         ``seed_offset + i * 100_000 + question_index`` so the per-run
         and per-sweep axes don't collide.  Defaults to ``0`` so the
         existing ``--seeds N`` semantics are unchanged.
+    expand_graph:
+        Issue #458, Cell A.  When ``True``, mark the run as exercising
+        the graph-enabled retrieval path and write outputs to a
+        ``graph_regression_cell_a/`` subdirectory of ``output_dir`` so
+        the existing HEADLINE aggregator never confuses Cell A receipts
+        with HEADLINE receipts.  Until graph PRs (#422-#429) land, this
+        is metadata-only at the search call — the axis is recorded in
+        ``summary["axes"]["expand_graph"]`` and on every
+        ``_meta.expand_graph`` panel for receipt provenance, and the
+        retrieval call site is unchanged.  When the graph PRs merge,
+        the search call here gains the actual ``expand_graph=True``
+        kwarg and Cell A starts measuring the graph-enabled path
+        without further workflow changes.  Defaults to ``False``
+        (HEADLINE behaviour, no axis change).
     output_dir:
         Directory to write JSONL + summary files into.  When ``None``,
         no files are written and the caller can read
@@ -760,6 +797,7 @@ async def run_longmemeval_bench(
                 recency=recency,
                 embedder=embedder,
                 git_sha=git_sha,
+                expand_graph=expand_graph,
             )
             all_records.append(record)
 
@@ -772,6 +810,7 @@ async def run_longmemeval_bench(
         "embed_model": embed_model,
         "seeds": max(1, seeds),
         "seed_offset": seed_offset,
+        "expand_graph": expand_graph,
         "limit": limit,
     }
     summary["dataset"] = {
@@ -794,6 +833,7 @@ async def run_longmemeval_bench(
             recency=recency,
             embed_model=embed_model,
             stamp=stamp,
+            expand_graph=expand_graph,
         )
 
     return BenchReport(

--- a/tests/eval/test_longmemeval_runner.py
+++ b/tests/eval/test_longmemeval_runner.py
@@ -618,3 +618,79 @@ def test_filename_schema_includes_every_axis(tmp_path: Path) -> None:
     for axis in ("hybrid", "turn", "off", "bge-base", "20260502T010203Z"):
         assert axis in jsonl.name, f"jsonl name missing axis {axis!r}: {jsonl.name}"
         assert axis in summary.name, f"summary name missing axis {axis!r}: {summary.name}"
+
+
+def test_expand_graph_writes_to_subdirectory(tmp_path: Path) -> None:
+    """Issue #458, Cell A: ``expand_graph=True`` outputs land in a subdirectory.
+
+    The Cell A workflow writes graph-enabled receipts under
+    ``bench/results/graph_regression_cell_a/`` so the existing nightly
+    aggregator (which globs ``bench/results/`` non-recursively) cannot
+    confuse a Cell A receipt with a HEADLINE receipt.
+    """
+    from distillery.eval.longmemeval import _write_outputs
+
+    record = QuestionRecord(
+        question_id="x",
+        question_type="t",
+        expected_session_ids=[],
+        retrieved_session_ids=[],
+        rankings=[],
+        recall_at_5=0.0,
+        recall_all_at_5=0.0,
+        ndcg_at_5=0.0,
+        recall_at_10=0.0,
+        recall_all_at_10=0.0,
+        ndcg_at_10=0.0,
+        latency_ms=1.0,
+        n_corpus_entries=0,
+        meta={},
+    )
+    jsonl, summary = _write_outputs(
+        [record],
+        {"n_questions": 1, "overall": {}, "per_question_type": {}},
+        tmp_path,
+        retrieval="hybrid",
+        granularity="session",
+        recency="on",
+        embed_model="bge-small",
+        stamp="20260502T010203Z",
+        expand_graph=True,
+    )
+    assert jsonl.parent.name == "graph_regression_cell_a"
+    assert summary.parent.name == "graph_regression_cell_a"
+    assert jsonl.parent.parent == tmp_path
+
+
+async def test_expand_graph_axis_recorded_in_summary_and_meta() -> None:
+    """Issue #458, Cell A: ``expand_graph=True`` flag flows into summary axes
+    and per-record meta.
+
+    Even before the graph PRs (#422-#429) land — when the retrieval call
+    site is a no-op for graph expansion — Cell A's audit trail must be
+    distinguishable from HEADLINE so receipts cannot be silently
+    re-published as the headline number.
+    """
+    questions = _load_fixture()
+
+    report = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="on",
+        embed_model="bge-small",
+        questions=questions[:1],
+        expand_graph=True,
+    )
+    assert report.summary["axes"]["expand_graph"] is True
+    assert all(rec.meta["expand_graph"] is True for rec in report.per_question)
+
+    # Default path is unchanged (HEADLINE: graph features default-off).
+    report_default = await run_longmemeval_bench(
+        retrieval="hybrid",
+        granularity="session",
+        recency="on",
+        embed_model="bge-small",
+        questions=questions[:1],
+    )
+    assert report_default.summary["axes"]["expand_graph"] is False
+    assert all(rec.meta["expand_graph"] is False for rec in report_default.per_question)

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -56,6 +56,7 @@ class TestBenchLongmemevalHelp:
             "--embed-model",
             "--limit",
             "--seeds",
+            "--expand-graph",
             "--output-dir",
             "--quiet",
         ):
@@ -453,3 +454,139 @@ class TestBenchLongmemevalSeedOffsetFlag:
         assert exc.value.code == 0
         assert captured_kwargs.get("seed_offset") == 3
         assert captured_kwargs.get("seeds") == 1
+
+
+@pytest.mark.unit
+class TestBenchLongmemevalExpandGraphFlag:
+    """``--expand-graph`` is documented and round-trips through argparse.
+
+    Issue #458, Cell A: the bench-graph-regression-cell.yml workflow
+    relies on this flag being present and reaching the runner so the
+    Cell A path can be exercised independently of HEADLINE.
+    """
+
+    def test_expand_graph_appears_in_help(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--help`` lists ``--expand-graph`` so the Cell A workflow can
+        discover the flag without reading source.
+        """
+        with pytest.raises(SystemExit) as exc:
+            main(["bench", "longmemeval", "--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--expand-graph" in out
+
+    def test_expand_graph_default_is_false(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Omitting ``--expand-graph`` keeps the runner kwarg ``False``.
+
+        The HEADLINE path's defaults are unchanged — graph features stay
+        default-off (issue #458 acceptance criterion).
+        """
+        from distillery import cli as cli_module
+
+        captured_kwargs: dict[str, Any] = {}
+
+        async def _stub_runner(**kwargs: Any) -> Any:
+            captured_kwargs.update(kwargs)
+            from distillery.eval.longmemeval import BenchReport
+
+            return BenchReport(
+                summary={
+                    "n_questions": 0,
+                    "overall": {
+                        "recall_at_5": 0.0,
+                        "recall_at_10": 0.0,
+                        "ndcg_at_10": 0.0,
+                    },
+                },
+                per_question=[],
+                jsonl_path=None,
+                summary_path=None,
+            )
+
+        monkeypatch.setattr(
+            "distillery.eval.longmemeval.run_longmemeval_bench",
+            _stub_runner,
+        )
+        if hasattr(cli_module, "run_longmemeval_bench"):  # pragma: no cover - defensive
+            monkeypatch.setattr(
+                cli_module,
+                "run_longmemeval_bench",
+                _stub_runner,
+                raising=False,
+            )
+
+        out_dir = tmp_path / "results"
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    "bench",
+                    "longmemeval",
+                    "--output-dir",
+                    str(out_dir),
+                    "--quiet",
+                ]
+            )
+        assert exc.value.code == 0
+        assert captured_kwargs.get("expand_graph") is False
+
+    def test_expand_graph_round_trips_to_runner(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``--expand-graph`` reaches ``run_longmemeval_bench`` unchanged."""
+        from distillery import cli as cli_module
+
+        captured_kwargs: dict[str, Any] = {}
+
+        async def _stub_runner(**kwargs: Any) -> Any:
+            captured_kwargs.update(kwargs)
+            from distillery.eval.longmemeval import BenchReport
+
+            return BenchReport(
+                summary={
+                    "n_questions": 0,
+                    "overall": {
+                        "recall_at_5": 0.0,
+                        "recall_at_10": 0.0,
+                        "ndcg_at_10": 0.0,
+                    },
+                },
+                per_question=[],
+                jsonl_path=None,
+                summary_path=None,
+            )
+
+        monkeypatch.setattr(
+            "distillery.eval.longmemeval.run_longmemeval_bench",
+            _stub_runner,
+        )
+        if hasattr(cli_module, "run_longmemeval_bench"):  # pragma: no cover - defensive
+            monkeypatch.setattr(
+                cli_module,
+                "run_longmemeval_bench",
+                _stub_runner,
+                raising=False,
+            )
+
+        out_dir = tmp_path / "results"
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    "bench",
+                    "longmemeval",
+                    "--expand-graph",
+                    "--output-dir",
+                    str(out_dir),
+                    "--quiet",
+                ]
+            )
+        assert exc.value.code == 0
+        assert captured_kwargs.get("expand_graph") is True


### PR DESCRIPTION
## Summary

Implements [#458](https://github.com/norrietaylor/distillery/issues/458): plans benchmark coverage for the graph features (#422–#429) ahead of 0.5.0 by splitting the `+graph` axis into two cells, only one of which produces a publishable number.

- **Cell A — graph regression gate (DO).** Same headline config (`hybrid / session / recency-on / bge-small`, 500q × 5 seeds) re-run with `--expand-graph` enabled. Catches accidental regressions on the graph-enabled retrieval path. Default-off behaviour of graph features is unchanged; the public HEADLINE remains the existing variance-gate cell.
- **Cell B — graph value-add (DEFER).** LongMemEval is single-user / single-session and does not exercise the graph hypothesis. Deferred to a fit-for-purpose eval (multi-hop QA, synthetic team-knowledge eval, `/investigate` `/pour` synthesis eval). 0.5.0 release notes claim "no regression with graph enabled," never "graph improves LongMemEval."

## Files changed

- `.github/workflows/bench-graph-regression-cell.yml` — nightly Cell A matrix (5 seed offsets, full-500q on dispatch / 100q on schedule), aggregator computes mean R@5 + delta vs HEADLINE mean from `bench/results/variance_baseline.json`, auto-PRs the aggregate to `bench/results/graph_regression_cell_a.json`. Per-seed receipts live as workflow artifacts only (90-day retention) — the repo never accumulates a graph-receipt history that could be silently re-published as HEADLINE.
- `src/distillery/cli.py`, `src/distillery/eval/longmemeval.py` — wire `--expand-graph` flag through CLI to the runner; record `expand_graph` axis on summary and per-record meta panel; route Cell A outputs into a `graph_regression_cell_a/` subdirectory of `--output-dir` so the existing HEADLINE aggregator (non-recursive `glob`) cannot mistake Cell A receipts for HEADLINE receipts. Until graph PRs (#422–#429) land, the retrieval call site is a no-op for graph expansion — the axis is metadata-only. Once graph PRs merge, the runner can be wired to invoke graph-enabled retrieval without further workflow changes.
- `bench/LIMITATIONS.md` §(f) — formal Cell A / Cell B discipline note. Mirrors the existing (a)–(e) discipline rules.
- `docs/benchmarks.md` — public Cell A description and Cell B deferral rationale.
- Tests cover `--expand-graph` argparse round-trip, default=False, axis recorded in summary + meta, and Cell A subdirectory routing.

## Acceptance criteria (from #458)

- [x] `bench-graph-regression-cell.yml` runs Cell A on the same nightly + variance-gate cadence as HEADLINE (sequenced after `bench-longmemeval.yml` at 06:00 UTC vs 05:00 UTC).
- [x] Cell A surfaces in `bench/results/` alongside the existing HEADLINE; delta computed against HEADLINE mean from `variance_baseline.json`.
- [x] `docs/benchmarks.md` documents Cell A and explicitly notes Cell B is deferred and why.
- [x] 0.5.0 release notes wording prepared: "no regression with graph enabled," not "graph improves LongMemEval" (claim is enforced by `bench/LIMITATIONS.md` §(f)).

## Test plan

- [x] `pytest -m unit` — 1847 passed, 2 skipped (no regressions)
- [x] `ruff check` — clean on changed files
- [x] `ruff format --check` — clean on changed files
- [x] `mypy --strict src/distillery/` — no new errors (one pre-existing `huggingface_hub` import-not-found unchanged by this PR)
- [x] `mkdocs build --strict` — pre-existing 4 broken-link warnings on `docs/benchmarks.md` (HEADLINE.md, LIMITATIONS.md, METHODOLOGY.md, README.md links to `../bench/`) are unchanged by this PR; no new warnings introduced.

## Constraints honoured

- No graph PR (#422–#429) modified.
- Default-off graph behaviour unchanged — HEADLINE path is byte-identical.
- Strictly additive CLI / runner surface — `expand_graph=False` is the default.

Closes #458.

References: graph PRs #422–#429, epic #147, variance baseline #455 #456, discipline scaffolding #431.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public CLI flag (--expand-graph) to enable graph feature expansion in benchmarks
  * Introduced an automated graph-regression gate (Cell A) for nightly benchmark runs

* **Documentation**
  * Added governance and publication guidance for graph-feature evaluation cells
  * Documented graph-regression gate and deferred evaluation paths in benchmarking docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->