### PR TITLE
ci(staging): noop job on push to suppress 0-job phantom failures

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -28,14 +28,17 @@ on:
   issue_comment:
     types: [created]
   # Phantom-run suppression. With only `issue_comment` declared, every
-  # push to main creates a 0-job check_suite entry that records as
-  # `failure` in the Actions UI even though no jobs ran (verified:
-  # billing=0, jobs=0, conclusion=failure). Declaring an unreachable
-  # `push:` trigger gives the check-suite enumerator an explicit
-  # branch filter to match against, which suppresses the phantom
-  # entries without ever firing real jobs on push events.
+  # push creates a 0-job check_suite entry that records as `failure`
+  # in the Actions UI even though no jobs ran. Two earlier attempts
+  # (workflow deregister/re-register in #488/#489 and an unreachable
+  # branch filter in #491) failed to suppress those check_suites.
+  # Declaring `push:` here so the workflow has a real handler, paired
+  # with the `phantom_suppression_noop` job below that runs on push
+  # events and exits 0, makes every push produce a 1-job success run
+  # instead of the 0-job failure phantom. The existing issue_comment
+  # jobs gate themselves with `if: github.event_name == 'issue_comment'`,
+  # so push events never trigger any real work.
   push:
-    branches: ["__phantom_run_suppression__"]
 
 # Default permissions are minimal. Each job opts in to what it needs.
 # The deploy job — which checks out PR head code and builds it — is
@@ -51,6 +54,25 @@ env:
   IMAGE_NAME: ghcr.io/norrietaylor/distillery
 
 jobs:
+  # ──────────────────────────────────────────────────────────────────
+  # Job 0: phantom-suppression no-op.
+  #
+  # Fires only on push events. Records the workflow run as 1-job
+  # success instead of a 0-job failure phantom in the Actions UI.
+  # See the `on:` block comment for why two earlier suppression
+  # attempts (#488/#489 deregister, #491 unreachable branch filter)
+  # failed and this is what's left.
+  #
+  # The job is intentionally trivial — fastest possible runner spin,
+  # single echo, no side effects. ~10 s of runner time per push.
+  # ──────────────────────────────────────────────────────────────────
+  phantom_suppression_noop:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - run: echo "no-op marker — staging-deploy real jobs only run on issue_comment events"
+
   # ──────────────────────────────────────────────────────────────────
   # Job 1a: Resolve the PR head SHA on a trusted, unprivileged runner.
   #


### PR DESCRIPTION
Third attempt at suppressing the phantom failures #488/#489 (deregister+re-register) and #491 (unreachable branch filter) both missed.

## What this changes

- Removes the unreachable \`branches: [\"__phantom_run_suppression__\"]\` filter from the push trigger.
- Adds a single \`phantom_suppression_noop\` job that fires on push events, exits 0, and consumes ~10s of runner time. Permissions \`{}\`.
- Existing \`resolve\` / \`build\` / \`teardown_comment\` jobs are unchanged — they're already gated by \`if: github.event_name == 'issue_comment' && ...\`.

## Why this works when the others didn't

\`#488/#489\`: GitHub kept workflow ID \`259268012\` across delete+re-add. No actual reset.

\`#491\`: \`branches:\` filter still resolves to \"no jobs match\" → 0-job failure phantom record.

This PR makes a job actually run on push events. Every push to main produces a 1-job **success** run. Different record state, no phantom failure to record.

## Verification after merge

Push another commit to main (or rely on this PR's merge commit) and check:

\`\`\`
gh run list --workflow=staging-deploy.yml --event=push --limit 3
\`\`\`

Recent entries should now be \`success\`, with 1 job (\`phantom_suppression_noop\`).

## Cost

~10 s of runner time per push to main. GitHub Actions free-tier rate for public repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved spurious CI/CD check failures in the staging deployment pipeline, improving build reliability and preventing false negative status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->