### PR TITLE
feat(feeds): per-source threshold overrides (#480)

### DIFF
--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -666,6 +666,8 @@ def _cmd_poll(config_path: str | None, fmt: str, source_url: str | None) -> int:
                         label=source.label,
                         poll_interval_minutes=source.poll_interval_minutes,
                         trust_weight=source.trust_weight,
+                        threshold_alert=source.thresholds.alert,
+                        threshold_digest=source.thresholds.digest,
                     )
 
         # Check sources from DB.
@@ -1317,12 +1319,20 @@ def _cmd_import(
         sources_imported = 0
         for fsrc in feed_sources_data:
             with contextlib.suppress(ValueError):
+                threshold_alert_raw = fsrc.get("threshold_alert")
+                threshold_digest_raw = fsrc.get("threshold_digest")
                 await store.add_feed_source(
                     url=fsrc.get("url", ""),
                     source_type=fsrc.get("source_type", "rss"),
                     label=fsrc.get("label", ""),
                     poll_interval_minutes=int(fsrc.get("poll_interval_minutes", 60)),
                     trust_weight=float(fsrc.get("trust_weight", 1.0)),
+                    threshold_alert=(
+                        float(threshold_alert_raw) if threshold_alert_raw is not None else None
+                    ),
+                    threshold_digest=(
+                        float(threshold_digest_raw) if threshold_digest_raw is not None else None
+                    ),
                 )
                 sources_imported += 1
 

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -851,6 +851,13 @@ def _parse_feed_source_thresholds(raw: Any, index: int) -> FeedSourceThresholdsC
         value_raw = raw[field_name]
         if value_raw is None:
             return None
+        # Reject booleans explicitly: ``float(True)`` returns ``1.0`` so YAML
+        # ``true``/``false`` would otherwise be silently accepted as numeric.
+        if isinstance(value_raw, bool):
+            raise ValueError(
+                f"feeds.sources[{index}].thresholds.{field_name} must be a float, "
+                f"got: {value_raw!r}"
+            )
         try:
             value = float(value_raw)
         except (TypeError, ValueError) as exc:

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -170,6 +170,28 @@ class TagsConfig:
 
 
 @dataclass
+class FeedSourceThresholdsConfig:
+    """Per-source override of :class:`FeedsThresholdsConfig`.
+
+    When either field is ``None`` the corresponding global threshold from
+    ``feeds.thresholds`` applies.  ``trust_weight`` only attenuates scores
+    downward, so to *raise* the bar for a noisy aggregator (HN/Lobsters/Reddit)
+    operators set ``digest`` (and optionally ``alert``) explicitly here.
+
+    Attributes:
+        alert: Cosine similarity score at or above which an item from this
+            source triggers an alert.  ``None`` falls back to
+            ``feeds.thresholds.alert``.
+        digest: Cosine similarity score at or above which (but below
+            *alert*) an item from this source is included in the next
+            digest.  ``None`` falls back to ``feeds.thresholds.digest``.
+    """
+
+    alert: float | None = None
+    digest: float | None = None
+
+
+@dataclass
 class FeedSourceConfig:
     """Configuration for a single monitored feed source.
 
@@ -182,6 +204,12 @@ class FeedSourceConfig:
         trust_weight: Relevance trust multiplier in the range ``[0.0, 1.0]``.
             Higher values amplify relevance scores from this source.  Defaults
             to ``1.0``.
+        thresholds: Optional per-source override for
+            :class:`FeedsThresholdsConfig`.  When unset, the global
+            ``feeds.thresholds`` values apply.  Used to raise the bar for
+            noisy aggregators (HN, Lobsters, Reddit) that ``trust_weight``
+            cannot separate from vendor blogs because ``trust_weight`` only
+            attenuates downward.
     """
 
     url: str = ""
@@ -189,6 +217,7 @@ class FeedSourceConfig:
     label: str = ""
     poll_interval_minutes: int = 60
     trust_weight: float = 1.0
+    thresholds: FeedSourceThresholdsConfig = field(default_factory=FeedSourceThresholdsConfig)
 
 
 @dataclass
@@ -766,13 +795,83 @@ def _parse_feed_source(raw: dict[str, Any], index: int) -> FeedSourceConfig:
             f"feeds.sources[{index}].trust_weight must be between 0.0 and 1.0, got: {trust_weight}"
         )
 
+    thresholds = _parse_feed_source_thresholds(raw.get("thresholds"), index)
+
     return FeedSourceConfig(
         url=url,
         source_type=source_type,
         label=label,
         poll_interval_minutes=poll_interval,
         trust_weight=trust_weight,
+        thresholds=thresholds,
     )
