### PR TITLE
fix(store): re-run entry_relations backfill on upgrade and on every write (#490)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -948,6 +948,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 content=content,
                 llm_responses=llm_responses,
                 source_entry_id=source_entry_id,
+                accept_action=accept_action,
             ),
         )
         return await _handle_find_similar(store=c["store"], cfg=c["config"], arguments=args)

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -889,6 +889,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         llm_responses: list[dict[str, Any]] | None = None,
         source_entry_id: str | None = None,
         exclude_linked: bool = False,
+        accept_action: str | None = None,
     ) -> list[types.TextContent]:
         """Find stored entries similar to the given text (cosine similarity).
 
@@ -915,6 +916,11 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - exclude_linked (bool, optional, default=false): When true, filters out
             entries already linked to source_entry_id via entry_relations
             (any direction, any relation_type). Surfaces hidden connections.
+          - accept_action (str, optional): When set, persists an
+            entry_relations row from source_entry_id to each result above
+            threshold. Valid: ['link' → related, 'merge' → merge_source,
+            'duplicate' → duplicate]. Requires source_entry_id. Idempotent via
+            the unique (from_id, to_id, relation_type) index.
 
         RETURNS (success): { results: [{ score: float, entry: {...} }], count: int, threshold: float,
           dedup?: { action: str, similar_entries: list },

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -83,10 +83,11 @@ async def _handle_relations(
         )
     action = action_raw.strip().lower()
 
-    if action not in ("add", "get", "remove", "traverse", "metrics"):
+    if action not in ("add", "get", "remove", "traverse", "metrics", "reconcile"):
         return error_response(
             "INVALID_PARAMS",
-            f"action must be one of 'add', 'get', 'remove', 'traverse', 'metrics'; got: {action!r}",
+            "action must be one of 'add', 'get', 'remove', 'traverse', 'metrics', "
+            f"'reconcile'; got: {action!r}",
         )
 
     # ------------------------------------------------------------------
@@ -325,6 +326,24 @@ async def _handle_relations(
     # ------------------------------------------------------------------
     if action == "metrics":
         return await _handle_metrics(store, arguments)
+
+    # ------------------------------------------------------------------
+    # action == "reconcile"
+    # ------------------------------------------------------------------
+    if action == "reconcile":
+        try:
+            counts = await store.reconcile_relations()
+        except Exception:  # noqa: BLE001
+            logger.exception("distillery_relations reconcile: unexpected error")
+            return error_response("INTERNAL", "Failed to reconcile relations")
+
+        return success_response(
+            {
+                "action": "reconcile",
+                "metadata_links": counts.get("metadata_links", 0),
+                "total": counts.get("total", 0),
+            }
+        )
 
     # ------------------------------------------------------------------
     # action == "remove"

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -660,15 +660,25 @@ async def _handle_find_similar(
                 # exists, so we use the pre-fetched ``existing_targets`` set
                 # to distinguish "newly inserted" from "already present".
                 relation_id = await store.add_relation(source_entry_id, target_id, relation_type)
-            except ValueError as exc:
+            except ValueError:
                 # Source or target missing — surface but don't abort the
                 # whole batch; this should be rare since source_entry_id was
                 # validated earlier and target ids come from the search.
+                # Log details server-side; keep client payload generic so we
+                # don't leak raw store error text to MCP callers.
+                logger.warning(
+                    "find_similar accept_action: relation validation failed "
+                    "from=%s to=%s type=%s",
+                    source_entry_id,
+                    target_id,
+                    relation_type,
+                    exc_info=True,
+                )
                 accept_outcomes.append(
                     {
                         "to_id": target_id,
                         "persisted": False,
-                        "error": str(exc),
+                        "error": "missing source or target entry",
                     }
                 )
                 continue

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -30,6 +30,16 @@ from distillery.mcp.tools.crud import (
 
 logger = logging.getLogger(__name__)
 
+# Maps ``distillery_find_similar(accept_action=...)`` values to the
+# ``entry_relations.relation_type`` written when the caller accepts a match
+# (issue #490 mechanism #2). Mirrors the dedup actions returned by
+# :class:`distillery.classification.dedup.DeduplicationChecker`.
+_ACCEPT_ACTION_TO_RELATION_TYPE: dict[str, str] = {
+    "link": "related",
+    "merge": "merge_source",
+    "duplicate": "duplicate",
+}
+
 # ---------------------------------------------------------------------------
 # _handle_search
 # ---------------------------------------------------------------------------
@@ -354,6 +364,15 @@ async def _handle_find_similar(
       entries already linked to ``source_entry_id`` via ``entry_relations``
       (any direction, any relation_type). Requires ``source_entry_id``.
 
+    * **accept_action** (str | None): when set to ``"link"``, ``"merge"``, or
+      ``"duplicate"``, persists an ``entry_relations`` row from
+      ``source_entry_id`` to each result entry above ``threshold``.  Requires
+      ``source_entry_id``.  The action maps to relation_type as follows:
+      ``link → "related"``, ``merge → "merge_source"``,
+      ``duplicate → "duplicate"``.  Idempotent via the unique
+      ``(from_id, to_id, relation_type)`` index — re-running silently skips
+      already-persisted edges.  Issue #490 mechanism #2.
+
     Args:
         store: Initialised :class:`~distillery.store.duckdb.DuckDBStore`.
         arguments: Tool argument dict; must contain ``content`` or
@@ -379,6 +398,30 @@ async def _handle_find_similar(
             "INVALID_PARAMS",
             "exclude_linked=true requires source_entry_id",
         )
+
+    # accept_action persists relations from source_entry_id to each match
+    # (issue #490 mechanism #2). Validate up-front so the caller sees a clean
+    # error before we burn an embedding on the search.
+    accept_action_raw = arguments.get("accept_action")
+    err_accept = validate_type(arguments, "accept_action", str, "string")
+    if err_accept:
+        return error_response("INVALID_PARAMS", err_accept)
+    accept_action: str | None = (
+        accept_action_raw.strip().lower() if isinstance(accept_action_raw, str) else None
+    )
+    accept_action = accept_action or None
+    if accept_action is not None:
+        if accept_action not in _ACCEPT_ACTION_TO_RELATION_TYPE:
+            return error_response(
+                "INVALID_PARAMS",
+                f"accept_action must be one of {sorted(_ACCEPT_ACTION_TO_RELATION_TYPE)}, "
+                f"got: {accept_action_raw!r}",
+            )
+        if source_entry_id is None:
+            return error_response(
+                "INVALID_PARAMS",
+                "accept_action requires source_entry_id",
+            )
 
     # Resolve source entry up-front so we can supply its content as the
     # similarity probe when caller omits an explicit ``content`` argument.
@@ -582,6 +625,84 @@ async def _handle_find_similar(
             except Exception:  # noqa: BLE001
                 logger.exception("Error running conflict discovery in find_similar")
                 return error_response("INTERNAL", "Conflict check failed")
+
+    # --- accept_action persistence (issue #490 mechanism #2) ----------------
+    # Persist relations from source_entry_id → each result entry as a typed
+    # relation, mirroring the user/agent's accepted dedup outcome. Idempotent
+    # via the unique (from_id, to_id, relation_type) index, so re-running over
+    # an already-linked result silently skips. We surface a count plus the
+    # per-result outcome so callers can verify the write took.
+    if accept_action is not None and source_entry_id is not None:
+        relation_type = _ACCEPT_ACTION_TO_RELATION_TYPE[accept_action]
+        accept_outcomes: list[dict[str, Any]] = []
+        persisted_new = 0
+        # Fetch existing outgoing relations of this type once so the per-target
+        # "newly persisted" classification is one query rather than N (each
+        # call would otherwise serialise on the shared store lock).
+        try:
+            existing_outgoing = await store.get_related(
+                source_entry_id, direction="outgoing", relation_type=relation_type
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("find_similar accept_action: failed to fetch existing relations")
+            return error_response("INTERNAL", "Failed to inspect existing relations")
+        existing_targets: set[str] = {
+            rel["to_id"] for rel in existing_outgoing if isinstance(rel.get("to_id"), str)
+        }
+        for sr in search_results:
+            target_id = sr.entry.id
+            if target_id == source_entry_id:
+                continue
+            already_linked = target_id in existing_targets
+            try:
+                # ``add_relation`` is itself idempotent — it returns the
+                # existing row's id when the (from, to, type) triple already
+                # exists, so we use the pre-fetched ``existing_targets`` set
+                # to distinguish "newly inserted" from "already present".
+                relation_id = await store.add_relation(source_entry_id, target_id, relation_type)
+            except ValueError as exc:
+                # Source or target missing — surface but don't abort the
+                # whole batch; this should be rare since source_entry_id was
+                # validated earlier and target ids come from the search.
+                accept_outcomes.append(
+                    {
+                        "to_id": target_id,
+                        "persisted": False,
+                        "error": str(exc),
+                    }
+                )
+                continue
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "find_similar accept_action: failed to persist relation from=%s to=%s type=%s",
+                    source_entry_id,
+                    target_id,
+                    relation_type,
+                )
+                accept_outcomes.append(
+                    {
+                        "to_id": target_id,
+                        "persisted": False,
+                        "error": "persist failed",
+                    }
+                )
+                continue
+            if not already_linked:
+                persisted_new += 1
+                existing_targets.add(target_id)
+            accept_outcomes.append(
+                {
+                    "to_id": target_id,
+                    "relation_id": relation_id,
+                    "relation_type": relation_type,
+                    "persisted": True,
+                    "newly_persisted": not already_linked,
+                }
+            )
+        payload["accept_action"] = accept_action
+        payload["accept_relation_type"] = relation_type
+        payload["accept_outcomes"] = accept_outcomes
+        payload["accept_persisted_count"] = persisted_new
 
     return success_response(payload)
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -3147,6 +3147,10 @@ class DuckDBStore:
             with contextlib.suppress(Exception):
                 conn.execute("ROLLBACK")
             raise
+        # Force a checkpoint so recovered edges reach the main DB file rather
+        # than sitting in the WAL where an ungraceful restart could lose them
+        # (issue #346 semantics — see :meth:`_checkpoint_after_write`).
+        self._checkpoint_after_write(conn)
         return {"metadata_links": inserted_metadata, "total": inserted_metadata}
 
     async def reconcile_relations(self) -> dict[str, int]:

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -31,7 +31,11 @@ from urllib.parse import unquote, urlparse
 import duckdb
 
 from distillery.models import Entry, EntryStatus, validate_metadata
-from distillery.store.migrations import _CREATE_META_TABLE, run_pending_migrations
+from distillery.store.migrations import (
+    _CREATE_META_TABLE,
+    backfill_relations_from_metadata,
+    run_pending_migrations,
+)
 
 if TYPE_CHECKING:
     from distillery.embedding.protocol import EmbeddingProvider
@@ -762,6 +766,27 @@ class DuckDBStore:
                 # 5. Record DuckDB / VSS version info in _meta.
                 self._track_version_info(conn)
 
+                # 6. Re-scan ``metadata.related_entries`` on every startup so
+                #    deployments that captured related_entries *after* migration
+                #    8 first ran (e.g. seed data ingested before this codepath
+                #    existed, or any drift between metadata and the relations
+                #    table) populate retroactively. The helper is idempotent
+                #    via the ``idx_entry_relations_unique`` index, so the cost
+                #    on a healthy DB is one ``SELECT id, metadata`` scan plus
+                #    suppressed inserts. See issue #490.
+                try:
+                    backfilled = backfill_relations_from_metadata(conn)
+                    if backfilled:
+                        logger.info(
+                            "Startup backfill: inserted %d entry_relations rows from "
+                            "metadata.related_entries",
+                            backfilled,
+                        )
+                except duckdb.CatalogException:
+                    # entry_relations table absent — should not happen post-migration,
+                    # but treat defensively so a missing schema does not block init.
+                    logger.debug("Startup backfill skipped: entry_relations table not present")
+
                 logger.info(
                     "Schema at version %d, DuckDB %s",
                     schema_version,
@@ -1025,6 +1050,56 @@ class DuckDBStore:
         }
     )
 
+    @staticmethod
+    def _fan_out_related_entries(
+        conn: duckdb.DuckDBPyConnection,
+        from_id: str,
+        metadata: dict[str, Any] | None,
+    ) -> int:
+        """Insert ``entry_relations`` rows for ``metadata.related_entries`` of *from_id*.
+
+        Mechanism #1 from issue #490 — fan-out on every store/update write so
+        the relations table stays in sync with whatever the caller persisted in
+        ``metadata.related_entries``. Idempotent via the
+        ``idx_entry_relations_unique`` index on
+        ``(from_id, to_id, relation_type)``.
+
+        Args:
+            conn: Active DuckDB connection (caller manages the transaction).
+            from_id: UUID of the source entry that owns this metadata blob.
+            metadata: The entry's ``metadata`` dict (may be ``None`` or absent
+                ``related_entries``); falsy / non-dict input is a no-op.
+
+        Returns:
+            Number of relation rows actually inserted (excludes index-suppressed
+            duplicates and skipped invalid targets).
+        """
+        if not isinstance(metadata, dict):
+            return 0
+        related = metadata.get("related_entries")
+        if not isinstance(related, list) or not related:
+            return 0
+
+        inserted = 0
+        for to_id in related:
+            if not isinstance(to_id, str) or not to_id or to_id == from_id:
+                continue
+            # Validate target exists — mirror migration 8 behaviour so we never
+            # introduce dangling edges from a typo / stale metadata payload.
+            target = conn.execute("SELECT id FROM entries WHERE id = ?", [to_id]).fetchone()
+            if target is None:
+                continue
+            relation_id = str(uuid.uuid4())
+            row = conn.execute(
+                "INSERT OR IGNORE INTO entry_relations "
+                "(id, from_id, to_id, relation_type) "
+                "VALUES (?, ?, ?, 'link') RETURNING id",
+                [relation_id, from_id, to_id],
+            ).fetchone()
+            if row is not None:
+                inserted += 1
+        return inserted
+
     def _sync_store(self, entry: Entry) -> str:
         """Synchronous implementation of store(); called via asyncio.to_thread."""
         validate_metadata(entry.entry_type.value, entry.metadata)
@@ -1059,6 +1134,12 @@ class DuckDBStore:
             entry.session_id,
         ]
         conn.execute(sql, params)
+        # Fan out metadata.related_entries → entry_relations (issue #490). The
+        # underlying unique index makes this idempotent; failures here would
+        # leave the entry in place but with missing edges, so we let any DB
+        # error surface to the caller (mirrors transactional intent — caller's
+        # outer retry/abort logic decides how to handle).
+        self._fan_out_related_entries(conn, entry.id, entry.metadata)
         # Rebuild FTS index so new content is searchable via BM25.
         self._rebuild_fts_index(conn)
         # Flush WAL so the new row survives ungraceful termination.
@@ -1128,6 +1209,14 @@ class DuckDBStore:
                     entry.session_id,
                 ]
                 conn.execute(sql, params)
+            # Fan out metadata.related_entries on every batched entry so the
+            # relations table stays in sync (issue #490). Run inside the same
+            # transaction as the entry inserts so a partial fan-out is rolled
+            # back together with the failing batch. Targets that point at
+            # entries earlier in the *same* batch resolve via the in-flight
+            # transactional view.
+            for entry in entries:
+                self._fan_out_related_entries(conn, entry.id, entry.metadata)
             conn.commit()
         except Exception:
             conn.rollback()
@@ -1302,6 +1391,12 @@ class DuckDBStore:
         set_params.append(entry_id)
 
         conn.execute(sql, set_params)
+        # Fan out metadata.related_entries → entry_relations whenever the
+        # caller writes a new metadata blob (issue #490). The unique index
+        # provides idempotency and we never *delete* edges here — this is a
+        # forward-only sync mirroring mechanism #1's "additive" semantic.
+        if "metadata" in updates and isinstance(updates["metadata"], dict):
+            self._fan_out_related_entries(conn, entry_id, updates["metadata"])
         # Rebuild FTS index when content changes.
         if "content" in updates:
             self._rebuild_fts_index(conn)
@@ -3036,6 +3131,39 @@ class DuckDBStore:
             ascending ``created_at``.
         """
         return await self._run_sync(self._sync_list_relations)
