### PR TITLE
fix(mcp): resolve org-check identity from the verified access token

### DIFF
--- a/src/distillery/mcp/__main__.py
+++ b/src/distillery/mcp/__main__.py
@@ -202,6 +202,7 @@ def main(argv: list[str] | None = None) -> int:
                 trust_proxy=rl.trust_proxy,
                 loopback_exempt=rl.loopback_exempt,
                 org_checker=org_checker,
+                token_verifier=auth.verify_token if auth is not None else None,
                 audit_callback=_auth_audit_cb,
             )
 

--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -11,13 +11,12 @@ when ``--transport http`` is selected.
 
 from __future__ import annotations
 
-import hmac
 import json
 import logging
 import time
 import uuid
 from collections import deque
-from collections.abc import MutableMapping
+from collections.abc import Awaitable, Callable, MutableMapping
 from typing import TYPE_CHECKING, Any
 
 from starlette.datastructures import Headers
@@ -379,19 +378,29 @@ class OrgMembershipMiddleware:
     an ``Authorization: Bearer`` header are also passed through — FastMCP
     will reject them with 401 anyway.
 
-    For requests bearing a JWT access token, the middleware decodes the JWT
-    payload (without re-verifying the signature — FastMCP already did that)
-    to extract the ``login`` claim and then calls
-    :meth:`~distillery.mcp.org_membership.OrgMembershipChecker.is_allowed`.
-    Non-members receive a JSON 403 response with a clear error message.
+    For requests bearing an ``Authorization: Bearer`` token, the middleware
+    resolves the caller's identity through *token_verifier* — the auth
+    provider's ``verify_token`` — and reads the ``login`` claim from the
+    verified :class:`AccessToken`. It cannot decode the raw bearer itself:
+    a FastMCP OAuth-proxy access token is a reference token and carries no
+    ``login`` claim; only ``verify_token`` resolves it to the upstream
+    GitHub identity (the same data tool handlers read via
+    ``get_access_token()``). The middleware then calls
+    :meth:`~distillery.mcp.org_membership.OrgMembershipChecker.is_allowed`;
+    non-members receive a JSON 403.
 
-    If the token is not a JWT (e.g. an opaque token) or the JWT does not
-    contain a ``login``/``sub`` claim, the middleware rejects the request
-    with a 403 (fail-closed) rather than passing it through unenforced.
+    A token carrying the ``machine`` claim (a pre-shared machine token) is
+    passed through — possession of the token is the authorization, and the
+    org gate applies only to interactive GitHub OAuth users. A token that
+    ``verify_token`` rejects is passed through so FastMCP's own auth issues
+    the 401. A verified token with no ``login``/``sub`` claim fails closed.
 
     Args:
         app: The wrapped ASGI application.
         checker: Configured :class:`~distillery.mcp.org_membership.OrgMembershipChecker`.