+
+
+def _parse_feed_source_thresholds(raw: Any, index: int) -> FeedSourceThresholdsConfig:
+    """Parse the optional ``thresholds`` block on a feed source entry.
+
+    A missing block (``None`` or absent key) yields a config with both
+    fields ``None`` so the global ``feeds.thresholds`` values apply.
+
+    Args:
+        raw: The raw value associated with the ``thresholds`` key, or
+            ``None`` when the key is absent.
+        index: Zero-based position of the parent feed source (used in
+            error messages).
+
+    Returns:
+        A populated :class:`FeedSourceThresholdsConfig`.  Either field may
+        be ``None`` when the operator only overrode the other tier.
+
+    Raises:
+        ValueError: If ``raw`` is not a mapping or ``None``, an unknown
+            key is present, a value is not a float, or a value falls
+            outside ``[0.0, 1.0]``.  When both fields are set the
+            ``digest <= alert`` invariant is also enforced (mirrors the
+            global ``feeds.thresholds`` constraint).
+    """
+    if raw is None:
+        return FeedSourceThresholdsConfig()
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"feeds.sources[{index}].thresholds must be a YAML mapping, got: {type(raw).__name__}"
+        )
+
+    valid_keys = {"alert", "digest"}
+    extra = set(raw.keys()) - valid_keys
+    if extra:
+        raise ValueError(
+            f"feeds.sources[{index}].thresholds has unknown keys: {sorted(extra)}; "
+            f"expected any of {sorted(valid_keys)}"
+        )
+
+    def _parse_optional(field_name: str) -> float | None:
+        if field_name not in raw:
+            return None
+        value_raw = raw[field_name]
+        if value_raw is None:
+            return None
+        try:
+            value = float(value_raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"feeds.sources[{index}].thresholds.{field_name} must be a float, "
+                f"got: {value_raw!r}"
+            ) from exc
+        if not (0.0 <= value <= 1.0):
+            raise ValueError(
+                f"feeds.sources[{index}].thresholds.{field_name} must be between "
+                f"0.0 and 1.0, got: {value}"
+            )
+        return value
+
+    alert = _parse_optional("alert")
+    digest = _parse_optional("digest")
+    if alert is not None and digest is not None and digest > alert:
+        raise ValueError(
+            f"feeds.sources[{index}].thresholds.digest ({digest}) must be <= alert ({alert})"
+        )
+    return FeedSourceThresholdsConfig(alert=alert, digest=digest)
 
 
 def _parse_feeds(raw: dict[str, Any]) -> FeedsConfig:

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -555,6 +555,31 @@ class FeedPoller:
         self._alert_threshold_warning_emitted = False
         self._reader = reader
 
+    def _resolve_digest_threshold(self, source: FeedSourceConfig) -> float:
+        """Return the effective digest threshold for *source*.
+
+        Prefers ``source.thresholds.digest`` when set; otherwise falls back
+        to the poller-level default (which itself is sourced from
+        ``feeds.thresholds.digest`` unless overridden via the
+        ``relevance_threshold`` constructor argument).  The fallback path
+        preserves pre-#480 behaviour exactly.
+        """
+        override: float | None = getattr(getattr(source, "thresholds", None), "digest", None)
+        if override is not None:
+            return override
+        return self._threshold
+
+    def _resolve_alert_threshold(self, source: FeedSourceConfig) -> float:
+        """Return the effective alert threshold for *source*.
+
+        Prefers ``source.thresholds.alert`` when set; otherwise falls back
+        to ``feeds.thresholds.alert`` (the poller-level default).
+        """
+        override: float | None = getattr(getattr(source, "thresholds", None), "alert", None)
+        if override is not None:
+            return override
+        return self._alert_threshold
+
     async def poll(self, *, source_url: str | None = None) -> PollerSummary:
         """Execute a full poll cycle across configured sources.
 
@@ -566,7 +591,7 @@ class FeedPoller:
         """
         summary = PollerSummary(started_at=datetime.now(tz=UTC))
 
-        from distillery.config import FeedSourceConfig
+        from distillery.config import FeedSourceConfig, FeedSourceThresholdsConfig
 
         db_sources = await self._store.list_feed_sources()
         if source_url is not None:
@@ -576,9 +601,14 @@ class FeedPoller:
         # kwargs before instantiation.  Capture which sources have never been
         # polled so the first batch can be flagged as backfill (issue #444).
         _cfg_fields = {"url", "source_type", "label", "poll_interval_minutes", "trust_weight"}
-        sources = [
-            FeedSourceConfig(**{k: v for k, v in s.items() if k in _cfg_fields}) for s in db_sources
-        ]
+        sources: list[FeedSourceConfig] = []
+        for s in db_sources:
+            kwargs = {k: v for k, v in s.items() if k in _cfg_fields}
+            kwargs["thresholds"] = FeedSourceThresholdsConfig(
+                alert=s.get("threshold_alert"),
+                digest=s.get("threshold_digest"),
+            )
+            sources.append(FeedSourceConfig(**kwargs))
         first_poll_urls: set[str] = {
             s["url"] for s in db_sources if s.get("last_polled_at") is None
         }
@@ -868,13 +898,18 @@ class FeedPoller:
                 continue
             adjusted_score = score * source.trust_weight
 
-            if adjusted_score < self._threshold:
+            # Resolve effective thresholds: per-source overrides win over
+            # the poller-level (global) defaults so noisy aggregators
+            # (HN/Lobsters/Reddit) can be held to a higher bar than vendor
+            # blogs even though ``trust_weight`` only attenuates downward.
+            effective_digest = self._resolve_digest_threshold(source)
+            if adjusted_score < effective_digest:
                 result.items_below_threshold += 1
                 logger.debug(
                     "FeedPoller: item %r score %.3f below threshold %.3f",
                     item.item_id,
                     adjusted_score,
-                    self._threshold,
+                    effective_digest,
                 )
                 continue
 
