### PR TITLE
fix(supply-chain): unblock Grype scan (python-multipart 0.0.27, python-3.14.4-r4)

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -40,9 +40,9 @@ ignore:
   - vulnerability: CVE-2026-3298
     package:
       name: python-3.14
-      version: 3.14.4-r3
+      version: 3.14.4-r4
       type: apk
-    reason: "CPython 3.14.4-r3 — CVSS High; affects the interpreter's startup path under specific PYTHONHOME / site-packages override conditions on multi-user systems.  Not exploitable in our deployment: Distillery runs as the Chainguard distroless 'nonroot' user (uid 65532) inside an immutable distroless container with a fixed PYTHONHOME and no shared-tenant site-packages directory.  No upstream fix released by CPython upstream or Wolfi.  Reviewed: 2026-05-03"
+    reason: "CPython 3.14.4-r4 — CVSS High; affects the interpreter's startup path under specific PYTHONHOME / site-packages override conditions on multi-user systems.  Not exploitable in our deployment: Distillery runs as the Chainguard distroless 'nonroot' user (uid 65532) inside an immutable distroless container with a fixed PYTHONHOME and no shared-tenant site-packages directory.  No upstream fix released by CPython upstream or Wolfi.  Reviewed: 2026-05-07"
 
   - vulnerability: CVE-2026-5435
     package:

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -32,9 +32,9 @@
 ignore:
   # ---------------------------------------------------------------------
   # Active suppressions — confirmed against the CI scan of the python-3.14
-  # runtime image (SBOM: python-3.14.4-r3 + glibc 2.43-r7, Chainguard
+  # runtime image (SBOM: python-3.14.4-r4 + glibc 2.43-r7, Chainguard
   # distroless `cgr.dev/chainguard/python` base, which is built on Wolfi).
-  # Reviewed: 2026-05-03 (issue #418, distroless migration #419).
+  # Reviewed: 2026-05-07 (issue #418, distroless migration #419).
   # ---------------------------------------------------------------------
 
   - vulnerability: CVE-2026-3298

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "httpx>=0.24.0,<1.0",
     "fastmcp>=2.12.0,<4.0",
     "defusedxml>=0.7.0,<1.0",
+    # Transitive via fastmcp/starlette; pin floor for GHSA-pp6c-gr5w-3c5g.
+    "python-multipart>=0.0.27",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3025,11 +3025,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649617Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The supply-chain `Scan (distillery)` Grype gate has been failing on every open PR (#473, #474, #467, #479) with two HIGH-severity findings. This PR unblocks them.

Unblocks #473, #474, #467, #479.

## Findings

| Finding | Package | Currently | Action |
|---|---|---|---|
| **GHSA-pp6c-gr5w-3c5g** | `python-multipart` (PyPI) | 0.0.26 (transitive via `fastmcp -> starlette/fastapi`) | Add defensive floor `>=0.0.27` in `[project].dependencies` so the resolver picks the fixed release. |
| **CVE-2026-3298** | `python-3.14` (apk, Wolfi) | `3.14.4-r4` in current Chainguard base; existing suppression scoped to `-r3` | Retag the existing scoped suppression to `3.14.4-r4`; rationale unchanged. |

### GHSA-pp6c-gr5w-3c5g (python-multipart)

Upstream DoS via unbounded multipart part-header parsing, fixed in [`0.0.27`](https://github.com/Kludex/python-multipart/releases/tag/0.0.27). Distillery does not import `python-multipart` directly, but it ships transitively through FastMCP's HTTP transport / Starlette. A defensive lower-bound pin in our top-level `dependencies` is the cleanest fix: it nudges the resolver without forcing a fork of the upstream chain, and it documents intent for future audits.

### CVE-2026-3298 (python-3.14, apk)

The Chainguard distroless base image rolled from `python-3.14.4-r3` to `-r4`, so the existing version-scoped suppression no longer matches what grype emits and the gate trips. Per `.grype.yaml`'s own audit policy, the right move is to retag the suppression to the new package version — the not-exploitable rationale (immutable distroless, nonroot uid 65532, fixed `PYTHONHOME`, no shared-tenant `site-packages`) is identical between `-r3` and `-r4`. Reviewed date bumped to `2026-05-07`.

## Verification

- `python -c "import tomllib; tomllib.loads(open('pyproject.toml').read())"` — TOML parses.
- Structural check on `.grype.yaml` confirms `version: 3.14.4-r4` and `Reviewed: 2026-05-07` are present and `-r3` is gone (PyYAML not installed locally; CI will fully parse).
- No CI workflows touched. Other suppressions in `.grype.yaml` (CVE-2026-5435 on glibc) untouched.

## Test plan
- [ ] CI `Scan (distillery)` Grype job is green on this PR
- [ ] CI tests / mypy / ruff stay green
- [ ] After merge, rebase #473 / #474 / #467 / #479 onto main and confirm their Grype gates clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability suppression entry for CVE-2026-3298 to reflect the reviewed Python patch level and reviewed date.
  * Added a direct runtime dependency on python-multipart (minimum version 0.0.27) to address a security advisory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->