+        token_verifier: The auth provider's ``verify_token`` coroutine.
+            Required whenever *checker* is enabled.
+        audit_callback: Optional async audit-log callback.
     """
 
     # Paths that handle the OAuth dance — never block these.
@@ -405,16 +414,17 @@ class OrgMembershipMiddleware:
         self,
         app: ASGIApp,
         checker: OrgMembershipChecker,
+        token_verifier: Callable[[str], Awaitable[Any]] | None = None,
         audit_callback: AuditCallback | None = None,
     ) -> None:
         self.app = app
         self.checker = checker
+        # The auth provider's verify_token: resolves a raw bearer to the
+        # verified AccessToken whose claims carry the GitHub `login` (and
+        # `machine` for pre-shared machine tokens). Required whenever the
+        # checker is enabled — see __call__.
+        self._token_verifier = token_verifier
         self._audit_callback = audit_callback
-        # Pre-shared machine tokens are exempt from the org gate (see __call__).
-        # Loaded once at construction from DISTILLERY_MCP_MACHINE_TOKEN.
-        from distillery.mcp.auth import load_machine_token_values
-
-        self._machine_tokens: list[str] = load_machine_token_values()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or not self.checker.enabled:
@@ -435,37 +445,49 @@ class OrgMembershipMiddleware:
 
         bearer_token = auth[7:]
 
-        # Machine tokens (DISTILLERY_MCP_MACHINE_TOKEN) are pre-shared
-        # credentials for non-interactive clients — CI / agentic workflows
-        # that cannot complete the GitHub OAuth flow. They are not GitHub
-        # identities and carry no org membership: possession of the token is
-        # the authorization. Pass them through — the org gate applies only to
-        # interactive GitHub OAuth users. Constant-time compare on a secret.
-        for machine_token in self._machine_tokens:
-            if hmac.compare_digest(bearer_token.encode(), machine_token.encode()):
-                await self.app(scope, receive, send)
-                return
+        # Resolve the caller from the *verified* access token. The raw bearer
+        # is a FastMCP OAuth-proxy reference token and carries no `login`
+        # claim of its own; verify_token() performs the jti -> upstream
+        # lookup and returns an AccessToken whose claims include `login`
+        # (and `machine` for pre-shared machine tokens) — the same data tool
+        # handlers read via get_access_token().
+        if self._token_verifier is None:
+            # Misconfiguration: an enabled checker with no verifier wired.
+            # Fail closed rather than admit every request unchecked.
+            logger.error("OrgMembershipMiddleware enabled but no token_verifier wired")
+            await self._audit_org_denied("<unknown>")
+            await self._send_403(send, "<unknown>", list(self.checker.allowed_orgs))
+            return
 
-        # Attempt to decode the JWT to get the GitHub login claim.
-        # FastMCP 3.x may include GitHub identity claims in the JWT payload.
-        from distillery.mcp.org_membership import _try_decode_jwt_claims
+        access = await self._token_verifier(bearer_token)
+        if access is None:
+            # Invalid/unrecognised token — let FastMCP's own auth reject it
+            # with 401. The org gate decides membership, not token validity.
+            await self.app(scope, receive, send)
+            return
 
-        claims = _try_decode_jwt_claims(bearer_token)
-        if claims:
-            raw = claims.get("login") or claims.get("sub") or ""
-            username = raw.strip() if isinstance(raw, str) else ""
-            if username:
-                if not await self.checker.is_allowed(username):
-                    await self._audit_org_denied(username)
-                    await self._send_403(send, username, list(self.checker.allowed_orgs))
-                    return
-                await self.app(scope, receive, send)
-                return
+        claims = getattr(access, "claims", None) or {}
+        # Machine tokens are pre-shared credentials for non-interactive
+        # clients (CI / agentic workflows); possession of the token is the
+        # authorization. The org gate applies only to interactive GitHub
+        # OAuth users.
+        if claims.get("machine"):
+            await self.app(scope, receive, send)
+            return
 
-        # Cannot identify the user (opaque token or JWT without
-        # login/sub claim) — fail closed.
-        await self._audit_org_denied("<unknown>")
-        await self._send_403(send, "<unknown>", list(self.checker.allowed_orgs))
+        raw = claims.get("login") or claims.get("sub") or ""
+        username = raw.strip() if isinstance(raw, str) else ""
+        if not username:
+            # Verified token with no GitHub identity claim — fail closed.
+            await self._audit_org_denied("<unknown>")
+            await self._send_403(send, "<unknown>", list(self.checker.allowed_orgs))
+            return
+
+        if not await self.checker.is_allowed(username):
+            await self._audit_org_denied(username)
+            await self._send_403(send, username, list(self.checker.allowed_orgs))
+            return
+        await self.app(scope, receive, send)
 
     async def _audit_org_denied(self, username: str) -> None:
         """Fire the audit callback when a user is denied by org membership check.
