### PR TITLE
fix(mcp): sweep stale active_job_id on startup + request-time TTL

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -217,6 +217,25 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                     )
             except Exception:  # noqa: BLE001
                 logger.exception("Sync-job tracker hydration failed (non-fatal)")
+
+            # Sweep any stale webhook job pointers carried over from a
+            # previous run.  In-memory state is normally empty on cold
+            # start, but Fly autosuspend (issue #507) can resume a process
+            # with the ``_active_job_by_endpoint`` dict still populated
+            # from a poll that never reached a terminal state — leaving
+            # every subsequent ``/api/poll`` permanently blocked on a 409.
+            try:
+                from distillery.mcp.webhooks import sweep_stale_jobs
+
+                swept = await sweep_stale_jobs()
+                if swept:
+                    logger.info(
+                        "Swept %d stale webhook job pointer(s) on startup "
+                        "(issue #507 recovery path)",
+                        swept,
+                    )
+            except Exception:  # noqa: BLE001
+                logger.exception("Stale-job sweep failed (non-fatal)")
             _shared.update(store=store, config=config, embedding_provider=ep)
             # Record startup timestamp for distillery_status uptime reporting.
             # Stored in shared state (not replaced on subsequent lifespan entries

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -97,6 +97,19 @@ _init_lock = asyncio.Lock()
 # Maximum number of job records to retain in memory.
 _JOBS_MAX = 100
 
+# Maximum age (seconds) before an in-flight job is treated as orphaned.
+#
+# Issue #507: when Fly autosuspends a machine mid-poll, the background asyncio
+# task dies but the in-memory ``_jobs`` / ``_active_job_by_endpoint`` registry
+# survives across resume.  Without an age guard the stale "running" pointer
+# permanently blocks every subsequent ``/api/poll`` with a 409.  Any
+# non-terminal job whose ``submitted_at`` is older than this threshold is
+# swept (marked failed and cleared from the active-job pointer) so the next
+# request either succeeds or returns 429 for a real cooldown — never a stale
+# 409.  Sized well above the longest realistic poll cycle so live jobs are
+# never misclassified.
+_ACTIVE_JOB_TTL_SECONDS: int = 1800  # 30 minutes
+
 
 @dataclass
 class _JobStatus:
@@ -116,6 +129,67 @@ class _JobStatus:
 _jobs: OrderedDict[str, _JobStatus] = OrderedDict()
 _active_job_by_endpoint: dict[str, str] = {}
 _jobs_lock = asyncio.Lock()
+
+
+def _is_stale(job: _JobStatus, *, now: datetime | None = None) -> bool:
+    """Return ``True`` when *job* is non-terminal and older than the TTL.
+
+    A job is considered stale when it has not reached ``succeeded`` or
+    ``failed`` and its ``submitted_at`` timestamp is more than
+    :data:`_ACTIVE_JOB_TTL_SECONDS` in the past.  The Fly autosuspend
+    scenario (issue #507) is the canonical example: the asyncio task is
+    dead but the in-memory record cannot tell, so we use elapsed time as
+    a proxy for "this cannot still be running".
+    """
+    if job.state in ("succeeded", "failed"):
+        return False
+    now = now or datetime.now(UTC)
+    age = (now - job.submitted_at).total_seconds()
+    return age > _ACTIVE_JOB_TTL_SECONDS
+
+
+async def sweep_stale_jobs() -> int:
+    """Clear stale in-flight jobs from the in-memory registry.
+
+    Sweeps both the ``_jobs`` table and the ``_active_job_by_endpoint``
+    pointer.  Any non-terminal job older than :data:`_ACTIVE_JOB_TTL_SECONDS`
+    is transitioned to ``failed`` with a descriptive error so callers
+    polling ``GET /jobs/{id}`` see a clear cause; its endpoint pointer is
+    also dropped so the next ``POST`` can enqueue a fresh job.
+
+    Called from the webhook app's startup hook (issue #507) and as a
+    request-time safety net inside :func:`_active_job_id`.  Returns the
+    number of jobs that were marked stale, which the startup hook logs.
+    """
+    swept = 0
+    async with _jobs_lock:
+        now = datetime.now(UTC)
+        stale_ids: list[str] = []
+        for job_id, job in _jobs.items():
+            if _is_stale(job, now=now):
+                stale_ids.append(job_id)
+        for job_id in stale_ids:
+            job = _jobs[job_id]
+            job.state = "failed"
+            job.finished_at = now
+            job.error = (
+                f"orphaned: no terminal state after {_ACTIVE_JOB_TTL_SECONDS}s "
+                "(likely killed by machine suspend or crash)"
+            )
+            if _active_job_by_endpoint.get(job.endpoint) == job_id:
+                del _active_job_by_endpoint[job.endpoint]
+            swept += 1
+        # Defensive: drop any active-job pointer whose underlying record was
+        # evicted from the FIFO (mirrors the existing _active_job_id guard
+        # but covers the startup-time sweep where _active_job_id has not
+        # yet been called).
+        orphan_pointers = [
+            endpoint for endpoint, jid in _active_job_by_endpoint.items() if jid not in _jobs
+        ]
+        for endpoint in orphan_pointers:
+            del _active_job_by_endpoint[endpoint]
+            swept += 1
+    return swept
 
 
 async def _register_job(endpoint: str) -> _JobStatus:
