### PR TITLE
fix(ci): align grype suppressions with current base image

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -32,24 +32,21 @@
 ignore:
   # ---------------------------------------------------------------------
   # Active suppressions — confirmed against the CI scan of the python-3.14
-  # runtime image (SBOM: python-3.14.4-r4 + glibc 2.43-r7, Chainguard
-  # distroless `cgr.dev/chainguard/python` base, which is built on Wolfi).
-  # Reviewed: 2026-05-07 (issue #418, distroless migration #419).
+  # runtime image (SBOM: python-3.14.5-r1, Chainguard distroless
+  # `cgr.dev/chainguard/python` base, which is built on Wolfi).
+  # Reviewed: 2026-05-17 (issue #418).
+  #
+  # Removed 2026-05-17: CVE-2026-3298 (python-3.14) and CVE-2026-5435
+  # (glibc) — neither matches the current scan after the base image
+  # rebuilt from python-3.14.4-r4 to python-3.14.5-r1.
   # ---------------------------------------------------------------------
 
-  - vulnerability: CVE-2026-3298
+  - vulnerability: CVE-2026-7210
     package:
       name: python-3.14
-      version: 3.14.4-r4
+      version: 3.14.5-r1
       type: apk
-    reason: "CPython 3.14.4-r4 — CVSS High; affects the interpreter's startup path under specific PYTHONHOME / site-packages override conditions on multi-user systems.  Not exploitable in our deployment: Distillery runs as the Chainguard distroless 'nonroot' user (uid 65532) inside an immutable distroless container with a fixed PYTHONHOME and no shared-tenant site-packages directory.  No upstream fix released by CPython upstream or Wolfi.  Reviewed: 2026-05-07"
-
-  - vulnerability: CVE-2026-5435
-    package:
-      name: glibc
-      version: 2.43-r7
-      type: apk
-    reason: "glibc 2.43-r7 (Wolfi) — CVSS High; locale/charset boundary handling.  Not exploitable in our deployment: container runs with the C.UTF-8 locale, all I/O is UTF-8 end-to-end (HTTP/JSON, DuckDB, Python source), and no user-controlled locale strings reach glibc.  Sourceware tracking issue open; no fix released yet.  Reviewed: 2026-05-03"
+    reason: "CPython 3.14.5-r1 — CVSS Critical; libexpat hash-flooding: xml.parsers.expat and xml.etree.ElementTree use insufficient entropy for hash-flooding protection, so a crafted XML document can trigger a hash-collision DoS.  Distillery parses feed XML, so this is a real but DoS-only exposure; defusedxml guards XXE / entity expansion but not expat's hash entropy.  No upstream fix available: full mitigation requires libexpat >= 2.8.0 plus a CPython patch, and neither Wolfi nor CPython has released a fixed python-3.14 build.  Grype matched via NVD CPE with no version constraint.  Revisit on the next Chainguard base-image rebuild.  Reviewed: 2026-05-17"
 
 
 # Fail on critical and high severity vulnerabilities.


### PR DESCRIPTION
## Problem

`Supply Chain Security → Scan (distillery)` fails the build. Grype scans the runtime image SBOM with `--fail-on high` and reports one Critical:

```
[Critical] CVE-2026-7210  python-3.14 3.14.5-r1 (apk)  fix: none
```

CVE-2026-7210 — libexpat hash-flooding: `xml.parsers.expat` / `xml.etree.ElementTree` use insufficient entropy for hash-flooding protection; a crafted XML document triggers a hash-collision DoS. It is in the CPython interpreter shipped by the `cgr.dev/chainguard/python` (Wolfi) base image. No fixed `python-3.14` build is published — full mitigation needs libexpat ≥ 2.8.0 plus a CPython patch. Grype matched it via NVD CPE with no version constraint (`fix.state: ""`).

## Change

`.grype.yaml`:

- **Add** a scoped ignore for `CVE-2026-7210` on `python-3.14` / `3.14.5-r1` / `apk`. Reason states it plainly: real but DoS-only exposure (Distillery parses feed XML; `defusedxml` does not cover expat hash entropy), no upstream fix, revisit on the next base-image rebuild.
- **Remove** the stale `CVE-2026-3298` and `CVE-2026-5435` entries. Both were pinned to `python-3.14 3.14.4-r4` / `glibc 2.43-r7`; the base image has since rebuilt to `python-3.14 3.14.5-r1` and neither CVE appears in the current scan at any severity. Per the file's audit policy, dead entries are removed.

Net: `ignore` list stays at one entry. `fail-on-severity: high` unchanged.

## Verification

Current scan (run 26008416119) High/Critical matches: `CVE-2026-7210` only. Other matches (`CVE-2025-15366/15367/12781`, `CVE-2026-8328`, `GHSA-r95x-qfjj-fjj2`) are Medium — below the cutoff, not suppressed.

## Follow-up

CVE-2026-7210 clears when Chainguard ships a patched `cgr.dev/chainguard/python` image and the scan runs against a rebuild. Because the match is CPE-based, it may persist until NVD adds a version range or Chainguard publishes a Wolfi advisory with a fixed version. The ignore entry should be re-audited then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
