### PR TITLE
chore(security): refresh Grype suppressions for upstream Wolfi CVEs

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -34,7 +34,7 @@ ignore:
   # Active suppressions — confirmed against the CI scan of the python-3.14
   # runtime image (SBOM: python-3.14.4-r4 + glibc 2.43-r7, Chainguard
   # distroless `cgr.dev/chainguard/python` base, which is built on Wolfi).
-  # Reviewed: 2026-05-15 (issue #271, suppressions refresh).
+  # Refreshed: 2026-05-15 (issue #271, checking for new CVEs; individual CVE review dates in each entry's reason field).
   # ---------------------------------------------------------------------
 
   - vulnerability: CVE-2026-3298

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -34,7 +34,7 @@ ignore:
   # Active suppressions — confirmed against the CI scan of the python-3.14
   # runtime image (SBOM: python-3.14.4-r4 + glibc 2.43-r7, Chainguard
   # distroless `cgr.dev/chainguard/python` base, which is built on Wolfi).
-  # Reviewed: 2026-05-07 (issue #418, distroless migration #419).
+  # Reviewed: 2026-05-15 (issue #271, suppressions refresh).
   # ---------------------------------------------------------------------
 
   - vulnerability: CVE-2026-3298


### PR DESCRIPTION
## Summary

Refresh `.grype.yaml` suppression header to 2026-05-15 to trigger a fresh CI scan with the current Grype DB. Identifies any new high/critical CVEs published since the last review (2026-05-07) in the Chainguard distroless `python-3.14.4-r4` + `glibc 2.43-r7` base.

This is an iterative PR — if the `Scan (distillery)` check flags new CVEs, suppressions with documented rationale will be added in follow-up commits on this branch.

## CVEs suppressed

Existing suppressions carried forward from the last review (2026-05-07):

| CVE | Package | Version | Rationale |
|-----|---------|---------|-----------|
| CVE-2026-3298 | python-3.14 | 3.14.4-r4 | CPython startup-path issue under specific PYTHONHOME/site-packages overrides — not exploitable in our distroless nonroot container with fixed PYTHONHOME |
| CVE-2026-5435 | glibc | 2.43-r7 | locale/charset boundary handling — container runs C.UTF-8, no user-controlled locale strings reach glibc |

New suppressions will be added once the CI scan reports which additional CVEs are now flagged by the updated Grype DB.

Refs #271

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpEb9PwMWtwDj3DnAFnU31)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability suppression configuration refresh date (Reviewed/Refreshed: 2026-05-15). No suppression entries or criteria were added, removed, or modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/522)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->