@@ -887,14 +922,15 @@ class FeedPoller:
                 # failure as "not alert-worthy" — we never want a malformed
                 # threshold to break the store path.  Log once per poller so
                 # misconfiguration is observable without spamming the log.
+                effective_alert = self._resolve_alert_threshold(source)
                 try:
-                    is_alert = adjusted_score >= float(self._alert_threshold)
+                    is_alert = adjusted_score >= float(effective_alert)
                 except (TypeError, ValueError) as exc:
                     if not self._alert_threshold_warning_emitted:
                         logger.warning(
                             "FeedPoller: invalid alert threshold %r (%s); "
                             "alert tagging disabled for this poller instance",
-                            self._alert_threshold,
+                            effective_alert,
                             exc,
                         )
                         self._alert_threshold_warning_emitted = True

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -198,6 +198,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                             label=src.label,
                             poll_interval_minutes=src.poll_interval_minutes,
                             trust_weight=src.trust_weight,
+                            threshold_alert=src.thresholds.alert,
+                            threshold_digest=src.thresholds.digest,
                         )
                 await store.set_metadata("feeds_seeded", "true")
             # Wire the sync-job tracker to the store and reconcile any
@@ -1071,6 +1073,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         label: str | None = None,
         poll_interval_minutes: int | None = None,
         trust_weight: float | None = None,
+        thresholds: dict[str, float] | None = None,
         sync_history: bool = False,
         purge: bool = False,
         probe: bool = True,
@@ -1088,6 +1091,13 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - label (str, optional): Human-readable label for the source.
           - poll_interval_minutes (int, optional, default=60): Polling frequency in minutes.
           - trust_weight (float, optional, default=1.0): Source trust weight (0-1).
+          - thresholds (object, optional): Per-source overrides for the global
+            ``feeds.thresholds`` values.  Mapping with optional float keys
+            ``alert`` and/or ``digest`` in [0.0, 1.0] (when both set,
+            ``digest <= alert``).  When omitted, the global cutoffs apply
+            (pre-existing behaviour).  Use this to raise the bar for noisy
+            aggregators (HN/Lobsters/Reddit) since ``trust_weight`` only
+            attenuates downward.
           - sync_history (bool, optional, default=false): When true and source_type is
             "github", kicks off an async background import of historical issues/PRs
             (returns immediately with job_id; use distillery_sync_status to check progress).
@@ -1123,6 +1133,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                     label=label,
                     poll_interval_minutes=poll_interval_minutes,
                     trust_weight=trust_weight,
+                    thresholds=thresholds,
                     sync_history=sync_history or None,
                     purge=purge or None,
                 ),

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -151,6 +151,61 @@ async def _probe_url(url: str) -> str | None:
     return None
 
 
