### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "distillery",
       "source": "./",
       "description": "Knowledge base skills — capture, search, and synthesize project knowledge",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings"],
       "category": "knowledge-management"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "distillery",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Knowledge base skills for Claude Code — capture, search, and synthesize project knowledge",
   "author": {
     "name": "norrietaylor",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,70 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.5.0] - 2026-05-07
+
+### Features
+
+- /radar issues all top-5 queries and raises default limit to 35 (#461) (#462) *(skills)*
+- /radar --topic flag and namespace-aware tag selection (#460) (#463) *(skills)*
+- /radar --structure flag for orphans + bridges + communities (#141) (#429) *(skill)*
+- /investigate uses multi-hop traverse + hidden-connections gap filling (#427) *(skill)*
+- /pour --graph flag for graph-expanded retrieval (#138) (#428) *(skill)*
+- add structural=["orphans"] filter to distillery_list (#141) (#423) *(mcp)*
+- add action="metrics" to distillery_relations + [graph] extra (#138, #141) (#426) *(mcp)*
+- add expand_graph + expand_hops to distillery_search (#138) (#425) *(mcp)*
+- add exclude_linked + source_entry_id to find_similar (#140) (#422) *(mcp)*
+- add action="traverse" to distillery_relations (#138) (#424) *(mcp)*
+- add Cell A graph regression gate; defer Cell B value-add (#458) (#464) *(bench)*
+
+### Bug Fixes
+
+- add include_archived opt-in to get(); update consumers *(store)*
+- log once when alert threshold coercion fails *(feeds)*
+- apply alert threshold in FeedPoller (#472) (#477) *(feeds)*
+- accept case-insensitive Bearer auth scheme (#476) *(mcp)*
+- clamp HeuristicClassifier confidence to [0.0, 1.0] (#475) *(classification)*
+- filter archived entries from get() (#468) (#474) *(store)*
+- validate OpenAI response length matches input (#473) *(embedding)*
+- structural filter validation + cap-exceeded fail-fast (review) *(mcp)*
+- cache eviction + async DB + pagination + error-msg hygiene (review) *(mcp,graph)*
+- expand_graph honours archived-visibility filter (review) *(mcp)*
+- align YAML and MCP validation for feeds.digest.candidate_limit *(config)*
+- guard Q==0 in /radar budget distribution *(skills)*
+- simplify /radar 6b/6c NetworkX error flow *(skills)*
+- clarify --topic skip semantics in Step 3a *(skills)*
+
+### CI/CD
+
+- bump python-multipart to >=0.0.27 and refresh .grype.yaml python suppression *(supply-chain)*
+- sync .grype.yaml SBOM banner to python-3.14.4-r4 *(supply-chain)*
+
+### Documentation
+
+- clarify excluded_linked_count return semantics (CR feedback) *(mcp)*
+- clarify Cell A LIMIT comment matches sample-size guard *(bench)*
+- clarify investigate Phase 2b cap behaviour (review) *(skill)*
+- clarify investigate BFS depth wording (review feedback) *(skill)*
+- align investigate Output Format example with summary template *(skills)*
+- fix MD038 code-span spacing in /pour --graph (review) *(skill)*
+- clarify /radar 6c community ordering and member rendering *(skills)*
+
+### Skills
+
+- /investigate gains Phase 2 multi-hop traverse + Phase 2b hidden-connections gap fill (#427)
+- /pour gains opt-in `--graph` flag for 1-hop graph-expanded retrieval (#428)
+- /radar gains `--structure` (orphans / bridges / communities), `--topic` (literal-string queries with namespace-aware fallback), and `--limit` honoring `feeds.digest.candidate_limit` (#429, #463, #462)
+
+### Bench
+
+- Cell A graph regression gate live: 500q × 5 seeds, mean R@5 0.972, delta 0.0pp vs HEADLINE, gate_pass=true ([run 25453787717](https://github.com/norrietaylor/distillery/actions/runs/25453787717))
+- Cell B (graph value-add) deferred — LongMemEval is single-user/single-session and cannot measure the cross-user/cross-session graph hypothesis (see `bench/LIMITATIONS.md` §(f))
+
+### Miscellaneous
+
+- nightly LongMemEval results 2026-05-05 / 2026-05-06 / 2026-05-07 *(bench)*
+- update Cell A regression aggregate from run *(bench,graph)*
+
 ## [0.4.1] - 2026-05-06
 
 ### Bug Fixes

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -127,20 +127,24 @@ features regress baseline recall when the entry graph is sparse?** The pass crit
 is that Cell A's mean R@5 stays within the variance-gate threshold (default 0.5pp) of
 the HEADLINE mean.
 
-!!! note "Status: forward-compatible plumbing until graph PRs land"
+!!! success "Status: gate live — first 500q × 5-seed result lands at delta = 0.0pp"
 
-    Until the graph retrieval PRs ([#422](https://github.com/norrietaylor/distillery/pull/422)–[#429](https://github.com/norrietaylor/distillery/pull/429))
-    merge, `--expand-graph` is **metadata and output-routing only** in the
-    LongMemEval bench runner (`src/distillery/eval/longmemeval.py`). The flag
-    records the `expand_graph` axis on every receipt and routes outputs into a
-    separate subdirectory so Cell A receipts can never be confused with
-    HEADLINE receipts, but the underlying `store.search` call site is
-    unchanged — Cell A is currently measuring the same retrieval path as
-    HEADLINE. Once the graph PRs merge, the runner will be wired to invoke
-    graph-enabled retrieval without further workflow or docs changes, and
-    Cell A's regression-gate semantics become live. Until then, treat any
-    Cell A delta as a sanity check on the receipt-isolation infrastructure,
-    not a measurement of the graph-enabled path.
+    The graph retrieval PRs ([#422](https://github.com/norrietaylor/distillery/pull/422)–[#429](https://github.com/norrietaylor/distillery/pull/429))
+    merged ahead of the 0.5.0 release, and Cell A's regression-gate semantics
+    are live. The first full-500q × 5-seed Cell A run on the v0.5.0 commit
+    landed at **mean R@5 = 0.972** (stddev 0.000), exactly matching the
+    HEADLINE mean of 0.972 over the same 500q sample for a **delta of 0.0pp**
+    against the 0.5pp variance-gate threshold (`gate_pass=true`,
+    `sample_size_match=true`). Run:
+    [`actions/runs/25453787717`](https://github.com/norrietaylor/distillery/actions/runs/25453787717).
+    Aggregate receipt: [`bench/results/graph_regression_cell_a.json`](https://github.com/norrietaylor/distillery/blob/main/bench/results/graph_regression_cell_a.json).
+
+    Per the discipline in `bench/LIMITATIONS.md` §(f), this is a regression
+    result only — *no* value-add claim is implied. Cell A passing means
+    "enabling graph features did not regress baseline recall on
+    LongMemEval-S" and nothing more. The graph hypothesis (cross-user /
+    cross-session relations) is not exercised by LongMemEval and is deferred
+    to Cell B.
 
 - **Workflow.** [`.github/workflows/bench-graph-regression-cell.yml`](https://github.com/norrietaylor/distillery/blob/main/.github/workflows/bench-graph-regression-cell.yml)
   runs nightly at 06:00 UTC, sequenced after the HEADLINE workflow at 05:00 UTC.

--- a/docs/blog/distillery-0-5-0-graph.md
+++ b/docs/blog/distillery-0-5-0-graph.md
@@ -1,0 +1,112 @@
+---
+title: "Walking the Graph: Distillery 0.5.0"
+published: false
+description: "What 0.5.0 ships — multi-hop traversal, hidden-link discovery, structural insights — and how a regression gate kept the graph launch honest."
+tags: [claudecode, mcp, devtools, release, knowledgegraph]
+canonical_url: https://norrietaylor.github.io/distillery/blog/distillery-0-5-0-graph/
+---
+
+# Walking the Graph: Distillery 0.5.0
+
+!!! note "Release summary"
+    Distillery 0.5.0 shipped May 7, 2026. It's the release where the
+    knowledge graph stops being plumbing and becomes a primary retrieval
+    surface — multi-hop traversal in `/investigate`, opt-in graph-expanded
+    synthesis in `/pour --graph`, and structural insights (orphans /
+    bridges / communities) in `/radar --structure`. Graph features are
+    default-off. The release body lives on the
+    [GitHub release page](https://github.com/norrietaylor/distillery/releases/tag/v0.5.0).
+
+[The 0.4.0 post](distillery-0-4-0-full-proof.md) was about turning the MCP tool surface into a public contract. This post is about what we built on top of that contract once the contract was load-bearing.
+
+The single sentence is: **Distillery learned to walk the graph.**
+
+The longer version is that we'd been carrying an `entry_relations` table since 0.3.0 — every entry could be linked to every other entry with a typed edge — but only one skill (`/investigate` Phase 2) actually traversed it, and only one hop deep, and only after a per-relation `distillery_get` fan-out that punished any seed with more than a handful of neighbours. The graph existed; nothing read it well. 0.5.0 fixes that, end to end, in eight PRs and a regression gate.
+
+## What we shipped
+
+### Hidden-connections discovery in `/investigate`
+
+`/investigate` already retrieved seeds, walked their direct relations, expanded by tag, and probed for gaps. 0.5.0 adds two changes that, together, change the character of what comes back.
+
+The first is multi-hop traversal. Phase 2 now issues a single `distillery_relations(action="traverse", hops=2, direction="both")` per seed, and the MCP server runs the BFS internally and returns the full subgraph — nodes (with depth), edges, and counts — in one envelope. Two-hop neighbours surface in the same call as one-hop. The previous fan-out (one `get` per related id, per seed) is gone.
+
+The second, more interesting change is **Phase 2b — hidden connections**. For each Phase 1 seed, the skill calls `distillery_find_similar(source_entry_id=<seed>, exclude_linked=true, threshold=0.7)`. The MCP server filters out anything that already shares a stored relation with the seed in either direction, so what comes back is unlinked-but-semantically-related — the entries the graph alone would never surface, because nobody wrote down that they were related, but that the embedding space says belong with this seed.
+
+These are tagged `potentially related` in the synthesis and the sources table — never added to the relationship map, because they have no recorded edge. The framing matters: a stored relation is something a human authored; a Phase 2b hit is a hypothesis the embedding space is generating. Treating them differently in the output is what makes the skill useful instead of noisy.
+
+In practice this is the fix for the "I know we wrote about this somewhere but it never gets cited together" failure mode. The graph captures intentional knowledge structure; embeddings capture incidental similarity. Phase 2b reads both.
+
+### Multi-hop synthesis in `/pour --graph`
+
+`/pour` runs four-pass retrieval (curated → broad → concept follow-up → tag expansion → gap fill) and synthesizes the union into a structured narrative with citations. Until 0.5.0, all four passes were pure semantic search. Now there's an opt-in `--graph` flag that adds 1-hop graph expansion to every search call.
+
+The mechanism is one new MCP feature: `distillery_search` accepts `expand_graph=true, expand_hops=1`. The server runs the underlying hybrid search, then for each hit follows outgoing relations one hop and includes the neighbours in the response, with a 0.5-per-hop score discount and `provenance: "search" | "graph"` recorded on every result. The skill picks this up in synthesis: graph-only entries are labelled `[Entry abc12345, structurally related]` in the prose, and the sources table gains a `Provenance` column showing `search` or `graph (via <parent_short_id>)`.
+
+The audit trail is the point. When a synthesis cites an entry, the reader can tell whether that entry matched the query directly or was pulled in because it's linked to a match. The first signal is "this entry talks about your topic"; the second is "this entry is what your topic depends on, even though it doesn't mention your topic by name." Both are useful; treating them as the same signal is how you get LLM-generated synthesis that confidently cites a paragraph that has nothing to do with the question.
+
+`--graph` is **off by default**. On a sparse graph it adds nothing. On a well-curated graph (sessions linked to PRs, references, follow-up minutes) it pulls in exactly the context that semantic search misses — the downstream impacts, the prior decisions a search-matched entry references, the related work in adjacent subsystems.
+
+### Structural insights in `/radar --structure`
+
+`/radar` digests recent feed activity. With `--structure`, it also appends a snapshot of the **shape** of your knowledge base:
+
+- **Orphans** — entries with no incoming or outgoing relations. Knowledge fragments worth reviewing for connection opportunities. Surfaced via `distillery_list(structural=["orphans"])`.
+- **Bridges** — top-5 entries by betweenness centrality. The "joints" of the graph; the entries whose loss or contradiction would disconnect the most knowledge. Surfaced via `distillery_relations(action="metrics", metric="bridges")`.
+- **Communities** — clusters detected in the entry-relations graph, sorted by member count, with optional `[stale]` tagging when every member's `updated_at` is older than 60 days.
+
+Bridges and communities require the `[graph]` extra (NetworkX); if it's missing, `/radar` emits a one-line `pip install distillery-mcp[graph]` hint and continues without those subsections. Orphans don't need NetworkX — they're a pure SQL filter on `entry_relations`.
+
+The framing here is "what does the shape of my knowledge look like, separate from what's new this week." Most digest tools answer the second question. `--structure` answers the first.
+
+## Skill ergonomics
+
+Two changes that are smaller than the graph work but matter every day.
+
+`/radar --topic <query>` lets you bypass the auto-derived interest profile and pass a literal search query straight through. Repeatable — `/radar --topic build --topic wheels` issues two separate `distillery_search` calls. The 5-query namespace cap doesn't apply to `--topic`; every distinct topic you supply is honored, up to `--limit`. This is the right flag when you want to follow a specific thread without your dominant tag clusters drowning it out.
+
+The default `/radar` (no flags) also got rewired. We now select **5 namespace-diverse tags** rather than the raw top-5 by count. A tag's namespace is its hierarchical path with the leaf removed, capped at two segments — `domain/build/hermeticity` belongs to `domain/build`, `tech/duckdb` to `tech`. Selection picks one leader per namespace, sorts namespaces by aggregate population, and returns the top-5 leaders. The result is that the query set spans up to five distinct conceptual clusters instead of returning five close variants of the same cluster.
+
+The candidate budget moved from 20 to 35 by default (`feeds.digest.candidate_limit`), and `--limit` is a per-invocation override. With Q=5 queries and a 35-entry budget, each query gets 7 results — 35 raw → ~30 unique candidates after dedup. Small overrides like `--limit 3` reduce Q to 3 so the override is honored exactly; no zero-budget queries are issued.
+
+## The discipline: regression-gated launch
+
+The graph features are default-off, but they touch the same call sites that the LongMemEval headline numbers come from. Shipping them without measuring whether they regressed the baseline would be exactly the kind of silent quality drift that `bench/LIMITATIONS.md` exists to prevent.
+
+So we ran a regression gate. The full discipline note is in [`bench/LIMITATIONS.md`](https://github.com/norrietaylor/distillery/blob/main/bench/LIMITATIONS.md) §(f); the short version is that we split the graph bench coverage into two cells.
+
+**Cell A — graph regression gate (DO).** Same config as HEADLINE (`hybrid / session / recency-on / bge-small`, 500q × 5 seeds), re-run with `--expand-graph` enabled. Pass criterion: Cell A's mean R@5 must be within 0.5pp of the HEADLINE mean. The first full-500q × 5-seed run on the 0.5.0 commit landed at **mean R@5 = 0.972** (stddev 0.000), exactly matching the HEADLINE mean of 0.972 — **delta = 0.0pp, gate_pass=true**. Aggregate receipt: [`bench/results/graph_regression_cell_a.json`](https://github.com/norrietaylor/distillery/blob/main/bench/results/graph_regression_cell_a.json). Workflow run: [`actions/runs/25453787717`](https://github.com/norrietaylor/distillery/actions/runs/25453787717).
+
+**Cell B — graph value-add (DEFER).** A claim of the form "graph features improve LongMemEval" is **not supported** by this benchmark and we don't make it. LongMemEval is single-user, single-session — every question is scored against one user's haystack — and the graph hypothesis Distillery's features are designed to exploit is cross-user / cross-session entry relations. Measuring graph value-add on LongMemEval would be a category error. The deferred eval is one of: a multi-hop QA dataset, a synthetic team-knowledge eval (multiple authors, cross-author lookups), or an in-house `/investigate` / `/pour` synthesis eval that scores the value the graph adds to multi-document narrative answers. Until that eval exists, no public surface — this post, the README, the benchmarks page, the release notes — claims that graph features improve LongMemEval scores.
+
+Concretely: the 0.5.0 release notes say **"no regression with graph enabled"**, never "graph improves LongMemEval." A Cell A run with mean R@5 *higher* than HEADLINE would not be a value-add result either — it would be within the noise band the variance gate already characterises in `bench/results/variance_baseline.json`.
+
+This is not the most exciting thing we could have written about a release shipping graph features. It is the most honest one.
+
+## What's next
+
+Epic [#147](https://github.com/norrietaylor/distillery/issues/147) — the graph epic — closes with this release. The remaining work points outward:
+
+- A **multi-hop QA eval** that actually exercises the graph hypothesis. Some combination of an existing dataset (HotpotQA-shaped) adapted to the Distillery store, or a synthetic eval generated against the team-knowledge use case.
+- A **synthesis eval** that scores the value the graph adds to `/investigate` and `/pour` narrative outputs — judging whether graph-only context made the synthesis better or just longer.
+- More **structural surfaces** in the skills layer: graph-aware deduplication, bridge-aware retention policies, community-derived tag suggestions.
+
+The graph is now first-class infrastructure. The interesting questions are about what to do with it.
+
+## Try it
+
+```bash
+uvx distillery-mcp@0.5.0
+# or
+pip install distillery-mcp==0.5.0
+# graph metrics (bridges + communities) require NetworkX:
+pip install -e ".[graph]"
+```
+
+Hosted demo at `https://distillery-mcp.fly.dev/mcp` is redeployed to match. Skills remain as before for anyone who doesn't opt into the new flags — `/pour` without `--graph` and `/radar` without `--structure` behave identically to 0.4.x.
+
+The full release notes are on the [GitHub release](https://github.com/norrietaylor/distillery/releases/tag/v0.5.0). Discussion thread lives in [GitHub Discussions](https://github.com/norrietaylor/distillery/discussions).
+
+---
+
+The 0.4.0 pledge was that the surface is a contract. 0.5.0 is what that contract enables: a release that adds a new retrieval modality without breaking anything downstream, gated behind a regression check, with the value-add claim deferred until we have an eval that can measure it. Walk the graph. Don't oversell it.

--- a/docs/skills/investigate.md
+++ b/docs/skills/investigate.md
@@ -1,13 +1,13 @@
 # /investigate — Deep Context Builder
 
-Compiles comprehensive context on a topic by executing a 4-phase retrieval: seed search, relationship expansion, tag expansion, and gap filling. Combines semantic search with explicit relationship traversal to surface context that keyword search alone misses.
+Compiles comprehensive context on a topic by executing a 4-phase retrieval: seed search, relationship expansion (with hidden-connection gap fill), tag expansion, and gap filling. Combines semantic search with explicit relationship traversal — and similarity-based hidden-link discovery — to surface context that keyword search alone misses.
 
 ## Usage
 
 ```text
 /investigate authentication flow
 /investigate --entry <uuid>
-/investigate DuckDB migration --depth 3
+/investigate DuckDB migration --project distillery
 ```
 
 **Trigger phrases:** "investigate", "deep context", "what do we know about", "trace connections", "follow relationships"
@@ -22,45 +22,61 @@ Compiles comprehensive context on a topic by executing a 4-phase retrieval: seed
 ## What It Does
 
 ### Phase 1: Seed Search
-Performs semantic search for the topic, collecting the initial set of relevant entries.
 
-### Phase 2: Relationship Expansion
-Follows explicit relations (corrections, references, parent/child) from seed entries to discover connected knowledge.
+Performs a semantic search for the topic (or loads a single entry when `--entry <uuid>` is supplied), collecting the initial set of relevant entries.
+
+### Phase 2: Multi-Hop Relationship Expansion
+
+For each seed entry, issues a single `distillery_relations(action="traverse", hops=2, direction="both")` call. The server-side BFS returns nodes reachable within two hops (depth 0 = the seed, depth 1 = directly linked, depth 2 = reached via one intermediate) along with the edges between them. One round-trip per seed replaces the previous per-relation `get` fan-out, so deeper subgraphs surface in fewer calls.
+
+### Phase 2b: Hidden Connections (similarity-based gap fill)
+
+For each seed entry (capped at the top 20 seeds by Phase 1 relevance), calls `distillery_find_similar(source_entry_id=<seed>, exclude_linked=true, threshold=0.7, limit=5)`. The MCP server filters out entries that already share a stored relation with the seed in either direction, so what comes back is unlinked-but-semantically-related — the entries the graph alone would miss. These appear in the synthesis tagged `potentially related` and are *never* added to the Relationship Map (they have no recorded edge).
 
 ### Phase 3: Tag Expansion
-Uses shared tags to find entries in the same topic space that weren't surfaced by semantic search.
+
+Extracts unique tag-namespace prefixes from the result set and runs up to 3 follow-up searches derived from the most-populated namespaces.
 
 ### Phase 4: Gap Filling
-Identifies areas where knowledge is thin and reports gaps — topics mentioned but not well-covered.
+
+Identifies people, projects, or topics that are mentioned but sparsely represented (fewer than 2 entries) and runs up to 3 targeted searches to fill the gaps.
 
 ## Output Format
 
 ```text
-Investigation: authentication flow
-Sources: 12 entries across 4 phases
+# Investigate: authentication flow
 
-[Structured narrative organized by theme]
+Investigated "authentication flow": 14 entries across 4 phases, 9 relationship edges traversed (hops=2), 3 potentially related via similarity.
 
-Relationships:
-  entry-A --corrects--> entry-B
-  entry-C --references--> entry-D
+## Context Summary
+The team adopted GitHub OAuth as an identity gate [Entry a1b2c3d4],
+verified via the /user endpoint [Entry e5f6g7h8]. A SQLite-backed
+session store from a sibling project [Entry b9c0d1e2, potentially
+related] surfaces similar token-lifetime trade-offs but is not
+formally linked to the auth subsystem.
 
-Knowledge Gaps:
-  - OAuth refresh token handling (mentioned but no dedicated entry)
-  - Rate limiting strategy (referenced in 2 entries, no decision recorded)
+## Relationship Map
+Entry a1b2c3d4 [session] "OAuth identity gate"
+  —[citation]→ Entry e5f6g7h8 [reference] "Token verification"
+  —[link]→ Entry i9j0k1l2 [github] "Issue #42: scope decision"
+
+## Knowledge Gaps
+- Token refresh behavior (mentioned but no dedicated entry)
+- Multi-team RBAC design (referenced once, no decision recorded)
 ```
 
 ## Options
 
 | Flag | Description |
 |------|-------------|
-| `--entry UUID` | Start from a specific entry instead of a topic search |
-| `--depth N` | Maximum relationship traversal depth (default: 2) |
-| `--project NAME` | Scope to a specific project |
+| `--entry <uuid>` | Start from a specific entry instead of a topic search |
+| `--project <name>` | Scope Phase 1 and Phase 4 searches to a specific project |
 
 ## Tips
 
-- More thorough than `/recall` — follows relationships and identifies gaps
+- More thorough than `/recall` — follows relationships **and** surfaces hidden similarity-only links
+- The `potentially related` marker tells you the connection was inferred from embeddings, not from a stored relation — useful as a prompt to capture the link via `distillery_relations(action="add")`
+- Phase 2b is capped at the top 20 seeds to keep cost bounded; results beyond that are skipped silently
 - Use before important decisions to ensure you have full context
-- The gap analysis helps identify what to capture next with `/distill`
+- The gap analysis (Phase 4) helps identify what to capture next with `/distill`
 - Works well with `/gh-sync` entries — follow issue chains and PR discussions

--- a/docs/skills/pour.md
+++ b/docs/skills/pour.md
@@ -1,12 +1,13 @@
 # /pour — Multi-Entry Synthesis
 
-Performs multi-pass retrieval and synthesizes findings into a structured narrative with inline citations, contradiction flags, and knowledge gap analysis.
+Performs multi-pass retrieval and synthesizes findings into a structured narrative with inline citations, contradiction flags, and knowledge gap analysis. Optionally augments retrieval with 1-hop graph expansion via `--graph`.
 
 ## Usage
 
 ```text
 /pour how does our auth system work?
 /pour --project billing payment processing
+/pour --graph DuckDB migration plan
 ```
 
 **Trigger phrases:** "synthesize", "what's the full picture on", "deep dive into"
@@ -16,21 +17,39 @@ Performs multi-pass retrieval and synthesizes findings into a structured narrati
 - Building a comprehensive understanding of a topic from multiple entries
 - Preparing for a design review or decision by gathering all related knowledge
 - Identifying contradictions or gaps in the team's knowledge
+- Pulling in *structurally related* context (linked but not semantically matched) via `--graph`
 
 ## How It Works
 
-1. **Broad search** — initial semantic search across the knowledge base (up to 20 results)
-2. **Follow-up searches** — up to 3 additional queries for related concepts found in pass 1
-3. **Gap-filling** — up to 2 targeted queries for referenced but missing topics
-4. **Synthesis** — combines all unique entries into a structured narrative
+1. **Curated-content search** — limit=10 over `session`/`bookmark`/`minutes`/`reference`/`idea`/`digest` so high-value entries aren't drowned out by feed volume
+2. **Broad search** — limit=20 across all entry types
+3. **Follow-up searches** — up to 3 additional queries for related concepts found in the earlier passes
+4. **Tag expansion** — up to 3 additional queries derived from the namespace-prefixed tag vocabulary in the seed results
+5. **Gap-filling** — up to 2 targeted queries for referenced but missing topics
+6. **Synthesis** — combines all unique entries into a structured narrative with inline citations
 
 If fewer than 2 entries are found, falls back to a standard `/recall`-style display.
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--project <name>` | Scope synthesis to a specific project |
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--project <name>` | Scope synthesis to a specific project | — |
+| `--graph` | Enable 1-hop graph-expanded retrieval — every search call passes `expand_graph=true, expand_hops=1` | Off |
+
+## `--graph` flag
+
+`--graph` is **off by default** and must be opted into explicitly. When set, every `distillery_search` call across Pass 1a, 1b, Pass 2 (concept and tag-derived), Pass 3, and Step 7 refinement is invoked with `expand_graph=true, expand_hops=1`. Each search seed is augmented with its 1-hop structural neighbours from `entry_relations`, with a 0.5-per-hop score discount. Each result carries `provenance: "search" | "graph"`, `depth`, and `parent_id`.
+
+In synthesis, graph-only entries are labelled `[Entry abc12345, structurally related]` in the prose, and the **Sources** table gains a `Provenance` column showing `search` or `graph (via <parent_short_id>)`. The retrieval audit trail is therefore explicit — readers can tell which entries matched the query directly and which were pulled in because they're linked to a match. If the same entry appears via both provenances across passes, `search` wins (the stronger signal).
+
+The retrieval summary line gains a graph-expansion total when `--graph` is set:
+
+```text
+Retrieved 18 unique entries across 4 search passes (graph expansion: 12 seed → 18 after 1-hop neighbours).
+```
+
+Without `--graph`, Pour's behaviour is unchanged from prior releases — no provenance column, no "structurally related" labels, no expansion totals.
 
 ## Output
 
@@ -39,7 +58,10 @@ If fewer than 2 entries are found, falls back to a standard `/recall`-style disp
 
 ## Summary
 The authentication system uses GitHub OAuth as an identity gate [Entry a1b2c3d4],
-with tokens verified via the /user endpoint [Entry e5f6g7h8]...
+with tokens verified via the /user endpoint [Entry e5f6g7h8]. A downstream
+session-store decision [Entry m1n2o3p4, structurally related] is linked to
+the OAuth entry via `entry_relations` and explains why tokens are stored
+locally rather than on the server.
 
 ## Timeline
 - 2026-03-10: Initial OAuth implementation decided [Entry a1b2c3d4]
@@ -49,31 +71,26 @@ with tokens verified via the /user endpoint [Entry e5f6g7h8]...
 - Use `user` scope only — no repo access [Entry a1b2c3d4]
 - Tokens stored locally, never on server [Entry e5f6g7h8]
 
-## Contradictions
-- Entry a1b2c3d4 says tokens expire after 24h, but Entry e5f6g7h8
-  says GitHub tokens are valid indefinitely
-
-## Knowledge Gaps
-- No entries found about token refresh behavior
-- Multi-team RBAC design not yet documented
-
 ## Sources
-| # | Entry ID | Type | Date | Similarity |
-|---|----------|------|------|------------|
-| 1 | a1b2c3d4 | session | 2026-03-10 | 95% |
-| 2 | e5f6g7h8 | bookmark | 2026-03-12 | 88% |
+| # | Entry ID | Type      | Date       | Similarity | Provenance        |
+|---|----------|-----------|------------|------------|-------------------|
+| 1 | a1b2c3d4 | session   | 2026-03-10 | 95%        | search            |
+| 2 | e5f6g7h8 | bookmark  | 2026-03-12 | 88%        | search            |
+| 3 | m1n2o3p4 | reference | 2026-03-14 | 71%        | graph (via a1b2c3d4) |
 ```
 
 ### Citations
 
-Every claim is traced back to a source using `[Entry <short-id>]` format (first 8 characters of the UUID). Empty sections are omitted.
+Every claim is traced back to a source using `[Entry <short-id>]` format (first 8 characters of the UUID). Empty sections are omitted. Graph-only entries carry the `structurally related` qualifier inline.
 
 ### Interactive Refinement
 
-After the initial synthesis, you can ask follow-up questions (up to 5 rounds). Each refinement is appended as an addendum.
+After the initial synthesis, you can ask follow-up questions (up to 5 rounds). Each refinement is appended as an addendum. When `--graph` is set, refinement searches also pass `expand_graph=true, expand_hops=1`.
 
 ## Tips
 
 - `/pour` is best for broad topics — use `/recall` for quick lookups
+- `--graph` shines when the topic has well-curated relations (e.g., a feature with linked sessions, GitHub PRs, and reference docs); on a sparse graph it adds little
+- Graph-only context is supporting, not primary — treat the search-matched entries as load-bearing claims and graph-only entries as "why this matters" or "what follows"
 - If only one author contributed, the output includes a perspective bias note
 - Entries are deduplicated by ID across all search passes

--- a/docs/skills/radar.md
+++ b/docs/skills/radar.md
@@ -1,16 +1,17 @@
 # /radar — Ambient Intelligence Digest
 
-Surfaces recent feed entries, synthesizes them into a grouped digest, and optionally suggests new sources based on your interest profile.
+Surfaces recent feed entries, synthesizes them into a grouped digest, optionally suggests new sources, and optionally appends a structural view of the knowledge graph (`--structure`).
 
 ## Usage
 
 ```text
 /radar                                  # Default: last 7 days, up to 35 entries
 /radar --days 3                         # Last 3 days
-/radar --limit 10                       # Limit to 10 entries
+/radar --limit 10                       # Limit to 10 entries (overrides feeds.digest.candidate_limit)
 /radar --topic "build hermeticity"      # Use an explicit topic instead of mining tags
 /radar --topic agentic-eval --days 14   # Topic + custom window
 /radar --topic build --topic wheels     # Multiple topics; one search query each
+/radar --structure                      # Append orphans + bridges + communities
 /radar --suggest                        # Include source suggestions
 /radar --store                          # Store the digest as an entry (default: display-only)
 /radar --include-evergreen              # Surface older / first-poll backfill items
@@ -25,6 +26,7 @@ Surfaces recent feed entries, synthesizes them into a grouped digest, and option
 | `--days <n>` | Look back period in days (overrides `feeds.digest.window_days`) | `feeds.digest.window_days` (7 if unset) |
 | `--limit <n>` | Maximum entries to include (overrides `feeds.digest.candidate_limit`) | `feeds.digest.candidate_limit` (35 if unset) |
 | `--topic <query>` | Use the literal string as the semantic-search query instead of mining tags. Repeatable. | Off (auto-mine) |
+| `--structure` | Append a Knowledge Structure section (orphans + bridges + communities) | Off |
 | `--suggest` | Include new source suggestions | Off |
 | `--store` | Store the digest as an entry | Off (display-only) |
 | `--include-evergreen` | Include items older than the window or flagged as first-poll backfill | Off |
@@ -36,10 +38,50 @@ items pulled when a feed source is first registered — are flagged
 they don't surface as "new intelligence". Use `--include-evergreen` to
 override.
 
+## Query selection
+
+Two paths feed the candidate-search step:
+
+**Path 1 — `--topic` override.** Each `--topic <query>` flag becomes one literal `distillery_search` call. Topics are deduplicated case-insensitively, preserving order. The 5-query namespace cap does *not* apply — every distinct user-supplied topic is honored, up to `--limit`. Tag mining is skipped entirely.
+
+**Path 2 — Namespace-diverse interest profile (default).** The skill mines curated entries (`session`, `reference`, `bookmark`, `idea`, `note`, `minutes`) for a tag profile, then picks **5 namespace-diverse tags** rather than the raw top-5 by count. A tag's namespace is its hierarchical path with the leaf removed, capped at two segments (e.g., `domain/build/hermeticity` → `domain/build`; `tech/duckdb` → `tech`). One leader per namespace prevents a dominant cluster from crowding out distinct topics. The reference implementation lives in `distillery.feeds.radar_selection.select_namespace_diverse_tags`.
+
+## Limit semantics and the 5-query default
+
+The candidate budget is distributed across queries so the sum of per-query limits never exceeds `--limit`:
+
+- Compute `Q` (the query count): up to 5 for Path 2, up to `min(distinct_topics, --limit)` for Path 1.
+- Let `base = limit // Q` and `rem = limit % Q`. The first `rem` queries get `base + 1`, the rest get `base`.
+
+With the default `--limit 35` and Q=5 (Path 2), this yields 5 queries × 7 results each → ~30 unique candidates after dedup. For small overrides like `--limit 3`, Q is reduced to 3 so the override is honored exactly (no zero-budget queries are issued). If `Q == 0` (e.g., `--limit 0` or both paths yielded an empty set), the search step short-circuits and falls back to a recent-listing query.
+
+Configure the system-wide default via `feeds.digest.candidate_limit` in `distillery.yaml`:
+
+```yaml
+feeds:
+  digest:
+    window_days: 7
+    candidate_limit: 35
+```
+
+Both YAML loading and the MCP `distillery_configure` tool validate this knob the same way (positive integer); `--limit` overrides it per-invocation.
+
+## `--structure` flag — Knowledge Structure section
+
+When `--structure` is set, an additional section is appended to the digest with three subsections:
+
+**Orphans.** Up to 10 entries with no incoming or outgoing relations, surfaced via `distillery_list(structural=["orphans"])`. These are knowledge fragments worth reviewing for connection opportunities. Empty list renders as `No orphan entries — every entry has at least one relation.`
+
+**Bridges.** Top-5 entries by **betweenness centrality** in the entry-relations graph, surfaced via `distillery_relations(action="metrics", metric="bridges")`. Scores are rendered to 3 decimals (e.g., `0.412`). High-centrality entries are knowledge "joints" — losing or contradicting them disconnects the graph the most.
+
+**Communities.** Detected clusters in the entry-relations graph, surfaced via `distillery_relations(action="metrics", metric="communities")`. Communities are sorted by `total_members` (largest first). For each community, the line shows the first three member ids: `Community 1 (12 entries): <id1>, <id2>, <id3>`. If every member has `updated_at < now - 60 days`, the community is tagged `[stale]`.
+
+Bridges and communities require the `[graph]` extra (NetworkX). If the MCP server returns `INTERNAL` with `"NetworkX not installed"`, `/radar` emits a single one-line note — `Run \`pip install distillery-mcp[graph]\` to enable bridges/communities.` — and continues without the structural metrics. The orphans subsection does not require NetworkX.
+
 ## Output
 
 ```markdown
-# Radar Digest — 2026-03-31
+# Radar Digest — 2026-05-07
 
 12 feed entries from the last 7 days.
 
@@ -49,7 +91,6 @@ JSON extension for nested document queries.
 
 - v1.2 release includes 3x faster vector search indexing
 - New JSON extension supports path-based queries
-- Community contribution guide updated
 
 ## Claude Code
 Two new features landed: hook-based automation and MCP server improvements.
@@ -62,30 +103,25 @@ This week saw performance improvements in DuckDB's vector search (directly
 relevant to Distillery's storage layer) and new automation capabilities
 in Claude Code.
 
-## Suggested Sources
-| URL | Type | Why |
-|-----|------|-----|
-| github.com/jlowin/fastmcp | github | FastMCP is a core dependency |
-| simonwillison.net/atom/everything | rss | Covers DuckDB, embeddings, AI tooling |
+## Knowledge Structure
 
-Digest stored: m3n4o5p6
+### Orphans
+- a1b2c3d4 — One-off reference doc on token rotation
+- e5f6g7h8 — Standalone bookmark, no follow-up captured
+
+### Bridges (top by betweenness centrality)
+1. m1n2o3p4 — OAuth design session (score: 0.412)
+2. q1r2s3t4 — DuckDB migration plan (score: 0.387)
+
+### Communities (ordered by total member count; top 3 members shown per community)
+- Community 1 (12 entries): m1n2o3p4, q1r2s3t4, u1v2w3x4
+- Community 2 (8 entries) [stale]: y1z2a3b4, c1d2e3f4, g1h2i3j4
 ```
-
-## How It Works
-
-1. Determines the query set:
-   - If one or more `--topic` flags are supplied, the literal strings become the queries (deduplicated, preserving order).
-   - Otherwise the skill mines curated entries (`session`, `reference`, `bookmark`, `idea`, `note`, `minutes`) for a tag profile, then picks **5 namespace-diverse tags** rather than the raw top-5 by count. A tag's namespace is its hierarchical path with the leaf removed, capped at two segments (e.g., `domain/build/hermeticity` → `domain/build`; `tech/duckdb` → `tech`). One leader per namespace prevents one dominant cluster from crowding out distinct topics.
-2. Runs one `distillery_search` per query against feed entries, deduplicating results by entry ID.
-3. Groups entries by source tag or topic.
-4. Synthesizes 2-4 sentence summaries per group with bullet points.
-5. Generates a cross-group overall summary.
-6. If `--suggest` is enabled, the feed scorer mines the knowledge base for an interest profile and emits source recommendations inline (the former `distillery_interests` tool was folded into `/radar`'s internal pipeline).
-7. Stores the digest as an entry (type `digest`) only when `--store` is specified.
 
 ## Tips
 
 - Digests are display-only by default; pass `--store` to persist with tags `digest/radar/ambient` for future retrieval
-- Source suggestions are based on your interest profile (mined from existing entries)
+- `--topic` is the right flag when you want to follow a specific thread *and* you don't want the digest diluted by your dominant tag clusters
+- `--structure` is most useful as an occasional pulse-check, not every run — bridges and communities don't move much day-to-day
+- Source suggestions (`--suggest`) are based on the same query set used in Step 3a
 - Use `/watch add` to subscribe to suggested sources
-- Groups are organized by source when available, falling back to topic clustering

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
   - Benchmarks: benchmarks.md
   - Contributing: contributing.md
   - Blog:
+    - "Walking the Graph: Distillery 0.5.0": blog/distillery-0-5-0-graph.md
     - "Full-Proof: Distillery 0.4.0 and the Agent Memory Problem": blog/distillery-0-4-0-full-proof.md
     - Building a Second Brain for Claude Code: blog/building-a-second-brain-for-claude-code.md
   - Roadmap: roadmap.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distillery-mcp"
-version = "0.4.1"
+version = "0.5.0"
 description = "Persistent shared memory for Claude Code — MCP server with DuckDB vector search, semantic dedup, and ambient intelligence for team knowledge"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.norrietaylor/distillery-mcp",
   "title": "Distillery",
   "description": "Knowledge base for Claude Code with semantic search, feed intelligence, and teams",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "repository": {
     "url": "https://github.com/norrietaylor/distillery",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "transport": {
         "type": "streamable-http",
         "url": "https://distillery-mcp.fly.dev/mcp"

--- a/src/distillery/__init__.py
+++ b/src/distillery/__init__.py
@@ -2,5 +2,5 @@
 
 import os
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 __build_sha__ = os.environ.get("DISTILLERY_BUILD_SHA", "dev")


### PR DESCRIPTION
## Summary

**Walking the Graph release.** Ships the knowledge-graph epic ([#147](https://github.com/norrietaylor/distillery/issues/147)) end to end with regression-gated discipline.

### Features

- **Knowledge graph (epic [#147](https://github.com/norrietaylor/distillery/issues/147))**: `find_similar` exclude_linked + source_entry_id ([#422](https://github.com/norrietaylor/distillery/pull/422)), `distillery_list` structural=["orphans"] ([#423](https://github.com/norrietaylor/distillery/pull/423)), `distillery_relations` traverse + metrics actions + `[graph]` extra ([#424](https://github.com/norrietaylor/distillery/pull/424), [#426](https://github.com/norrietaylor/distillery/pull/426)), `distillery_search` expand_graph + expand_hops ([#425](https://github.com/norrietaylor/distillery/pull/425)), `/investigate` multi-hop + hidden connections ([#427](https://github.com/norrietaylor/distillery/pull/427)), `/pour --graph` ([#428](https://github.com/norrietaylor/distillery/pull/428)), `/radar --structure` ([#429](https://github.com/norrietaylor/distillery/pull/429)).
- **Skill ergonomics**: `/radar --topic` + namespace-aware tag selection ([#463](https://github.com/norrietaylor/distillery/pull/463) / [#460](https://github.com/norrietaylor/distillery/issues/460)); `/radar` 5 queries + default candidate limit 35 + `feeds.digest.candidate_limit` knob ([#462](https://github.com/norrietaylor/distillery/pull/462) / [#461](https://github.com/norrietaylor/distillery/issues/461)).
- **Bench discipline**: Cell A `+graph` regression gate ([#464](https://github.com/norrietaylor/distillery/pull/464) / [#458](https://github.com/norrietaylor/distillery/issues/458)).

### Cell A regression gate evidence

500q × 5 seeds against the v0.5.0 commit, `--expand-graph` enabled, same config as HEADLINE (`hybrid / session / recency-on / bge-small`):

- mean R@5 = **0.972** (stddev 0.000)
- HEADLINE mean R@5 = **0.972** (same 500q sample)
- **delta = 0.0pp** vs the 0.5pp variance-gate threshold
- `gate_pass=true`, `sample_size_match=true`
- Run: [`actions/runs/25453787717`](https://github.com/norrietaylor/distillery/actions/runs/25453787717)
- Aggregate: [`bench/results/graph_regression_cell_a.json`](https://github.com/norrietaylor/distillery/blob/release/v0.5.0/bench/results/graph_regression_cell_a.json)

Per `bench/LIMITATIONS.md` §(f), this is a regression result only — *no* value-add claim is implied. Release notes say **"no regression with graph enabled"**, never "graph improves LongMemEval." Cell B (graph value-add) is deferred to a fit-for-purpose eval (multi-hop QA / synthetic team-knowledge / `/investigate`-`/pour` synthesis).

### Files touched

- `pyproject.toml`: `0.4.1` → `0.5.0`
- `CHANGELOG.md`: new `## [0.5.0] - 2026-05-07` entry mirroring v0.4.1 section structure
- `docs/skills/{investigate,pour,radar}.md`: align human-facing pages with shipped SKILL.md semantics for the new flags
- `docs/benchmarks.md`: replace "forward-compatible plumbing" admonition with live empirical Cell A result + discipline note
- `docs/blog/distillery-0-5-0-graph.md` + `mkdocs.yml` nav: release blog post (`cross-post-blog.yml` auto-publishes to dev.to + Hashnode on push to `docs/blog/`)

`uv.lock` regeneration is intentionally **not** included — known follow-up.

## Test plan

- [x] `python3 -c "import tomllib; tomllib.loads(open('pyproject.toml').read())"` — passes
- [x] `mkdocs build --strict` (via `uv run --extra docs`) — only the 5 pre-existing `bench/*.md` link warnings; no new warnings from the v0.5.0 docs changes
- [x] CHANGELOG section header matches existing date+format conventions (`## [X.Y.Z] - YYYY-MM-DD`)
- [x] Skill doc pages mirror the canonical `skills/*/SKILL.md` semantics
- [x] No content claims graph improves LongMemEval; gate framing matches `bench/LIMITATIONS.md` §(f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-hop relationship expansion and hidden-connection discovery in /investigate; /pour --graph for 1‑hop graph-expanded retrieval with provenance; /radar --structure for orphans, bridges, communities and improved query selection.

* **Documentation**
  * Added Distillery v0.5.0 blog post, updated skill docs, examples, and site navigation.

* **Benchmarks**
  * Graph regression gate is live and passing.

* **Release**
  * Version bumped to 0.5.0 and top changelog entry added.

* **Bug Fixes**
  * Various fixes and clarifications across skills and docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->