### PR TITLE
feat(bench): publish nightly numbers into docs/benchmarks.md

### DIFF
--- a/.github/workflows/bench-longmemeval.yml
+++ b/.github/workflows/bench-longmemeval.yml
@@ -15,9 +15,10 @@
 #   1. Granting only the minimum permissions required (contents: write,
 #      pull-requests: write).
 #   2. A `verify-paths` step in the aggregator job that fails the build
-#      if the auto-PR diff touches anything outside `bench/results/**`
-#      and `bench/badge_*.json` (r5/r10/ndcg10 — emitted by the W2
-#      aggregator via --output-dir).
+#      if the auto-PR diff touches anything outside `bench/results/**`,
+#      `bench/badge_*.json` (r5/r10/ndcg10 — emitted by the W2 aggregator
+#      via --output-dir), and `docs/benchmarks.md` (templated in place by
+#      the aggregator's --docs-path step from the same source data).
 # A reviewer-side check (the `benchmark` label) is the third defence.
 #
 # Dependencies (subsequent slices, not yet landed):
@@ -346,7 +347,8 @@ jobs:
           if [ -f scripts/bench/aggregate_results.py ]; then
             python scripts/bench/aggregate_results.py \
               --results-dir bench/results/ \
-              --output-dir bench/
+              --output-dir bench/ \
+              --docs-path docs/benchmarks.md
           else
             # TODO: created by W2-bench-runner or follow-up.
             # Until the aggregator script lands, we surface the bench
@@ -362,7 +364,7 @@ jobs:
       - name: Verify paths (allowlist enforcement)
         run: |
           set -euo pipefail
-          ALLOW='^(bench/results/|bench/badge_(r5|r10|ndcg10)\.json$)'
+          ALLOW='^(bench/results/|bench/badge_(r5|r10|ndcg10)\.json$|docs/benchmarks\.md$)'
           # Stage everything that would be committed and inspect the
           # paths against the allowlist.
           git add -A
@@ -375,7 +377,7 @@ jobs:
           echo "${CHANGED}"
           BAD=$(echo "${CHANGED}" | grep -Ev "${ALLOW}" || true)
           if [ -n "${BAD}" ]; then
-            echo "ERROR: changes outside allowlist (bench/results/**, bench/badge_*.json):"
+            echo "ERROR: changes outside allowlist (bench/results/**, bench/badge_*.json, docs/benchmarks.md):"
             echo "${BAD}"
             exit 1
           fi
@@ -417,12 +419,14 @@ jobs:
             - Date (UTC): ${{ steps.pr-meta.outputs.date }}
             - JSONL receipts in this commit: ${{ steps.commit-set.outputs.include_jsonl }}
 