@@ -142,8 +216,13 @@ async def _register_job(endpoint: str) -> _JobStatus:
 async def _active_job_id(endpoint: str) -> str | None:
     """Return the current active job id for *endpoint*, if any is in flight.
 
-    Stale pointers (job record evicted or already terminal) are cleaned up so
-    subsequent requests aren't blocked by a pointer to a completed job.
+    Stale pointers (job record evicted, already terminal, or older than
+    :data:`_ACTIVE_JOB_TTL_SECONDS` without reaching a terminal state) are
+    cleaned up so subsequent requests aren't blocked by a pointer to a
+    completed or orphaned job.  The TTL guard is the request-time half of
+    the issue #507 fix: even when startup never runs (e.g. Fly autosuspend
+    resumes the same process with memory intact), an aged-out pointer is
+    self-healed on the next request.
     """
     async with _jobs_lock:
         job_id = _active_job_by_endpoint.get(endpoint)
@@ -151,6 +230,15 @@ async def _active_job_id(endpoint: str) -> str | None:
             return None
         job = _jobs.get(job_id)
         if job is None or job.state in ("succeeded", "failed"):
+            _active_job_by_endpoint.pop(endpoint, None)
+            return None
+        if _is_stale(job):
+            job.state = "failed"
+            job.finished_at = datetime.now(UTC)
+            job.error = (
+                f"orphaned: no terminal state after {_ACTIVE_JOB_TTL_SECONDS}s "
+                "(likely killed by machine suspend or crash)"
+            )
             _active_job_by_endpoint.pop(endpoint, None)
             return None
         return job_id
