### PR TITLE
fix(mcp): resolve a 302 org check via /public_members

### DIFF
--- a/src/distillery/mcp/org_membership.py
+++ b/src/distillery/mcp/org_membership.py
@@ -231,8 +231,9 @@ class OrgMembershipChecker:
         Response codes:
         * 204 — member.
         * 404 — not a member (or org does not exist).
-        * 302 — org is private and the token cannot see it; fall back to
-          ``GET /user/orgs`` if a token is available.
+        * 302 — the token is not seen as an org member, so GitHub will only
+          answer the public-membership endpoint; follow there via
+          :meth:`_fetch_public_member`.
         * anything else / network error — fail closed (deny).
         """
         headers: dict[str, str] = {
@@ -255,15 +256,10 @@ class OrgMembershipChecker:
             if resp.status_code == 404:
                 return False
             if resp.status_code == 302:
-                if token:
-                    return await self._fetch_via_user_orgs(token, org)
-                logger.warning(
-                    "Org %r is private but no GitHub token is available for the "
-                    "/user/orgs fallback. Set GITHUB_ORG_CHECK_TOKEN or enable "
-                    "read:org scope on the OAuth app.",
-                    org,
-                )
-                return False
+                # The token lacks org-member context, so GitHub redirects to
+                # the public-membership endpoint. Follow there — a public
+                # member resolves with no token scope at all.
+                return await self._fetch_public_member(username, org)
             logger.warning(
                 "Unexpected GitHub API status %s checking %s in %s",
                 resp.status_code,
@@ -280,41 +276,47 @@ class OrgMembershipChecker:
             )
             return False
 
-    async def _fetch_via_user_orgs(self, token: str, org: str) -> bool:
-        """Fallback: ``GET /user/orgs`` — lists all orgs the user belongs to.
+    async def _fetch_public_member(self, username: str, org: str) -> bool:
+        """Call ``GET /orgs/{org}/public_members/{username}``.
 
-        Used when ``GET /orgs/{org}/members/{username}`` returns 302 (private
-        org; token cannot see direct member list).  The user's own token with
-        ``read:org`` scope *can* list their private org memberships here.
+        Reached when ``GET /orgs/{org}/members/{username}`` returns 302 — the
+        token is not seen as an org member, so GitHub will only confirm
+        *public* membership. This endpoint needs no token or scope.
 
-        Paginates through all pages (100 per page) to handle users who are
-        members of more than 100 organisations.
+        * 204 — the user is a public member of the org.
+        * 404 — not a public member. A *private* membership is invisible
+          here; to gate private members, set ``GITHUB_ORG_CHECK_TOKEN`` (a
+          ``read:org`` PAT) so the members endpoint answers 204/404 directly.
+        * anything else / network error — fail closed (deny).
         """
         headers = {
-            "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
         }
-        org_lower = org.lower()
-        # Cap at 50 pages (5 000 orgs) to avoid infinite loops.
-        max_pages = 50
         try:
-            async with httpx.AsyncClient(timeout=10.0, verify=True) as client:
-                for page in range(1, max_pages + 1):
-                    resp = await client.get(
-                        f"{GITHUB_API}/user/orgs",
-                        headers=headers,
-                        params={"per_page": 100, "page": page},
-                    )
-                    if resp.status_code != 200:
-                        logger.warning("GET /user/orgs returned %s", resp.status_code)
-                        return False
-                    orgs: list[dict[str, Any]] = resp.json()
-                    if not orgs:
-                        break
-                    if any(o.get("login", "").lower() == org_lower for o in orgs):
-                        return True
-        except (httpx.HTTPError, ValueError) as exc:
-            logger.error("GitHub /user/orgs API error: %s", exc)
+            async with httpx.AsyncClient(
+                timeout=10.0, follow_redirects=False, verify=True
+            ) as client:
+                resp = await client.get(
+                    f"{GITHUB_API}/orgs/{org}/public_members/{username}",
+                    headers=headers,
+                )
+            if resp.status_code == 204:
+                return True
+            if resp.status_code == 404:
+                return False
+            logger.warning(
+                "Unexpected GitHub API status %s on public_members for %s in %s",
+                resp.status_code,
+                username,
+                org,
+            )
             return False
-        return False
+        except httpx.HTTPError as exc:
+            logger.error(
+                "GitHub public_members API error for %s in %s: %s",
+                username,
+                org,
+                exc,
+            )
+            return False

--- a/tests/test_mcp_org_membership.py
+++ b/tests/test_mcp_org_membership.py
@@ -166,52 +166,47 @@ class TestOrgMembershipApiNonMember:
 
 
 class TestOrgMembershipApiPrivateOrg:
-    async def test_302_without_token_returns_false(self) -> None:
+    """302 on /members/{user} -> follow to /public_members/{user}."""
+
+    @staticmethod
+    def _patched_client(members_resp: MagicMock, public_resp: MagicMock) -> MagicMock:
+        """An httpx.AsyncClient mock routing members vs public_members."""
+
+        async def fake_get(url: str, **kwargs: object) -> MagicMock:
+            return public_resp if "public_members" in url else members_resp
+
+        mock_client = _make_async_client_mock()
+        mock_client.get = fake_get
+        return mock_client
+
+    async def test_302_then_public_member_204_returns_true(self) -> None:
+        """302 on /members -> /public_members 204 -> True (no token needed)."""
         checker = OrgMembershipChecker(allowed_orgs=["private-corp"])
         with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client_cls.return_value = _make_async_client_mock(_mock_response(302))
+            mock_client_cls.return_value = self._patched_client(
+                _mock_response(302), _mock_response(204)
+            )
+            result = await checker.is_allowed("alice")
+        assert result is True
+
+    async def test_302_then_public_member_404_returns_false(self) -> None:
+        """302 on /members -> /public_members 404 (not a public member) -> False."""
+        checker = OrgMembershipChecker(allowed_orgs=["private-corp"])
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.return_value = self._patched_client(
+                _mock_response(302), _mock_response(404)
+            )
             result = await checker.is_allowed("alice")
         assert result is False
 
-    async def test_302_with_token_falls_back_to_user_orgs_member(self) -> None:
-        """302 on /members/{user} + user in /user/orgs → True."""
+    async def test_302_then_public_member_unexpected_status_returns_false(self) -> None:
+        """302 on /members -> unexpected status on /public_members -> fail closed."""
         checker = OrgMembershipChecker(allowed_orgs=["private-corp"])
-
-        members_resp = _mock_response(302)
-        user_orgs_resp = _mock_response(200, [{"login": "private-corp"}])
-
         with patch("httpx.AsyncClient") as mock_client_cls:
-
-            async def fake_get(url: str, **kwargs: object) -> MagicMock:
-                if "members" in url:
-                    return members_resp
-                return user_orgs_resp
-
-            mock_client = _make_async_client_mock()
-            mock_client.get = fake_get
-            mock_client_cls.return_value = mock_client
-
-            result = await checker.is_allowed("alice", hint_token="ghp_tok")
-        assert result is True
-
-    async def test_302_with_token_falls_back_to_user_orgs_non_member(self) -> None:
-        checker = OrgMembershipChecker(allowed_orgs=["private-corp"])
-
-        members_resp = _mock_response(302)
-        user_orgs_resp = _mock_response(200, [{"login": "other-org"}])
-
-        with patch("httpx.AsyncClient") as mock_client_cls:
-
-            async def fake_get(url: str, **kwargs: object) -> MagicMock:
-                if "members" in url:
-                    return members_resp
-                return user_orgs_resp
-
-            mock_client = _make_async_client_mock()
-            mock_client.get = fake_get
-            mock_client_cls.return_value = mock_client
-
-            result = await checker.is_allowed("alice", hint_token="ghp_tok")
+            mock_client_cls.return_value = self._patched_client(
+                _mock_response(302), _mock_response(500)
+            )
+            result = await checker.is_allowed("alice")
         assert result is False
 
 


### PR DESCRIPTION
## Problem

`GET /orgs/{org}/members/{username}` returns **302** when the requesting token isn't seen as an org member — the norm for a bare `user`-scope OAuth-app token. The 302 handler then fell back to `GET /user/orgs`, which itself requires `read:org`. A scope-less token gets nothing there, so a legitimate **public** org member was denied.

Confirmed against the GCP deployment — the *same* check, the user's OAuth token, minutes apart:

```
07:03  GET /orgs/gominimal/members/norrietaylor → 204 → True  → /mcp 200
08:07  GET /orgs/gominimal/members/norrietaylor → 302 → False → /mcp 403
```

GitHub grants org-member context to a `user`-scope OAuth-app token inconsistently, so the gate was flaky for public members.

## Fix

On a 302, follow to `GET /orgs/{org}/public_members/{username}` instead of `/user/orgs`. That endpoint needs **no token or scope**:

- `204` → the user is a public member → allowed.
- `404` → not a public member → denied.

A public org member now resolves deterministically, regardless of the OAuth token's flaky org context. Private members still need `GITHUB_ORG_CHECK_TOKEN` (a `read:org` PAT) — with it, the members endpoint answers `204`/`404` directly and the 302 path isn't reached.

`_fetch_via_user_orgs` is removed: it was only reachable from the 302 branch, and on that path (a scope-less token) `/user/orgs` never worked anyway.

## Tests

`TestOrgMembershipApiPrivateOrg` rewritten for the new path: 302 → `/public_members` `204` → True; → `404` → False; → unexpected status → fail closed.

```
tests/test_mcp_org_membership.py tests/test_middleware.py → 95 passed
```
`ruff` clean.

## References

Follows #533. Diagnosed live: the 302/204 inconsistency above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of GitHub organization membership verification for private organizations by streamlining the resolution process and enhancing error handling.

* **Tests**
  * Updated test suite to reflect improved membership verification logic with expanded coverage of edge cases and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->