+
+    def _sync_reconcile_relations(self) -> dict[str, int]:
+        """Synchronous implementation of reconcile_relations(); via asyncio.to_thread."""
+        assert self._conn is not None
+        conn = self._conn
+        # Wrap in a transaction so a mid-scan failure leaves the table in its
+        # prior state. The helper is itself idempotent, so the worst-case is a
+        # retried no-op on the next call.
+        try:
+            conn.execute("BEGIN TRANSACTION")
+            inserted_metadata = backfill_relations_from_metadata(conn)
+            conn.execute("COMMIT")
+        except Exception:
+            with contextlib.suppress(Exception):
+                conn.execute("ROLLBACK")
+            raise
+        return {"metadata_links": inserted_metadata, "total": inserted_metadata}
+
+    async def reconcile_relations(self) -> dict[str, int]:
+        """Re-run the metadata-driven entry_relations backfill and return counts.
+
+        Idempotent recovery hook for issue #490 mechanism #9.  Re-scans every
+        entry's ``metadata.related_entries`` and inserts any missing rows into
+        ``entry_relations``; existing rows are left alone via the unique
+        ``(from_id, to_id, relation_type)`` index.
+
+        Returns:
+            Dict with ``metadata_links`` (rows inserted from
+            ``metadata.related_entries``) and ``total`` (sum across all
+            mechanisms — currently equal to ``metadata_links``; future
+            mechanisms #3-#8 in issue #490 will contribute additional fields).
+        """
+        return await self._run_sync(self._sync_reconcile_relations)
 
     def _sync_get_all_related_entry_ids(self) -> set[str]:
         """Synchronous implementation of get_all_related_entry_ids()."""