-            All paths in this PR are restricted to `bench/results/**` and
-            `bench/badge_*.json` by the verify-paths step.
+            All paths in this PR are restricted to `bench/results/**`,
+            `bench/badge_*.json`, and `docs/benchmarks.md` by the
+            verify-paths step.
           labels: benchmark
           add-paths: |
             bench/results/**
             bench/badge_r5.json
             bench/badge_r10.json
             bench/badge_ndcg10.json
+            docs/benchmarks.md
           delete-branch: true

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -15,14 +15,14 @@ displayed here until that gate is green.
 The pre-registered headline triplet — Recall@5, Recall@10, NDCG@10 — for the headline cell
 (`retrieval=hybrid, granularity=session, recency=on, embed=bge-small`).
 
+<!-- BENCH:HEADLINE-CARDS:START -->
 <div class="grid cards" markdown>
 
 -   __Recall@5__
 
     ---
 
-    <!-- TODO: populated by first nightly -->
-    `—`
+    `0.970`
 
     Headline cell, mean across seeds.
 
@@ -30,8 +30,7 @@ The pre-registered headline triplet — Recall@5, Recall@10, NDCG@10 — for the
 
     ---
 
-    <!-- TODO: populated by first nightly -->
-    `—`
+    `0.990`
 
     Headline cell, mean across seeds.
 
@@ -39,12 +38,12 @@ The pre-registered headline triplet — Recall@5, Recall@10, NDCG@10 — for the
 
     ---
 
-    <!-- TODO: populated by first nightly -->
-    `—`
+    `0.890`
 
     Headline cell, mean across seeds.
 
 </div>
+<!-- BENCH:HEADLINE-CARDS:END -->
 
 ## Configuration
 
@@ -88,12 +87,14 @@ Full pre-registration rationale and change-control rules live in
 configuration evaluated against the same LongMemEval-S question set with the same SHA-pinned
 dataset and embedding model.
 
+<!-- BENCH:MATRIX:START -->
 | Configuration | R@5 | R@10 | NDCG@10 |
 |---|---|---|---|
-| `hybrid + recency on` (headline) | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
-| `raw + recency on` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
-| `hybrid + recency off` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
-| `hybrid + granularity=turn` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `hybrid + recency on` (headline) | `0.970` | `0.990` | `0.890` |
+| `raw + recency on` | `0.870` | `0.940` | `0.787` |
+| `hybrid + recency off` | `0.970` | `0.990` | `0.892` |
+| `hybrid + granularity=turn` | `0.980` | `1.000` | `0.681` |
+<!-- BENCH:MATRIX:END -->
 
 The `granularity=turn` row is shown for ablation interest only; it is not directly
 comparable to the session rows above (see the LIMITATIONS callout).
@@ -103,14 +104,16 @@ comparable to the session rows above (see the LIMITATIONS callout).
 LongMemEval-S partitions questions into six types. The headline cell scores each
 type independently.
 
+<!-- BENCH:PER-TYPE:START -->
 | Question type | R@5 | R@10 | NDCG@10 |
 |---|---|---|---|
-| `knowledge-update` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
-| `multi-session` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
-| `temporal` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
-| `single-session-user` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
-| `single-session-preference` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
-| `single-session-assistant` | <!-- placeholder --> `—` | <!-- placeholder --> `—` | <!-- placeholder --> `—` |
+| `knowledge-update` | `—` | `—` | `—` |
+| `multi-session` | `1.000` | `1.000` | `0.914` |
+| `temporal` | `—` | `—` | `—` |
+| `single-session-user` | `0.957` | `0.986` | `0.880` |
+| `single-session-preference` | `—` | `—` | `—` |
+| `single-session-assistant` | `—` | `—` | `—` |
+<!-- BENCH:PER-TYPE:END -->
 
 ## Graph features — Cell A regression gate, Cell B deferred
 

--- a/scripts/bench/aggregate_results.py
+++ b/scripts/bench/aggregate_results.py
@@ -16,6 +16,14 @@ and writes:
   triplet, a Distillery-only matrix of recent runs, the per-question-type
   breakdown for the headline cell, and a 7-day history of headline R@5.
 
+* ``docs/benchmarks.md`` — the public mkdocs page. Three marker-delimited
+  regions (``BENCH:HEADLINE-CARDS``, ``BENCH:MATRIX``, ``BENCH:PER-TYPE``)
+  are rewritten in place with the headline triplet, the four-row internal
+  comparison matrix, and the per-question-type breakdown. The hand-authored
+  prose around each region is preserved verbatim. Templating is skipped
+  (placeholders remain) when no headline run is available, mirroring the
+  badge "unknown" fallback.
+
 Honesty constraint
 ------------------
 
@@ -30,11 +38,14 @@ CLI
 
     python scripts/bench/aggregate_results.py \\
         --results-dir bench/results/ \\
-        --output-dir bench/
+        --output-dir bench/ \\
+        --docs-path docs/benchmarks.md
 
 The ``--output-dir`` controls where the three badge files land.
 ``SUMMARY.md`` is always written into ``<results_dir>/SUMMARY.md``
-because it documents the runs in that directory.
+because it documents the runs in that directory. ``--docs-path``
+points at the public mkdocs page; pass ``--no-docs`` to skip
+templating it.
 
 See the plan in ``/Users/norrie/.claude/plans/look-at-mempalace-hook-dynamic-mccarthy.md``
 (Wave 2, deliverable 3 — "Nightly automation" — and deliverable 4 —
@@ -494,6 +505,222 @@ def _render_summary_md(
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# docs/benchmarks.md templating
+# ---------------------------------------------------------------------------
+#
+# The mkdocs page contains three dynamic regions delimited by HTML
+# comments. The aggregator regenerates each region in place; everything
+# outside the markers is preserved verbatim so hand-authored prose
+# survives nightly runs.
+#
+# Marker contract:
+#   <!-- BENCH:<NAME>:START -->\n<content>\n<!-- BENCH:<NAME>:END -->
+#
+# The block between START and END (exclusive of the marker lines
+# themselves) is replaced wholesale.
+
+# Order matches the four rows hand-authored in docs/benchmarks.md. The
+# aggregator looks up the latest run for each (retrieval, granularity,
+# recency, embed_model) tuple; missing cells render as ``—``.
+_DOCS_MATRIX_ROWS: tuple[tuple[str, dict[str, str]], ...] = (
+    (
+        "`hybrid + recency on` (headline)",
+        {
+            "retrieval": "hybrid",
+            "granularity": "session",
+            "recency": "on",
+            "embed_model": "bge-small",
+        },
+    ),
+    (
+        "`raw + recency on`",
+        {
+            "retrieval": "raw",
+            "granularity": "session",
+            "recency": "on",
+            "embed_model": "bge-small",
+        },
+    ),
+    (
+        "`hybrid + recency off`",
+        {
+            "retrieval": "hybrid",
+            "granularity": "session",
+            "recency": "off",
+            "embed_model": "bge-small",
+        },
+    ),
+    (
+        "`hybrid + granularity=turn`",
+        {
+            "retrieval": "hybrid",
+            "granularity": "turn",
+            "recency": "on",
+            "embed_model": "bge-small",
+        },
+    ),
+)
+
+# Six LongMemEval-S question types, in the order documented in
+# docs/benchmarks.md. Types absent from the headline summary render
+# as ``—`` rather than zero — that distinction matters for honesty.
+_DOCS_PER_TYPE_ROWS: tuple[str, ...] = (
+    "knowledge-update",
+    "multi-session",
+    "temporal",
+    "single-session-user",
+    "single-session-preference",
+    "single-session-assistant",
+)
+
+
+def _render_docs_headline_cards(headline: SummaryRecord) -> str:
+    """Render the three Material grid cards with current headline scores."""
+    overall = headline.data.get("overall", {}) if isinstance(headline.data, dict) else {}
+    r5 = _format_score(overall.get("recall_at_5"))
+    r10 = _format_score(overall.get("recall_at_10"))
+    nd = _format_score(overall.get("ndcg_at_10"))
+    return (
+        '<div class="grid cards" markdown>\n'
+        "\n"
+        "-   __Recall@5__\n"
+        "\n"
+        "    ---\n"
+        "\n"
+        f"    `{r5}`\n"
+        "\n"
+        "    Headline cell, mean across seeds.\n"
+        "\n"
+        "-   __Recall@10__\n"
+        "\n"
+        "    ---\n"
+        "\n"
+        f"    `{r10}`\n"
+        "\n"
+        "    Headline cell, mean across seeds.\n"
+        "\n"
+        "-   __NDCG@10__\n"
+        "\n"
+        "    ---\n"
+        "\n"
+        f"    `{nd}`\n"
+        "\n"
+        "    Headline cell, mean across seeds.\n"
+        "\n"
+        "</div>"
+    )
+
+
+def _render_docs_matrix_table(matrix: list[SummaryRecord]) -> str:
+    """Render the 4-row Distillery-only matrix table for docs/benchmarks.md.
+
+    Doc-row labels are hand-authored prose mapped to canonical 4-axis
+    keys via ``_DOCS_MATRIX_ROWS``. Cells with no matching record render
+    as ``—``.
+    """
+    by_axes: dict[tuple[str, str, str, str], SummaryRecord] = {}
+    for record in matrix:
+        record_key = (
+            record.axes["retrieval"],
+            record.axes["granularity"],
+            record.axes["recency"],
+            record.axes["embed_model"],
+        )
+        by_axes[record_key] = record
+
+    lines = [
+        "| Configuration | R@5 | R@10 | NDCG@10 |",
+        "|---|---|---|---|",
+    ]
+    for label, axes in _DOCS_MATRIX_ROWS:
+        key = (
+            axes["retrieval"],
+            axes["granularity"],
+            axes["recency"],
+            axes["embed_model"],
+        )
+        match: SummaryRecord | None = by_axes.get(key)
+        if match is None:
+            lines.append(f"| {label} | `—` | `—` | `—` |")
+            continue
+        overall = match.data.get("overall", {}) if isinstance(match.data, dict) else {}
+        lines.append(
+            f"| {label} | `{_format_score(overall.get('recall_at_5'))}` | "
+            f"`{_format_score(overall.get('recall_at_10'))}` | "
+            f"`{_format_score(overall.get('ndcg_at_10'))}` |"
+        )
+    return "\n".join(lines)
+
+
+def _render_docs_per_type_table(headline: SummaryRecord) -> str:
+    """Render the 6-row per-question-type breakdown table for the headline cell.
+
+    Question types absent from ``headline.data['per_question_type']``
+    keep ``—`` cells — the LongMemEval-S sample may not include every
+    type on every run, and zero would be a misleading rendering.
+    """
+    per_type = headline.data.get("per_question_type", {}) if isinstance(headline.data, dict) else {}
+    if not isinstance(per_type, dict):
+        per_type = {}
+
+    lines = [
+        "| Question type | R@5 | R@10 | NDCG@10 |",
+        "|---|---|---|---|",
+    ]
+    for qtype in _DOCS_PER_TYPE_ROWS:
+        bucket = per_type.get(qtype) if isinstance(per_type.get(qtype), dict) else None
+        if bucket is None:
+            lines.append(f"| `{qtype}` | `—` | `—` | `—` |")
+            continue
+        lines.append(
+            f"| `{qtype}` | `{_format_score(bucket.get('recall_at_5'))}` | "
+            f"`{_format_score(bucket.get('recall_at_10'))}` | "
+            f"`{_format_score(bucket.get('ndcg_at_10'))}` |"
+        )
+    return "\n".join(lines)
+
+
+def _substitute_marker_block(content: str, marker_name: str, replacement: str) -> str:
+    """Replace the body between ``BENCH:<marker_name>`` markers.
+
+    Raises ``ValueError`` when the markers are missing or out of order
+    — that is a doc-template bug that should fail loudly rather than
+    silently no-op the publish step.
+    """
+    start = f"<!-- BENCH:{marker_name}:START -->"
+    end = f"<!-- BENCH:{marker_name}:END -->"
+    pattern = re.compile(
+        re.escape(start) + r"\n(.*?)\n" + re.escape(end),
+        re.DOTALL,
+    )
+    if not pattern.search(content):
+        raise ValueError(f"Marker pair BENCH:{marker_name} missing from docs page")
+    return pattern.sub(f"{start}\n{replacement}\n{end}", content, count=1)
+
+
+def _render_docs_benchmarks_md(
+    *,
+    existing: str,
+    headline: SummaryRecord | None,
+    matrix: list[SummaryRecord],
+) -> str:
+    """Return ``docs/benchmarks.md`` content with all three regions rewritten.
+
+    When ``headline is None`` the file is returned unchanged — the
+    placeholders stay until a headline run lands, matching the
+    "unknown" badge fallback discipline.
+    """
+    if headline is None:
+        return existing
+    out = _substitute_marker_block(
+        existing, "HEADLINE-CARDS", _render_docs_headline_cards(headline)
+    )
+    out = _substitute_marker_block(out, "MATRIX", _render_docs_matrix_table(matrix))
+    out = _substitute_marker_block(out, "PER-TYPE", _render_docs_per_type_table(headline))
+    return out
+
+
 def _normalise_headline_keys(config: dict[str, str]) -> dict[str, str]:
     """Map a user-supplied headline config to the canonical axes dict.
 
@@ -530,6 +757,7 @@ class AggregateReport:
     history: list[SummaryRecord] = field(default_factory=list)
     badge_paths: dict[str, Path] = field(default_factory=dict)
     summary_path: Path | None = None
+    docs_path: Path | None = None
 
 
 def aggregate(
@@ -537,6 +765,7 @@ def aggregate(
     *,
     headline_config: dict[str, str] | None = None,
     output_dir: Path,
+    docs_path: Path | None = None,
     now: datetime | None = None,
 ) -> AggregateReport:
     """Aggregate bench results, write badges and SUMMARY.md.
@@ -553,6 +782,12 @@ def aggregate(
         Where the three ``badge_*.json`` files are written. The
         ``SUMMARY.md`` always lands in ``results_dir`` because it
         documents the runs there.
+    docs_path:
+        Optional path to ``docs/benchmarks.md``. When provided and a
+        headline run exists, the three marker-delimited regions in
+        the file are rewritten in place. ``None`` (or no headline run)
+        leaves the docs page untouched — placeholders persist until
+        the next nightly with a headline cell.
     now:
         Optional override for "current time" — used by tests so the
         7-day history window is deterministic.
@@ -594,12 +829,28 @@ def aggregate(
     with summary_path.open("w", encoding="utf-8") as f:
         f.write(summary_md)
 
+    docs_written: Path | None = None
+    if docs_path is not None and headline is not None:
+        if not docs_path.exists():
+            logger.warning("docs_path %s does not exist; skipping docs publish", docs_path)
+        else:
+            existing = docs_path.read_text(encoding="utf-8")
+            updated = _render_docs_benchmarks_md(
+                existing=existing,
+                headline=headline,
+                matrix=matrix,
+            )
+            if updated != existing:
+                docs_path.write_text(updated, encoding="utf-8")
+            docs_written = docs_path
+
     return AggregateReport(
         headline=headline,
         matrix=matrix,
         history=history,
         badge_paths=badge_paths,
         summary_path=summary_path,
+        docs_path=docs_written,
     )
 
 
@@ -656,6 +907,20 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Override headline embed-model axis.",
     )
     parser.add_argument(
+        "--docs-path",
+        type=Path,
+        default=Path("docs/benchmarks.md"),
+        help=(
+            "Path to docs/benchmarks.md to template in place "
+            "(default: docs/benchmarks.md). Pass --no-docs to skip."
+        ),
+    )
+    parser.add_argument(
+        "--no-docs",
+        action="store_true",
+        help="Skip docs/benchmarks.md templating.",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -679,10 +944,12 @@ def main(argv: list[str] | None = None) -> int:
         "embed_model": args.headline_embed,
     }
 
+    docs_path = None if args.no_docs else args.docs_path
     report = aggregate(
         args.results_dir,
         headline_config=headline_config,
         output_dir=args.output_dir,
+        docs_path=docs_path,
     )
 
     if report.headline is None:
@@ -703,6 +970,9 @@ def main(argv: list[str] | None = None) -> int:
             overall.get("ndcg_at_10"),
             report.headline.path.name,
         )
+
+    if report.docs_path is not None:
+        logger.info("Templated docs page: %s", report.docs_path)
 
     return 0
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -440,3 +440,241 @@ class TestDefaultHeadlineConfig:
             "recency": "on",
             "embed_model": "bge-small",
         }
+
+
+# ---------------------------------------------------------------------------
+# docs/benchmarks.md templating
+# ---------------------------------------------------------------------------
+
+
+_DOC_TEMPLATE = """# Benchmarks
+
+Some hand-authored prose.
+
+## Headline
+
+<!-- BENCH:HEADLINE-CARDS:START -->
+<div class="grid cards" markdown>
+
+-   __Recall@5__
+
+    ---
+
+    `—`
+
+    Headline cell, mean across seeds.
+
+-   __Recall@10__
+
+    ---
+
+    `—`
+
+    Headline cell, mean across seeds.
+
+-   __NDCG@10__
+
+    ---
+
+    `—`
+
+    Headline cell, mean across seeds.
+
+</div>
+<!-- BENCH:HEADLINE-CARDS:END -->
+
+## Internal comparison table
+
+<!-- BENCH:MATRIX:START -->
+| Configuration | R@5 | R@10 | NDCG@10 |
+|---|---|---|---|
+| `hybrid + recency on` (headline) | `—` | `—` | `—` |
+| `raw + recency on` | `—` | `—` | `—` |
+| `hybrid + recency off` | `—` | `—` | `—` |
+| `hybrid + granularity=turn` | `—` | `—` | `—` |
+<!-- BENCH:MATRIX:END -->
+
+The granularity=turn row is for ablation interest only.
+
+## Per-question-type breakdown
+
+<!-- BENCH:PER-TYPE:START -->
+| Question type | R@5 | R@10 | NDCG@10 |
+|---|---|---|---|
+| `knowledge-update` | `—` | `—` | `—` |
+| `multi-session` | `—` | `—` | `—` |
+| `temporal` | `—` | `—` | `—` |
+| `single-session-user` | `—` | `—` | `—` |
+| `single-session-preference` | `—` | `—` | `—` |
+| `single-session-assistant` | `—` | `—` | `—` |
+<!-- BENCH:PER-TYPE:END -->
+
+End of doc.
+"""
+
+
+@pytest.mark.unit
+class TestDocsTemplating:
+    """The aggregator must rewrite the three marker-delimited regions in
+    ``docs/benchmarks.md`` and leave hand-authored prose untouched.
+    """
+
+    def _seed_matrix(self, results_dir: Path) -> None:
+        """Write headline + 3 matrix cells with distinguishable scores."""
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="session",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260430T050000Z",
+            payload=_summary_payload(
+                retrieval="hybrid",
+                granularity="session",
+                recency="on",
+                embed_model="bge-small",
+                r5=0.970,
+                r10=0.990,
+                ndcg10=0.890,
+            ),
+        )
+        _write_summary(
+            results_dir,
+            retrieval="raw",
+            granularity="session",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260430T050100Z",
+            payload=_summary_payload(
+                retrieval="raw",
+                granularity="session",
+                recency="on",
+                embed_model="bge-small",
+                r5=0.870,
+                r10=0.940,
+                ndcg10=0.787,
+            ),
+        )
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="session",
+            recency="off",
+            embed_model="bge-small",
+            stamp="20260430T050200Z",
+            payload=_summary_payload(
+                retrieval="hybrid",
+                granularity="session",
+                recency="off",
+                embed_model="bge-small",
+                r5=0.972,
+                r10=0.992,
+                ndcg10=0.892,
+            ),
+        )
+        _write_summary(
+            results_dir,
+            retrieval="hybrid",
+            granularity="turn",
+            recency="on",
+            embed_model="bge-small",
+            stamp="20260430T050300Z",
+            payload=_summary_payload(
+                retrieval="hybrid",
+                granularity="turn",
+                recency="on",
+                embed_model="bge-small",
+                r5=0.980,
+                r10=1.000,
+                ndcg10=0.681,
+            ),
+        )
+
+    def test_docs_templated_when_headline_present(self, tmp_path: Path) -> None:
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+        docs_path = tmp_path / "benchmarks.md"
+        docs_path.write_text(_DOC_TEMPLATE, encoding="utf-8")
+
+        self._seed_matrix(results_dir)
+
+        report = aggregate(results_dir, output_dir=output_dir, docs_path=docs_path)
+
+        assert report.docs_path == docs_path
+        rendered = docs_path.read_text(encoding="utf-8")
+
+        # Headline cards carry the headline triplet.
+        assert "`0.970`" in rendered
+        assert "`0.990`" in rendered
+        assert "`0.890`" in rendered
+
+        # Matrix has the four mapped rows with their cell-specific scores.
+        assert "| `hybrid + recency on` (headline) | `0.970` | `0.990` | `0.890` |" in rendered
+        assert "| `raw + recency on` | `0.870` | `0.940` | `0.787` |" in rendered
+        assert "| `hybrid + recency off` | `0.972` | `0.992` | `0.892` |" in rendered
+        assert "| `hybrid + granularity=turn` | `0.980` | `1.000` | `0.681` |" in rendered
+
+        # Per-type table — fixture only carries multi-session and
+        # single-session-user; the other four stay as ``—``.
+        assert "| `multi-session` | `0.870` | `0.940` | `0.840` |" in rendered
+        assert "| `single-session-user` | `0.970` | `0.990` | `0.890` |" in rendered
+        assert "| `knowledge-update` | `—` | `—` | `—` |" in rendered
+        assert "| `temporal` | `—` | `—` | `—` |" in rendered
+
+        # Hand-authored prose preserved.
+        assert "Some hand-authored prose." in rendered
+        assert "The granularity=turn row is for ablation interest only." in rendered
+        assert "End of doc." in rendered
+
+    def test_docs_untouched_when_no_headline(self, tmp_path: Path) -> None:
+        """Honesty: keep placeholders when no headline run is available."""
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+        docs_path = tmp_path / "benchmarks.md"
+        docs_path.write_text(_DOC_TEMPLATE, encoding="utf-8")
+
+        # Only a non-headline cell.
+        _write_summary(
+            results_dir,
+            retrieval="raw",
+            granularity="session",
+            recency="off",
+            embed_model="bge-small",
+            stamp="20260430T050000Z",
+        )
+
+        report = aggregate(results_dir, output_dir=output_dir, docs_path=docs_path)
+
+        assert report.headline is None
+        assert report.docs_path is None
+        assert docs_path.read_text(encoding="utf-8") == _DOC_TEMPLATE
+
+    def test_docs_skipped_when_path_absent(self, tmp_path: Path) -> None:
+        """A pointer to a missing file is a warning, not a crash."""
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+        docs_path = tmp_path / "does-not-exist.md"
+
+        self._seed_matrix(results_dir)
+
+        report = aggregate(results_dir, output_dir=output_dir, docs_path=docs_path)
+
+        assert report.headline is not None
+        assert report.docs_path is None
+        assert not docs_path.exists()
+
+    def test_docs_missing_marker_fails_loudly(self, tmp_path: Path) -> None:
+        """A doc without a marker pair is a template bug — surface it."""
+        results_dir = tmp_path / "results"
+        output_dir = tmp_path / "out"
+        docs_path = tmp_path / "benchmarks.md"
+        # Drop the per-type marker pair entirely.
+        broken = _DOC_TEMPLATE.replace("<!-- BENCH:PER-TYPE:START -->", "").replace(
+            "<!-- BENCH:PER-TYPE:END -->", ""
+        )
+        docs_path.write_text(broken, encoding="utf-8")
+
+        self._seed_matrix(results_dir)
+
+        with pytest.raises(ValueError, match="BENCH:PER-TYPE"):
+            aggregate(results_dir, output_dir=output_dir, docs_path=docs_path)


### PR DESCRIPTION
## Summary

The aggregator already produced `bench/results/SUMMARY.md` and the three Shields.io badges, but `docs/benchmarks.md` remained static. The variance gate is green (`bench/results/variance_baseline.json`, 5 seeds, stddev 0.000, `gate_pass: true`) and headline runs are landing nightly — yet every numeric cell on the public mkdocs page still rendered as `—`.

This wires the publication step into `scripts/bench/aggregate_results.py`. Three marker-delimited regions in `docs/benchmarks.md` are rewritten in place from the same data that already feeds `SUMMARY.md` and the badges:

- `BENCH:HEADLINE-CARDS` — Material grid cards for R@5 / R@10 / NDCG@10
- `BENCH:MATRIX` — four-row internal comparison table
- `BENCH:PER-TYPE` — six-row per-question-type breakdown for the headline cell

Hand-authored prose around each region is preserved verbatim.

## Discipline preserved

- **No headline ⇒ no rewrite.** When no run matches the pre-registered headline cell, `docs/benchmarks.md` is left untouched and placeholders persist. Mirrors the existing `unknown / lightgrey` badge fallback.
- **Per-type honesty.** Question types that the headline run did not sample render as `—` rather than `0`. The current LongMemEval-S sample only includes `multi-session` and `single-session-user`; the other four rows stay as placeholders, exactly as the runner reports.

## Changes

- `scripts/bench/aggregate_results.py` — new `_render_docs_*` helpers, `_substitute_marker_block`, `--docs-path` / `--no-docs` CLI flags, `AggregateReport.docs_path` field
- `docs/benchmarks.md` — marker pairs added; numbers populated from the current nightly (`R@5=0.970, R@10=0.990, NDCG@10=0.890`)
- `.github/workflows/bench-longmemeval.yml` — aggregator invocation gains `--docs-path`; `verify-paths` allowlist + auto-PR `add-paths` extended to include `docs/benchmarks.md`; header comment updated for the new path scope
- `tests/test_aggregator.py` — four new cases: templated-when-headline-present, untouched-when-no-headline, skipped-when-path-absent, fails-loudly-when-marker-missing

## Test plan

- [x] `pytest tests/test_aggregator.py` — 11/11 pass
- [x] `mypy --strict scripts/bench/aggregate_results.py` — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mkdocs build --strict` — succeeds; rendered HTML carries the templated numbers
- [ ] First nightly auto-PR on `main` opens with `docs/benchmarks.md` in the diff alongside the existing `bench/results/**` and `bench/badge_*.json` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Benchmark documentation automatically updates with measured performance metrics during aggregation.

* **Documentation**
  * Populated benchmark results with actual Recall@5, Recall@10, and NDCG@10 values across all configurations and question types.

* **Tests**
  * Added comprehensive tests for documentation templating and generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->