+def _parse_thresholds_arg(
+    raw: Any,
+) -> tuple[float | None, float | None]:
+    """Parse the optional ``thresholds`` argument on ``distillery_watch add``.
+
+    Accepts either ``None`` (no override) or a mapping with optional
+    ``alert`` / ``digest`` keys.  Each value, when provided, must be a
+    finite float in ``[0.0, 1.0]``.  When both are provided the
+    ``digest <= alert`` invariant is enforced.
+
+    Returns:
+        ``(alert, digest)`` — either may be ``None`` when the operator
+        only overrode the other tier.
+
+    Raises:
+        ValueError: With a structured message suitable for surfacing as
+            ``INVALID_PARAMS`` when the input shape or values are wrong.
+    """
+    if raw is None:
+        return None, None
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"thresholds must be a mapping with optional 'alert'/'digest' keys, "
+            f"got: {type(raw).__name__}"
+        )
+    valid_keys = {"alert", "digest"}
+    extra = set(raw.keys()) - valid_keys
+    if extra:
+        raise ValueError(
+            f"thresholds has unknown keys: {sorted(extra)}; expected any of {sorted(valid_keys)}"
+        )
+
+    def _parse_optional(field_name: str) -> float | None:
+        if field_name not in raw:
+            return None
+        value_raw = raw[field_name]
+        if value_raw is None:
+            return None
+        try:
+            value = float(value_raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"thresholds.{field_name} must be a float, got: {value_raw!r}"
+            ) from exc
+        if not (0.0 <= value <= 1.0):
+            raise ValueError(f"thresholds.{field_name} must be between 0.0 and 1.0, got: {value}")
+        return value
+
+    alert = _parse_optional("alert")
+    digest = _parse_optional("digest")
+    if alert is not None and digest is not None and digest > alert:
+        raise ValueError(f"thresholds.digest ({digest}) must be <= thresholds.alert ({alert})")
+    return alert, digest
+
+
 def _parse_bool_arg(raw: Any, *, default: bool) -> bool:
     """Parse a boolean argument without silently accepting malformed input.
 
@@ -276,6 +331,12 @@ async def _handle_watch(
                 f"trust_weight must be between 0.0 and 1.0, got: {trust_weight}",
             )
 
+        thresholds_raw = arguments.get("thresholds")
+        try:
+            threshold_alert, threshold_digest = _parse_thresholds_arg(thresholds_raw)
+        except ValueError as exc:
+            return error_response("INVALID_PARAMS", str(exc))
+
         try:
             sync_history = _parse_bool_arg(arguments.get("sync_history"), default=False)
         except ValueError as exc:
@@ -331,6 +392,8 @@ async def _handle_watch(
                 label=label,
                 poll_interval_minutes=poll_interval,
                 trust_weight=trust_weight,
+                threshold_alert=threshold_alert,
+                threshold_digest=threshold_digest,
             )
             db_sources = await store.list_feed_sources()
         except ValueError:

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -189,6 +189,10 @@ def _parse_thresholds_arg(
         value_raw = raw[field_name]
         if value_raw is None:
             return None
+        # Reject booleans explicitly: ``float(True)`` returns ``1.0`` so JSON
+        # ``true``/``false`` would otherwise be silently accepted as numeric.
+        if isinstance(value_raw, bool):
+            raise ValueError(f"thresholds.{field_name} must be a float, got: {value_raw!r}")
         try:
             value = float(value_raw)
         except (TypeError, ValueError) as exc:

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -367,6 +367,8 @@ async def _ensure_store(
                         label=source.label,
                         poll_interval_minutes=source.poll_interval_minutes,
                         trust_weight=source.trust_weight,
+                        threshold_alert=source.thresholds.alert,
+                        threshold_digest=source.thresholds.digest,
                     )
             await store.set_metadata("feeds_seeded", "true")
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2480,7 +2480,8 @@ class DuckDBStore:
         assert self._conn is not None
         result = self._conn.execute(
             "SELECT url, source_type, label, poll_interval_minutes, trust_weight, "
-            "last_polled_at, last_item_count, last_error "
+            "last_polled_at, last_item_count, last_error, "
+            "threshold_alert, threshold_digest "
             "FROM feed_sources ORDER BY created_at"
         )
         rows = result.fetchall()
@@ -2505,6 +2506,8 @@ class DuckDBStore:
                 if last_polled_at is not None
                 else None
             )
+            threshold_alert_raw: float | None = row[8]
+            threshold_digest_raw: float | None = row[9]
             sources.append(
                 {
                     "url": row[0],
@@ -2516,6 +2519,12 @@ class DuckDBStore:
                     "last_item_count": row[6] if row[6] is not None else 0,
                     "last_error": row[7],
                     "next_poll_at": next_poll_at,
+                    "threshold_alert": (
+                        float(threshold_alert_raw) if threshold_alert_raw is not None else None
+                    ),
+                    "threshold_digest": (
+                        float(threshold_digest_raw) if threshold_digest_raw is not None else None
+                    ),
                 }
             )
         return sources
@@ -2527,15 +2536,26 @@ class DuckDBStore:
         label: str = "",
         poll_interval_minutes: int = 60,
         trust_weight: float = 1.0,
+        threshold_alert: float | None = None,
+        threshold_digest: float | None = None,
     ) -> dict[str, Any]:
         """Add a feed source. Raises ValueError if URL already exists."""
         assert self._conn is not None
         try:
             self._conn.execute(
                 "INSERT INTO feed_sources "
-                "(url, source_type, label, poll_interval_minutes, trust_weight) "
-                "VALUES (?, ?, ?, ?, ?)",
-                [url, source_type, label, poll_interval_minutes, trust_weight],
+                "(url, source_type, label, poll_interval_minutes, trust_weight, "
+                "threshold_alert, threshold_digest) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [
+                    url,
+                    source_type,
+                    label,
+                    poll_interval_minutes,
+                    trust_weight,
+                    threshold_alert,
+                    threshold_digest,
+                ],
             )
         except duckdb.ConstraintException as exc:
             raise ValueError(f"Feed source with URL {url!r} already exists.") from exc
@@ -2545,6 +2565,8 @@ class DuckDBStore:
             "label": label,
             "poll_interval_minutes": poll_interval_minutes,
             "trust_weight": trust_weight,
+            "threshold_alert": threshold_alert,
+            "threshold_digest": threshold_digest,
         }
 
     def _sync_remove_feed_source(self, url: str) -> bool:
@@ -2608,10 +2630,19 @@ class DuckDBStore:
         label: str = "",
         poll_interval_minutes: int = 60,
         trust_weight: float = 1.0,
+        threshold_alert: float | None = None,
+        threshold_digest: float | None = None,
     ) -> dict[str, Any]:
         """Add a feed source. Raises ValueError if URL already exists."""
         return await self._run_sync(
-            self._sync_add_feed_source, url, source_type, label, poll_interval_minutes, trust_weight
+            self._sync_add_feed_source,
+            url,
+            source_type,
+            label,
+            poll_interval_minutes,
+            trust_weight,
+            threshold_alert,
+            threshold_digest,
         )
 
     async def remove_feed_source(self, url: str) -> bool:

--- a/src/distillery/store/migrations.py
+++ b/src/distillery/store/migrations.py
@@ -403,6 +403,30 @@ def create_sync_jobs(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
     logger.info("Migration 13: sync_jobs table created")
 
 
+_ADD_FEED_SOURCE_THRESHOLD_COLUMNS = [
+    "ALTER TABLE feed_sources ADD COLUMN IF NOT EXISTS threshold_alert FLOAT;",
+    "ALTER TABLE feed_sources ADD COLUMN IF NOT EXISTS threshold_digest FLOAT;",
+]
+
+
+def add_feed_source_thresholds(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
+    """Migration 14: Add per-source threshold override columns.
+
+    Adds two nullable ``FLOAT`` columns to ``feed_sources``:
+
+    - ``threshold_alert`` — overrides ``feeds.thresholds.alert`` for this
+      source when non-NULL.
+    - ``threshold_digest`` — overrides ``feeds.thresholds.digest`` for this
+      source when non-NULL.
+
+    NULL means "fall back to global", preserving pre-#480 behaviour for
+    sources that were created before the migration ran.
+    """
+    for stmt in _ADD_FEED_SOURCE_THRESHOLD_COLUMNS:
+        conn.execute(stmt)
+    logger.info("Migration 14: feed_sources threshold override columns added")
+
+
 # ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
@@ -421,6 +445,7 @@ MIGRATIONS: dict[int, MigrationFunc] = {
     11: add_session_id,
     12: add_feed_source_liveness,
     13: create_sync_jobs,
+    14: add_feed_source_thresholds,
 }
 """Ordered mapping of schema version to migration function.
 

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -366,8 +366,11 @@ class DistilleryStore(Protocol):
         Each dict contains keys: ``url``, ``source_type``, ``label``,
         ``poll_interval_minutes``, ``trust_weight``, ``last_polled_at``
         (ISO 8601 string or ``None``), ``last_item_count`` (int),
