### PR TITLE
fix(mcp): accept case-insensitive Bearer auth scheme

### DIFF
--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -390,8 +390,11 @@ async def _ensure_store(
 def _verify_bearer_token(request: Request, secret: str) -> bool:
     """Check the ``Authorization: Bearer <token>`` header.
 
-    Uses :func:`hmac.compare_digest` for constant-time comparison to
-    prevent timing-based attacks on the token value.
+    The auth scheme is matched case-insensitively per RFC 7235 §2.1
+    ("case-insensitive token"), so ``Bearer``, ``bearer``, and ``BEARER``
+    are all accepted.  The token value itself is compared with
+    :func:`hmac.compare_digest` for constant-time comparison to prevent
+    timing-based attacks.
 
     Args:
         request: The incoming Starlette request.
@@ -401,9 +404,9 @@ def _verify_bearer_token(request: Request, secret: str) -> bool:
         ``True`` if the token matches, ``False`` otherwise.
     """
     auth_header = request.headers.get("authorization", "")
-    if not auth_header.startswith("Bearer "):
+    scheme, _, token = auth_header.partition(" ")
+    if scheme.lower() != "bearer" or not token:
         return False
-    token = auth_header[len("Bearer ") :]
     return hmac.compare_digest(token, secret)
 
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -24,7 +24,7 @@ from starlette.routing import Mount, Route
 from starlette.testclient import TestClient
 
 from distillery.config import DistilleryConfig, ServerConfig, WebhookConfig
-from distillery.mcp.webhooks import create_webhook_app
+from distillery.mcp.webhooks import _verify_bearer_token, create_webhook_app
 from distillery.store.duckdb import DuckDBStore
 
 # The autouse fixture that clears ``_jobs``, ``_active_job_by_endpoint``,
@@ -147,6 +147,62 @@ async def test_auth_valid_token_returns_202(
         # the empty fixture store and returns an all-zeros poll summary.
         final = _wait_for_job(client, body["job_id"])
         assert final["state"] == "succeeded"
+
+
+def _make_request_with_auth(header_value: str) -> Request:
+    """Build a minimal Starlette :class:`Request` carrying *header_value* as Authorization."""
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/poll",
+        "headers": [(b"authorization", header_value.encode("latin-1"))],
+    }
+    return Request(scope)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "scheme",
+    ["Bearer", "bearer", "BEARER", "BeArEr"],
+    ids=["title-case", "lower-case", "upper-case", "mixed-case"],
+)
+def test_verify_bearer_token_scheme_case_insensitive(scheme: str) -> None:
+    """Regression for #469: RFC 7235 §2.1 makes the auth scheme case-insensitive."""
+    request = _make_request_with_auth(f"{scheme} {_SECRET}")
+    assert _verify_bearer_token(request, _SECRET) is True
+
+
+@pytest.mark.unit
+def test_verify_bearer_token_rejects_other_schemes() -> None:
+    """Schemes other than ``bearer`` must still be rejected even if the token matches."""
+    request = _make_request_with_auth(f"Basic {_SECRET}")
+    assert _verify_bearer_token(request, _SECRET) is False
+
+
+@pytest.mark.unit
+def test_verify_bearer_token_rejects_missing_token() -> None:
+    """A header with the right scheme but no token value must be rejected."""
+    assert _verify_bearer_token(_make_request_with_auth("Bearer"), _SECRET) is False
+    assert _verify_bearer_token(_make_request_with_auth("Bearer "), _SECRET) is False
+
+
+@pytest.mark.unit
+async def test_auth_lowercase_bearer_scheme_accepted(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end regression: ``Authorization: bearer <token>`` is accepted (#469)."""
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+    app = create_webhook_app(shared, config)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/poll", headers={"Authorization": f"bearer {_SECRET}"})
+
+        assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert body["ok"] is True
+        assert isinstance(body["job_id"], str) and body["job_id"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -204,6 +204,11 @@ async def test_auth_lowercase_bearer_scheme_accepted(
         assert body["ok"] is True
         assert isinstance(body["job_id"], str) and body["job_id"]
 
+        # Wait for the background job to terminate so teardown doesn't race
+        # with the autouse fixture that clears the in-process job registry.
+        final = _wait_for_job(client, body["job_id"])
+        assert final["state"] == "succeeded"
+
 
 # ---------------------------------------------------------------------------
 # Cooldown tests


### PR DESCRIPTION
## Problem

`_verify_bearer_token` in `src/distillery/mcp/webhooks.py` matched the
literal prefix `Bearer ` only, so requests sending the scheme in any
other case (`bearer`, `BEARER`, mixed) were rejected with 401 even
when the token was correct. RFC 7235 §2.1 explicitly defines auth
schemes as case-insensitive tokens, and several HTTP client libraries
and proxy intermediaries normalize the scheme to lowercase, which made
the bug observable in the wild.

## Fix

Partition the header on the first space, compare the scheme via
`.lower() == "bearer"`, and continue to compare the token value with
`hmac.compare_digest` for constant-time equality. An empty token (e.g.
`"Bearer"` or `"Bearer "` with nothing after) is now also rejected
explicitly, preserving the previous behaviour.

The function signature, callers, and the constant-time compare path
are all unchanged.

## Test plan

- [x] New unit tests parametrize the scheme over `Bearer`, `bearer`,
      `BEARER`, `BeArEr` and assert all succeed.
- [x] New unit tests assert `Basic <token>` and an empty token are
      still rejected.
- [x] New end-to-end test confirms the live `/poll` endpoint accepts
      `Authorization: bearer <token>`.
- [x] Existing auth tests (missing token, wrong token, valid token)
      continue to pass — 35/35 in `tests/test_webhooks.py`.
- [x] `ruff format`, `ruff check`, `mypy --strict` all clean.

Closes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook bearer token handling now accepts mixed-case "Bearer" declarations and more flexible token formatting, improving compatibility with varied clients and RFC 7235 compliance.

* **Security**
  * Token comparisons now use constant-time methods to reduce timing-attack risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->