### PR TITLE
fix(mcp): exempt machine tokens from the org-membership gate

### DIFF
--- a/src/distillery/mcp/auth.py
+++ b/src/distillery/mcp/auth.py
@@ -45,6 +45,18 @@ _MACHINE_IDENTITY_ENV = "DISTILLERY_MCP_MACHINE_IDENTITY"
 _DEFAULT_MACHINE_IDENTITY = "distillery-machine"
 
 
+def load_machine_token_values() -> list[str]:
+    """Return the configured pre-shared machine token(s), or ``[]`` when unset.
+
+    Single source of truth for reading ``DISTILLERY_MCP_MACHINE_TOKEN``. Both
+    the auth verifier (:func:`_load_machine_tokens`) and ``OrgMembershipMiddleware``
+    use it — the middleware to recognise machine-token requests and exempt them
+    from the org-membership gate.
+    """
+    raw = os.environ.get(_MACHINE_TOKEN_ENV, "").strip()
+    return [raw] if raw else []
+
+
 def _load_machine_tokens() -> list[tuple[str, AccessToken]]:
     """Load the optional pre-shared machine token from the environment.
 
@@ -64,9 +76,10 @@ def _load_machine_tokens() -> list[tuple[str, AccessToken]]:
     ``403 insufficient_scope`` — so it must present the same scope an
     interactive GitHub OAuth user would.
     """
-    raw = os.environ.get(_MACHINE_TOKEN_ENV, "").strip()
-    if not raw:
+    values = load_machine_token_values()
+    if not values:
         return []
+    raw = values[0]
     identity = os.environ.get(_MACHINE_IDENTITY_ENV, "").strip() or _DEFAULT_MACHINE_IDENTITY
     access = AccessToken(
         token=raw,

--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -11,6 +11,7 @@ when ``--transport http`` is selected.
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import time
@@ -409,6 +410,11 @@ class OrgMembershipMiddleware:
         self.app = app
         self.checker = checker
         self._audit_callback = audit_callback
+        # Pre-shared machine tokens are exempt from the org gate (see __call__).
+        # Loaded once at construction from DISTILLERY_MCP_MACHINE_TOKEN.
+        from distillery.mcp.auth import load_machine_token_values
+
+        self._machine_tokens: list[str] = load_machine_token_values()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or not self.checker.enabled:
@@ -428,6 +434,17 @@ class OrgMembershipMiddleware:
             return
 
         bearer_token = auth[7:]
+
+        # Machine tokens (DISTILLERY_MCP_MACHINE_TOKEN) are pre-shared
+        # credentials for non-interactive clients — CI / agentic workflows
+        # that cannot complete the GitHub OAuth flow. They are not GitHub
+        # identities and carry no org membership: possession of the token is
+        # the authorization. Pass them through — the org gate applies only to
+        # interactive GitHub OAuth users. Constant-time compare on a secret.
+        for machine_token in self._machine_tokens:
+            if hmac.compare_digest(bearer_token.encode(), machine_token.encode()):
+                await self.app(scope, receive, send)
+                return
 
         # Attempt to decode the JWT to get the GitHub login claim.
         # FastMCP 3.x may include GitHub identity claims in the JWT payload.

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -489,6 +489,34 @@ class TestOrgMembershipMiddleware:
         assert cap.status == 200
         checker.is_allowed.assert_not_awaited()
 
+    async def test_machine_token_bypasses_org_check(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pre-shared machine token is exempt from the org gate."""
+        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_TOKEN", "machine-tok-xyz")
+        checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)
+        mw = OrgMembershipMiddleware(_dummy_app, checker)
+
+        scope = _make_scope(headers=[(b"authorization", b"Bearer machine-tok-xyz")])
+        cap = _ResponseCapture()
+        await mw(scope, _noop_receive, cap)
+        assert cap.status == 200
+        checker.is_allowed.assert_not_awaited()
+
+    async def test_non_machine_bearer_still_org_checked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With a machine token configured, a different bearer is still gated."""
+        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_TOKEN", "machine-tok-xyz")
+        checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)
+        mw = OrgMembershipMiddleware(_dummy_app, checker)
+
+        token = _make_jwt({"login": "baduser"})
+        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        cap = _ResponseCapture()
+        await mw(scope, _noop_receive, cap)
+        assert cap.status == 403
+
     async def test_oauth_path_bypasses_check(self) -> None:
         """OAuth paths should always pass through regardless of auth."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)


### PR DESCRIPTION
## Problem

`OrgMembershipMiddleware` decodes the bearer token as a JWT to read the `login` claim, then checks GitHub org membership. A pre-shared **machine token** (`DISTILLERY_MCP_MACHINE_TOKEN`, #530) is a random string, not a JWT — the decode yields nothing and the middleware **fails closed**:

```
403 {"error": "forbidden", "message": "User '<unknown>' is not a member of any required GitHub org..."}
```

So with `DISTILLERY_ALLOWED_ORGS` set, machine-token clients (CI / agentic workflows) are locked out. Confirmed end-to-end on the GCP deployment: machine token → `200` without the org gate, `403` with it.

#530 stated machine tokens bypass the org gate "by design" — but it only bypassed the OAuth path in `verify_token`, never this ASGI middleware.

## Fix

`OrgMembershipMiddleware` loads the configured machine token(s) at construction and passes a matching bearer straight through — constant-time compare, before the JWT decode. A machine token is its own credential: possession authorises the call. The org gate applies only to interactive GitHub OAuth users.

- `auth.py` — the `DISTILLERY_MCP_MACHINE_TOKEN` read is factored into `load_machine_token_values()`, shared by the auth verifier and the middleware (one source of truth).
- `middleware.py` — `OrgMembershipMiddleware.__init__` loads the machine tokens; `__call__` exempts a matching bearer.

## Tests

`tests/test_middleware.py`:
- `test_machine_token_bypasses_org_check` — a machine-token bearer → `200`, `is_allowed` not awaited.
- `test_non_machine_bearer_still_org_checked` — with a machine token configured, a non-member JWT bearer is still `403`.

```
tests/test_middleware.py tests/test_mcp_auth.py → 76 passed
```
`ruff check` clean.

## References

Follows #530, #531. Required before `DISTILLERY_ALLOWED_ORGS` can be set on a deployment that also serves machine-token clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