--- a/src/distillery/store/migrations.py
+++ b/src/distillery/store/migrations.py
@@ -246,6 +246,11 @@ def backfill_relations_from_metadata(conn: duckdb.DuckDBPyConnection) -> int:
         except (json.JSONDecodeError, TypeError):
             continue
 
+        # ``json.loads`` can return list/str/number/None for malformed blobs;
+        # guard so a single bad row doesn't abort the whole backfill/reconcile.
+        if not isinstance(meta, dict):
+            continue
+
         related: object = meta.get("related_entries")
         if not isinstance(related, list):
             continue

--- a/src/distillery/store/migrations.py
+++ b/src/distillery/store/migrations.py
@@ -209,27 +209,29 @@ def create_hnsw_index(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
         logger.warning("Migration 6: HNSW index type not recognized, skipping")
 
 
-def create_entry_relations(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
-    """Migration 8: Create ``entry_relations`` table and backfill from metadata.
+def backfill_relations_from_metadata(conn: duckdb.DuckDBPyConnection) -> int:
+    """Scan ``entries.metadata.related_entries`` and insert missing ``entry_relations`` rows.
 
-    Creates the ``entry_relations`` table for typed, queryable relationships
-    between entries.  After table creation, backfills existing entries whose
-    ``metadata`` JSON column contains a ``related_entries`` list: each element
-    is inserted as a row with ``relation_type='link'``.
+    Idempotent: relies on the ``idx_entry_relations_unique`` unique index on
+    ``(from_id, to_id, relation_type)`` so re-running never produces duplicates.
+    Returns the number of rows actually inserted (excludes index-suppressed
+    duplicates).
 
-    The backfill is idempotent because the ``CREATE TABLE IF NOT EXISTS`` guard
-    means this migration is only executed once per database.
+    This helper is the single source of truth for mechanism #1 in issue #490
+    (re-scan on upgrade and on every write) and is invoked from:
+
+      * Migration 8 (initial table creation + backfill).
+      * The ``DuckDBStore`` write paths (``_sync_store``,
+        ``_sync_store_batch``, ``_sync_update``) after entry insert.
+      * ``distillery_relations action="reconcile"`` for operator-initiated
+        recovery from drift.
+
+    The caller is responsible for transaction management — this function
+    assumes ``entry_relations`` (and its unique index) already exist.
     """
     import json
     import uuid
 
-    conn.execute(_CREATE_ENTRY_RELATIONS_TABLE)
-    conn.execute(_CREATE_ENTRY_RELATIONS_UNIQUE_INDEX)
-    conn.execute(_CREATE_ENTRY_RELATIONS_TO_ID_INDEX)
-    logger.info("Migration 8: entry_relations table created")
-
-    # Backfill: scan all entries whose metadata contains a 'related_entries' list.
-    # Collect all existing entry IDs so we only create relations to valid targets.
     existing_ids: set[str] = {r[0] for r in conn.execute("SELECT id FROM entries").fetchall()}
     rows = conn.execute("SELECT id, metadata FROM entries WHERE metadata IS NOT NULL").fetchall()
     backfilled = 0
@@ -251,6 +253,9 @@ def create_entry_relations(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> No
         for to_id in related:
             if not isinstance(to_id, str) or not to_id:
                 continue
+            if to_id == entry_id:
+                # Self-loops are not meaningful for related_entries.
+                continue
             if to_id not in existing_ids:
                 continue
             relation_id = str(uuid.uuid4())
@@ -262,6 +267,29 @@ def create_entry_relations(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> No
             if inserted:
                 backfilled += 1
 
+    return backfilled
+
+
+def create_entry_relations(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
+    """Migration 8: Create ``entry_relations`` table and backfill from metadata.
+
+    Creates the ``entry_relations`` table for typed, queryable relationships
+    between entries.  After table creation, backfills existing entries whose
+    ``metadata`` JSON column contains a ``related_entries`` list: each element
+    is inserted as a row with ``relation_type='link'``.
+
+    The backfill is idempotent — the underlying
+    :func:`backfill_relations_from_metadata` helper relies on the unique
+    ``(from_id, to_id, relation_type)`` index — and is reused on every store
+    startup (issue #490) so entries written before this migration first ran
+    populate edges retroactively.
+    """
+    conn.execute(_CREATE_ENTRY_RELATIONS_TABLE)
+    conn.execute(_CREATE_ENTRY_RELATIONS_UNIQUE_INDEX)
+    conn.execute(_CREATE_ENTRY_RELATIONS_TO_ID_INDEX)
+    logger.info("Migration 8: entry_relations table created")
+
+    backfilled = backfill_relations_from_metadata(conn)
     if backfilled:
         logger.info("Migration 8: backfilled %d entry_relations rows from metadata", backfilled)
     else:

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -529,6 +529,22 @@ class DistilleryStore(Protocol):
         """
         ...
 
+    async def reconcile_relations(self) -> dict[str, int]:
+        """Re-run idempotent edge-population mechanisms and return insert counts.
+
+        Recovery hook for ``distillery_relations action="reconcile"`` (issue
+        #490 mechanism #9).  Re-scans every entry's ``metadata.related_entries``
+        and inserts any missing rows into ``entry_relations``; relies on the
+        unique ``(from_id, to_id, relation_type)`` index for idempotency.
+
+        Returns:
+            Dict with at least ``metadata_links`` (rows inserted from
+            ``metadata.related_entries``) and ``total``.  Future mechanisms
+            (#3-#8 in issue #490) will contribute additional named keys
+            without changing the existing contract.
+        """
+        ...
+
     async def get_metadata(self, key: str) -> str | None:
         """Read a value from the ``_meta`` key-value table.
 

--- a/tests/test_relations_backfill_on_write.py
+++ b/tests/test_relations_backfill_on_write.py
@@ -1,0 +1,425 @@
+"""Tests for issue #490 — entry_relations backfill on write + reconcile + accept_action.
+
+Covers the three patch-fix mechanisms scoped into the initial PR:
+
+  * Mechanism #1 — ``metadata.related_entries`` is fanned out into
+    ``entry_relations`` on every ``store`` / ``store_batch`` / ``update`` call,
+    AND re-scanned at startup on every ``DuckDBStore.initialize()`` so DBs
+    that captured related_entries before this codepath existed populate
+    retroactively.
+  * Mechanism #2 — ``distillery_find_similar(accept_action=...)`` persists a
+    typed relation from ``source_entry_id`` to each result above threshold.
+  * Mechanism #9 — ``distillery_relations action="reconcile"`` re-runs the
+    metadata backfill and reports per-mechanism counts.
+
+All tests use the deterministic / controlled embedding provider so similarity
+scoring is reproducible.
+"""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pytest
+
+from distillery.config import DistilleryConfig, load_config
+from distillery.mcp.tools.relations import _handle_relations
+from distillery.mcp.tools.search import _handle_find_similar
+from distillery.store.duckdb import DuckDBStore
+from distillery.store.migrations import (
+    backfill_relations_from_metadata,
+    run_pending_migrations,
+)
+from tests.conftest import ControlledEmbeddingProvider, make_entry, parse_mcp_response
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# backfill_relations_from_metadata helper (idempotency, self-loop guard)
+# ---------------------------------------------------------------------------
+
+
+_DIMENSIONS = 4
+_EMBEDDING = [0.25, 0.25, 0.25, 0.25]
+
+
+def _setup_through_8(conn: duckdb.DuckDBPyConnection) -> None:
+    """Run all migrations to bring up entry_relations + entries."""
+    run_pending_migrations(conn, dimensions=_DIMENSIONS, vss_available=False)
+
+
+def _insert_entry(
+    conn: duckdb.DuckDBPyConnection,
+    entry_id: str,
+    metadata: dict | None = None,
+) -> None:
+    meta_json = json.dumps(metadata) if metadata else None
+    conn.execute(
+        "INSERT INTO entries (id, content, entry_type, source, author, metadata, embedding) "
+        "VALUES (?, 'test content', 'inbox', 'manual', 'tester', ?, ?)",
+        [entry_id, meta_json, _EMBEDDING],
+    )
+
+
+def test_backfill_helper_is_idempotent() -> None:
+    """Running the helper twice produces the same row count — no duplicates."""
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        _insert_entry(conn, "a", metadata={"related_entries": ["b", "c"]})
+        _insert_entry(conn, "b")
+        _insert_entry(conn, "c")
+
+        first = backfill_relations_from_metadata(conn)
+        second = backfill_relations_from_metadata(conn)
+
+        assert first == 2
+        # Second run is a no-op because all edges already exist.
+        assert second == 0
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM entry_relations WHERE relation_type = 'link'"
+        ).fetchone()
+        assert rows is not None and rows[0] == 2
+    finally:
+        conn.close()
+
+
+def test_backfill_helper_skips_self_loops() -> None:
+    """An entry whose related_entries lists itself must not produce a self-edge."""
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        _insert_entry(conn, "a", metadata={"related_entries": ["a", "b"]})
+        _insert_entry(conn, "b")
+
+        inserted = backfill_relations_from_metadata(conn)
+        assert inserted == 1
+        rows = conn.execute("SELECT from_id, to_id FROM entry_relations").fetchall()
+        assert ("a", "a") not in [(r[0], r[1]) for r in rows]
+        assert ("a", "b") in [(r[0], r[1]) for r in rows]
+    finally:
+        conn.close()
+
+
+def test_backfill_helper_skips_dangling_targets() -> None:
+    """Targets that don't exist in entries are silently skipped."""
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        _insert_entry(conn, "a", metadata={"related_entries": ["ghost", "b"]})
+        _insert_entry(conn, "b")
+
+        inserted = backfill_relations_from_metadata(conn)
+        assert inserted == 1
+        to_ids = {r[0] for r in conn.execute("SELECT to_id FROM entry_relations").fetchall()}
+        assert to_ids == {"b"}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Write-path fan-out (mechanism #1) — store / store_batch / update
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def store(  # type: ignore[no-untyped-def]
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+):
+    s = DuckDBStore(db_path=":memory:", embedding_provider=controlled_embedding_provider)
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+async def test_store_fans_out_related_entries_to_entry_relations(store: DuckDBStore) -> None:
+    """``store(entry)`` writes one entry_relations row per metadata.related_entries id."""
+    target_a = make_entry(content="target A")
+    target_b = make_entry(content="target B")
+    a_id = await store.store(target_a)
+    b_id = await store.store(target_b)
+
+    source = make_entry(content="source", metadata={"related_entries": [a_id, b_id]})
+    src_id = await store.store(source)
+
+    rows = await store.get_related(src_id, direction="outgoing")
+    to_ids = {r["to_id"] for r in rows}
+    assert to_ids == {a_id, b_id}
+    assert {r["relation_type"] for r in rows} == {"link"}
+
+
+async def test_store_fan_out_is_idempotent_via_unique_index(
+    store: DuckDBStore,
+) -> None:
+    """A second store with the same metadata.related_entries must not duplicate edges."""
+    target = make_entry(content="target")
+    t_id = await store.store(target)
+
+    source = make_entry(content="source", metadata={"related_entries": [t_id]})
+    src_id = await store.store(source)
+
+    # Reconcile (re-run the metadata scan) to prove idempotency on the same
+    # input. The unique index on (from_id, to_id, relation_type) suppresses
+    # the duplicate insert.
+    counts = await store.reconcile_relations()
+    assert counts["metadata_links"] == 0
+
+    rows = await store.get_related(src_id, direction="outgoing")
+    assert len(rows) == 1
+
+
+async def test_update_fans_out_new_related_entries(store: DuckDBStore) -> None:
+    """Adding ``related_entries`` via update writes the corresponding edges."""
+    a = await store.store(make_entry(content="a"))
+    b = await store.store(make_entry(content="b"))
+    src_id = await store.store(make_entry(content="src"))
+
+    # Initially no relations.
+    assert await store.get_related(src_id, direction="outgoing") == []
+
+    # Update with related_entries — fan-out should fire.
+    await store.update(src_id, {"metadata": {"related_entries": [a, b]}})
+    to_ids = {r["to_id"] for r in await store.get_related(src_id, direction="outgoing")}
+    assert to_ids == {a, b}
+
+
+async def test_store_batch_fans_out_related_entries(store: DuckDBStore) -> None:
+    """``store_batch`` populates entry_relations from each entry's metadata."""
+    # Pre-existing target so cross-entry references resolve.
+    pre_id = await store.store(make_entry(content="pre"))
+
+    e1 = make_entry(content="e1", metadata={"related_entries": [pre_id]})
+    e2 = make_entry(content="e2", metadata={"related_entries": [pre_id]})
+    [e1_id, e2_id] = await store.store_batch([e1, e2])
+
+    rows1 = await store.get_related(e1_id, direction="outgoing")
+    rows2 = await store.get_related(e2_id, direction="outgoing")
+    assert {r["to_id"] for r in rows1} == {pre_id}
+    assert {r["to_id"] for r in rows2} == {pre_id}
+
+
+async def test_startup_rescan_recovers_pre_migration_metadata(
+    controlled_embedding_provider: ControlledEmbeddingProvider, tmp_path
+) -> None:
+    """A persisted DB where edges are missing recovers them on the next initialize().
+
+    Simulates the field instance described in issue #490: entries written
+    after migration 8 ran, with metadata.related_entries populated, but with
+    the entry_relations table empty (e.g. edges were never written by the
+    write-path because the fan-out hook didn't exist yet).
+    """
+    db_path = str(tmp_path / "rescan.duckdb")
+    s1 = DuckDBStore(db_path=db_path, embedding_provider=controlled_embedding_provider)
+    await s1.initialize()
+    a = await s1.store(make_entry(content="a"))
+    b = await s1.store(make_entry(content="b"))
+    src_id = await s1.store(make_entry(content="src", metadata={"related_entries": [a, b]}))
+    # Manually wipe entry_relations to simulate the regression — entries are
+    # there with metadata but no edges exist yet.
+    s1.connection.execute("DELETE FROM entry_relations")
+    assert s1.connection.execute("SELECT COUNT(*) FROM entry_relations").fetchone()[0] == 0
+    await s1.close()
+
+    # Re-open: startup re-scan should re-create the edges from metadata.
+    s2 = DuckDBStore(db_path=db_path, embedding_provider=controlled_embedding_provider)
+    await s2.initialize()
+    try:
+        rows = await s2.get_related(src_id, direction="outgoing")
+        assert {r["to_id"] for r in rows} == {a, b}
+    finally:
+        await s2.close()
+
+
+# ---------------------------------------------------------------------------
+# action="reconcile" handler (mechanism #9)
+# ---------------------------------------------------------------------------
+
+
+async def test_reconcile_handler_returns_zero_on_clean_db(store: DuckDBStore) -> None:
+    """On a freshly initialised DB with no metadata, reconcile inserts nothing."""
+    result = await _handle_relations(store, {"action": "reconcile"})
+    payload = parse_mcp_response(result)
+    assert payload["action"] == "reconcile"
+    assert payload["metadata_links"] == 0
+    assert payload["total"] == 0
+
+
+async def test_reconcile_handler_recovers_missing_edges(
+    store: DuckDBStore,
+) -> None:
+    """Reconcile fills in edges that are missing despite metadata.related_entries."""
+    a = await store.store(make_entry(content="a"))
+    b = await store.store(make_entry(content="b"))
+    src_id = await store.store(make_entry(content="src", metadata={"related_entries": [a, b]}))
+    # Wipe edges to simulate drift.
+    store.connection.execute("DELETE FROM entry_relations")
+
+    result = await _handle_relations(store, {"action": "reconcile"})
+    payload = parse_mcp_response(result)
+    assert payload["action"] == "reconcile"
+    assert payload["metadata_links"] == 2
+    assert payload["total"] == 2
+
+    rows = await store.get_related(src_id, direction="outgoing")
+    assert {r["to_id"] for r in rows} == {a, b}
+
+
+async def test_reconcile_handler_is_idempotent_on_re_run(store: DuckDBStore) -> None:
+    """Calling reconcile twice never produces more edges than the first run."""
+    a = await store.store(make_entry(content="a"))
+    src_id = await store.store(make_entry(content="src", metadata={"related_entries": [a]}))
+    store.connection.execute("DELETE FROM entry_relations")
+
+    first = parse_mcp_response(await _handle_relations(store, {"action": "reconcile"}))
+    second = parse_mcp_response(await _handle_relations(store, {"action": "reconcile"}))
+
+    assert first["metadata_links"] == 1
+    assert second["metadata_links"] == 0
+    rows = await store.get_related(src_id, direction="outgoing")
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# distillery_find_similar(accept_action=...) — mechanism #2
+# ---------------------------------------------------------------------------
+
+
+_UNIT_A = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+@pytest.fixture
+def cfg() -> DistilleryConfig:
+    return load_config()
+
+
+async def test_find_similar_accept_action_link_persists_related_relation(
+    store: DuckDBStore,
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """accept_action='link' writes a 'related' edge to each match."""
+    controlled_embedding_provider.register("source", _UNIT_A)
+    controlled_embedding_provider.register("target one", _UNIT_A)
+    controlled_embedding_provider.register("target two", _UNIT_A)
+
+    src_id = await store.store(make_entry(content="source"))
+    t1_id = await store.store(make_entry(content="target one"))
+    t2_id = await store.store(make_entry(content="target two"))
+
+    result = await _handle_find_similar(
+        store,
+        {
+            "source_entry_id": src_id,
+            "threshold": 0.5,
+            "limit": 10,
+            "accept_action": "link",
+        },
+        cfg=cfg,
+    )
+    payload = parse_mcp_response(result)
+    assert payload["accept_action"] == "link"
+    assert payload["accept_relation_type"] == "related"
+    assert payload["accept_persisted_count"] == 2
+    persisted_to = {o["to_id"] for o in payload["accept_outcomes"] if o.get("persisted")}
+    assert persisted_to == {t1_id, t2_id}
+
+    rows = await store.get_related(src_id, direction="outgoing")
+    types_by_to = {r["to_id"]: r["relation_type"] for r in rows}
+    assert types_by_to == {t1_id: "related", t2_id: "related"}
+
+
+async def test_find_similar_accept_action_merge_persists_merge_source(
+    store: DuckDBStore,
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """accept_action='merge' maps to relation_type='merge_source'."""
+    controlled_embedding_provider.register("a", _UNIT_A)
+    controlled_embedding_provider.register("b", _UNIT_A)
+    src_id = await store.store(make_entry(content="a"))
+    t_id = await store.store(make_entry(content="b"))
+
+    payload = parse_mcp_response(
+        await _handle_find_similar(
+            store,
+            {
+                "source_entry_id": src_id,
+                "threshold": 0.5,
+                "limit": 10,
+                "accept_action": "merge",
+            },
+            cfg=cfg,
+        )
+    )
+    assert payload["accept_relation_type"] == "merge_source"
+    rows = await store.get_related(src_id, direction="outgoing")
+    assert {r["relation_type"] for r in rows} == {"merge_source"}
+    assert {r["to_id"] for r in rows} == {t_id}
+
+
+async def test_find_similar_accept_action_idempotent_re_call(
+    store: DuckDBStore,
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+    cfg: DistilleryConfig,
+) -> None:
+    """Calling find_similar with accept_action twice does not duplicate edges."""
+    controlled_embedding_provider.register("a", _UNIT_A)
+    controlled_embedding_provider.register("b", _UNIT_A)
+    src_id = await store.store(make_entry(content="a"))
+    t_id = await store.store(make_entry(content="b"))
+
+    args = {
+        "source_entry_id": src_id,
+        "threshold": 0.5,
+        "limit": 10,
+        "accept_action": "link",
+    }
+    p1 = parse_mcp_response(await _handle_find_similar(store, args, cfg=cfg))
+    p2 = parse_mcp_response(await _handle_find_similar(store, args, cfg=cfg))
+    assert p1["accept_persisted_count"] == 1
+    # Second call sees the edge already exists, so persisted_new==0 even
+    # though every outcome reports persisted=True.
+    assert p2["accept_persisted_count"] == 0
+    assert all(o["persisted"] for o in p2["accept_outcomes"])
+    rows = await store.get_related(src_id, direction="outgoing")
+    assert len(rows) == 1
+    assert rows[0]["to_id"] == t_id
+
+
+async def test_find_similar_accept_action_requires_source_entry_id(
+    store: DuckDBStore,
+    cfg: DistilleryConfig,
+) -> None:
+    """accept_action without source_entry_id returns INVALID_PARAMS."""
+    payload = parse_mcp_response(
+        await _handle_find_similar(
+            store,
+            {"content": "anything", "accept_action": "link"},
+            cfg=cfg,
+        )
+    )
+    assert payload.get("error") is True
+    assert payload.get("code") == "INVALID_PARAMS"
+    assert "source_entry_id" in payload.get("message", "")
+
+
+async def test_find_similar_accept_action_rejects_unknown_value(
+    store: DuckDBStore,
+    cfg: DistilleryConfig,
+) -> None:
+    """Unknown accept_action value is rejected before any work is done."""
+    src_id = await store.store(make_entry(content="x"))
+    payload = parse_mcp_response(
+        await _handle_find_similar(
+            store,
+            {
+                "source_entry_id": src_id,
+                "accept_action": "bogus",
+            },
+            cfg=cfg,
+        )
+    )
+    assert payload.get("error") is True
+    assert payload.get("code") == "INVALID_PARAMS"


### PR DESCRIPTION
## Summary

Migration 8 created `entry_relations` and backfilled `metadata.related_entries` once at upgrade time, but the `CREATE TABLE IF NOT EXISTS` gate meant it never re-ran. A field instance with 18,316 entries reports `node_count: 0, edge_count: 0` from `distillery_relations action=metrics` because all sessions containing `metadata.related_entries` were captured **after** migration 8 had already run.

This PR scopes three patch-fix mechanisms from issue #490:

- **Mechanism #1** — `metadata.related_entries` is fanned out into `entry_relations` on every `store` / `store_batch` / `update` call AND re-scanned at startup on every `DuckDBStore.initialize()`. The metadata-scan is extracted from migration 8 as `backfill_relations_from_metadata` and relies on the existing `idx_entry_relations_unique` index for idempotency.
- **Mechanism #2** — new `accept_action` argument on `distillery_find_similar` (`"link"` → `related`, `"merge"` → `merge_source`, `"duplicate"` → `duplicate`). When set with `source_entry_id`, persists a typed relation to each match above threshold. Idempotent via the same unique index.
- **Mechanism #9** — new `distillery_relations action="reconcile"` action. Operator-initiated recovery hook that re-runs the metadata-driven backfill and returns `{action, metadata_links, total}`.

Mechanisms #3–#8 (canonical-URL match, title trigram, tag co-occurrence, GitHub closure-keyword, RSS bookmark URL, `[[entry-xxxxxxxx]]` inline parsing) are split into a follow-up tracking issue.

Closes #490 partially — see the follow-up tracking issue for mechanisms #3–#8.

## Test plan

- [x] `pytest -m unit` — 1954 passed (including 16 new tests in `test_relations_backfill_on_write.py`)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy --strict src/distillery/` — clean
- [x] Fresh-install seed data: edges populate as today (no regression — `test_relations_migration.py` still passes)
- [x] Pre-existing DB with `entry_relations` empty: edges populate after `action="reconcile"` (`test_reconcile_handler_recovers_missing_edges`)
- [x] `store` / `store_batch` / `update` with `metadata.related_entries` produce edges without manual backfill
- [x] `find_similar(accept_action="link"|"merge"|"duplicate")` produces edges going forward
- [x] Idempotent on re-run (`test_reconcile_handler_is_idempotent_on_re_run`, `test_find_similar_accept_action_idempotent_re_call`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Find-similar now supports an accept_action to optionally persist typed relations (link/merge/duplicate) from a source entry to matching results.
  * Relationships tool gains a reconcile action to re-scan and restore relations from entry metadata.
  * Store write/update paths auto-sync entry relationships from metadata.

* **Bug Fixes**
  * Startup now recovers previously missed relations from metadata and avoids duplicate edges.

* **Tests**
  * Added comprehensive tests covering backfill, fan-out, reconcile, idempotency, and accept_action behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->