### PR TITLE
ci(staging): suppress phantom 0-job push failures

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -27,6 +27,15 @@ name: Staging Deploy (on comment)
 on:
   issue_comment:
     types: [created]
+  # Phantom-run suppression. With only `issue_comment` declared, every
+  # push to main creates a 0-job check_suite entry that records as
+  # `failure` in the Actions UI even though no jobs ran (verified:
+  # billing=0, jobs=0, conclusion=failure). Declaring an unreachable
+  # `push:` trigger gives the check-suite enumerator an explicit
+  # branch filter to match against, which suppresses the phantom
+  # entries without ever firing real jobs on push events.
+  push:
+    branches: ["__phantom_run_suppression__"]
 
 # Default permissions are minimal. Each job opts in to what it needs.
 # The deploy job — which checks out PR head code and builds it — is


### PR DESCRIPTION
## Why

Every push to \`main\` was creating a 0-job phantom run for \`staging-deploy.yml\` that recorded as \`failure\`:

- \`billing_keys: 0\`, \`jobs_count: 0\`, \`conclusion: failure\`
- 5 most recent \"failures\" all \`event=push\` 0-job runs (no compute used)
- The \`/deploy-staging\` PR-comment flow itself is unaffected and works correctly

\`#488\` (deregister) + \`#489\` (re-register) didn't fix the symptom — GitHub kept workflow ID \`259268012\` across the delete + re-add cycle, so the underlying check-suite registration never reset. Phantom failures continued post-merge: https://github.com/norrietaylor/distillery/actions/runs/25534158526 (created 03:00:20Z, after #489 merged at 02:55).

## Change

3-line addition to the \`on:\` block:

\`\`\`yaml
push:
  branches: [\"__phantom_run_suppression__\"]
\`\`\`

This declares the workflow handles push events but uses a branch filter that can't match any real branch, so:

- Check-suite enumerator now resolves push events to a definite no-op via the explicit filter (instead of producing a phantom 0-job failure record)
- No real jobs ever fire on pushes
- The existing \`issue_comment\` trigger and all downstream jobs are unchanged

## Verification after merge

After this PR merges, push another commit to main (or check the next merge that happens) and verify:

\`\`\`
gh run list --workflow=staging-deploy.yml --event=push --limit 3
\`\`\`

Should return no new failed phantom entries on subsequent pushes.

## Risk

Negligible. The \`__phantom_run_suppression__\` branch is fictional. The yaml parses (verified locally with \`python3 -c \"import yaml; yaml.safe_load(...)\"\`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to improve deployment pipeline reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->