-        ``last_error`` (str or ``None``), and ``next_poll_at``
-        (ISO 8601 string or ``None``).
+        ``last_error`` (str or ``None``), ``next_poll_at``
+        (ISO 8601 string or ``None``), and per-source threshold
+        overrides ``threshold_alert`` / ``threshold_digest`` (float in
+        ``[0.0, 1.0]`` or ``None`` to fall back to the global
+        ``feeds.thresholds`` values).
 
         Returns:
             List of feed source dicts ordered by creation time.
@@ -381,6 +384,8 @@ class DistilleryStore(Protocol):
         label: str = "",
         poll_interval_minutes: int = 60,
         trust_weight: float = 1.0,
+        threshold_alert: float | None = None,
+        threshold_digest: float | None = None,
     ) -> dict[str, Any]:
         """Persist a new feed source and return it as a dict.
 
@@ -390,6 +395,12 @@ class DistilleryStore(Protocol):
             label: Human-readable label.
             poll_interval_minutes: Poll frequency in minutes.
             trust_weight: Relevance multiplier in ``[0.0, 1.0]``.
+            threshold_alert: Optional per-source override of
+                ``feeds.thresholds.alert`` in ``[0.0, 1.0]``.  ``None``
+                falls back to the global value.
+            threshold_digest: Optional per-source override of
+                ``feeds.thresholds.digest`` in ``[0.0, 1.0]``.  ``None``
+                falls back to the global value.
 
         Returns:
             Dict with the stored feed source fields.

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1190,3 +1190,283 @@ class TestPollCycleTopicTagIntegration:
         assert "source/rss" in stored_tags
         # No topic tags since vocabulary fetch failed
         assert "domain/authentication" not in stored_tags
+
+
+# ---------------------------------------------------------------------------
+# Per-source threshold overrides (issue #480)
+# ---------------------------------------------------------------------------
+
+
+class TestPerSourceThresholdOverrides:
+    """Per-source ``thresholds`` block beats the global default in the poller."""
+
+    @staticmethod
+    def _make_item(
+        item_id: str = "test-item",
+        title: str = "OAuth authentication guide",
+        content: str = "",
+    ) -> FeedItem:
+        return FeedItem(
+            source_url="https://example.com/rss",
+            source_type="rss",
+            item_id=item_id,
+            title=title,
+            content=content,
+        )
+
+    @pytest.mark.asyncio
+    async def test_per_source_digest_override_filters_when_score_below(self) -> None:
+        """A per-source digest override above the global default filters items
+        whose score sits between the two thresholds."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from distillery.feeds.poller import FeedPoller
+
+        config = MagicMock()
+        # Global digest is 0.0 — would normally accept everything.
+        config.feeds.thresholds.digest = 0.0
+        config.feeds.thresholds.alert = 0.85
+
+        store = AsyncMock()
+        store.list_feed_sources.return_value = [
+            {
+                "url": "https://example.com/rss",
+                "source_type": "rss",
+                "label": "",
+                "poll_interval_minutes": 60,
+                "trust_weight": 1.0,
+                "threshold_alert": None,
+                # Per-source digest raises the bar to 0.80; score 0.5 should
+                # therefore be filtered out as below threshold.
+                "threshold_digest": 0.80,
+            }
+        ]
+        store.get_tag_vocabulary.return_value = {}
+        store.find_similar.return_value = []
+        store.list_entries.return_value = []
+
+        item = self._make_item(item_id="below-override", title="lobsters submission")
+
+        with (
+            patch("distillery.feeds.poller._build_adapter") as mock_build_adapter,
+            patch("distillery.feeds.poller.RelevanceScorer") as mock_scorer_cls,
+            patch("distillery.feeds.interests.InterestExtractor") as mock_extractor_cls,
+        ):
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = [item]
+            mock_build_adapter.return_value = mock_adapter
+
+            mock_scorer = AsyncMock()
+            mock_scorer.score.return_value = 0.5
+            mock_scorer_cls.return_value = mock_scorer
+
+            mock_extractor = AsyncMock()
+            mock_extractor.extract.return_value = MagicMock(entry_count=0, top_tags=[])
+            mock_extractor_cls.return_value = mock_extractor
+
+            poller = FeedPoller(store=store, config=config)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 0
+        assert summary.total_below_threshold == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_override_falls_back_to_global(self) -> None:
+        """A source without a per-source threshold uses the global default
+        — pre-#480 behaviour preserved exactly when the new field is unset."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from distillery.feeds.poller import FeedPoller
+
+        config = MagicMock()
+        # Global digest 0.4 — score 0.5 should be kept (>= 0.4).
+        config.feeds.thresholds.digest = 0.4
+        config.feeds.thresholds.alert = 0.85
+
+        store = AsyncMock()
+        store.list_feed_sources.return_value = [
+            {
+                "url": "https://example.com/rss",
+                "source_type": "rss",
+                "label": "",
+                "poll_interval_minutes": 60,
+                "trust_weight": 1.0,
+                # No per-source override — both threshold_* keys are None.
+                "threshold_alert": None,
+                "threshold_digest": None,
+            }
+        ]
+        store.get_tag_vocabulary.return_value = {}
+        store.find_similar.return_value = []
+        store.list_entries.return_value = []
+
+        stored: list = []
+
+        async def capture_store(entry: object) -> None:
+            stored.append(entry)
+
+        store.store.side_effect = capture_store
+
+        item = self._make_item(item_id="fallback-keeps", title="vendor blog post")
+
+        with (
+            patch("distillery.feeds.poller._build_adapter") as mock_build_adapter,
+            patch("distillery.feeds.poller.RelevanceScorer") as mock_scorer_cls,
+            patch("distillery.feeds.interests.InterestExtractor") as mock_extractor_cls,
+        ):
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = [item]
+            mock_build_adapter.return_value = mock_adapter
+
+            mock_scorer = AsyncMock()
+            mock_scorer.score.return_value = 0.5
+            mock_scorer_cls.return_value = mock_scorer
+
+            mock_extractor = AsyncMock()
+            mock_extractor.extract.return_value = MagicMock(entry_count=0, top_tags=[])
+            mock_extractor_cls.return_value = mock_extractor
+
+            poller = FeedPoller(store=store, config=config)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 1
+        assert summary.total_below_threshold == 0
+        assert len(stored) == 1
+
+    @pytest.mark.asyncio
+    async def test_per_source_alert_override_drives_alert_tagging(self) -> None:
+        """A per-source ``alert`` override controls ``metadata.is_alert`` flag
+        independently of the global ``feeds.thresholds.alert``."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from distillery.feeds.poller import FeedPoller
+
+        config = MagicMock()
+        # Global alert is high — score 0.92 would normally NOT alert.
+        config.feeds.thresholds.digest = 0.0
+        config.feeds.thresholds.alert = 0.95
+
+        store = AsyncMock()
+        store.list_feed_sources.return_value = [
+            {
+                "url": "https://example.com/rss",
+                "source_type": "rss",
+                "label": "",
+                "poll_interval_minutes": 60,
+                "trust_weight": 1.0,
+                # Per-source alert lowered to 0.90 — score 0.92 should alert.
+                "threshold_alert": 0.90,
+                "threshold_digest": None,
+            }
+        ]
+        store.get_tag_vocabulary.return_value = {}
+        store.find_similar.return_value = []
+        store.list_entries.return_value = []
+
+        stored: list = []
+
+        async def capture_store(entry: object) -> None:
+            stored.append(entry)
+
+        store.store.side_effect = capture_store
+
+        item = self._make_item(item_id="alert-flagged", title="security advisory")
+
+        with (
+            patch("distillery.feeds.poller._build_adapter") as mock_build_adapter,
+            patch("distillery.feeds.poller.RelevanceScorer") as mock_scorer_cls,
+            patch("distillery.feeds.interests.InterestExtractor") as mock_extractor_cls,
+        ):
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = [item]
+            mock_build_adapter.return_value = mock_adapter
+
+            mock_scorer = AsyncMock()
+            mock_scorer.score.return_value = 0.92
+            mock_scorer_cls.return_value = mock_scorer
+
+            mock_extractor = AsyncMock()
+            mock_extractor.extract.return_value = MagicMock(entry_count=0, top_tags=[])
+            mock_extractor_cls.return_value = mock_extractor
+
+            poller = FeedPoller(store=store, config=config)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 1
+        assert len(stored) == 1
+        assert stored[0].metadata.get("is_alert") is True
+
+    def test_yaml_round_trip_preserves_overrides(self) -> None:
+        """Parsing YAML with a per-source ``thresholds`` block populates
+        :class:`FeedSourceThresholdsConfig`; missing keys leave ``None``."""
+        from distillery.config import _parse_feed_source
+
+        cfg = _parse_feed_source(
+            {
+                "url": "https://lobste.rs/rss",
+                "source_type": "rss",
+                "thresholds": {"alert": 0.90, "digest": 0.80},
+            },
+            index=0,
+        )
+        assert cfg.thresholds.alert == pytest.approx(0.90)
+        assert cfg.thresholds.digest == pytest.approx(0.80)
+
+        cfg_partial = _parse_feed_source(
+            {
+                "url": "https://news.ycombinator.com/rss",
+                "source_type": "rss",
+                "thresholds": {"digest": 0.75},
+            },
+            index=1,
+        )
+        assert cfg_partial.thresholds.alert is None
+        assert cfg_partial.thresholds.digest == pytest.approx(0.75)
+
+        cfg_default = _parse_feed_source(
+            {
+                "url": "https://blog.example.com/rss",
+                "source_type": "rss",
+            },
+            index=2,
+        )
+        assert cfg_default.thresholds.alert is None
+        assert cfg_default.thresholds.digest is None
+
+    def test_invalid_threshold_range_rejected(self) -> None:
+        """Out-of-range values fail YAML parsing rather than silently coercing."""
+        from distillery.config import _parse_feed_source
+
+        with pytest.raises(ValueError, match="thresholds.digest"):
+            _parse_feed_source(
+                {
+                    "url": "https://example.com/rss",
+                    "source_type": "rss",
+                    "thresholds": {"digest": 1.5},
+                },
+                index=0,
+            )
+        with pytest.raises(ValueError, match="thresholds.alert"):
+            _parse_feed_source(
+                {
+                    "url": "https://example.com/rss",
+                    "source_type": "rss",
+                    "thresholds": {"alert": -0.1},
+                },
+                index=0,
+            )
+
+    def test_digest_above_alert_rejected(self) -> None:
+        """When both fields are set, ``digest <= alert`` is enforced (mirrors
+        the global ``feeds.thresholds`` invariant)."""
+        from distillery.config import _parse_feed_source
+
+        with pytest.raises(ValueError, match="must be <="):
+            _parse_feed_source(
+                {
+                    "url": "https://example.com/rss",
+                    "source_type": "rss",
+                    "thresholds": {"alert": 0.6, "digest": 0.9},
+                },
+                index=0,
+            )

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1470,3 +1470,31 @@ class TestPerSourceThresholdOverrides:
                 },
                 index=0,
             )
