### PR TITLE
fix(embedding): validate OpenAI response length matches input

### DIFF
--- a/src/distillery/embedding/openai.py
+++ b/src/distillery/embedding/openai.py
@@ -246,6 +246,10 @@ class OpenAIEmbeddingProvider:
 
         # Sort results by index to guarantee order matches input
         embeddings_data = sorted(data["data"], key=lambda d: d["index"])
+        if len(embeddings_data) != len(texts):
+            raise RuntimeError(
+                f"OpenAI returned {len(embeddings_data)} embeddings, expected {len(texts)}."
+            )
         return [item["embedding"] for item in embeddings_data]
 
     def __del__(self) -> None:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -605,6 +605,29 @@ class TestOpenAIEmbeddingProviderErrors:
         assert result[0] == [0.1, 0.2, 0.3, 0.4]
         assert result[1] == [0.5, 0.6, 0.7, 0.8]
 
+    def test_embed_batch_raises_when_response_count_mismatches(self) -> None:
+        """A short OpenAI response must raise RuntimeError instead of silently
+        misaligning embeddings with their input texts.
+
+        Regression for #470 — without this guard a 2-input request that
+        receives 1 embedding back would return a single vector mapped to
+        the first input, dropping the second silently. Mirrors the Jina
+        provider's check in ``_parse_response``.
+        """
+        # Request two texts but mock only one embedding back.
+        short_payload = _make_openai_response([[0.1, 0.2, 0.3, 0.4]])
+        short_response = _mock_httpx_response(200, short_payload)
+
+        provider = OpenAIEmbeddingProvider(api_key="sk-test", dimensions=4)
+
+        with patch.object(provider, "_client") as mock_client:
+            mock_client.post.return_value = short_response
+            with pytest.raises(
+                RuntimeError,
+                match=r"OpenAI returned 1 embeddings, expected 2\.",
+            ):
+                provider.embed_batch(["first", "second"])
+
 
 # ---------------------------------------------------------------------------
 # OpenAIEmbeddingProvider: rate limiting and retry behaviour


### PR DESCRIPTION
## Summary

`OpenAIEmbeddingProvider._request` previously extracted embeddings from the API response without verifying that the returned count matched the number of input texts. A short response would silently misalign embeddings with their inputs (or drop trailing inputs entirely), corrupting any downstream pipeline that relies on positional matching between texts and vectors.

The Jina provider already guards against this in `_parse_response` (`src/distillery/embedding/jina.py:276-278`). This change adds the symmetric check to the OpenAI provider, raising `RuntimeError(f"OpenAI returned {len(embeddings_data)} embeddings, expected {len(texts)}.")` whenever counts differ.

## Test plan

- [x] Added `test_embed_batch_raises_when_response_count_mismatches` regression test that mocks a 1-vector response to a 2-text request and asserts the new error is raised
- [x] `ruff format src/ tests/` (no changes needed)
- [x] `ruff check src/ tests/` passes
- [x] `mypy --strict src/distillery/embedding/openai.py` passes
- [x] `pytest tests/test_embedding.py -v` — all 69 tests pass including the new regression test

Closes #470

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to embedding responses to detect mismatches between input and output counts, with clear error messaging for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->