### PR TITLE
fix(classification): clamp HeuristicClassifier confidence to [0.0, 1.0]

### DIFF
--- a/src/distillery/classification/heuristic.py
+++ b/src/distillery/classification/heuristic.py
@@ -129,10 +129,14 @@ class HeuristicClassifier:
         entry_embedding = embedding_provider.embed(entry.content)
         best_type, best_similarity = self.classify_entry(entry_embedding, centroids)
 
+        # Cosine similarity is in [-1.0, 1.0]; clamp to ClassificationResult's
+        # documented confidence range of [0.0, 1.0] (mirrors engine.py:155).
+        confidence = max(0.0, min(1.0, best_similarity))
+
         if best_type is not None:
             return ClassificationResult(
                 entry_type=EntryType(best_type),
-                confidence=best_similarity,
+                confidence=confidence,
                 status=EntryStatus.ACTIVE,
                 reasoning=(
                     f"Heuristic classification: best centroid match is "
@@ -144,7 +148,7 @@ class HeuristicClassifier:
 
         return ClassificationResult(
             entry_type=EntryType.INBOX,
-            confidence=best_similarity,
+            confidence=confidence,
             status=EntryStatus.PENDING_REVIEW,
             reasoning=(
                 f"Heuristic classification: no centroid exceeded threshold "
@@ -305,11 +309,15 @@ class HeuristicClassifier:
             entry_embedding = embedding_provider.embed(entry.content)
             best_type, best_similarity = self.classify_entry(entry_embedding, centroids)
 
+            # Cosine similarity is in [-1.0, 1.0]; clamp to ClassificationResult's
+            # documented confidence range of [0.0, 1.0] (mirrors engine.py:155).
+            confidence = max(0.0, min(1.0, best_similarity))
+
             if best_type is not None:
                 results.append(
                     ClassificationResult(
                         entry_type=EntryType(best_type),
-                        confidence=best_similarity,
+                        confidence=confidence,
                         status=EntryStatus.ACTIVE,
                         reasoning=(
                             f"Heuristic classification: best centroid match is "
@@ -323,7 +331,7 @@ class HeuristicClassifier:
                 results.append(
                     ClassificationResult(
                         entry_type=EntryType.INBOX,
-                        confidence=best_similarity,
+                        confidence=confidence,
                         status=EntryStatus.PENDING_REVIEW,
                         reasoning=(
                             f"Heuristic classification: no centroid exceeded threshold "

--- a/tests/test_classification/test_heuristic.py
+++ b/tests/test_classification/test_heuristic.py
@@ -386,3 +386,99 @@ class TestClassifyIntegration:
         result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
 
         assert isinstance(result, ClassificationResult)
+
+
+# ---------------------------------------------------------------------------
+# Regression: confidence stays within [0.0, 1.0]  (issue #471)
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceClamping:
+    """Regression tests ensuring confidence is always within [0.0, 1.0].
+
+    Cosine similarity ranges over [-1.0, 1.0], but the
+    :class:`~distillery.classification.models.ClassificationResult` contract
+    documents ``confidence`` as ``[0.0, 1.0]``.  When an entry's embedding
+    points opposite to every centroid, the raw best_similarity is negative
+    and must be clamped before being assigned to ``confidence``.
+    """
+
+    async def test_classify_clamps_negative_similarity_to_zero(
+        self,
+        store: Any,
+        deterministic_embedding_provider: DeterministicEmbeddingProvider,
+    ) -> None:
+        """An entry opposite to every centroid yields confidence == 0.0."""
+        # Build a session cluster pointing along +axis 0.
+        dims = deterministic_embedding_provider.dimensions
+        positive = _axis_vector(dims, 0)
+        negative = [-x for x in positive]
+
+        for i in range(MIN_ENTRIES_PER_TYPE):
+            content = f"positive cluster entry {i}"
+            deterministic_embedding_provider.register(content, positive)
+            entry = make_entry(
+                content=content,
+                entry_type=EntryType.SESSION,
+                status=EntryStatus.ACTIVE,
+            )
+            await store.store(entry)
+
+        # Inbox entry points in the opposite direction -> cosine sim = -1.0.
+        inbox_content = "diametrically opposed entry"
+        deterministic_embedding_provider.register(inbox_content, negative)
+        inbox_entry = make_entry(
+            content=inbox_content,
+            entry_type=EntryType.INBOX,
+        )
+
+        classifier = HeuristicClassifier()
+        result = await classifier.classify(inbox_entry, store, deterministic_embedding_provider)
+
+        # The raw best_similarity is -1.0 (opposite cluster), well below
+        # SIMILARITY_THRESHOLD, so the entry is sent to review.  But the
+        # reported confidence MUST remain within the documented [0.0, 1.0]
+        # range, not the raw cosine value.
+        assert result.status == EntryStatus.PENDING_REVIEW
+        assert result.confidence >= 0.0, f"confidence must be >= 0.0, got {result.confidence}"
+        assert result.confidence <= 1.0, f"confidence must be <= 1.0, got {result.confidence}"
+        assert result.confidence == pytest.approx(0.0, abs=1e-9)
+
+    async def test_classify_batch_clamps_negative_similarity_to_zero(
+        self,
+        store: Any,
+        deterministic_embedding_provider: DeterministicEmbeddingProvider,
+    ) -> None:
+        """classify_batch must also clamp negative similarities to 0.0."""
+        dims = deterministic_embedding_provider.dimensions
+        positive = _axis_vector(dims, 0)
+        negative = [-x for x in positive]
+
+        for i in range(MIN_ENTRIES_PER_TYPE):
+            content = f"batch positive entry {i}"
+            deterministic_embedding_provider.register(content, positive)
+            await store.store(
+                make_entry(
+                    content=content,
+                    entry_type=EntryType.SESSION,
+                    status=EntryStatus.ACTIVE,
+                )
+            )
+
+        # Two inbox entries: one opposite, one orthogonal.
+        opposite_content = "batch opposite entry"
+        deterministic_embedding_provider.register(opposite_content, negative)
+        orthogonal_content = "batch orthogonal entry"
+        deterministic_embedding_provider.register(orthogonal_content, _axis_vector(dims, dims - 1))
+        entries = [
+            make_entry(content=opposite_content, entry_type=EntryType.INBOX),
+            make_entry(content=orthogonal_content, entry_type=EntryType.INBOX),
+        ]
+
+        classifier = HeuristicClassifier()
+        results = await classifier.classify_batch(entries, store, deterministic_embedding_provider)
+
+        assert len(results) == 2
+        for result in results:
+            assert result.confidence >= 0.0, f"confidence must be >= 0.0, got {result.confidence}"
+            assert result.confidence <= 1.0, f"confidence must be <= 1.0, got {result.confidence}"


### PR DESCRIPTION
## Problem

`HeuristicClassifier` in `src/distillery/classification/heuristic.py` was assigning the raw `best_similarity` (cosine similarity, range `[-1.0, 1.0]`) directly to `ClassificationResult.confidence`, whose contract at `src/distillery/classification/models.py:48-49` documents `[0.0, 1.0]`. The LLM-backed `ClassificationEngine` already clamps via `max(0.0, min(1.0, confidence))` at `engine.py:154-155`; the heuristic path did not.

When an entry embedding points opposite to every centroid (e.g. brand-new content type), the raw `best_similarity` is negative — the regression test below confirms `confidence == -1.0` without the fix. This violates the documented contract and could produce nonsense downstream (status thresholds compared against a negative value).

## Fix

Apply the engine's clamp pattern at every `ClassificationResult` construction site in `heuristic.py` — both `classify` (lines 132/147) and `classify_batch` (lines 312/326). The raw `best_similarity` is preserved in the human-readable reasoning text for diagnostic purposes.

## Test plan

- [x] New `TestConfidenceClamping` regression class with two tests (one for `classify`, one for `classify_batch`) that build a centroid configuration where the entry embedding is diametrically opposite to the only cluster (cosine similarity = -1.0). Both tests assert `0.0 <= confidence <= 1.0`.
- [x] Verified tests fail with `confidence == -1.0` against the unpatched source.
- [x] Verified tests pass with the patch applied.
- [x] All 21 tests in `tests/test_classification/test_heuristic.py` pass (19 existing + 2 new).
- [x] `ruff format` and `ruff check` clean on edited files.
- [x] `mypy --strict src/distillery/` succeeds.
- [x] No previously-passing test changes behavior — the existing tests intentionally checked confidence against `SIMILARITY_THRESHOLD` (>= 0.5 or < 0.5), not raw negative values, so clamping doesn't change them.

Closes #471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Classification results now include properly calibrated confidence values constrained to the [0.0, 1.0] range
  * Fixed issue where extreme similarity calculations could produce out-of-bounds confidence measurements

* **Tests**
  * Added regression tests verifying confidence values remain within valid bounds for single-entry and batch classification operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->