+
+    def test_boolean_threshold_rejected(self) -> None:
+        """YAML booleans must not be silently coerced to ``0.0``/``1.0``.
+
+        ``float(True)`` returns ``1.0`` so without an explicit
+        ``isinstance(..., bool)`` guard a malformed ``alert: true`` would pass
+        validation as a fully-saturated threshold.
+        """
+        from distillery.config import _parse_feed_source
+
+        with pytest.raises(ValueError, match="thresholds.alert"):
+            _parse_feed_source(
+                {
+                    "url": "https://example.com/rss",
+                    "source_type": "rss",
+                    "thresholds": {"alert": True},
+                },
+                index=0,
+            )
+        with pytest.raises(ValueError, match="thresholds.digest"):
+            _parse_feed_source(
+                {
+                    "url": "https://example.com/rss",
+                    "source_type": "rss",
+                    "thresholds": {"digest": False},
+                },
+                index=0,
+            )

--- a/tests/test_mcp_feeds.py
+++ b/tests/test_mcp_feeds.py
@@ -94,6 +94,8 @@ class FakeSourceStore:
         label: str = "",
         poll_interval_minutes: int = 60,
         trust_weight: float = 1.0,
+        threshold_alert: float | None = None,
+        threshold_digest: float | None = None,
     ) -> dict[str, Any]:
         if any(s["url"] == url for s in self._sources):
             raise ValueError(f"Feed source with URL {url!r} already exists.")
