### PR TITLE
fix(mcp): give the machine token the user scope

### DIFF
--- a/src/distillery/mcp/auth.py
+++ b/src/distillery/mcp/auth.py
@@ -57,6 +57,12 @@ def _load_machine_tokens() -> list[tuple[str, AccessToken]]:
     attributed to ``DISTILLERY_MCP_MACHINE_IDENTITY`` via the ``login`` claim —
     the same claim a GitHub OAuth user carries — so authorship and audit keep
     working unchanged.
+
+    The access token carries the ``user`` scope: distillery's GitHub OAuth
+    requests that scope, and FastMCP's auth layer enforces it on every verified
+    token. A machine token without it is authenticated but then rejected with
+    ``403 insufficient_scope`` — so it must present the same scope an
+    interactive GitHub OAuth user would.
     """
     raw = os.environ.get(_MACHINE_TOKEN_ENV, "").strip()
     if not raw:
@@ -65,7 +71,7 @@ def _load_machine_tokens() -> list[tuple[str, AccessToken]]:
     access = AccessToken(
         token=raw,
         client_id=identity,
-        scopes=["machine"],
+        scopes=["user"],
         expires_at=None,
         claims={"login": identity, "machine": True},
     )

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -388,6 +388,9 @@ class TestMachineTokenAuth:
         assert raw == "tok-secret-123"
         assert access.client_id == "spectacles-bot"
         assert access.claims["login"] == "spectacles-bot"
+        # Must carry the `user` scope or FastMCP's auth layer rejects the
+        # otherwise-authenticated token with 403 insufficient_scope.
+        assert "user" in access.scopes
 
     def test_load_machine_tokens_default_identity(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Problem

Follow-up to #530. The machine-token `AccessToken` was built with `scopes=["machine"]`. distillery's GitHub OAuth requests the `user` scope, and FastMCP's auth layer enforces it on every verified token. A machine token without `user` authenticates (`verify_token` matches it) but is then rejected with `403 insufficient_scope`.

Confirmed end-to-end against the deployed `norrie-testing` Cloud Run service:

```
POST /mcp   Authorization: Bearer <machine token>
→ 403 {"error": "insufficient_scope", "error_description": "Required scope: user"}
```

(A bogus token correctly gets `401 invalid_token` — the machine token is recognised; only the scope check fails.)

So #530 as merged does not actually work end-to-end.

## Fix

Build the machine token's `AccessToken` with `scopes=["user"]` — the same scope an interactive GitHub OAuth user carries. One line; the machine marker stays in `claims` (`{"machine": True}`).

```diff
-        scopes=["machine"],
+        scopes=["user"],
```

## Test

`test_load_machine_tokens_builds_access_token` now also asserts `"user" in access.scopes`.

```
tests/test_mcp_auth.py -k MachineToken → 6 passed
```
`ruff check` clean.

## References

Follows #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
