### PR TITLE
ci(supply-chain): trigger gcp-deploy alongside fly-deploy

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -280,9 +280,15 @@ jobs:
             sbom-${{ matrix.target }}.cdx.json
             grype-report-${{ matrix.target }}.json
 
-      - name: Trigger deploy in distill_ops
+      - name: Trigger deploys in distill_ops
         run: |
+          # Fire both deploy targets for the freshly published image.
+          # gcp-deploy's region is omitted — it defaults inside that
+          # workflow, keeping region knowledge in distill_ops.
           gh workflow run fly-deploy.yml \
+            --repo norrietaylor/distill_ops \
+            -f image_tag=sha-${{ steps.tags.outputs.short_sha }}
+          gh workflow run gcp-deploy.yml \
             --repo norrietaylor/distill_ops \
             -f image_tag=sha-${{ steps.tags.outputs.short_sha }}
         env:


### PR DESCRIPTION
## Problem

The auto-deploy never reached GCP Cloud Run. `supply-chain.yml`'s post-publish "Trigger deploy in distill_ops" step ran only:

```sh
gh workflow run fly-deploy.yml --repo norrietaylor/distill_ops -f image_tag=sha-<short_sha>
```

It triggers `fly-deploy.yml` and nothing else — `gcp-deploy.yml` is never fired. Every GCP deploy has had to be dispatched by hand. `distill_ops` has zero `repository_dispatch` runs in its history; the mechanism is `gh workflow run` (a `workflow_dispatch`), not `repository_dispatch`.

## Fix

Add a second `gh workflow run` for `gcp-deploy.yml` with the same image tag, so a freshly published container reaches both deploy targets:

```sh
gh workflow run fly-deploy.yml  --repo norrietaylor/distill_ops -f image_tag=sha-<short_sha>
gh workflow run gcp-deploy.yml  --repo norrietaylor/distill_ops -f image_tag=sha-<short_sha>
```

`gcp-deploy.yml`'s `region` input is omitted — it defaults inside that workflow (`us-west2`), keeping region knowledge in `distill_ops` rather than hardcoding it here.

## Notes

- `gcp-deploy.yml` already accepts `workflow_dispatch` with an `image_tag` input (distill_ops), so no change is needed there.
- `gcp-deploy.yml` also carries a `repository_dispatch: container-published` trigger (distill_ops PR #25), parallel to `fly-deploy.yml`'s — both are currently vestigial since this step uses `gh workflow run`. Left as-is for fly/gcp consistency.
- `distill_ops` `CLAUDE.md` still describes this as `repository_dispatch: container-published` — stale; worth a separate doc correction.

## Verification

`actionlint .github/workflows/supply-chain.yml` — clean. Full end-to-end confirmation is the next merge-to-`main` that publishes an image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
