### PR TITLE
feat(mcp): opt-in pre-shared machine-token auth for /mcp

### DIFF
--- a/src/distillery/mcp/auth.py
+++ b/src/distillery/mcp/auth.py
@@ -19,12 +19,14 @@ Includes a workaround for FastMCP CIMD localhost redirect validation
 from __future__ import annotations
 
 import fnmatch
+import hmac
 import logging
 import os
 from typing import Any
 from urllib.parse import urlparse
 
 import httpx
+from fastmcp.server.auth import AccessToken
 from fastmcp.server.auth.providers.github import GitHubProvider
 
 from distillery.config import DistilleryConfig, parse_env_allowed_orgs
@@ -34,7 +36,77 @@ from distillery.mcp.types import AuditCallback
 logger = logging.getLogger(__name__)
 
 
-class OrgRestrictedGitHubProvider(GitHubProvider):
+# Environment variables for the optional pre-shared machine-token auth path.
+# DISTILLERY_MCP_MACHINE_TOKEN holds the token; DISTILLERY_MCP_MACHINE_IDENTITY
+# is the GitHub-style login attributed to calls made with it (authorship and
+# audit). The feature is off unless the token variable is set.
+_MACHINE_TOKEN_ENV = "DISTILLERY_MCP_MACHINE_TOKEN"
+_MACHINE_IDENTITY_ENV = "DISTILLERY_MCP_MACHINE_IDENTITY"
+_DEFAULT_MACHINE_IDENTITY = "distillery-machine"
+
+
+def _load_machine_tokens() -> list[tuple[str, AccessToken]]:
+    """Load the optional pre-shared machine token from the environment.
+
+    Returns an empty list when ``DISTILLERY_MCP_MACHINE_TOKEN`` is unset — the
+    machine-token path is opt-in and off by default, so existing deployments
+    are unaffected.
+
+    The token authenticates non-interactive MCP clients (CI workflows) that
+    cannot complete the browser-based GitHub OAuth flow. Calls made with it are
+    attributed to ``DISTILLERY_MCP_MACHINE_IDENTITY`` via the ``login`` claim —
+    the same claim a GitHub OAuth user carries — so authorship and audit keep
+    working unchanged.
+    """
+    raw = os.environ.get(_MACHINE_TOKEN_ENV, "").strip()
+    if not raw:
+        return []
+    identity = os.environ.get(_MACHINE_IDENTITY_ENV, "").strip() or _DEFAULT_MACHINE_IDENTITY
+    access = AccessToken(
+        token=raw,
+        client_id=identity,
+        scopes=["machine"],
+        expires_at=None,
+        claims={"login": identity, "machine": True},
+    )
+    logger.info("Machine-token MCP auth enabled (identity=%r)", identity)
+    return [(raw, access)]
+
+
+class _MachineTokenGitHubProvider(GitHubProvider):
+    """``GitHubProvider`` that also accepts pre-shared machine tokens.
+
+    Interactive clients authenticate through the GitHub OAuth flow and present
+    a FastMCP-issued JWT, which the ``OAuthProxy`` base verifies. Non-interactive
+    clients — CI workflows that cannot run the browser OAuth flow — present a
+    static pre-shared token instead.
+
+    :meth:`verify_token` checks the configured machine tokens first, with a
+    constant-time comparison, and falls through to the OAuth-proxy verification
+    otherwise. A machine token is its own credential: possession authorises the
+    call, so it does not pass through the GitHub OAuth flow or the
+    org-membership gate.
+    """
+
+    def __init__(
+        self,
+        *,
+        machine_tokens: list[tuple[str, AccessToken]] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._machine_tokens: list[tuple[str, AccessToken]] = machine_tokens or []
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Verify a bearer token: machine tokens first, then the OAuth proxy."""
+        for candidate, access in self._machine_tokens:
+            if hmac.compare_digest(token.encode(), candidate.encode()):
+                logger.debug("Authenticated machine token (identity=%s)", access.client_id)
+                return access
+        return await super().verify_token(token)
+
+
+class OrgRestrictedGitHubProvider(_MachineTokenGitHubProvider):
     """GitHubProvider subclass that captures user tokens for org membership checks.
 
     Overrides :meth:`_extract_upstream_claims` to:
@@ -43,6 +115,10 @@ class OrgRestrictedGitHubProvider(GitHubProvider):
        can identify the user without an extra API call.
     3. Call :meth:`OrgMembershipChecker.store_user_token` so private-org
        membership checks can use the user's own OAuth token.
+
+    Inherits the pre-shared machine-token path from
+    :class:`_MachineTokenGitHubProvider`; machine tokens skip the OAuth flow and
+    the org-membership gate by design.
     """
 
     def __init__(
@@ -53,11 +129,13 @@ class OrgRestrictedGitHubProvider(GitHubProvider):
         client_secret: str,
         base_url: str,
         audit_callback: AuditCallback | None = None,
+        machine_tokens: list[tuple[str, AccessToken]] | None = None,
     ) -> None:
         super().__init__(
             client_id=client_id,
             client_secret=client_secret,
             base_url=base_url,
+            machine_tokens=machine_tokens,
         )
         self._org_checker = org_checker
         self._audit_callback = audit_callback
@@ -384,6 +462,8 @@ def build_github_auth(
         base_url,
     )
 
+    machine_tokens = _load_machine_tokens()
+
     if org_checker is not None:
         return OrgRestrictedGitHubProvider(
             org_checker=org_checker,
@@ -391,12 +471,14 @@ def build_github_auth(
             client_secret=client_secret,
             base_url=base_url,
             audit_callback=audit_callback,
+            machine_tokens=machine_tokens,
         )
 
-    return GitHubProvider(
+    return _MachineTokenGitHubProvider(
         client_id=client_id,
         client_secret=client_secret,
         base_url=base_url,
+        machine_tokens=machine_tokens,
     )
 
 

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -157,8 +157,16 @@ class TestBuildGithubAuthWithOrgChecker:
 
         assert isinstance(provider, OrgRestrictedGitHubProvider)
 
-    def test_returns_plain_provider_when_no_checker(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """build_github_auth() returns plain GitHubProvider when org_checker is None."""
+    def test_returns_non_org_restricted_provider_when_no_checker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """build_github_auth() returns a non-org-restricted GitHubProvider when
+        org_checker is None.
+
+        The provider is a GitHubProvider (so OAuth works) but not an
+        OrgRestrictedGitHubProvider. It is a _MachineTokenGitHubProvider so the
+        pre-shared machine-token path is available even without org gating.
+        """
         monkeypatch.setenv("GITHUB_CLIENT_ID", "test-id")
         monkeypatch.setenv("GITHUB_CLIENT_SECRET", "test-secret")
         monkeypatch.setenv("DISTILLERY_BASE_URL", "https://example.com")
@@ -168,7 +176,8 @@ class TestBuildGithubAuthWithOrgChecker:
 
         from fastmcp.server.auth.providers.github import GitHubProvider
 
-        assert type(provider) is GitHubProvider
+        assert isinstance(provider, GitHubProvider)
+        assert not isinstance(provider, OrgRestrictedGitHubProvider)
 
 
 class TestBuildOrgCheckerIntegration:
@@ -345,3 +354,103 @@ class TestAuthAuditEvents:
         provider = self._make_provider(audit_cb=None)
         result = await provider._extract_upstream_claims({})
         assert result is None  # no crash
+
+
+# ---------------------------------------------------------------------------
+# Tests: pre-shared machine-token auth
+# ---------------------------------------------------------------------------
+
+
+class TestMachineTokenAuth:
+    """The opt-in pre-shared machine-token MCP auth path."""
+
+    def test_load_machine_tokens_unset_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No DISTILLERY_MCP_MACHINE_TOKEN -> feature off, empty list."""
+        from distillery.mcp.auth import _load_machine_tokens
+
+        monkeypatch.delenv("DISTILLERY_MCP_MACHINE_TOKEN", raising=False)
+        assert _load_machine_tokens() == []
+
+    def test_load_machine_tokens_builds_access_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A configured token yields an AccessToken with the login claim."""
+        from distillery.mcp.auth import _load_machine_tokens
+
+        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_TOKEN", "tok-secret-123")
+        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_IDENTITY", "spectacles-bot")
+
+        loaded = _load_machine_tokens()
+        assert len(loaded) == 1
+        raw, access = loaded[0]
+        assert raw == "tok-secret-123"
+        assert access.client_id == "spectacles-bot"
+        assert access.claims["login"] == "spectacles-bot"
+
+    def test_load_machine_tokens_default_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Identity defaults when DISTILLERY_MCP_MACHINE_IDENTITY is unset."""
+        from distillery.mcp.auth import _load_machine_tokens
+
+        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_TOKEN", "tok-x")
+        monkeypatch.delenv("DISTILLERY_MCP_MACHINE_IDENTITY", raising=False)
+
+        _, access = _load_machine_tokens()[0]
+        assert access.client_id == "distillery-machine"
+
+    async def test_verify_token_accepts_configured_machine_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A request bearing the machine token resolves to its identity."""
+        monkeypatch.setenv("GITHUB_CLIENT_ID", "id")
+        monkeypatch.setenv("GITHUB_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("DISTILLERY_BASE_URL", "https://distillery.example.com")
+        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_TOKEN", "machine-tok-abc")
+        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_IDENTITY", "ci-bot")
+
+        provider = build_github_auth(_make_config())
+        access = await provider.verify_token("machine-tok-abc")
+
+        assert access is not None
+        assert access.claims["login"] == "ci-bot"
+
+    async def test_verify_token_unknown_falls_through_to_oauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-machine token is delegated to the OAuth-proxy verifier."""
+        monkeypatch.setenv("GITHUB_CLIENT_ID", "id")
+        monkeypatch.setenv("GITHUB_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("DISTILLERY_BASE_URL", "https://distillery.example.com")
+        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_TOKEN", "machine-tok-abc")
+
+        from fastmcp.server.auth.providers.github import GitHubProvider
+
+        oauth_verify = AsyncMock(return_value=None)
+        monkeypatch.setattr(GitHubProvider, "verify_token", oauth_verify)
+
+        provider = build_github_auth(_make_config())
+        result = await provider.verify_token("not-a-machine-token")
+
+        assert result is None
+        oauth_verify.assert_awaited_once_with("not-a-machine-token")
+
+    async def test_verify_token_off_by_default_delegates_to_oauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With the feature off, every token goes to the OAuth proxy."""
+        monkeypatch.setenv("GITHUB_CLIENT_ID", "id")
+        monkeypatch.setenv("GITHUB_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("DISTILLERY_BASE_URL", "https://distillery.example.com")
+        monkeypatch.delenv("DISTILLERY_MCP_MACHINE_TOKEN", raising=False)
+
+        from fastmcp.server.auth.providers.github import GitHubProvider
+
+        oauth_verify = AsyncMock(return_value=None)
+        monkeypatch.setattr(GitHubProvider, "verify_token", oauth_verify)
+
+        provider = build_github_auth(_make_config())
+        await provider.verify_token("anything")
+        oauth_verify.assert_awaited_once_with("anything")


### PR DESCRIPTION
## Problem

distillery's `/mcp` endpoint authenticates via FastMCP's `GitHubProvider`, an **OAuth proxy**. FastMCP 3.x `OAuthProxy.verify_token` requires every `/mcp` request to carry a **FastMCP-issued JWT** obtained through the interactive browser OAuth flow (DCR → `/authorize` → callback → token exchange):

```
1. Verify FastMCP JWT signature (proves it's our token)
2. Look up upstream token via JTI mapping
...
```

A raw GitHub token, PAT, or any other static bearer is rejected — verified empirically (`POST /mcp` with a valid GitHub token → `401 invalid_token`).

This blocks **non-interactive MCP clients**: CI / GitHub Actions agentic workflows (e.g. the `spectacles` `gh-aw` suite — `distillery-sync`, `mcp-smoke`, the `sdd-*` agents) attach over HTTP with a static `Authorization: Bearer` header. They cannot run a browser OAuth flow, so they cannot reach the MCP tools at all.

## Change

An **opt-in pre-shared machine token**, off by default.

`_MachineTokenGitHubProvider` overrides `verify_token()` to check a configured static token (constant-time `hmac.compare_digest`) before delegating to the OAuth-proxy path:

```python
async def verify_token(self, token):
    for candidate, access in self._machine_tokens:
        if hmac.compare_digest(token.encode(), candidate.encode()):
            return access
    return await super().verify_token(token)
```

A machine token is its own credential — possession authorises the call — so it deliberately **skips the OAuth flow and the org-membership gate**. Calls made with it carry a `login` claim, so `_get_authenticated_user`, authorship, and audit are unchanged.

`OrgRestrictedGitHubProvider` now extends `_MachineTokenGitHubProvider`, and both `build_github_auth` branches return that subclass — the machine-token path works with or without org gating.

## Configuration

Two env vars; feature is off unless the token is set:

| Env var | Purpose |
|---|---|
| `DISTILLERY_MCP_MACHINE_TOKEN` | The pre-shared bearer token. Unset → feature off, behaviour identical to before. |
| `DISTILLERY_MCP_MACHINE_IDENTITY` | GitHub-style `login` attributed to the token's calls. Default `distillery-machine`. |

Interactive GitHub OAuth is untouched.

## Tests

`tests/test_mcp_auth.py` — `TestMachineTokenAuth` (6 new tests): loader off-by-default, `AccessToken` construction + claims, default identity, `verify_token` accepts the machine token, unknown tokens fall through to the OAuth proxy, feature-off delegates everything. One existing test updated — the no-org-checker provider is now a `_MachineTokenGitHubProvider` subclass, so its assertion checks intent (not org-restricted) rather than exact type.

```
tests/test_mcp_auth.py tests/test_mcp_org_membership.py tests/test_real_author.py
→ 79 passed
```
`ruff check` clean.

## Follow-up

`docs/getting-started/mcp-setup.md` should document the two env vars — left out to keep this PR to code + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pre-shared token authentication support as an alternative to the OAuth flow when configured.

* **Tests**
  * Added comprehensive test coverage for machine-token authentication scenarios, including token verification and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->