@@ -1499,6 +1587,35 @@ def create_webhook_app(
     # proper Starlette instance (required for Mount).
     from distillery.mcp.middleware import RateLimitMiddleware
 
+    @contextlib.asynccontextmanager
+    async def _lifespan(_app: Starlette) -> Any:
+        """Sweep stale in-flight jobs at app boot (issue #507).
+
+        On a clean restart the in-memory registry is already empty so this
+        is a no-op.  On platforms whose lifecycle preserves Python memory
+        across "restart"-like events (the documented Fly autosuspend case)
+        the sweep is the recovery path: any non-terminal job whose
+        ``submitted_at`` predates the TTL is marked failed and its
+        active-job pointer dropped so the next ``POST /api/poll`` enqueues
+        a fresh job rather than returning a permanent 409.
+
+        Starlette removed ``on_startup``/``on_shutdown`` in newer versions
+        in favour of a single ``lifespan`` async context manager, so the
+        sweep is wired via this contextmanager.  Failure to sweep must
+        never block app startup — exceptions are logged and swallowed.
+        """
+        try:
+            swept = await sweep_stale_jobs()
+        except Exception:  # noqa: BLE001
+            logger.exception("Webhook startup: stale-job sweep failed")
+        else:
+            if swept:
+                logger.info(
+                    "Webhook startup: swept %d stale in-flight job(s) (issue #507 recovery path)",
+                    swept,
+                )
+        yield
+
     app = Starlette(
         routes=routes,
         middleware=[
@@ -1513,6 +1630,7 @@ def create_webhook_app(
                 skip_get_path_prefixes=("/jobs/",),
             ),
         ],
+        lifespan=_lifespan,
     )
 
     return app

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1119,3 +1119,225 @@ async def test_409_preferred_over_429_when_both_apply(
             assert second.json()["error"] == "job_in_progress"
 
             _wait_for_job(client, first.json()["job_id"], timeout_s=3.0)
+
+
+# ---------------------------------------------------------------------------
+# Stale active-job recovery (issue #507)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_stale_active_job_pointer_does_not_block_new_poll(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #507: a non-terminal job older than the TTL must not return 409.
+
+    Simulates the Fly autosuspend symptom by seeding a ``running`` job whose
+    ``submitted_at`` predates :data:`_ACTIVE_JOB_TTL_SECONDS` and pointing
+    the active-job map at it.  A subsequent ``POST /poll`` must self-heal
+    (sweep the orphan, enqueue a fresh job) and return 202 — never the
+    permanent 409 that prompted the issue.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from distillery.mcp import webhooks as _webhooks
+    from distillery.mcp.webhooks import _JobStatus
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+
+    # Seed an orphaned job: state=running, submitted_at well past TTL.
+    stale_id = "orphan-from-suspend"
+    stale_age = _webhooks._ACTIVE_JOB_TTL_SECONDS + 60
+    stale_job = _JobStatus(
+        id=stale_id,
+        endpoint="poll",
+        state="running",
+        submitted_at=datetime.now(UTC) - timedelta(seconds=stale_age),
+        started_at=datetime.now(UTC) - timedelta(seconds=stale_age),
+    )
+    _webhooks._jobs[stale_id] = stale_job
+    _webhooks._active_job_by_endpoint["poll"] = stale_id
+
+    app = create_webhook_app(shared, config)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/poll", headers=_AUTH_HEADER)
+        # 202 (sweep cleared the orphan and enqueued a new job) is the
+        # expected outcome.  429 would also be acceptable per the
+        # acceptance criteria — it would mean cooldown fired for a real
+        # reason — but with a fresh store no cooldown is in flight, so 202
+        # is what we get.  The forbidden outcome is 409.
+        assert resp.status_code in (202, 429), (
+            f"Expected 202 or 429 after sweep, got {resp.status_code}: {resp.text}"
+        )
+        assert resp.status_code != 409, (
+            "Stale active_job_id must not produce a permanent 409 (issue #507)"
+        )
+        body = resp.json()
+        if resp.status_code == 202:
+            # New job id must differ from the orphan — confirming the
+            # sweep cleared the pointer rather than re-issuing the old id.
+            assert body["job_id"] != stale_id
+            _wait_for_job(client, body["job_id"], timeout_s=5.0)
+
+    # Orphan should be terminal (failed) after the sweep so callers polling
+    # GET /jobs/<orphan-id> see a clear "killed by suspend" cause rather
+    # than an indefinite "running".
+    assert _webhooks._jobs[stale_id].state == "failed"
+    assert _webhooks._jobs[stale_id].error is not None
+    assert "orphan" in _webhooks._jobs[stale_id].error.lower()
+
+
+@pytest.mark.unit
+async def test_fresh_in_flight_job_still_returns_409(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The TTL guard must not regress legitimate in-flight 409s.
+
+    A job submitted moments ago is still live — the existing idempotency
+    contract (second concurrent poll returns 409 with the running job id)
+    must continue to hold so schedulers re-attach rather than race a
+    duplicate.
+    """
+    from datetime import UTC, datetime
+
+    from distillery.mcp import webhooks as _webhooks
+    from distillery.mcp.webhooks import _JobStatus
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+
+    fresh_id = "fresh-running-job"
+    fresh_job = _JobStatus(
+        id=fresh_id,
+        endpoint="poll",
+        state="running",
+        submitted_at=datetime.now(UTC),  # just submitted
+        started_at=datetime.now(UTC),
+    )
+    _webhooks._jobs[fresh_id] = fresh_job
+    _webhooks._active_job_by_endpoint["poll"] = fresh_id
+
+    app = create_webhook_app(shared, config)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post("/poll", headers=_AUTH_HEADER)
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"] == "job_in_progress"
+    assert body["job_id"] == fresh_id
+
+
+@pytest.mark.unit
+async def test_sweep_stale_jobs_marks_orphans_failed() -> None:
+    """``sweep_stale_jobs`` transitions stale jobs to terminal failed state.
+
+    Direct unit test on the sweep function so the startup-hook plumbing
+    (which TestClient does exercise) is not the only coverage of the
+    recovery primitive.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from distillery.mcp import webhooks as _webhooks
+    from distillery.mcp.webhooks import _JobStatus, sweep_stale_jobs
+
+    # Three jobs: one stale running, one fresh running, one already done.
+    now = datetime.now(UTC)
+    stale_age = _webhooks._ACTIVE_JOB_TTL_SECONDS + 60
+
+    stale = _JobStatus(
+        id="stale",
+        endpoint="poll",
+        state="running",
+        submitted_at=now - timedelta(seconds=stale_age),
+    )
+    fresh = _JobStatus(
+        id="fresh",
+        endpoint="rescore",
+        state="running",
+        submitted_at=now,
+    )
+    done = _JobStatus(
+        id="done",
+        endpoint="maintenance",
+        state="succeeded",
+        submitted_at=now - timedelta(seconds=stale_age),
+        finished_at=now - timedelta(seconds=10),
+    )
+    _webhooks._jobs["stale"] = stale
+    _webhooks._jobs["fresh"] = fresh
+    _webhooks._jobs["done"] = done
+    _webhooks._active_job_by_endpoint["poll"] = "stale"
+    _webhooks._active_job_by_endpoint["rescore"] = "fresh"
+
+    swept = await sweep_stale_jobs()
+
+    # Only the stale one is swept.  ``done`` is already terminal; ``fresh``
+    # is within TTL.
+    assert swept == 1
+    assert stale.state == "failed"
+    assert stale.error is not None
+    assert fresh.state == "running"  # untouched
+    assert done.state == "succeeded"  # untouched
+    # Active-job pointer for stale endpoint is dropped; fresh one remains.
+    assert "poll" not in _webhooks._active_job_by_endpoint
+    assert _webhooks._active_job_by_endpoint["rescore"] == "fresh"
+
+
+@pytest.mark.unit
+async def test_sweep_drops_pointer_to_evicted_job() -> None:
+    """A dangling active-job pointer whose job record was evicted is dropped.
+
+    Belt-and-braces: even if the FIFO ``_jobs`` eviction has discarded a
+    record while leaving its endpoint pointer behind, the sweep cleans up.
+    """
+    from distillery.mcp import webhooks as _webhooks
+    from distillery.mcp.webhooks import sweep_stale_jobs
+
+    # Pointer references a job id that does not exist in ``_jobs``.
+    _webhooks._active_job_by_endpoint["poll"] = "evicted-job-id"
+
+    swept = await sweep_stale_jobs()
+
+    assert swept == 1
+    assert "poll" not in _webhooks._active_job_by_endpoint
+
+
+@pytest.mark.unit
+async def test_startup_hook_clears_stale_pointer_on_app_boot(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Starlette ``on_startup`` fires the sweep when the app enters its lifecycle.
+
+    Exercises the wiring rather than the sweep semantics — confirms that
+    entering the TestClient's lifespan context actually invokes
+    ``sweep_stale_jobs`` against the module-level registry.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from distillery.mcp import webhooks as _webhooks
+    from distillery.mcp.webhooks import _JobStatus
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+
+    stale_age = _webhooks._ACTIVE_JOB_TTL_SECONDS + 60
+    stale = _JobStatus(
+        id="pre-boot-orphan",
+        endpoint="poll",
+        state="running",
+        submitted_at=datetime.now(UTC) - timedelta(seconds=stale_age),
+    )
+    _webhooks._jobs["pre-boot-orphan"] = stale
+    _webhooks._active_job_by_endpoint["poll"] = "pre-boot-orphan"
+
+    app = create_webhook_app(shared, config)
+    # Entering the TestClient context manager drives the Starlette lifespan,
+    # which runs the ``on_startup`` hook we installed.
+    with TestClient(app, raise_server_exceptions=False):
+        pass
+
+    assert stale.state == "failed"
+    assert "poll" not in _webhooks._active_job_by_endpoint


### PR DESCRIPTION
## Summary
- Fly autosuspend was killing the in-flight poll task while leaving the in-memory `_active_job_by_endpoint` pointer set to a non-terminal job, permanently blocking every subsequent `/api/poll` with 409.
- Adds `sweep_stale_jobs()` and wires it into both the webhook app's Starlette `lifespan` and the FastMCP lifespan in `server.py` (option 3) so any non-terminal job carried over from a previous run is marked failed on startup.
- Layers a 30-minute request-time TTL inside `_active_job_id` (option 2) so the same self-heal happens on the next request when Fly resumes a process with memory intact and no startup hook fires.

## Test plan
- [x] New unit test seeds an `active_job_id` with an old `submitted_at` and a `running` state, then POSTs `/poll` — gets 202 (or 429), never 409 (acceptance criterion verbatim).
- [x] New unit test confirms a fresh in-flight job still returns 409 (idempotency contract preserved).
- [x] Direct unit tests on `sweep_stale_jobs` cover the stale-job, fresh-job, terminal-job, and evicted-pointer cases.
- [x] Starlette lifespan test confirms the sweep runs on app boot via `TestClient` context.
- [x] Full test suite (`pytest`) green: 2763 passed, 86 skipped.
- [x] `ruff check`, `ruff format`, and `mypy --strict` all clean.

Closes #507

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook processing now automatically recovers from service interruptions. Jobs stuck in "in progress" state after service suspension are automatically detected and cleared at startup, preventing permanent processing blocks and improving webhook reliability.

* **Tests**
  * Added comprehensive test coverage for automatic webhook job recovery mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/518)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->