### PR TITLE
fix(store): filter archived entries from get()

### DIFF
--- a/src/distillery/mcp/tools/classify.py
+++ b/src/distillery/mcp/tools/classify.py
@@ -293,8 +293,12 @@ async def _handle_resolve_review(
     action: str = arguments["action"]
 
     # --- retrieve existing entry --------------------------------------------
+    # include_archived=True because resolve_review supports idempotent
+    # archive-of-archived and reclassify-of-archived (without flipping status
+    # back to active).  store.get() filters archived rows by default per the
+    # protocol contract.
     try:
-        entry = await store.get(entry_id)
+        entry = await store.get(entry_id, include_archived=True)
     except Exception:  # noqa: BLE001
         logger.exception("Error fetching entry id=%s for resolve_review", entry_id)
         return error_response("INTERNAL", "Failed to retrieve entry")

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -1834,8 +1834,11 @@ async def _handle_correct(
     wrong_entry_id: str = arguments["wrong_entry_id"]
 
     # --- fetch original entry -----------------------------------------------
+    # include_archived=True so we can distinguish "no such entry" (NOT_FOUND)
+    # from "entry exists but is archived" (INVALID_PARAMS).  store.get() filters
+    # archived rows by default per the protocol contract.
     try:
-        original = await store.get(wrong_entry_id)
+        original = await store.get(wrong_entry_id, include_archived=True)
     except Exception:  # noqa: BLE001
         logger.exception("Error fetching entry id=%s for correction", wrong_entry_id)
         return error_response("INTERNAL", "Failed to retrieve original entry")

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -276,9 +276,13 @@ async def _expand_search_with_graph(
 
     # Fetch entries for all expanded ids; skip any that have been deleted
     # or whose status would have been filtered out by the seed search.
+    # When the seed search permits archived entries (allowed_statuses is None
+    # or contains "archived"), pass include_archived=True so store.get() will
+    # surface them; otherwise the default (filter-out) behaviour applies.
+    fetch_archived = allowed_statuses is None or "archived" in allowed_statuses
     expanded_results: list[dict[str, Any]] = []
     for entry_id, info in expanded.items():
-        entry = await store.get(entry_id)
+        entry = await store.get(entry_id, include_archived=fetch_archived)
         if entry is None:
             continue
         if allowed_statuses is not None and str(entry.status) not in allowed_statuses:

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1151,22 +1151,30 @@ class DuckDBStore:
         """
         return await self._run_sync(self._sync_store_batch, entries)
 
-    def _sync_get(self, entry_id: str) -> Entry | None:
+    def _sync_get(self, entry_id: str, include_archived: bool = False) -> Entry | None:
         """
         Retrieve the entry with the given ID and convert it to an Entry object.
 
         Parameters:
             entry_id (str): UUID of the entry to retrieve.
+            include_archived (bool): If True, archived (soft-deleted) entries are
+                also returned. Defaults to False so callers must opt in.
 
         Returns:
-            Entry | None: The matching Entry if found, `None` if no entry exists with the given ID.
+            Entry | None: The matching Entry if found, `None` if no entry exists
+            with the given ID, or if the entry is archived and
+            ``include_archived`` is ``False``.
 
         Notes:
             Also attempts to update the entry's `accessed_at` timestamp; failures to update are ignored.
         """
         conn = self.connection
-        sql = f"SELECT {self._ENTRY_COLUMNS} FROM entries WHERE id = ? AND status != ?"
-        result = conn.execute(sql, [entry_id, EntryStatus.ARCHIVED.value])
+        if include_archived:
+            sql = f"SELECT {self._ENTRY_COLUMNS} FROM entries WHERE id = ?"
+            result = conn.execute(sql, [entry_id])
+        else:
+            sql = f"SELECT {self._ENTRY_COLUMNS} FROM entries WHERE id = ? AND status != ?"
+            result = conn.execute(sql, [entry_id, EntryStatus.ARCHIVED.value])
         col_names = [desc[0] for desc in result.description]
         row = result.fetchone()
         if row is None:
@@ -1181,13 +1189,19 @@ class DuckDBStore:
             logger.debug("accessed_at update failed for id=%s (ignored)", entry_id)
         return self._row_to_entry(row, col_names)
 
-    async def get(self, entry_id: str) -> Entry | None:
+    async def get(self, entry_id: str, *, include_archived: bool = False) -> Entry | None:
         """Retrieve an entry by its ID.
 
+        Args:
+            entry_id: The UUID string of the entry to fetch.
+            include_archived: If ``True``, soft-deleted entries (status
+                ``archived``) are also returned. Defaults to ``False``.
+
         Returns:
-            The matching ``Entry``, or ``None`` if the ID does not exist.
+            The matching ``Entry``, or ``None`` if the ID does not exist or
+            the entry is archived and ``include_archived`` is ``False``.
         """
-        return await self._run_sync(self._sync_get, entry_id)
+        return await self._run_sync(self._sync_get, entry_id, include_archived)
 
     def _sync_update(self, entry_id: str, updates: dict[str, Any]) -> Entry:
         """

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1165,8 +1165,8 @@ class DuckDBStore:
             Also attempts to update the entry's `accessed_at` timestamp; failures to update are ignored.
         """
         conn = self.connection
-        sql = f"SELECT {self._ENTRY_COLUMNS} FROM entries WHERE id = ?"
-        result = conn.execute(sql, [entry_id])
+        sql = f"SELECT {self._ENTRY_COLUMNS} FROM entries WHERE id = ? AND status != ?"
+        result = conn.execute(sql, [entry_id, EntryStatus.ARCHIVED.value])
         col_names = [desc[0] for desc in result.description]
         row = result.fetchone()
         if row is None:

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -98,15 +98,19 @@ class DistilleryStore(Protocol):
         """
         ...
 
-    async def get(self, entry_id: str) -> Entry | None:
+    async def get(self, entry_id: str, *, include_archived: bool = False) -> Entry | None:
         """Retrieve an entry by its ID.
 
         Args:
             entry_id: The UUID string of the entry to fetch.
+            include_archived: If ``True``, soft-deleted entries (status
+                ``archived``) are also returned.  Defaults to ``False`` so
+                callers must opt in to seeing archived data.
 
         Returns:
             The matching ``Entry``, or ``None`` if no entry with that ID
-            exists or if the entry has been soft-deleted (status ``archived``).
+            exists or if the entry has been soft-deleted (status ``archived``)
+            and ``include_archived`` is ``False``.
         """
         ...
 

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -40,8 +40,9 @@ async def test_correct_entry(store: DuckDBStore, original_entry: str) -> None:
     assert data["archived_entry_id"] == original_entry
     assert "correction_entry_id" in data
 
-    # Original should be archived.
-    orig = await store.get(original_entry)
+    # Original should be archived (use include_archived=True since get()
+    # filters archived by default per the protocol contract).
+    orig = await store.get(original_entry, include_archived=True)
     assert orig is not None
     assert orig.status == EntryStatus.ARCHIVED
 
@@ -161,9 +162,10 @@ async def test_correction_chain(store: DuckDBStore, original_entry: str) -> None
     d2 = parse_mcp_response(r2)
     entry_c_id = d2["correction_entry_id"]
 
-    # A and B should both be archived.
-    a = await store.get(original_entry)
-    b = await store.get(entry_b_id)
+    # A and B should both be archived (use include_archived=True since get()
+    # filters archived by default per the protocol contract).
+    a = await store.get(original_entry, include_archived=True)
+    b = await store.get(entry_b_id, include_archived=True)
     c = await store.get(entry_c_id)
     assert a is not None and a.status == EntryStatus.ARCHIVED
     assert b is not None and b.status == EntryStatus.ARCHIVED

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -273,20 +273,24 @@ class TestDelete:
         assert entry.id in ids
 
     async def test_delete_entry_not_returned_by_get(self, store: DuckDBStore) -> None:
-        """get() returns None for archived (soft-deleted) entries by default is OK --
-        but actually the current protocol says get returns None for archived entries.
-        Let's verify what the implementation does: get() fetches by ID with no status filter."""
+        """get() must return None for archived (soft-deleted) entries.
+
+        The protocol contract (store/protocol.py) requires get() to return None
+        for entries whose status is ARCHIVED. Regression test for #468.
+        """
         entry = make_entry()
         await store.store(entry)
         await store.delete(entry.id)
-        # get() may or may not filter archived -- verify what it returns
         fetched = await store.get(entry.id)
-        # The entry exists in DB but is archived; get() returns it regardless
-        # (protocol says None for soft-deleted, but implementation may differ --
-        # we verify the status is ARCHIVED).
-        if fetched is not None:
-            assert fetched.status is EntryStatus.ARCHIVED
-        # Either None or ARCHIVED is valid behaviour for soft-delete.
+        assert fetched is None
+
+    async def test_get_returns_none_after_archive_via_update(self, store: DuckDBStore) -> None:
+        """get() must return None when an entry's status is set to ARCHIVED via update()."""
+        entry = make_entry()
+        await store.store(entry)
+        await store.update(entry.id, {"status": EntryStatus.ARCHIVED})
+        fetched = await store.get(entry.id)
+        assert fetched is None
 
     async def test_delete_twice_still_returns_true(self, store: DuckDBStore) -> None:
         """Deleting an already-archived entry sets it to archived again -> True."""
@@ -1546,9 +1550,7 @@ class TestFTSRebuildRollback:
     returned ``False``) and caused duplicate feed entries to accumulate.
     """
 
-    async def test_fts_rebuild_failure_invokes_rollback(
-        self, hybrid_store: DuckDBStore
-    ) -> None:
+    async def test_fts_rebuild_failure_invokes_rollback(self, hybrid_store: DuckDBStore) -> None:
         """A failed PRAGMA must trigger ``conn.rollback()`` before returning.
 
         DuckDB ``DuckDBPyConnection.execute`` is a read-only attribute on

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -1550,7 +1550,9 @@ class TestFTSRebuildRollback:
     returned ``False``) and caused duplicate feed entries to accumulate.
     """
 
-    async def test_fts_rebuild_failure_invokes_rollback(self, hybrid_store: DuckDBStore) -> None:
+    async def test_fts_rebuild_failure_invokes_rollback(
+        self, hybrid_store: DuckDBStore
+    ) -> None:
         """A failed PRAGMA must trigger ``conn.rollback()`` before returning.
 
         DuckDB ``DuckDBPyConnection.execute`` is a read-only attribute on


### PR DESCRIPTION
## Problem

`DuckDBStore._sync_get()` runs `SELECT ... WHERE id = ?` with no status filter, so archived (soft-deleted) entries are returned to callers. This violates the `DistilleryStore.get()` protocol contract in `src/distillery/store/protocol.py:109`, which says:

> Returns: The matching `Entry`, or `None` if no entry with that ID exists **or if the entry has been soft-deleted (status `archived`)**.

Other queries in the same module already follow this rule (e.g. `get_tag_vocabulary` at `duckdb.py:2704` filters with `WHERE status != 'archived'`). `get()` was the outlier and silently leaked deleted data to every caller.

## Fix

Append `AND status != ?` to the `_sync_get` SELECT and bind `EntryStatus.ARCHIVED.value`, matching the enum-based parameter style used elsewhere (e.g. `_sync_delete` at `duckdb.py:1333`). Single-line, two-parameter change.

## Tests

- Tightened the existing `test_delete_entry_not_returned_by_get` (it was permissively accepting either `None` or `ARCHIVED`) so it now asserts `fetched is None` per the protocol.
- Added `test_get_returns_none_after_archive_via_update` to cover the second archive path (`store.update(id, {"status": ARCHIVED})`).

## Test plan

- [x] `uv run ruff format src/ tests/` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy --strict src/distillery/` — clean
- [x] `uv run pytest tests/test_duckdb_store.py::TestDelete tests/test_duckdb_store.py::TestGet -v` — 13/13 pass
- [ ] Full CI pipeline

Closes #468

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optionally include archived entries when retrieving an item by ID.

* **Bug Fixes**
  * Retrieval by ID now excludes archived items by default to prevent returning soft-deleted entries.

* **Tests**
  * Added and strengthened tests to ensure archived entries are excluded by default and can be returned when explicitly requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->