@@ -523,6 +545,7 @@ def apply_http_middleware(
     trust_proxy: bool = False,
     loopback_exempt: bool = True,
     org_checker: OrgMembershipChecker | None = None,
+    token_verifier: Callable[[str], Awaitable[Any]] | None = None,
     audit_callback: AuditCallback | None = None,
 ) -> ASGIApp:
     """Wrap *app* with rate-limit, body-size, request-ID, and org-membership middleware.
@@ -546,6 +569,9 @@ def apply_http_middleware(
         org_checker: Optional org membership checker.  When provided and
             :attr:`~distillery.mcp.org_membership.OrgMembershipChecker.enabled`
             is ``True``, :class:`OrgMembershipMiddleware` is added.
+        token_verifier: The auth provider's ``verify_token`` coroutine, used
+            by :class:`OrgMembershipMiddleware` to resolve the verified
+            caller identity.  Required when *org_checker* is enabled.
         audit_callback: Optional async callback for writing audit log entries
             when org membership checks deny access.  Signature:
             ``(user_id, operation, entry_id, action, outcome) -> Awaitable[None]``.
@@ -555,7 +581,9 @@ def apply_http_middleware(
     """
     app = BodySizeLimitMiddleware(app, max_bytes=max_body_bytes)
     if org_checker is not None and org_checker.enabled:
-        app = OrgMembershipMiddleware(app, org_checker, audit_callback=audit_callback)
+        app = OrgMembershipMiddleware(
+            app, org_checker, token_verifier=token_verifier, audit_callback=audit_callback
+        )
     app = RateLimitMiddleware(
         app,
         requests_per_minute=requests_per_minute,

--- a/src/distillery/mcp/middleware.py
+++ b/src/distillery/mcp/middleware.py
@@ -436,6 +436,17 @@ class OrgMembershipMiddleware:
             await self.app(scope, receive, send)
             return
 
+        # Misconfiguration: the checker is enabled but no verifier was wired.
+        # Fail closed for *every* request — including ones with no
+        # Authorization header — rather than admit any request unchecked.
+        # Checked before the header inspection so the no-bearer passthrough
+        # below cannot leak requests past a broken gate.
+        if self._token_verifier is None:
+            logger.error("OrgMembershipMiddleware enabled but no token_verifier wired")
+            await self._audit_org_denied("<unknown>")
+            await self._send_403(send, "<unknown>", list(self.checker.allowed_orgs))
+            return
+
         headers = Headers(scope=scope)
         auth = headers.get("authorization", "")
         if not auth.lower().startswith("bearer "):
@@ -451,14 +462,6 @@ class OrgMembershipMiddleware:
         # lookup and returns an AccessToken whose claims include `login`
         # (and `machine` for pre-shared machine tokens) — the same data tool
         # handlers read via get_access_token().
-        if self._token_verifier is None:
-            # Misconfiguration: an enabled checker with no verifier wired.
-            # Fail closed rather than admit every request unchecked.
-            logger.error("OrgMembershipMiddleware enabled but no token_verifier wired")
-            await self._audit_org_denied("<unknown>")
-            await self._send_403(send, "<unknown>", list(self.checker.allowed_orgs))
-            return
-
         access = await self._token_verifier(bearer_token)
         if access is None:
             # Invalid/unrecognised token — let FastMCP's own auth reject it

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -490,7 +490,9 @@ class TestOrgMembershipMiddleware:
     async def test_missing_auth_header_passes_through(self) -> None:
         """No auth header -> pass through to app (FastMCP will 401)."""
         checker = self._make_checker(allowed_orgs=["myorg"])
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
+        mw = OrgMembershipMiddleware(
+            _dummy_app, checker, token_verifier=_verifier(_make_access({"login": "x"}))
+        )
 
         cap = _ResponseCapture()
         await mw(_make_scope(), _noop_receive, cap)
@@ -500,7 +502,9 @@ class TestOrgMembershipMiddleware:
     async def test_non_bearer_auth_passes_through(self) -> None:
         """Auth header without Bearer prefix -> pass through."""
         checker = self._make_checker(allowed_orgs=["myorg"])
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
+        mw = OrgMembershipMiddleware(
+            _dummy_app, checker, token_verifier=_verifier(_make_access({"login": "x"}))
+        )
 
         scope = _make_scope(headers=[(b"authorization", b"Basic dXNlcjpwYXNz")])
         cap = _ResponseCapture()
@@ -594,13 +598,18 @@ class TestOrgMembershipMiddleware:
         assert "<unknown>" in cap.json["message"]
 
     async def test_missing_token_verifier_fails_closed(self) -> None:
-        """An enabled checker with no token_verifier wired -> 403 fail-closed."""
+        """Enabled checker, no token_verifier wired -> 403 fail-closed.
+
+        Uses a request with no Authorization header: the guard must fire
+        before the no-bearer passthrough, so a misconfigured gate cannot
+        leak unauthenticated requests.
+        """
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
         mw = OrgMembershipMiddleware(_dummy_app, checker)  # no token_verifier
-        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
-        await mw(scope, _noop_receive, cap)
+        await mw(_make_scope(), _noop_receive, cap)
         assert cap.status == 403
+        checker.is_allowed.assert_not_awaited()
 
     async def test_sub_claim_used_when_no_login(self) -> None:
         """A verified token with `sub` (no `login`) uses sub as the username."""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import base64
 import json
 import time
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -428,6 +429,20 @@ class TestBodySizeLimitMiddleware:
 # ===================================================================
 
 
+def _make_access(claims: dict[str, Any]) -> Any:
+    """Stand-in for a verified AccessToken carrying the given claims."""
+    return SimpleNamespace(claims=claims)
+
+
+def _verifier(result: Any) -> Any:
+    """An async token_verifier (provider.verify_token stand-in) returning result."""
+
+    async def _verify(_token: str) -> Any:
+        return result
+
+    return _verify
+
+
 class TestOrgMembershipMiddleware:
     """Tests for OrgMembershipMiddleware."""
 
@@ -445,10 +460,12 @@ class TestOrgMembershipMiddleware:
 
     async def test_valid_org_member_passes(self) -> None:
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
-
-        token = _make_jwt({"login": "gooduser"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({"login": "gooduser"})),
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 200
@@ -456,10 +473,12 @@ class TestOrgMembershipMiddleware:
 
     async def test_non_member_rejected_403(self) -> None:
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
-
-        token = _make_jwt({"login": "baduser"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({"login": "baduser"})),
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 403
@@ -489,30 +508,31 @@ class TestOrgMembershipMiddleware:
         assert cap.status == 200
         checker.is_allowed.assert_not_awaited()
 
-    async def test_machine_token_bypasses_org_check(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A pre-shared machine token is exempt from the org gate."""
-        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_TOKEN", "machine-tok-xyz")
+    async def test_machine_token_bypasses_org_check(self) -> None:
+        """A verified token carrying the `machine` claim is exempt from the gate."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
-
-        scope = _make_scope(headers=[(b"authorization", b"Bearer machine-tok-xyz")])
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(
+                _make_access({"machine": True, "login": "spectacles"})
+            ),
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer machine-tok")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 200
         checker.is_allowed.assert_not_awaited()
 
-    async def test_non_machine_bearer_still_org_checked(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """With a machine token configured, a different bearer is still gated."""
-        monkeypatch.setenv("DISTILLERY_MCP_MACHINE_TOKEN", "machine-tok-xyz")
+    async def test_non_machine_bearer_still_org_checked(self) -> None:
+        """A non-machine verified token is still org-checked."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
-
-        token = _make_jwt({"login": "baduser"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({"login": "baduser"})),
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 403
@@ -533,8 +553,7 @@ class TestOrgMembershipMiddleware:
         checker = self._make_checker(allowed_orgs=[])  # empty -> disabled
         mw = OrgMembershipMiddleware(_dummy_app, checker)
 
-        token = _make_jwt({"login": "anyone"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 200
@@ -548,65 +567,81 @@ class TestOrgMembershipMiddleware:
         await mw(scope, _noop_receive, cap)
         assert cap.status == 200
 
-    async def test_opaque_token_fail_closed(self) -> None:
-        """Non-JWT bearer token (no dots) -> 403 fail-closed."""
+    async def test_unverifiable_token_passes_to_fastmcp(self) -> None:
+        """A token verify_token rejects -> pass through; FastMCP issues the 401."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
+        mw = OrgMembershipMiddleware(
+            _dummy_app, checker, token_verifier=_verifier(None)
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer bogus")])
+        cap = _ResponseCapture()
+        await mw(scope, _noop_receive, cap)
+        assert cap.status == 200
+        checker.is_allowed.assert_not_awaited()
 
-        scope = _make_scope(headers=[(b"authorization", b"Bearer opaque-token-no-dots")])
+    async def test_verified_token_without_identity_fails_closed(self) -> None:
+        """A verified token with no login/sub claim -> 403 fail-closed."""
+        checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({"email": "user@example.com"})),
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 403
         assert "<unknown>" in cap.json["message"]
 
-    async def test_jwt_without_login_claim_fail_closed(self) -> None:
-        """JWT with no login/sub claim -> 403 fail-closed."""
+    async def test_missing_token_verifier_fails_closed(self) -> None:
+        """An enabled checker with no token_verifier wired -> 403 fail-closed."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
-
-        token = _make_jwt({"email": "user@example.com"})  # no login or sub
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        mw = OrgMembershipMiddleware(_dummy_app, checker)  # no token_verifier
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 403
 
-    async def test_jwt_with_sub_claim_used_as_username(self) -> None:
-        """JWT with 'sub' (no 'login') should use sub as username."""
+    async def test_sub_claim_used_when_no_login(self) -> None:
+        """A verified token with `sub` (no `login`) uses sub as the username."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
-
-        token = _make_jwt({"sub": "subuser"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({"sub": "subuser"})),
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 200
         checker.is_allowed.assert_awaited_once_with("subuser")
 
-    async def test_caching_via_checker(self) -> None:
-        """Multiple requests with same token use the checker's cache."""
+    async def test_checker_called_each_request(self) -> None:
+        """The middleware calls is_allowed per request; the checker caches."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
-        mw = OrgMembershipMiddleware(_dummy_app, checker)
-
-        token = _make_jwt({"login": "cacheduser"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
-
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({"login": "cacheduser"})),
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         for _ in range(3):
             cap = _ResponseCapture()
             await mw(scope, _noop_receive, cap)
             assert cap.status == 200
-
-        # The checker.is_allowed is called each time by the middleware;
-        # the OrgMembershipChecker itself handles caching internally.
         assert checker.is_allowed.await_count == 3
 
     async def test_org_denied_fires_audit_callback(self) -> None:
         """Org membership denial fires the audit callback."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)
         audit_cb = AsyncMock()
-        mw = OrgMembershipMiddleware(_dummy_app, checker, audit_callback=audit_cb)
-
-        token = _make_jwt({"login": "baduser"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({"login": "baduser"})),
+            audit_callback=audit_cb,
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 403
@@ -616,12 +651,16 @@ class TestOrgMembershipMiddleware:
         )
 
     async def test_org_denied_unknown_user_fires_audit(self) -> None:
-        """Opaque token (unknown user) denial fires audit callback."""
+        """A verified token with no identity claim fires the audit callback."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
         audit_cb = AsyncMock()
-        mw = OrgMembershipMiddleware(_dummy_app, checker, audit_callback=audit_cb)
-
-        scope = _make_scope(headers=[(b"authorization", b"Bearer opaque-token-no-dots")])
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({})),
+            audit_callback=audit_cb,
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 403
@@ -634,10 +673,13 @@ class TestOrgMembershipMiddleware:
         """A failing audit callback must not prevent the 403 response."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=False)
         audit_cb = AsyncMock(side_effect=RuntimeError("db down"))
-        mw = OrgMembershipMiddleware(_dummy_app, checker, audit_callback=audit_cb)
-
-        token = _make_jwt({"login": "baduser"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({"login": "baduser"})),
+            audit_callback=audit_cb,
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         # 403 is still sent despite audit failure.
@@ -647,10 +689,13 @@ class TestOrgMembershipMiddleware:
         """Audit callback is NOT fired when user is allowed."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
         audit_cb = AsyncMock()
-        mw = OrgMembershipMiddleware(_dummy_app, checker, audit_callback=audit_cb)
-
-        token = _make_jwt({"login": "gooduser"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        mw = OrgMembershipMiddleware(
+            _dummy_app,
+            checker,
+            token_verifier=_verifier(_make_access({"login": "gooduser"})),
+            audit_callback=audit_cb,
+        )
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)
         assert cap.status == 200
@@ -720,10 +765,13 @@ class TestApplyHttpMiddleware:
         checker.allowed_orgs = ["testorg"]
         checker.is_allowed = AsyncMock(return_value=True)
 
-        app = apply_http_middleware(_dummy_app, org_checker=checker)
+        app = apply_http_middleware(
+            _dummy_app,
+            org_checker=checker,
+            token_verifier=_verifier(_make_access({"login": "devuser"})),
+        )
 
-        token = _make_jwt({"login": "devuser"})
-        scope = _make_scope(headers=[(b"authorization", f"Bearer {token}".encode())])
+        scope = _make_scope(headers=[(b"authorization", b"Bearer ref-token")])
         cap = _ResponseCapture()
         await app(scope, _noop_receive, cap)
         assert cap.status == 200


### PR DESCRIPTION
## Problem

`OrgMembershipMiddleware` decoded the raw bearer token as a JWT to read the `login` claim. But a FastMCP 3.x OAuth-proxy access token is a **reference token** — `jti` + standard claims, no `login`. The middleware could not identify *any* interactive GitHub OAuth user, fell through to its fail-closed branch, and returned **403 for every human** — org members included.

Confirmed end-to-end against the GCP deployment with `DISTILLERY_ALLOWED_ORGS` set: the OAuth flow fully completes (consent → GitHub token exchange → `POST /token` 200), then `POST /mcp` → 403 — with **no GitHub org-membership API call ever made**, because the middleware never resolved a username.

The org gate was therefore unusable: it rejected exactly the users it was meant to admit.

## Root cause

The raw bearer carries no identity. The identity *is* available — in the **verified `AccessToken.claims`** after `verify_token` runs. `_get_authenticated_user()` reads `get_access_token().claims["login"]` and works for tool authorship; the raw-ASGI middleware decoding the raw token could not see it.

## Fix

`OrgMembershipMiddleware` resolves identity through the auth provider's `verify_token`:

- New `token_verifier` parameter (`provider.verify_token`); `apply_http_middleware` and `__main__.py` thread it through.
- `__call__` calls `verify_token(bearer)` → reads `login`/`sub` from the verified `AccessToken.claims`.
- **Machine-token exemption is now claim-based** — the `machine` claim on the verified token — replacing #532's raw-token string match. Cleaner, and it drops the env read from the middleware.
- A token `verify_token` rejects is passed through so FastMCP issues the 401 (the gate decides membership, not validity). A verified token with no `login`/`sub` still fails closed. An enabled checker with no verifier wired fails closed.

## Tests

`tests/test_middleware.py` `TestOrgMembershipMiddleware` rewritten for the verify-token model (mock `token_verifier` returning a verified token); added `test_unverifiable_token_passes_to_fastmcp`, `test_verified_token_without_identity_fails_closed`, `test_missing_token_verifier_fails_closed`.

```
tests/test_middleware.py tests/test_mcp_auth.py tests/test_mcp_org_membership.py → 118 passed
```
`ruff check` clean.

## Follow-up

`_try_decode_jwt_claims` in `org_membership.py` is now unused by the middleware (still has its own unit tests) — left for a separate cleanup.

## References

Follows #530, #531, #532. Required before `DISTILLERY_ALLOWED_ORGS` is usable on any deployment serving interactive OAuth users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization membership validation now fails closed when required checks are incomplete.
  * Improved token handling for unrecognized credentials.

* **Refactor**
  * Authentication system refactored to use configurable token verifier mechanism.
  * Updated identity resolution from verified token claims.
  * Test suite aligned with new verification approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->