### PR TITLE
feat(classification): add kind/ content-type axis

### DIFF
--- a/distillery.yaml.example
+++ b/distillery.yaml.example
@@ -241,4 +241,4 @@ tags:
   # content-type axis (kind/release, kind/opinion, ...) assigned by the
   # classifier.  Setting this key explicitly (including to []) overrides the
   # default.  Example: ["kind", "system"] reserves both namespaces.
-  reserved_prefixes: []
+  reserved_prefixes: ["kind"]

--- a/distillery.yaml.example
+++ b/distillery.yaml.example
@@ -236,5 +236,9 @@ tags:
   # Each prefix must be a valid lowercase alphanumeric slug (e.g. "system").
   # Entries with tags under a reserved prefix submitted via MCP will be
   # rejected unless the source is an authorized internal source.
-  # Example: ["system"] reserves system/* tags for internal use.
+  #
+  # Default (when this key is omitted): ["kind"] — the kind/ namespace is the
+  # content-type axis (kind/release, kind/opinion, ...) assigned by the
+  # classifier.  Setting this key explicitly (including to []) overrides the
+  # default.  Example: ["kind", "system"] reserves both namespaces.
   reserved_prefixes: []

--- a/docs/skills/classify.md
+++ b/docs/skills/classify.md
@@ -24,8 +24,17 @@ Entry: a1b2c3d4
 Type: session
 Confidence: 92% (high)
 Reasoning: Contains decisions and action items from a working session
-Suggested tags: domain/caching, project/billing/decisions
+Suggested tags: domain/caching, project/billing/decisions, kind/howto
 ```
+
+The classifier also assigns a `kind/<value>` tag from a fixed enum
+(`release`, `reference`, `howto`, `opinion`, `incident`, `announcement`,
+`discussion`).  This is the **content-type axis** — orthogonal to the
+entry type — and lives under the reserved `kind/` namespace.  See
+[skills/CONVENTIONS.md][conventions-tag-namespaces] for the full list of
+tag namespaces.
+
+[conventions-tag-namespaces]: https://github.com/norrietaylor/distillery/blob/main/skills/CONVENTIONS.md#tag-namespaces
 
 ### Batch Inbox (`--inbox`)
 

--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -388,6 +388,32 @@ Actions:
 - Prefer hierarchical: `project/{repo}/sessions`, `domain/{topic}`, `source/bookmark/{domain}`
 - Strip leading `#` from user-provided tags
 
