### PR TITLE
feat(store): wikilink edge population (#496 mechanism 8)

### DIFF
--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -341,6 +341,7 @@ async def _handle_relations(
             {
                 "action": "reconcile",
                 "metadata_links": counts.get("metadata_links", 0),
+                "wikilink_links": counts.get("wikilink_links", 0),
                 "total": counts.get("total", 0),
             }
         )

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -34,6 +34,7 @@ from distillery.models import Entry, EntryStatus, validate_metadata
 from distillery.store.migrations import (
     _CREATE_META_TABLE,
     backfill_relations_from_metadata,
+    backfill_relations_from_wikilinks,
     run_pending_migrations,
 )
 
@@ -3168,11 +3169,12 @@ class DuckDBStore:
         assert self._conn is not None
         conn = self._conn
         # Wrap in a transaction so a mid-scan failure leaves the table in its
-        # prior state. The helper is itself idempotent, so the worst-case is a
-        # retried no-op on the next call.
+        # prior state. The helpers are themselves idempotent, so the
+        # worst-case is a retried no-op on the next call.
         try:
             conn.execute("BEGIN TRANSACTION")
             inserted_metadata = backfill_relations_from_metadata(conn)
+            inserted_wikilinks = backfill_relations_from_wikilinks(conn)
             conn.execute("COMMIT")
         except Exception:
             with contextlib.suppress(Exception):
@@ -3182,21 +3184,31 @@ class DuckDBStore:
         # than sitting in the WAL where an ungraceful restart could lose them
         # (issue #346 semantics — see :meth:`_checkpoint_after_write`).
         self._checkpoint_after_write(conn)
-        return {"metadata_links": inserted_metadata, "total": inserted_metadata}
+        return {
+            "metadata_links": inserted_metadata,
+            "wikilink_links": inserted_wikilinks,
+            "total": inserted_metadata + inserted_wikilinks,
+        }
 
     async def reconcile_relations(self) -> dict[str, int]:
-        """Re-run the metadata-driven entry_relations backfill and return counts.
+        """Re-run the entry_relations backfill mechanisms and return counts.
 
-        Idempotent recovery hook for issue #490 mechanism #9.  Re-scans every
-        entry's ``metadata.related_entries`` and inserts any missing rows into
-        ``entry_relations``; existing rows are left alone via the unique
-        ``(from_id, to_id, relation_type)`` index.
+        Idempotent recovery hook for issue #490 mechanism #9 plus issue
+        #496 mechanism #8.  Currently runs two passes:
+
+          * ``metadata.related_entries`` fan-out (mechanism #1).
+          * Inline ``[[entry-<8-hex>]]`` wikilink parsing in ``content``
+            (mechanism #8 from issue #496).
+
+        Existing rows are left alone via the unique ``(from_id, to_id,
+        relation_type)`` index, so re-running never duplicates edges.
 
         Returns:
             Dict with ``metadata_links`` (rows inserted from
-            ``metadata.related_entries``) and ``total`` (sum across all
-            mechanisms — currently equal to ``metadata_links``; future
-            mechanisms #3-#8 in issue #490 will contribute additional fields).
+            ``metadata.related_entries``), ``wikilink_links`` (rows inserted
+            from inline ``[[entry-<8-hex>]]`` references) and ``total`` (sum
+            across all mechanisms — future mechanisms #3-#7 in issue #496
+            will contribute additional fields).
         """
         return await self._run_sync(self._sync_reconcile_relations)
 

--- a/src/distillery/store/migrations.py
+++ b/src/distillery/store/migrations.py
@@ -210,7 +210,7 @@ def create_hnsw_index(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
         logger.warning("Migration 6: HNSW index type not recognized, skipping")
 
 
-_WIKILINK_PATTERN = re.compile(r"\[\[entry-([0-9a-f]{8})\]\]")
+_WIKILINK_PATTERN = re.compile(r"\[\[entry-([0-9A-Fa-f]{8})\]\]")
 
 
 def backfill_relations_from_wikilinks(conn: duckdb.DuckDBPyConnection) -> int:

--- a/src/distillery/store/migrations.py
+++ b/src/distillery/store/migrations.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import re
 from typing import Any, Protocol
 
 import duckdb
@@ -207,6 +208,89 @@ def create_hnsw_index(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
         logger.debug("Migration 6: HNSW index already exists, skipping")
     except duckdb.BinderException:
         logger.warning("Migration 6: HNSW index type not recognized, skipping")
+
+
+_WIKILINK_PATTERN = re.compile(r"\[\[entry-([0-9a-f]{8})\]\]")
+
+
+def backfill_relations_from_wikilinks(conn: duckdb.DuckDBPyConnection) -> int:
+    """Scan ``entries.content`` for ``[[entry-<8-hex>]]`` refs and insert ``link`` rows.
+
+    Idempotent: relies on the ``idx_entry_relations_unique`` unique index on
+    ``(from_id, to_id, relation_type)`` so re-running never produces duplicates.
+    Returns the number of rows actually inserted (excludes index-suppressed
+    duplicates, self-references, dangling targets and ambiguous prefixes).
+
+    This helper is the single source of truth for mechanism #8 in issue #496
+    (inline wikilink reference parsing).  Entry IDs are UUID4 strings, so the
+    leading 8-hex prefix is the first dash-delimited segment.  When two or
+    more existing entries share the same 8-hex prefix the reference is
+    ambiguous and is skipped entirely (no edge is written to either
+    candidate) — idempotency + safety beat completeness.
+
+    The caller is responsible for transaction management — this function
+    assumes ``entry_relations`` (and its unique index) already exist.
+    """
+    import uuid
+
+    # Build a prefix -> id map up front.  Prefixes that collide (>= 2 entries
+    # share the same first 8 hex chars) are tracked as "ambiguous" and
+    # excluded from the lookup, mirroring the safety-over-completeness rule.
+    prefix_to_id: dict[str, str] = {}
+    ambiguous: set[str] = set()
+    all_ids: set[str] = set()
+    for (entry_id,) in conn.execute("SELECT id FROM entries").fetchall():
+        if not isinstance(entry_id, str) or len(entry_id) < 8:
+            continue
+        all_ids.add(entry_id)
+        prefix = entry_id[:8].lower()
+        if prefix in ambiguous:
+            continue
+        existing = prefix_to_id.get(prefix)
+        if existing is None:
+            prefix_to_id[prefix] = entry_id
+        elif existing != entry_id:
+            # Two distinct entries share the same 8-hex prefix — refuse to
+            # link to either to avoid silently picking the wrong target.
+            ambiguous.add(prefix)
+            del prefix_to_id[prefix]
+            logger.debug(
+                "Wikilink backfill: prefix %r is ambiguous; skipping all references", prefix
+            )
+
+    rows = conn.execute("SELECT id, content FROM entries WHERE content IS NOT NULL").fetchall()
+    inserted = 0
+    for entry_id, content in rows:
+        if not isinstance(content, str) or not content:
+            continue
+        # ``set`` to dedupe multiple occurrences of the same prefix within a
+        # single entry — the unique index would catch them anyway, but this
+        # avoids the extra round-trips.
+        seen_prefixes: set[str] = set()
+        for match in _WIKILINK_PATTERN.finditer(content):
+            prefix = match.group(1).lower()
+            if prefix in seen_prefixes:
+                continue
+            seen_prefixes.add(prefix)
+            to_id = prefix_to_id.get(prefix)
+            if to_id is None:
+                # Either ambiguous (already logged above) or no such entry.
+                continue
+            if to_id == entry_id:
+                # Self-references are not meaningful.
+                continue
+            if to_id not in all_ids:
+                continue
+            relation_id = str(uuid.uuid4())
+            row = conn.execute(
+                "INSERT OR IGNORE INTO entry_relations (id, from_id, to_id, relation_type) "
+                "VALUES (?, ?, ?, 'link') RETURNING id",
+                [relation_id, entry_id, to_id],
+            ).fetchone()
+            if row:
+                inserted += 1
+
+    return inserted
 
 
 def backfill_relations_from_metadata(conn: duckdb.DuckDBPyConnection) -> int:

--- a/tests/test_relations_backfill_on_write.py
+++ b/tests/test_relations_backfill_on_write.py
@@ -1,6 +1,7 @@
 """Tests for issue #490 — entry_relations backfill on write + reconcile + accept_action.
 
-Covers the three patch-fix mechanisms scoped into the initial PR:
+Covers the patch-fix mechanisms scoped into the initial PR plus the
+wikilink mechanism added under issue #496:
 
   * Mechanism #1 — ``metadata.related_entries`` is fanned out into
     ``entry_relations`` on every ``store`` / ``store_batch`` / ``update`` call,
@@ -9,6 +10,9 @@ Covers the three patch-fix mechanisms scoped into the initial PR:
     retroactively.
   * Mechanism #2 — ``distillery_find_similar(accept_action=...)`` persists a
     typed relation from ``source_entry_id`` to each result above threshold.
+  * Mechanism #8 (issue #496) — inline ``[[entry-<8-hex>]]`` wikilink
+    references in ``content`` are parsed during reconcile and added as
+    ``link`` rows.
   * Mechanism #9 — ``distillery_relations action="reconcile"`` re-runs the
     metadata backfill and reports per-mechanism counts.
 
@@ -19,6 +23,7 @@ scoring is reproducible.
 from __future__ import annotations
 
 import json
+import uuid
 
 import duckdb
 import pytest
@@ -29,6 +34,7 @@ from distillery.mcp.tools.search import _handle_find_similar
 from distillery.store.duckdb import DuckDBStore
 from distillery.store.migrations import (
     backfill_relations_from_metadata,
+    backfill_relations_from_wikilinks,
     run_pending_migrations,
 )
 from tests.conftest import ControlledEmbeddingProvider, make_entry, parse_mcp_response
@@ -423,3 +429,223 @@ async def test_find_similar_accept_action_rejects_unknown_value(
     )
     assert payload.get("error") is True
     assert payload.get("code") == "INVALID_PARAMS"
+
+
+# ---------------------------------------------------------------------------
+# Wikilink backfill helper (issue #496 mechanism #8) — pure-SQL pass
+# ---------------------------------------------------------------------------
+
+
+def _insert_entry_with_content(
+    conn: duckdb.DuckDBPyConnection,
+    entry_id: str,
+    content: str = "test content",
+) -> None:
+    conn.execute(
+        "INSERT INTO entries (id, content, entry_type, source, author, embedding) "
+        "VALUES (?, ?, 'inbox', 'manual', 'tester', ?)",
+        [entry_id, content, _EMBEDDING],
+    )
+
+
+def test_wikilink_backfill_links_pair_on_prefix_match() -> None:
+    """A ``[[entry-<prefix>]]`` reference in content resolves to a ``link`` row."""
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        # UUIDs are mutable so we hand-craft prefixes for deterministic resolution.
+        src_id = "11111111-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
+        tgt_id = "22222222-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
+        _insert_entry_with_content(conn, tgt_id, "target entry")
+        _insert_entry_with_content(conn, src_id, "see [[entry-22222222]] for details")
+
+        inserted = backfill_relations_from_wikilinks(conn)
+        assert inserted == 1
+        rows = conn.execute("SELECT from_id, to_id, relation_type FROM entry_relations").fetchall()
+        assert rows == [(src_id, tgt_id, "link")]
+    finally:
+        conn.close()
+
+
+def test_wikilink_backfill_is_idempotent() -> None:
+    """Re-running the helper never produces duplicate edges."""
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        src_id = "33333333-cccc-4ccc-cccc-cccccccccccc"
+        tgt_id = "44444444-dddd-4ddd-dddd-dddddddddddd"
+        _insert_entry_with_content(conn, tgt_id, "target")
+        _insert_entry_with_content(conn, src_id, "ref: [[entry-44444444]]")
+
+        first = backfill_relations_from_wikilinks(conn)
+        second = backfill_relations_from_wikilinks(conn)
+        assert first == 1
+        assert second == 0
+        count = conn.execute(
+            "SELECT COUNT(*) FROM entry_relations WHERE relation_type = 'link'"
+        ).fetchone()
+        assert count is not None and count[0] == 1
+    finally:
+        conn.close()
+
+
+def test_wikilink_backfill_skips_self_reference() -> None:
+    """An entry whose content references its own prefix must not get a self-edge."""
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        entry_id = "55555555-eeee-4eee-eeee-eeeeeeeeeeee"
+        _insert_entry_with_content(conn, entry_id, "I link to myself [[entry-55555555]]")
+
+        inserted = backfill_relations_from_wikilinks(conn)
+        assert inserted == 0
+        rows = conn.execute("SELECT COUNT(*) FROM entry_relations").fetchone()
+        assert rows is not None and rows[0] == 0
+    finally:
+        conn.close()
+
+
+def test_wikilink_backfill_skips_ambiguous_prefix() -> None:
+    """Two entries sharing the same 8-hex prefix produce no edge for either."""
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        # Two distinct UUIDs sharing the same 8-hex prefix '66666666'.
+        tgt_a = "66666666-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
+        tgt_b = "66666666-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
+        src_id = "77777777-cccc-4ccc-cccc-cccccccccccc"
+        _insert_entry_with_content(conn, tgt_a, "a")
+        _insert_entry_with_content(conn, tgt_b, "b")
+        _insert_entry_with_content(conn, src_id, "see [[entry-66666666]]")
+
+        inserted = backfill_relations_from_wikilinks(conn)
+        assert inserted == 0
+        rows = conn.execute(
+            "SELECT to_id FROM entry_relations WHERE from_id = ?",
+            [src_id],
+        ).fetchall()
+        assert rows == []
+    finally:
+        conn.close()
+
+
+def test_wikilink_backfill_skips_unknown_prefix() -> None:
+    """A reference whose prefix matches no existing entry is silently dropped."""
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        src_id = "88888888-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
+        _insert_entry_with_content(conn, src_id, "dangling [[entry-deadbeef]]")
+
+        inserted = backfill_relations_from_wikilinks(conn)
+        assert inserted == 0
+    finally:
+        conn.close()
+
+
+def test_wikilink_backfill_dedupes_repeated_prefix_in_same_content() -> None:
+    """Multiple occurrences of the same prefix in one entry yield a single edge."""
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        src_id = "99999999-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
+        tgt_id = "aaaaaaaa-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
+        _insert_entry_with_content(conn, tgt_id, "target")
+        _insert_entry_with_content(conn, src_id, "[[entry-aaaaaaaa]] and again [[entry-aaaaaaaa]]")
+
+        inserted = backfill_relations_from_wikilinks(conn)
+        assert inserted == 1
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM entry_relations WHERE from_id = ? AND to_id = ?",
+            [src_id, tgt_id],
+        ).fetchone()
+        assert rows is not None and rows[0] == 1
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# reconcile handler integration — mechanism #8 wired into action="reconcile"
+# ---------------------------------------------------------------------------
+
+
+async def test_reconcile_creates_link_from_wikilink_reference(store: DuckDBStore) -> None:
+    """A ``[[entry-<prefix>]]`` in one entry's content links it to the target via reconcile."""
+    tgt_id = await store.store(make_entry(content="target body"))
+    src_id = await store.store(
+        make_entry(content=f"see [[entry-{tgt_id[:8]}]] for the canonical version")
+    )
+
+    result = await _handle_relations(store, {"action": "reconcile"})
+    payload = parse_mcp_response(result)
+    assert payload["action"] == "reconcile"
+    assert payload["wikilink_links"] == 1
+    # Metadata pass contributes nothing because related_entries is unset.
+    assert payload["metadata_links"] == 0
+    assert payload["total"] == 1
+
+    rows = await store.get_related(src_id, direction="outgoing")
+    assert {(r["to_id"], r["relation_type"]) for r in rows} == {(tgt_id, "link")}
+
+
+async def test_reconcile_wikilink_is_idempotent(store: DuckDBStore) -> None:
+    """A second reconcile call after a wikilink has been linked reports zero new edges."""
+    tgt_id = await store.store(make_entry(content="canonical"))
+    src_id = await store.store(make_entry(content=f"ref [[entry-{tgt_id[:8]}]]"))
+
+    first = parse_mcp_response(await _handle_relations(store, {"action": "reconcile"}))
+    second = parse_mcp_response(await _handle_relations(store, {"action": "reconcile"}))
+
+    assert first["wikilink_links"] == 1
+    assert second["wikilink_links"] == 0
+    rows = await store.get_related(src_id, direction="outgoing")
+    assert len(rows) == 1
+
+
+async def test_reconcile_wikilink_self_reference_skipped(store: DuckDBStore) -> None:
+    """An entry referencing its own 8-hex prefix never gets a self-edge."""
+    # First insert with placeholder content so we can derive the prefix.
+    entry_id = await store.store(make_entry(content="placeholder"))
+    await store.update(entry_id, {"content": f"I cite myself [[entry-{entry_id[:8]}]]"})
+
+    payload = parse_mcp_response(await _handle_relations(store, {"action": "reconcile"}))
+    assert payload["wikilink_links"] == 0
+    assert await store.get_related(entry_id, direction="outgoing") == []
+
+
+async def test_reconcile_wikilink_ambiguous_prefix_skipped(store: DuckDBStore) -> None:
+    """Two existing entries sharing the same 8-hex prefix produce no wikilink edge.
+
+    We bypass ``store()`` because it allocates new UUIDs; instead we craft
+    the rows directly via the raw DuckDB connection so the prefix collision
+    is deterministic.
+    """
+    shared_prefix = "ffffeeee"
+    tgt_a = f"{shared_prefix}-1111-4111-9111-111111111111"
+    tgt_b = f"{shared_prefix}-2222-4222-9222-222222222222"
+    src_id = str(uuid.uuid4())
+
+    # Direct inserts so we control the IDs (and therefore the prefix collision).
+    # The local ``store`` fixture uses ControlledEmbeddingProvider (8 dims).
+    embedding = [0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25]
+    store.connection.execute(
+        "INSERT INTO entries (id, content, entry_type, source, author, embedding) "
+        "VALUES (?, 'target a', 'inbox', 'manual', 'tester', ?)",
+        [tgt_a, embedding],
+    )
+    store.connection.execute(
+        "INSERT INTO entries (id, content, entry_type, source, author, embedding) "
+        "VALUES (?, 'target b', 'inbox', 'manual', 'tester', ?)",
+        [tgt_b, embedding],
+    )
+    store.connection.execute(
+        "INSERT INTO entries (id, content, entry_type, source, author, embedding) "
+        "VALUES (?, ?, 'inbox', 'manual', 'tester', ?)",
+        [src_id, f"ambiguous [[entry-{shared_prefix}]]", embedding],
+    )
+
+    payload = parse_mcp_response(await _handle_relations(store, {"action": "reconcile"}))
+    assert payload["wikilink_links"] == 0
+    # Neither candidate gets the edge.
+    rows = await store.get_related(src_id, direction="outgoing")
+    assert rows == []

--- a/tests/test_relations_backfill_on_write.py
+++ b/tests/test_relations_backfill_on_write.py
@@ -564,6 +564,32 @@ def test_wikilink_backfill_dedupes_repeated_prefix_in_same_content() -> None:
         conn.close()
 
 
+def test_wikilink_backfill_matches_uppercase_hex_prefix() -> None:
+    """``[[entry-ABCDEF12]]`` should resolve the same as ``[[entry-abcdef12]]``.
+
+    Entry IDs are stored lowercase, so the captured prefix must be lowercased
+    before the prefix lookup.  Without ``[0-9A-Fa-f]`` in the regex character
+    class, the reference would be silently dropped.
+    """
+    conn = duckdb.connect(":memory:")
+    try:
+        _setup_through_8(conn)
+        src_id = "bbbbbbbb-1111-4111-1111-111111111111"
+        tgt_id = "abcdef12-2222-4222-2222-222222222222"
+        _insert_entry_with_content(conn, tgt_id, "target")
+        # Uppercase hex in the wikilink — must still resolve.
+        _insert_entry_with_content(conn, src_id, "see [[entry-ABCDEF12]] please")
+
+        inserted = backfill_relations_from_wikilinks(conn)
+        assert inserted == 1
+        rows = conn.execute(
+            "SELECT from_id, to_id, relation_type FROM entry_relations"
+        ).fetchall()
+        assert rows == [(src_id, tgt_id, "link")]
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # reconcile handler integration — mechanism #8 wired into action="reconcile"
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `[[entry-<8-hex>]]` wikilink parsing to the `reconcile` action.
- New helper `backfill_relations_from_wikilinks()` in `store/migrations.py` resolves each prefix to a single existing entry, then inserts a `link`-typed row. Self-references, ambiguous prefixes (shared by >= 2 entries), and dangling targets are skipped.
- `distillery_relations action="reconcile"` payload now includes `wikilink_links` alongside `metadata_links`; `total` is their sum.
- Idempotent via the existing `idx_entry_relations_unique` index, so re-runs never duplicate edges.

## Test plan
- [x] `test_wikilink_backfill_links_pair_on_prefix_match` — a `[[entry-<prefix>]]` reference resolves to a `link` row.
- [x] `test_wikilink_backfill_is_idempotent` — second run inserts zero new rows.
- [x] `test_wikilink_backfill_skips_self_reference` — entry referencing its own prefix produces no self-edge.
- [x] `test_wikilink_backfill_skips_ambiguous_prefix` — colliding 8-hex prefixes produce no edge for either candidate.
- [x] `test_wikilink_backfill_skips_unknown_prefix` — references to nonexistent prefixes are silently dropped.
- [x] `test_wikilink_backfill_dedupes_repeated_prefix_in_same_content` — repeated references in a single entry yield one edge.
- [x] `test_reconcile_creates_link_from_wikilink_reference` — end-to-end via the MCP handler.
- [x] `test_reconcile_wikilink_is_idempotent` — re-running reconcile reports zero new wikilink edges.
- [x] `test_reconcile_wikilink_self_reference_skipped` — store fixture, self-edge guard.
- [x] `test_reconcile_wikilink_ambiguous_prefix_skipped` — store fixture, ambiguous-prefix guard.
- [x] `ruff check src/ tests/`, `ruff format --check`, `mypy --strict src/distillery/` all pass.
- [x] Full pytest suite passes locally (2768 passed, 86 skipped).

Part of #496 (mechanism #8). Parent: #490.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline wikilink references (e.g., [[entry-<id>]]) are automatically resolved into relations, creating link edges between entries.
  * Relation reconciliation now reports wikilink-derived links separately from metadata links.

* **Behavioral**
  * Backfill is idempotent, skips self-links, ignores ambiguous or unknown prefixes, and deduplicates repeated references.

* **Tests**
  * Added coverage validating wikilink backfill, reconciliation reporting, and edge-case behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->