### PR TITLE
fix(feeds): apply alert threshold in FeedPoller

### DIFF
--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -403,6 +403,7 @@ def _item_to_entry_kwargs(
     *,
     enriched_content: str | None = None,
     is_backfill: bool = False,
+    is_alert: bool = False,
 ) -> dict[str, Any]:
     """Convert a :class:`~distillery.feeds.models.FeedItem` to Entry constructor kwargs.
 
@@ -426,6 +427,12 @@ def _item_to_entry_kwargs(
             backfill batch via ``metadata.backfill = True``.  ``/radar`` and
             other digest surfaces use this flag to suppress historic items
             that pre-date the source's registration.  See issue #444.
+        is_alert: When ``True``, mark this entry as having met the alert
+            threshold (``feeds.thresholds.alert``) via ``metadata.is_alert =
+            True``.  Items in the ``[digest, alert)`` band remain
+            digest-eligible only.  See issue #472.  A downstream alert
+            consumer (e.g. notification sink) is intentionally out of scope
+            for this fix and is left to a follow-up.
 
     Returns:
         A dict of keyword arguments for :class:`~distillery.models.Entry`.
@@ -447,6 +454,8 @@ def _item_to_entry_kwargs(
         metadata["published_at"] = item.published_at.isoformat()
     if is_backfill:
         metadata["backfill"] = True
+    if is_alert:
+        metadata["is_alert"] = True
 
     if enriched_content is not None:
         # Replace the body with Reader-fetched markdown but keep the title
@@ -536,6 +545,11 @@ class FeedPoller:
             if relevance_threshold is not None
             else config.feeds.thresholds.digest
         )
+        # Two-tier threshold: items with adjusted_score >= alert threshold get
+        # flagged via metadata.is_alert (issue #472).  Items in the
+        # ``[digest, alert)`` band remain digest-eligible only.  The constraint
+        # ``digest <= alert`` is enforced by validate_config().
+        self._alert_threshold = config.feeds.thresholds.alert
         self._reader = reader
 
     async def poll(self, *, source_url: str | None = None) -> PollerSummary:
@@ -865,12 +879,22 @@ class FeedPoller:
             try:
                 from distillery.models import Entry
 
+                # Defensive: alert threshold may be a non-numeric placeholder
+                # (e.g. MagicMock in some unit tests).  Treat any comparison
+                # failure as "not alert-worthy" — we never want a malformed
+                # threshold to break the store path.
+                try:
+                    is_alert = adjusted_score >= float(self._alert_threshold)
+                except (TypeError, ValueError):
+                    is_alert = False
+
                 kwargs = _item_to_entry_kwargs(
                     item,
                     adjusted_score,
                     keyword_map,
                     enriched_content=enriched,
                     is_backfill=is_backfill,
+                    is_alert=is_alert,
                 )
                 entry = Entry(**kwargs)
                 await self._store.store(entry)

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -550,6 +550,9 @@ class FeedPoller:
         # ``[digest, alert)`` band remain digest-eligible only.  The constraint
         # ``digest <= alert`` is enforced by validate_config().
         self._alert_threshold = config.feeds.thresholds.alert
+        # One-shot guard so a misconfigured / non-numeric alert threshold
+        # only logs once per poller instance instead of per item.
+        self._alert_threshold_warning_emitted = False
         self._reader = reader
 
     async def poll(self, *, source_url: str | None = None) -> PollerSummary:
@@ -882,10 +885,19 @@ class FeedPoller:
                 # Defensive: alert threshold may be a non-numeric placeholder
                 # (e.g. MagicMock in some unit tests).  Treat any comparison
                 # failure as "not alert-worthy" — we never want a malformed
-                # threshold to break the store path.
+                # threshold to break the store path.  Log once per poller so
+                # misconfiguration is observable without spamming the log.
                 try:
                     is_alert = adjusted_score >= float(self._alert_threshold)
-                except (TypeError, ValueError):
+                except (TypeError, ValueError) as exc:
+                    if not self._alert_threshold_warning_emitted:
+                        logger.warning(
+                            "FeedPoller: invalid alert threshold %r (%s); "
+                            "alert tagging disabled for this poller instance",
+                            self._alert_threshold,
+                            exc,
+                        )
+                        self._alert_threshold_warning_emitted = True
                     is_alert = False
 
                 kwargs = _item_to_entry_kwargs(

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -100,11 +100,12 @@ def _source_to_dict(source: FeedSourceConfig) -> dict[str, object]:
 def _make_config(
     sources: list[FeedSourceConfig] | None = None,
     digest_threshold: float = 0.0,
+    alert_threshold: float = 0.85,
 ) -> DistilleryConfig:
     cfg = DistilleryConfig()
     cfg.feeds = FeedsConfig(
         sources=sources or [],
-        thresholds=FeedsThresholdsConfig(alert=0.85, digest=digest_threshold),
+        thresholds=FeedsThresholdsConfig(alert=alert_threshold, digest=digest_threshold),
     )
     return cfg
 
@@ -420,6 +421,117 @@ class TestFeedPollerRSS:
 
         assert summary.total_stored == 0
         assert summary.total_below_threshold == 1
+
+
+# ---------------------------------------------------------------------------
+# FeedPoller.poll — alert threshold (issue #472)
+# ---------------------------------------------------------------------------
+
+
+class TestFeedPollerAlertThreshold:
+    """Two-tier threshold: items >= alert get metadata.is_alert=True;
+    items in [digest, alert) are stored without the alert flag.
+
+    Regression test for issue #472: FeedPoller previously read only the digest
+    threshold and ignored ``feeds.thresholds.alert`` entirely.
+    """
+
+    def _rss_source(self) -> FeedSourceConfig:
+        return FeedSourceConfig(
+            url="https://example.com/rss",
+            source_type="rss",
+            trust_weight=1.0,
+        )
+
+    async def test_init_reads_alert_threshold_from_config(self) -> None:
+        store = _make_store()
+        cfg = _make_config(digest_threshold=0.4, alert_threshold=0.9)
+        poller = FeedPoller(store=store, config=cfg)
+        assert poller._alert_threshold == pytest.approx(0.9)
+        assert poller._threshold == pytest.approx(0.4)
+
+    async def test_item_at_or_above_alert_threshold_flagged(self) -> None:
+        items = [_make_feed_item(item_id="alert-1", title="Critical", content="Hot news")]
+        src = self._rss_source()
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.5, alert_threshold=0.85)
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            async def _find_similar(content: str, threshold: float, limit: int) -> list:
+                if threshold == 0.95:
+                    return []  # no dedup match
+                return [_make_search_result(score=0.9)]  # >= alert (0.85)
+
+            store.find_similar.side_effect = _find_similar
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 1
+        # Inspect the Entry passed to store.store()
+        store.store.assert_awaited_once()
+        stored_entry = store.store.await_args.args[0]
+        assert stored_entry.metadata.get("is_alert") is True
+
+    async def test_item_in_digest_band_not_flagged_as_alert(self) -> None:
+        items = [_make_feed_item(item_id="digest-1", title="Mild", content="Lukewarm")]
+        src = self._rss_source()
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.5, alert_threshold=0.85)
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            async def _find_similar(content: str, threshold: float, limit: int) -> list:
+                if threshold == 0.95:
+                    return []
+                # 0.7 is in the [digest=0.5, alert=0.85) band — stored,
+                # but must NOT be flagged as alert.
+                return [_make_search_result(score=0.7)]
+
+            store.find_similar.side_effect = _find_similar
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 1
+        store.store.assert_awaited_once()
+        stored_entry = store.store.await_args.args[0]
+        assert "is_alert" not in stored_entry.metadata or stored_entry.metadata["is_alert"] is False
+
+    async def test_alert_threshold_respects_trust_weight(self) -> None:
+        """adjusted_score = score * trust_weight is what gets compared, not raw score."""
+        source = FeedSourceConfig(
+            url="https://example.com/rss",
+            source_type="rss",
+            trust_weight=0.5,
+        )
+        items = [_make_feed_item(item_id="tw-1")]
+        store = _make_store(feed_sources=[_source_to_dict(source)])
+        # digest=0.3 lets it through; alert=0.85 — raw 0.9 * 0.5 = 0.45 < 0.85.
+        cfg = _make_config(sources=[source], digest_threshold=0.3, alert_threshold=0.85)
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build.return_value = mock_adapter
+
+            async def _find_similar(content: str, threshold: float, limit: int) -> list:
+                if threshold == 0.95:
+                    return []
+                return [_make_search_result(score=0.9)]
+
+            store.find_similar.side_effect = _find_similar
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 1
+        stored_entry = store.store.await_args.args[0]
+        assert "is_alert" not in stored_entry.metadata or stored_entry.metadata["is_alert"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`FeedPoller` reads `config.feeds.thresholds.digest` but never reads `config.feeds.thresholds.alert`. The two-tier behavior promised by `FeedsThresholdsConfig` (items >= `alert` trigger immediate alerts; items in `[digest, alert)` go to the digest) is therefore not implemented.

* Init was at `src/distillery/feeds/poller.py:534-538` (digest only).
* The single threshold check was at `:854` (digest vs adjusted_score).

## Fix

* Read `self._alert_threshold` from `config.feeds.thresholds.alert` in `FeedPoller.__init__`. The constraint `digest <= alert` is already enforced by `validate_config()`.
* In `_do_poll_source`, after `adjusted_score` is computed, attach `metadata["is_alert"] = True` to entries whose score meets the alert threshold. The flag is omitted (rather than set `False`) for digest-only items to match existing optional-flag conventions in the metadata dict (consistent with `metadata.backfill`).
* Defensively guard the comparison against non-numeric thresholds (e.g. `MagicMock` in some unit tests in `tests/test_feeds.py` that previously got away with mocking only `digest`) by treating any `TypeError` / `ValueError` as "not alert-worthy" — the store path must never be broken by a malformed threshold.

## Scope note (out of scope, follow-up)

A downstream alert consumer (notification sink, Slack/email push, etc.) is intentionally **not** built by this PR. A grep for `is_alert` / `alert_threshold` showed no existing consumer. The minimal contract fix is to surface the flag on the entry's metadata; wiring an actual notifier is left to a follow-up issue.

## Test plan

- [x] `pytest tests/test_poller.py::TestFeedPollerAlertThreshold -v` — 4 new regression tests:
  - `test_init_reads_alert_threshold_from_config` — init wires both thresholds
  - `test_item_at_or_above_alert_threshold_flagged` — score 0.9, alert 0.85 → `metadata.is_alert is True`
  - `test_item_in_digest_band_not_flagged_as_alert` — score 0.7 in `[digest=0.5, alert=0.85)` → no alert flag
  - `test_alert_threshold_respects_trust_weight` — trust 0.5 × score 0.9 = 0.45 < alert 0.85 → no alert flag
- [x] `pytest tests/test_poller.py tests/test_feeds.py` — 153 passed (no regressions in adjacent suites that mock config)
- [x] `ruff format src/ tests/`, `ruff check src/ tests/` — clean
- [x] `mypy --strict src/distillery/` — clean

Closes #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-tier thresholds for feed items with an alert threshold; items meeting alert criteria are flagged and alert metadata stored with entries.

* **Bug Fixes**
  * Defensive handling for invalid alert thresholds: logs a warning once per run and disables alert tagging when threshold is unusable.

* **Tests**
  * Added tests validating alert-threshold behavior, boundary cases, and trust-weight interactions; alert threshold made configurable in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->