@@ -107,6 +109,8 @@ class FakeSourceStore:
             "last_item_count": 0,
             "last_error": None,
             "next_poll_at": None,
+            "threshold_alert": threshold_alert,
+            "threshold_digest": threshold_digest,
         }
         self._sources.append(entry)
         return entry
@@ -427,6 +431,95 @@ class TestHandleWatchAdd:
         data = parse(result)
         assert "sources" in data
         assert isinstance(data["sources"], list)
+
+    async def test_add_with_thresholds_persists_per_source_overrides(self) -> None:
+        """``thresholds`` argument is plumbed through to the store as
+        ``threshold_alert`` / ``threshold_digest`` columns (issue #480)."""
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "https://lobste.rs/rss",
+                "source_type": "rss",
+                "thresholds": {"alert": 0.92, "digest": 0.80},
+            },
+        )
+        data = parse(result)
+        assert "error" not in data
+        assert data["added"]["threshold_alert"] == pytest.approx(0.92)
+        assert data["added"]["threshold_digest"] == pytest.approx(0.80)
+        # Round-trip via list shows the persisted overrides.
+        listed = parse(await _handle_watch(store=store, arguments={"action": "list"}))["sources"][0]
+        assert listed["threshold_alert"] == pytest.approx(0.92)
+        assert listed["threshold_digest"] == pytest.approx(0.80)
+
+    async def test_add_with_partial_thresholds_only_overrides_supplied_field(self) -> None:
+        """A ``thresholds`` mapping with only ``digest`` leaves alert as ``None``
+        — the partial override falls back to global for the missing tier."""
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "https://news.ycombinator.com/rss",
+                "source_type": "rss",
+                "thresholds": {"digest": 0.75},
+            },
+        )
+        data = parse(result)
+        assert "error" not in data
+        assert data["added"]["threshold_digest"] == pytest.approx(0.75)
+        assert data["added"]["threshold_alert"] is None
+
+    async def test_add_thresholds_out_of_range_returns_invalid_params(self) -> None:
+        """Out-of-range threshold value is rejected with INVALID_PARAMS."""
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "https://example.com/rss",
+                "source_type": "rss",
+                "thresholds": {"digest": 1.5},
+            },
+        )
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
+    async def test_add_thresholds_digest_above_alert_returns_invalid_params(self) -> None:
+        """``digest > alert`` is rejected with INVALID_PARAMS to mirror the
+        global ``feeds.thresholds`` invariant."""
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "https://example.com/rss",
+                "source_type": "rss",
+                "thresholds": {"alert": 0.5, "digest": 0.9},
+            },
+        )
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
+    async def test_add_thresholds_unknown_key_returns_invalid_params(self) -> None:
+        """Unknown keys in the ``thresholds`` map are rejected (typo guard)."""
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "https://example.com/rss",
+                "source_type": "rss",
+                "thresholds": {"alarm": 0.9},
+            },
+        )
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_feeds.py
+++ b/tests/test_mcp_feeds.py
@@ -521,6 +521,39 @@ class TestHandleWatchAdd:
         assert data["error"] is True
         assert data["code"] == "INVALID_PARAMS"
 
