### PR TITLE
fix(store): make DuckDB file chmod best-effort

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -225,7 +225,21 @@ class DuckDBStore:
             and not self._is_motherduck_path(self._db_path)
         )
         if is_local and Path(self._db_path).exists():
-            os.chmod(self._db_path, 0o600)
+            # Best-effort: GCS FUSE and some network filesystems do not
+            # support chmod and raise OSError. On those mounts the file
+            # mode is governed by the mount options, not the process, and
+            # access is gated by the storage layer's own ACLs — so a
+            # failed chmod is not a security regression. Block-volume
+            # deployments (e.g. Fly) still get the 0600 lockdown.
+            try:
+                os.chmod(self._db_path, 0o600)
+            except OSError as exc:
+                logger.warning(
+                    "Could not chmod %s to 0600; filesystem may not "
+                    "support it (e.g. GCS FUSE): %s",
+                    self._db_path,
+                    exc,
+                )
 
         return conn
 

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -31,6 +31,24 @@ class TestInitialization:
         await s.initialize()  # should be a no-op
         await s.close()
 
+    async def test_initialize_survives_unsupported_chmod(
+        self, mock_embedding_provider, tmp_path, monkeypatch
+    ) -> None:
+        """A filesystem that rejects chmod (e.g. GCS FUSE) must not abort startup."""
+
+        def _refuse_chmod(*_args, **_kwargs) -> None:
+            raise OSError(1, "Operation not permitted")
+
+        monkeypatch.setattr("os.chmod", _refuse_chmod)
+
+        db_path = tmp_path / "distillery.db"
+        s = DuckDBStore(
+            db_path=str(db_path), embedding_provider=mock_embedding_provider
+        )
+        await s.initialize()
+        assert s.connection is not None
+        await s.close()
+
     async def test_connection_raises_before_initialize(self, mock_embedding_provider) -> None:
         s = DuckDBStore(db_path=":memory:", embedding_provider=mock_embedding_provider)
         with pytest.raises(RuntimeError, match="initialize"):


### PR DESCRIPTION
## Root cause

`DuckDBStore._open_connection()` (`src/distillery/store/duckdb.py:228`) chmods the database file to `0600` after opening it. On **GCS FUSE** — and some network filesystems — `chmod` is unsupported and raises `OSError`, aborting server startup:

```
File ".../distillery/store/duckdb.py", line 228, in _open_connection
    os.chmod(self._db_path, 0o600)
PermissionError: [Errno 1] Operation not permitted: '/data/distillery.db'
ERROR:    Application startup failed. Exiting.
```

Found while bringing up the Cloud Run deployment (`norrietaylor/distill_ops`), which mounts DuckDB on a GCS FUSE volume at `/data`. The container starts, GCS FUSE mounts, then this `chmod` kills startup. No mount-side config fixes it — gcsfuse has no option that makes `chmod` succeed.

## Fix

Wrap the `chmod` in `try/except OSError`, log a warning on failure:

```python
try:
    os.chmod(self._db_path, 0o600)
except OSError as exc:
    logger.warning("Could not chmod %s to 0600; filesystem may not support it ...", ...)
```

Not a security regression: on those mounts the file mode is governed by mount options, not the process, and access is gated by the storage layer's own ACLs (GCS IAM). Block-volume deployments (Fly) still get the `0600` lockdown unchanged — on a filesystem that supports `chmod` the call succeeds exactly as before.

## Test

`test_initialize_survives_unsupported_chmod` — mocks `os.chmod` to raise `OSError` (simulating GCS FUSE) and asserts `initialize()` still completes with a live connection. Fails without the fix.

```
tests/test_duckdb_store.py — 129 passed (full file), incl. the new test
```

## Follow-up

`chmod` is the first gcsfuse incompatibility hit on the Cloud Run path. DuckDB also does file locking and WAL writes; gcsfuse's consistency model is weak. This unblocks the next deploy iteration but may not be the last gcsfuse-related issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)