+### Tag namespaces
+
+The codebase recognises six top-level tag namespaces:
+
+| Namespace | What it answers | Example |
+|---|---|---|
+| `project/` | which repo / product is this about? | `project/distillery/decisions` |
+| `entity/` | which person, team, or org? | `entity/anthropic` |
+| `domain/` | what subject area? | `domain/api-design` |
+| `tech/` | which technology / tool? | `tech/duckdb` |
+| `source/` | where did the content come from? | `source/bookmark/docs-python-org` |
+| `kind/` | what *content type* is this? (#481) | `kind/release`, `kind/opinion` |
+
+The first five namespaces describe *what the entry is about*.  The sixth,
+`kind/`, is the **content-type axis** assigned by the classifier — it
+distinguishes (e.g.) a `kind/opinion` essay from a `kind/release` post on
+the same topic.  Exactly one `kind/<value>` tag per ingested entry, drawn
+from a fixed enum: `release`, `reference`, `howto`, `opinion`, `incident`,
+`announcement`, `discussion`.
+
+`kind/` is **reserved** in `tags.reserved_prefixes` by default — only the
+classifier may set it; user-supplied `kind/*` tags via `distillery_store`
+are rejected.  Pre-existing entries have no `kind/*` tag; *absence of
+`kind/*` is **not** equivalent to `kind/opinion`.*  Filters that exclude
+`kind/opinion` should not also exclude entries that lack a `kind/` tag.
+
 ## Provenance
 
 Search results must include: entry ID, `[type]` badge, author, created date, similarity %.

--- a/skills/distill/SKILL.md
+++ b/skills/distill/SKILL.md
@@ -98,6 +98,12 @@ Auto-extract 2-5 keywords from the summary. Prefer hierarchical tags:
 - `domain/{topic}` for domain-specific tags (e.g., `domain/storage`, `domain/api-design`)
 - Fall back to flat tags only when no project context is available
 
+Distillery recognises six top-level namespaces in total — `project/`,
+`entity/`, `domain/`, `tech/`, `source/`, and `kind/` (the content-type
+axis assigned by the classifier; see [CONVENTIONS.md](../CONVENTIONS.md#tag-namespaces)).
+**Do not set `kind/*` tags by hand** — the namespace is reserved and the
+store will reject user-supplied `kind/*` from non-internal sources.
+
 Repo name sanitization: lowercase, replace non-`[a-z0-9-]` chars with hyphens, collapse consecutive hyphens, trim leading/trailing hyphens, prefix with `repo-` if result doesn't start with `[a-z0-9]`. Final segment must match `[a-z0-9][a-z0-9\-]*`.
 
 Merge with any explicit `#tag` arguments (strip leading `#`). Tags are lowercase, hyphen-separated within segments.

--- a/src/distillery/classification/engine.py
+++ b/src/distillery/classification/engine.py
@@ -203,11 +203,15 @@ class ClassificationEngine:
             elif normalised:
                 logger.warning("ClassificationEngine: unknown kind %r, dropping", raw_kind)
 
-        # Merge ``kind/<value>`` into suggested_tags (de-duplicated, preserve order).
+        # Canonicalize the ``kind/`` axis: keep at most one ``kind/<value>`` tag,
+        # always sourced from the dedicated ``kind`` field.  Strip any pre-existing
+        # ``kind/*`` entries from suggested_tags (case-insensitive) to avoid
+        # conflicting or duplicate kind tags, then append the canonical tag.
+        suggested_tags = [
+            tag for tag in suggested_tags if not tag.strip().lower().startswith("kind/")
+        ]
         if suggested_kind is not None:
-            kind_tag = f"kind/{suggested_kind}"
-            if kind_tag not in suggested_tags:
-                suggested_tags.append(kind_tag)
+            suggested_tags.append(f"kind/{suggested_kind}")
 
         status = self._status_for(confidence)
 

--- a/src/distillery/classification/engine.py
+++ b/src/distillery/classification/engine.py
@@ -30,11 +30,27 @@ logger = logging.getLogger(__name__)
 # Prompt template
 # ---------------------------------------------------------------------------
 
+_KIND_VALUES: tuple[str, ...] = (
+    "release",
+    "reference",
+    "howto",
+    "opinion",
+    "incident",
+    "announcement",
+    "discussion",
+)
+"""Allowed values for the ``kind`` axis (without the ``kind/`` prefix).
+
+The ``kind/`` namespace is the *content-type* axis, orthogonal to the
+``entry_type`` (the *artifact form*).  See issue #481 for rationale.
+"""
+
+
 _CLASSIFY_PROMPT = """\
 You are a knowledge-base classifier.  Your task is to classify the following \
-content into one of these categories and return a JSON object.
+content and return a JSON object.
 
-Categories:
+Pick exactly one *entry_type* (the artifact form):
 - session: A captured work session or context snapshot (e.g. "explored auth module").
 - bookmark: A saved URL or external reference.
 - minutes: Notes from a meeting or discussion.
@@ -48,6 +64,16 @@ Categories:
 - feed: An ambient feed item captured from a monitored source (RSS, GitHub, Hacker News).
 - inbox: Cannot be classified (use as a fallback).
 
+Pick exactly one *kind* (the content-type axis, orthogonal to entry_type):
+- release: product / version announcement, changelog, launch.
+- reference: spec, RFC, doc, paper, persistent factual artifact.
+- howto: tutorial, guide, walkthrough.
+- opinion: essay, hot-take, position piece, retrospective.
+- incident: outage, postmortem, security advisory.
+- announcement: hire, funding, org news; non-product.
+- discussion: thread, forum, comment-driven (HN/Reddit/Lobsters submissions \
+when not classifiable as above).
+
 Content to classify:
 \"\"\"
 {content}
@@ -55,7 +81,8 @@ Content to classify:
 
 Respond with ONLY valid JSON in this exact format:
 {{
-  "entry_type": "<one of the categories above>",
+  "entry_type": "<one of the entry_type categories above>",
+  "kind": "<one of: release|reference|howto|opinion|incident|announcement|discussion>",
   "confidence": <float 0.0-1.0>,
   "reasoning": "<brief explanation>",
   "suggested_tags": ["<tag1>", "<tag2>"],
@@ -162,6 +189,26 @@ class ClassificationEngine:
         raw_project = data.get("suggested_project")
         suggested_project = str(raw_project) if raw_project else None
 
+        # Parse the ``kind`` axis.  Strict: only known values are accepted.
+        # Unknown / missing values yield ``suggested_kind=None`` and no tag.
+        suggested_kind: str | None = None
+        raw_kind = data.get("kind")
+        if isinstance(raw_kind, str):
+            normalised = raw_kind.lower().strip()
+            # Tolerate values the LLM may emit with the prefix already attached.
+            if normalised.startswith("kind/"):
+                normalised = normalised[len("kind/") :]
+            if normalised in _KIND_VALUES:
+                suggested_kind = normalised
+            elif normalised:
+                logger.warning("ClassificationEngine: unknown kind %r, dropping", raw_kind)
+
+        # Merge ``kind/<value>`` into suggested_tags (de-duplicated, preserve order).
+        if suggested_kind is not None:
+            kind_tag = f"kind/{suggested_kind}"
+            if kind_tag not in suggested_tags:
+                suggested_tags.append(kind_tag)
+
         status = self._status_for(confidence)
 
         return ClassificationResult(
@@ -171,6 +218,7 @@ class ClassificationEngine:
             reasoning=reasoning,
             suggested_tags=suggested_tags,
             suggested_project=suggested_project,
+            suggested_kind=suggested_kind,
         )
 
     def _fallback(self) -> ClassificationResult:
@@ -182,6 +230,7 @@ class ClassificationEngine:
             reasoning="",
             suggested_tags=[],
             suggested_project=None,
+            suggested_kind=None,
         )
 
     def _status_for(self, confidence: float) -> EntryStatus:

--- a/src/distillery/classification/models.py
+++ b/src/distillery/classification/models.py
@@ -52,8 +52,14 @@ class ClassificationResult:
             otherwise.
         reasoning: Human-readable explanation from the LLM.  May be empty
             on parse failure.
-        suggested_tags: Suggested string labels for the entry.
+        suggested_tags: Suggested string labels for the entry.  When
+            ``suggested_kind`` is set, the corresponding ``kind/<value>``
+            tag is included here automatically.
         suggested_project: Optional project name extracted from content.
+        suggested_kind: Predicted ``kind/`` content-type axis value
+            (without the ``kind/`` prefix), e.g. ``"opinion"``,
+            ``"release"``.  ``None`` when the LLM omitted the field, the
+            value was unrecognised, or the heuristic classifier was used.
     """
 
     entry_type: EntryType
@@ -62,6 +68,7 @@ class ClassificationResult:
     reasoning: str = ""
     suggested_tags: list[str] = field(default_factory=list)
     suggested_project: str | None = None
+    suggested_kind: str | None = None
 
 
 @dataclass

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -162,11 +162,15 @@ class TagsConfig:
         reserved_prefixes: Top-level namespace prefixes (e.g. ``["system"]``)
             that only specific internal sources may use.  Each entry must be a
             valid lowercase alphanumeric slug (same rules as a single tag
-            segment).  Defaults to ``[]``.
+            segment).  Defaults to ``["kind"]`` — the ``kind/`` namespace is
+            the content-type axis (``kind/release``, ``kind/opinion``, …)
+            assigned by the classifier; user-supplied ``kind/*`` tags via
+            ``distillery_store`` are rejected so the axis remains a single
+            source of truth.
     """
 
     enforce_namespaces: bool = False
-    reserved_prefixes: list[str] = field(default_factory=list)
+    reserved_prefixes: list[str] = field(default_factory=lambda: ["kind"])
 
 
 @dataclass
@@ -682,7 +686,9 @@ def _parse_tags(raw: dict[str, Any]) -> TagsConfig:
     Args:
         raw: Mapping (typically from YAML) containing any of the following keys:
             - ``enforce_namespaces`` (bool, default ``False``)
-            - ``reserved_prefixes`` (list[str], default ``[]``)
+            - ``reserved_prefixes`` (list[str]) — when absent, falls back to
+              the :class:`TagsConfig` dataclass default (``["kind"]``); when
+              present (including ``[]``), the explicit value wins.
 
     Returns:
         A populated :class:`TagsConfig` instance.
@@ -698,16 +704,20 @@ def _parse_tags(raw: dict[str, Any]) -> TagsConfig:
     if not isinstance(enforce_raw, bool):
         raise ValueError(f"tags.enforce_namespaces must be a boolean, got: {enforce_raw!r}")
 
-    prefixes_raw = raw.get("reserved_prefixes", [])
-    if not isinstance(prefixes_raw, list):
-        raise ValueError(
-            f"tags.reserved_prefixes must be a list, got: {type(prefixes_raw).__name__}"
+    if "reserved_prefixes" in raw:
+        prefixes_raw = raw["reserved_prefixes"]
+        if not isinstance(prefixes_raw, list):
+            raise ValueError(
+                f"tags.reserved_prefixes must be a list, got: {type(prefixes_raw).__name__}"
+            )
+        reserved_prefixes = [str(p) for p in prefixes_raw]
+        return TagsConfig(
+            enforce_namespaces=enforce_raw,
+            reserved_prefixes=reserved_prefixes,
         )
 
-    return TagsConfig(
-        enforce_namespaces=enforce_raw,
-        reserved_prefixes=[str(p) for p in prefixes_raw],
-    )
+    # Absent ``reserved_prefixes`` → use dataclass default (``["kind"]``).
+    return TagsConfig(enforce_namespaces=enforce_raw)
 
 
 def _parse_feed_source(raw: dict[str, Any], index: int) -> FeedSourceConfig:

--- a/tests/eval/golden_dataset.yaml
+++ b/tests/eval/golden_dataset.yaml
@@ -188,3 +188,136 @@ entries:
     author: carol
     tags: [meeting, roadmap, quarterly]
     project: distillery
+
+  # ---------------------------------------------------------------------------
+  # kind/ axis golden cases (issue #481)
+  #
+  # Each entry below pins one of the seven kind/* values.  These exist to
+  # exercise classifier prompts and downstream filters that key off the new
+  # content-type axis; entries are intentionally lightweight (single-line
+  # content sufficient to disambiguate the kind from the artifact form).
+  # ---------------------------------------------------------------------------
+
+  # kind/release (3)
+  - content: "Distillery v0.5.0 is out. Highlights: graph relations, namespace-diverse /radar, MotherDuck backend, hosted MCP transport. Upgrade with `pip install -U distillery-mcp`."
+    entry_type: feed
+    author: bot
+    tags: [feed, release-notes, kind/release]
+    project: distillery
+    metadata:
+      url: "https://github.com/norrietaylor/distillery/releases/tag/v0.5.0"
+
+  - content: "Anthropic ships Claude Sonnet 4.7 with 1M context window for paid tiers. Available immediately via Messages API; pricing and rate limits unchanged from 4.6."
+    entry_type: feed
+    author: bot
+    tags: [feed, anthropic, kind/release]
+
+  - content: "DuckDB 1.2 launches with native VSS HNSW index persistence, Apache Arrow zero-copy, and a 30% smaller wheel. Drop-in upgrade from 1.1.x."
+    entry_type: feed
+    author: bot
+    tags: [feed, duckdb, kind/release]
+
+  # kind/reference (3)
+  - content: "RFC 8949 (Concise Binary Object Representation, CBOR). Defines a binary data serialisation format derived from JSON, suited to constrained nodes and small message size."
+    entry_type: reference
+    author: alice
+    tags: [reference, rfc, kind/reference]
+    metadata:
+      url: "https://www.rfc-editor.org/rfc/rfc8949"
+
+  - content: "DuckDB VSS extension reference: HNSW index parameters (M, ef_construction), supported metrics (cosine, l2sq, ip), and persistence semantics across DuckDB restarts."
+    entry_type: reference
+    author: alice
+    tags: [reference, duckdb, vector-search, kind/reference]
+    project: distillery
+
+  - content: "Anthropic Messages API tool use spec — describes tool_use / tool_result blocks, parallel tool calls, error handling, and the input_schema JSONSchema dialect."
+    entry_type: reference
+    author: bob
+    tags: [reference, anthropic, tool-use, kind/reference]
+
+  # kind/howto (3)
+  - content: "Tutorial: Build a Claude Code MCP server in 50 lines. Steps: install fastmcp, decorate a function with @mcp.tool, register over stdio, register the server in ~/.claude/config.json."
+    entry_type: bookmark
+    author: bob
+    tags: [bookmark, mcp, tutorial, kind/howto]
+    project: distillery
+
+  - content: "How to enable HNSW vector search in DuckDB: INSTALL vss; LOAD vss; CREATE INDEX idx ON tbl USING HNSW(embedding) WITH (metric='cosine'). Walks through ingestion and a sample similarity query."
+    entry_type: bookmark
+    author: alice
+    tags: [bookmark, duckdb, tutorial, kind/howto]
+    project: distillery
+
+  - content: "Walkthrough: deploy a FastAPI service to Fly.io with a persistent volume, GitHub Actions CI, and a custom domain. Includes Dockerfile, fly.toml, and a smoke-test script."
+    entry_type: bookmark
+    author: carol
+    tags: [bookmark, fly-io, tutorial, kind/howto]
+
+  # kind/opinion (3)
+  - content: "Essay: Agentic Coding is a Trap. Argues that fully-autonomous coding agents incentivise quantity over taste; prefers tight human-in-the-loop tools that surface intent before edits."
+    entry_type: feed
+    author: bot
+    tags: [feed, essay, agents, kind/opinion]
+    metadata:
+      url: "https://example.com/agentic-coding-trap"
+
+  - content: "Hot-take: knowledge-base bloat is the new tech debt. Author claims most teams over-store decisions and under-prune them, leading to retrieval noise that masquerades as signal."
+    entry_type: feed
+    author: bot
+    tags: [feed, knowledge-management, kind/opinion]
+
+  - content: "Retrospective: why we abandoned microservices for a modular monolith. Two years in, deployment overhead and trace complexity outweighed the team-autonomy gains."
+    entry_type: feed
+    author: bot
+    tags: [feed, architecture, retrospective, kind/opinion]
+
+  # kind/incident (3)
+  - content: "GitHub incident: elevated Actions queue times across us-east-1 between 14:02 and 15:47 UTC on 2026-04-12. Root cause: scheduler hot-spotting after a config rollout. Mitigation: rollback + capacity bump."
+    entry_type: feed
+    author: bot
+    tags: [feed, github, postmortem, kind/incident]
+
+  - content: "CVE-2026-12345: prototype-pollution in popular-pkg <2.4.1. Severity: high. Affected versions allow attacker-controlled keys on Object.prototype via merge(). Upgrade to 2.4.1 or apply patch."
+    entry_type: feed
+    author: bot
+    tags: [feed, security, cve, kind/incident]
+
+  - content: "Postmortem: Cloudflare regional outage 2026-03-30. A BGP misconfiguration drained traffic from EU-West for 27 minutes. Action items: pre-deploy lint, regional canary, faster rollback."
+    entry_type: feed
+    author: bot
+    tags: [feed, cloudflare, postmortem, kind/incident]
+
+  # kind/announcement (3)
+  - content: "Acme Corp announces Series B funding of $40M led by Sequoia, with participation from existing investors. Plans to grow eng team and open a Berlin office."
+    entry_type: feed
+    author: bot
+    tags: [feed, funding, kind/announcement]
+
+  - content: "Jane Doe joins Anthropic as VP of Research. Previously led the alignment team at OpenAI. Role focuses on long-horizon agentic safety."
+    entry_type: feed
+    author: bot
+    tags: [feed, hiring, kind/announcement]
+
+  - content: "Linux Foundation announces a new working group on agent interoperability standards, chaired by maintainers from MCP, OpenAI, and Anthropic. Charter and first meeting in May."
+    entry_type: feed
+    author: bot
+    tags: [feed, standards, kind/announcement]
+
+  # kind/discussion (3)
+  - content: "Hacker News thread: Show HN: my AI knowledge-base app. 312 comments. Top thread debates whether vector search is sufficient or whether structured KGs are needed for high-stakes recall."
+    entry_type: feed
+    author: bot
+    tags: [feed, hn, kind/discussion]
+    metadata:
+      url: "https://news.ycombinator.com/item?id=99999999"
+
+  - content: "Reddit /r/programming thread on rewriting CRUD apps in Rust. 280 comments split between safety-evangelists and pragmatists pointing at hiring constraints."
+    entry_type: feed
+    author: bot
+    tags: [feed, reddit, kind/discussion]
+
+  - content: "Lobsters thread: 'Is it time to retire OOP?' 95 comments — long-form responses arguing that the question is malformed and that the inheritance-vs-composition debate has nothing to do with OOP per se."
+    entry_type: feed
+    author: bot
+    tags: [feed, lobsters, kind/discussion]

--- a/tests/test_classification/test_heuristic.py
+++ b/tests/test_classification/test_heuristic.py
@@ -290,6 +290,26 @@ class TestClassifyIntegration:
         assert result.entry_type == EntryType.SESSION
         assert result.status == EntryStatus.ACTIVE
         assert result.confidence >= SIMILARITY_THRESHOLD
+        # Heuristic classifier never assigns a kind/ axis (#481).
+        assert result.suggested_kind is None
+        assert not any(t.startswith("kind/") for t in result.suggested_tags)
+
+    async def test_heuristic_returns_no_kind_when_no_centroids(
+        self,
+        store: Any,
+        deterministic_embedding_provider: DeterministicEmbeddingProvider,
+    ) -> None:
+        """Empty-store path must return ``suggested_kind=None`` rather than crash (#481)."""
+        entry = make_entry(content="orphan", entry_type=EntryType.INBOX)
+        deterministic_embedding_provider.register(
+            "orphan",
+            _axis_vector(deterministic_embedding_provider.dimensions, 0),
+        )
+
+        classifier = HeuristicClassifier()
+        result = await classifier.classify(entry, store, deterministic_embedding_provider)
+
+        assert result.suggested_kind is None
 
     async def test_pending_review_when_no_centroid_match(
         self,

--- a/tests/test_classification_engine.py
+++ b/tests/test_classification_engine.py
@@ -353,6 +353,23 @@ class TestKindAxis:
         # Exactly one kind/opinion entry, even though the LLM listed it twice.
         assert result.suggested_tags.count("kind/opinion") == 1
 
+    def test_conflicting_kind_in_suggested_tags_is_replaced_by_canonical_kind(self) -> None:
+        """Canonical ``kind`` field wins; conflicting kind/* in suggested_tags is dropped."""
+        engine = _make_engine()
+        response = _json_response(
+            "feed",
+            0.9,
+            suggested_tags=["domain/api", "kind/opinion"],
+            kind="release",
+        )
+        result = engine.parse_response(response)
+
+        assert result.suggested_kind == "release"
+        # Only the canonical kind tag remains; the stale kind/opinion is stripped.
+        kind_tags = [t for t in result.suggested_tags if t.lower().startswith("kind/")]
+        assert kind_tags == ["kind/release"]
+        assert "domain/api" in result.suggested_tags
+
     def test_unknown_kind_yields_none_and_no_tag(self) -> None:
         engine = _make_engine()
         response = _json_response("feed", 0.8, kind="bogus-kind")

--- a/tests/test_classification_engine.py
+++ b/tests/test_classification_engine.py
@@ -408,7 +408,7 @@ class TestKindAxis:
         result = engine.parse_response("not json")
 
         assert result.suggested_kind is None
-        assert "kind/" not in result.suggested_tags
+        assert not any(tag.startswith("kind/") for tag in result.suggested_tags)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_classification_engine.py
+++ b/tests/test_classification_engine.py
@@ -7,6 +7,7 @@ API calls.  The engine's job is purely to format prompts and parse JSON.
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
@@ -32,15 +33,27 @@ def _json_response(
     reasoning: str = "Test reasoning.",
     suggested_tags: list[str] | None = None,
     suggested_project: str | None = None,
+    kind: str | None = "reference",
+    *,
+    omit_kind: bool = False,
 ) -> str:
-    """Build a well-formed JSON response string as if from an LLM."""
-    payload = {
+    """Build a well-formed JSON response string as if from an LLM.
+
+    Args:
+        kind: Value for the ``kind`` field.  Defaults to ``"reference"`` so
+            existing tests that don't care about the axis still produce a
+            well-formed payload.  Set ``omit_kind=True`` to drop the field
+            entirely (back-compat / unknown-LLM responses).
+    """
+    payload: dict[str, Any] = {
         "entry_type": entry_type,
         "confidence": confidence,
         "reasoning": reasoning,
         "suggested_tags": suggested_tags or [],
         "suggested_project": suggested_project,
     }
+    if not omit_kind:
+        payload["kind"] = kind
     return json.dumps(payload)
 
 
@@ -244,6 +257,7 @@ class TestOptionalFields:
             0.88,
             "Auth work.",
             suggested_tags=["auth", "oauth2", "security"],
+            omit_kind=True,
         )
         result = engine.parse_response(response)
 
@@ -253,7 +267,7 @@ class TestOptionalFields:
 
     def test_empty_suggested_tags_is_empty_list(self) -> None:
         engine = _make_engine()
-        response = _json_response("session", 0.88)
+        response = _json_response("session", 0.88, omit_kind=True)
         result = engine.parse_response(response)
 
         assert result.suggested_tags == []
@@ -294,6 +308,132 @@ class TestPromptBuilding:
         prompt = engine.build_prompt("anything")
 
         assert "JSON" in prompt or "json" in prompt
+
+
+# ---------------------------------------------------------------------------
+# kind/ axis (issue #481)
+# ---------------------------------------------------------------------------
+
+
+class TestKindAxis:
+    """The classifier emits a single ``kind/<value>`` tag per entry."""
+
+    @pytest.mark.parametrize(
+        "kind_value",
+        [
+            "release",
+            "reference",
+            "howto",
+            "opinion",
+            "incident",
+            "announcement",
+            "discussion",
+        ],
+    )
+    def test_each_kind_round_trips(self, kind_value: str) -> None:
+        engine = _make_engine()
+        response = _json_response("feed", 0.85, kind=kind_value)
+        result = engine.parse_response(response)
+
+        assert result.suggested_kind == kind_value
+        assert f"kind/{kind_value}" in result.suggested_tags
+
+    def test_kind_tag_is_de_duplicated_against_suggested_tags(self) -> None:
+        """If the LLM also lists the kind tag explicitly, it must not duplicate."""
+        engine = _make_engine()
+        response = _json_response(
+            "feed",
+            0.9,
+            suggested_tags=["domain/api", "kind/opinion"],
+            kind="opinion",
+        )
+        result = engine.parse_response(response)
+
+        assert result.suggested_kind == "opinion"
+        # Exactly one kind/opinion entry, even though the LLM listed it twice.
+        assert result.suggested_tags.count("kind/opinion") == 1
+
+    def test_unknown_kind_yields_none_and_no_tag(self) -> None:
+        engine = _make_engine()
+        response = _json_response("feed", 0.8, kind="bogus-kind")
+        result = engine.parse_response(response)
+
+        assert result.suggested_kind is None
+        assert not any(t.startswith("kind/") for t in result.suggested_tags)
+
+    def test_missing_kind_yields_none_and_no_tag(self) -> None:
+        engine = _make_engine()
+        response = _json_response("feed", 0.8, omit_kind=True)
+        result = engine.parse_response(response)
+
+        assert result.suggested_kind is None
+        assert not any(t.startswith("kind/") for t in result.suggested_tags)
+
+    def test_kind_with_prefix_is_accepted(self) -> None:
+        """LLMs sometimes emit ``kind/release``; strip the prefix gracefully."""
+        engine = _make_engine()
+        response = _json_response("feed", 0.8, kind="kind/release")
+        result = engine.parse_response(response)
+
+        assert result.suggested_kind == "release"
+        assert "kind/release" in result.suggested_tags
+
+    def test_kind_uppercase_normalised(self) -> None:
+        engine = _make_engine()
+        response = _json_response("feed", 0.8, kind="OPINION")
+        result = engine.parse_response(response)
+
+        assert result.suggested_kind == "opinion"
+        assert "kind/opinion" in result.suggested_tags
+
+    def test_fallback_result_has_no_kind(self) -> None:
+        engine = _make_engine()
+        result = engine.parse_response("not json")
+
+        assert result.suggested_kind is None
+        assert "kind/" not in result.suggested_tags
+
+
+# ---------------------------------------------------------------------------
+# Prompt contract (issue #481)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptContract:
+    """The classifier prompt must enumerate the ``kind`` axis enum."""
+
+    def test_prompt_requires_kind_field(self) -> None:
+        engine = _make_engine()
+        prompt = engine.build_prompt("anything")
+
+        assert '"kind"' in prompt
+
+    @pytest.mark.parametrize(
+        "kind_value",
+        [
+            "release",
+            "reference",
+            "howto",
+            "opinion",
+            "incident",
+            "announcement",
+            "discussion",
+        ],
+    )
+    def test_prompt_lists_each_kind_value(self, kind_value: str) -> None:
+        engine = _make_engine()
+        prompt = engine.build_prompt("anything")
+
+        assert kind_value in prompt
+
+    def test_prompt_documents_pipe_separated_enum(self) -> None:
+        """The contract line ``"kind": "<one of: release|...>"`` is present."""
+        engine = _make_engine()
+        prompt = engine.build_prompt("anything")
+
+        # Anchor on the full enum string the LLM must respect.
+        expected_enum = "release|reference|howto|opinion|incident|announcement|discussion"
+        assert expected_enum in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -537,7 +537,11 @@ class TestExampleConfigFile:
         cfg = load_config(str(example_path))
         assert isinstance(cfg.tags, TagsConfig)
         assert cfg.tags.enforce_namespaces is False
-        assert cfg.tags.reserved_prefixes == []
+        # The example explicitly reserves the ``kind/`` namespace (the
+        # classifier-owned content-type axis).  Setting this to ``[]`` would
+        # silently disable that invariant for users who copy the example
+        # verbatim, so the example mirrors the in-code default.
+        assert cfg.tags.reserved_prefixes == ["kind"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -554,7 +554,8 @@ class TestTagsConfig:
         cfg = load_config()
         assert isinstance(cfg.tags, TagsConfig)
         assert cfg.tags.enforce_namespaces is False
-        assert cfg.tags.reserved_prefixes == []
+        # ``kind/`` is reserved by default for the content-type axis (#481).
+        assert cfg.tags.reserved_prefixes == ["kind"]
 
     def test_tags_section_parsed_enforce_namespaces_true(self, tmp_path: Path) -> None:
         yaml_content = """\


### PR DESCRIPTION
## Summary

- Reserves a sixth tag namespace `kind/` and has the classifier assign exactly one `kind/<value>` tag per ingested entry from a fixed enum: `release`, `reference`, `howto`, `opinion`, `incident`, `announcement`, `discussion`.
- The first five active namespaces (`project/`, `entity/`, `domain/`, `tech/`, `source/`) describe what the entry is *about*; the new `kind/` axis describes what *kind of artifact* it is — orthogonal to `entry_type`. This lets downstream filters (e.g. `/radar`) suppress opinion essays without also suppressing release posts that share the same `domain/tech` tags.
- `tags.reserved_prefixes` default flips from `[]` to `["kind"]` so user-supplied `kind/*` tags via `distillery_store` are rejected and the namespace stays a single source of truth (the classifier writes via `store.update` and bypasses the guard).

## Touchpoints

- `src/distillery/classification/engine.py` — `_CLASSIFY_PROMPT` extended with a `kind` field and pipe-separated enum; `_parse` handles missing/unknown/prefixed/uppercase values gracefully and de-duplicates the merged `kind/<value>` tag.
- `src/distillery/classification/models.py` — `ClassificationResult.suggested_kind: str | None`.
- `src/distillery/classification/heuristic.py` — unchanged on the call path; `suggested_kind` defaults to `None` via the dataclass, so heuristic results omit the axis without requiring centroid computation.
- `src/distillery/config.py` — `TagsConfig.reserved_prefixes` default `["kind"]`; absent YAML key uses the dataclass default, explicit `[]` overrides.
- `distillery.yaml.example` — documents the default change.
- `skills/CONVENTIONS.md`, `skills/distill/SKILL.md`, `docs/skills/classify.md` — enumerate the six namespaces and warn against hand-setting `kind/*`.
- `tests/eval/golden_dataset.yaml` — adds 21 golden cases (3 per kind value).
- `tests/test_classification_engine.py` — 17 new assertions for the kind axis and prompt contract.
- `tests/test_classification/test_heuristic.py` — asserts heuristic path returns `suggested_kind=None` without crashing.
- `tests/test_config.py` — asserts `["kind"]` is the new default.

## Back-compat

Pre-existing entries have no `kind/*` tag. **Absence of `kind/*` is not equivalent to `kind/opinion`** — filters that exclude `kind/opinion` must not also exclude un-classified entries by default.

## Non-goals

Backfilling historical entries; `/radar` and `/digest` skill changes to use `kind/` filters.

## Test plan

- [x] `pytest -m unit` — 1961 passed, 15 skipped
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` on touched files — clean
- [x] `mypy --strict src/distillery/` — clean
- [x] New tests cover: each kind round-trip, prompt enum contract, missing/unknown/prefixed/uppercased values, de-duplication, fallback on parse failure, heuristic returns `None`.

Closes #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "kind" classification axis (release, reference, howto, opinion, incident, announcement, discussion). Classifier now suggests a canonical kind/<value> tag, normalizes and de-duplicates kind tags.
  * Tag config defaults to reserving the kind/ namespace when unspecified; explicitly setting reserved prefixes (including empty) overrides the default.

* **Documentation**
  * Updated docs and examples to describe tag namespaces, reserved kind/ behavior, and suggested-tags output.

* **Tests**
  * Added and updated tests and golden cases covering the kind axis and config default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->