+    async def test_add_thresholds_boolean_value_returns_invalid_params(self) -> None:
+        """JSON ``true``/``false`` must not be coerced to ``1.0``/``0.0``.
+
+        Without an explicit ``isinstance(..., bool)`` guard, ``float(True)``
+        would return ``1.0`` and silently saturate the threshold.
+        """
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "https://example.com/rss",
+                "source_type": "rss",
+                "thresholds": {"alert": True},
+            },
+        )
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "https://example.com/rss",
+                "source_type": "rss",
+                "thresholds": {"digest": False},
+            },
+        )
+        data = parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
 
 # ---------------------------------------------------------------------------
 # _handle_watch — remove action

--- a/tests/test_mcp_watch.py
+++ b/tests/test_mcp_watch.py
@@ -46,6 +46,8 @@ class FakeSourceStore:
         label: str = "",
         poll_interval_minutes: int = 60,
         trust_weight: float = 1.0,
+        threshold_alert: float | None = None,
+        threshold_digest: float | None = None,
     ) -> dict[str, Any]:
         if any(s["url"] == url for s in self._sources):
             raise ValueError(f"Feed source with URL {url!r} already exists.")
@@ -55,6 +57,8 @@ class FakeSourceStore:
             "label": label,
             "poll_interval_minutes": poll_interval_minutes,
             "trust_weight": trust_weight,
+            "threshold_alert": threshold_alert,
+            "threshold_digest": threshold_digest,
         }
         self._sources.append(entry)
         return entry

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -37,6 +37,8 @@ class FakeSourceStore:
         label: str = "",
         poll_interval_minutes: int = 60,
         trust_weight: float = 1.0,
+        threshold_alert: float | None = None,
+        threshold_digest: float | None = None,
     ) -> dict[str, Any]:
         if any(s["url"] == url for s in self._sources):
             raise ValueError(f"Feed source with URL {url!r} already exists.")
@@ -46,6 +48,8 @@ class FakeSourceStore:
             "label": label,
             "poll_interval_minutes": poll_interval_minutes,
             "trust_weight": trust_weight,
+            "threshold_alert": threshold_alert,
+            "threshold_digest": threshold_digest,
         }
         self._sources.append(d)
         return d


### PR DESCRIPTION
## Summary
- Adds optional ``thresholds`` block on ``FeedSourceConfig`` (``alert`` / ``digest``, both ``[0.0, 1.0]``); poller resolves the effective threshold per-source, falling back to the global ``feeds.thresholds`` when unset so noisy aggregators (HN, Lobsters, Reddit) can be held to a higher bar than vendor blogs without abusing ``trust_weight`` (which only attenuates downward).
- DB migration 14 adds nullable ``threshold_alert`` / ``threshold_digest`` columns; ``DuckDBStore`` and the protocol propagate the new optional fields through ``add_feed_source`` / ``list_feed_sources``.
- ``distillery_watch add`` MCP tool now accepts ``thresholds`` (mapping with ``alert``/``digest`` float keys) with structured ``INVALID_PARAMS`` for out-of-range, unknown-key, and ``digest > alert`` cases (mirrors the global invariant).

## Backwards compatibility
- Pre-existing rows have NULL override columns and continue to use the global cutoffs — pre-#480 behaviour unchanged.
- ``trust_weight`` semantics untouched.
- New API surface is purely additive (no signature changes that drop arguments).

## Test plan
- [x] Unit suite (``pytest -m unit``) — 1949 passed.
- [x] ``ruff check`` clean; ``ruff format --check`` clean for changed files.
- [x] ``mypy --strict src/distillery/`` — no issues.
- [x] New tests in ``tests/test_feeds.py``: per-source override beats global, missing override falls back, alert override drives ``metadata.is_alert``, YAML round-trip preserves overrides, invalid range rejected, ``digest > alert`` rejected.
- [x] New tests in ``tests/test_mcp_feeds.py``: MCP tool persists overrides, partial overrides leave the other tier ``None``, INVALID_PARAMS for bad shape / range / unknown key.

Closes #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-feed threshold overrides: configure alert and digest thresholds individually for each feed source
  * Override global thresholds via CLI import, configuration files, and API tools
  * Threshold validation ensures values are in 0.0-1.0 range with digest ≤ alert constraint

* **Tests**
  * Added comprehensive test coverage for per-source threshold behavior and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->