### PR TITLE
feat(embedding): wire fastembed provider + document in config/example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ export JINA_API_KEY=jina_...
 
 `uvx` inherits this from your shell environment. Without a key, Distillery falls back to a stub embedding provider (search quality degraded).
 
+For fully offline operation with no API key, install the optional `[fastembed]` extra and set `embedding.provider: fastembed` in your config — see [`distillery.yaml.example`](distillery.yaml.example) (Option C) for the full block.
+
 Restart Claude Code and run the onboarding wizard:
 
 ```text

--- a/distillery.yaml.example
+++ b/distillery.yaml.example
@@ -148,6 +148,24 @@ embedding:
 #   # Set it in your shell: export OPENAI_API_KEY=sk-...
 #   api_key_env: OPENAI_API_KEY
 
+# --- Option C: Local embeddings (fastembed, no API key) ---------------------
+# Runs ONNX inference on-device — no network call, no API key. Requires the
+# optional dependency group: `pip install distillery-mcp[fastembed]`.
+# The model is downloaded once on first use (cached under ~/.cache/fastembed).
+# embedding:
+#   provider: fastembed
+#   # HuggingFace model identifier. Aliases supported: "bge-small" (default,
+#   # ~67 MB, 384 dim), "bge-base" (~210 MB, 768 dim), "bge-large", "nomic",
+#   # "mxbai". See distillery.embedding.fastembed.MODEL_ALIASES.
+#   model: BAAI/bge-small-en-v1.5
+#   # Must match the model's native output size. The provider does not
+#   # reduce dimensions; mismatched values will fail at storage init.
+#   #   bge-small-en-v1.5  -> 384
+#   #   bge-base-en-v1.5   -> 768
+#   #   bge-large-en-v1.5  -> 1024
+#   dimensions: 384
+#   # api_key_env is ignored for fastembed — leave unset or empty.
+
 # ---------------------------------------------------------------------------
 # Team settings
 # ---------------------------------------------------------------------------

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -1269,7 +1269,7 @@ def _validate(config: DistilleryConfig) -> None:
                 "Set the environment variable before starting the server."
             )
 
-    valid_providers = {"jina", "openai", "mock"}
+    valid_providers = {"jina", "openai", "mock", "fastembed"}
     if config.embedding.provider and config.embedding.provider not in valid_providers:
         raise ValueError(
             f"embedding.provider must be one of {sorted(valid_providers)}, "

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -52,10 +52,18 @@ class EmbeddingConfig:
     """Embedding provider configuration.
 
     Attributes:
-        provider: Embedding provider name. One of 'jina' or 'openai'.
+        provider: Embedding provider name. One of ``"jina"``, ``"openai"``,
+            ``"fastembed"`` (local ONNX, no key), or ``"mock"`` (deterministic
+            hash, used by tests).
         model: Embedding model identifier.
-        dimensions: Dimensionality of embedding vectors.
+        dimensions: Dimensionality of embedding vectors. Forwarded to the API
+            for hosted providers (Jina / OpenAI) that support dimension
+            reduction. For ``"fastembed"`` the model dictates the dimension
+            and this value must match; see
+            :data:`distillery.embedding.fastembed._KNOWN_DIMENSIONS`.
         api_key_env: Name of the environment variable that holds the API key.
+            Ignored when ``provider == "fastembed"`` (local inference, no
+            key required).
     """
 
     provider: str = ""
@@ -1233,7 +1241,8 @@ def _validate(config: DistilleryConfig) -> None:
 
     Raises:
         ValueError: If any of the following conditions are violated:
-            - embedding.provider is non-empty and not one of "jina" or "openai".
+            - embedding.provider is non-empty and not one of "jina", "openai",
+              "fastembed", or "mock".
             - embedding.dimensions is not greater than 0.
             - classification.confidence_threshold is not between 0.0 and 1.0.
             - classification.dedup_link_threshold, classification.dedup_merge_threshold,

--- a/src/distillery/embedding/__init__.py
+++ b/src/distillery/embedding/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .errors import EmbeddingProviderError, parse_retry_after
+from .fastembed import FastembedProvider
 from .jina import JinaEmbeddingProvider
 from .openai import OpenAIEmbeddingProvider
 from .protocol import EmbeddingProvider
@@ -10,6 +11,7 @@ from .protocol import EmbeddingProvider
 __all__ = [
     "EmbeddingProvider",
     "EmbeddingProviderError",
+    "FastembedProvider",
     "JinaEmbeddingProvider",
     "OpenAIEmbeddingProvider",
     "create_provider",
@@ -27,6 +29,7 @@ def create_provider(config: object) -> EmbeddingProvider:
 
     - ``"openai"`` — :class:`OpenAIEmbeddingProvider` using the OpenAI API.
     - ``"jina"`` — :class:`JinaEmbeddingProvider` using the Jina AI API.
+    - ``"fastembed"`` — :class:`FastembedProvider` using local ONNX inference.
 
     Args:
         config: A :class:`~distillery.config.DistilleryConfig` instance (or
@@ -57,6 +60,10 @@ def create_provider(config: object) -> EmbeddingProvider:
             api_key_env=embedding_cfg.api_key_env or "JINA_API_KEY",
         )
 
+    if provider_name == "fastembed":
+        return FastembedProvider(model=embedding_cfg.model)
+
     raise ValueError(
-        f"Unknown embedding provider: {provider_name!r}. Supported values are 'openai' and 'jina'."
+        f"Unknown embedding provider: {provider_name!r}. "
+        "Supported values are 'openai', 'jina', and 'fastembed'."
     )

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -136,12 +136,17 @@ def _create_embedding_provider(config: DistilleryConfig) -> Any:
         from distillery.mcp._stub_embedding import HashEmbeddingProvider
 
         return HashEmbeddingProvider(dimensions=d)
+    if n == "fastembed":
+        from distillery.embedding.fastembed import FastembedProvider
+
+        return FastembedProvider(model=m)
     if n == "":
         from distillery.mcp._stub_embedding import StubEmbeddingProvider
 
         return StubEmbeddingProvider(dimensions=d)
     raise ValueError(
-        f"Unsupported embedding provider: {n!r}. Must be one of: 'jina', 'openai', 'mock'."
+        f"Unsupported embedding provider: {n!r}. "
+        "Must be one of: 'jina', 'openai', 'mock', 'fastembed'."
     )
 
 

--- a/tests/test_smoke_fastembed.py
+++ b/tests/test_smoke_fastembed.py
@@ -1,0 +1,91 @@
+"""Smoke test — verify the `fastembed` provider integrates cleanly with the
+embedding factory and the DuckDB store, without requiring any external API
+key (``JINA_API_KEY`` / ``OPENAI_API_KEY``).
+
+Marked ``integration`` so it does not run on a plain ``pytest -m unit``
+invocation; it can pull ~67 MB of ONNX weights from HuggingFace on first run.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _have_fastembed() -> bool:
+    try:
+        import fastembed  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _have_fastembed(), reason="fastembed extra not installed")
+def test_create_provider_fastembed_no_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`create_provider` returns a FastembedProvider when configured, with no
+    external API key set in the environment."""
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    from distillery.config import EmbeddingConfig
+    from distillery.embedding import FastembedProvider, create_provider
+
+    class _Cfg:
+        embedding = EmbeddingConfig(
+            provider="fastembed",
+            model="BAAI/bge-small-en-v1.5",
+            dimensions=384,
+            api_key_env="",
+        )
+
+    provider = create_provider(_Cfg())
+    assert isinstance(provider, FastembedProvider)
+    assert provider.model_name == "BAAI/bge-small-en-v1.5"
+    assert provider.dimensions == 384
+
+
+@pytest.mark.skipif(not _have_fastembed(), reason="fastembed extra not installed")
+@pytest.mark.asyncio
+async def test_store_with_fastembed_roundtrip(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Storing five entries and recalling the closest one against a fresh
+    DuckDB file works with a real fastembed provider — no API keys.
+    """
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    from distillery.embedding.fastembed import FastembedProvider
+    from distillery.models import Entry, EntrySource, EntryStatus, EntryType
+    from distillery.store.duckdb import DuckDBStore
+
+    provider = FastembedProvider(model="BAAI/bge-small-en-v1.5")
+    db_path = os.fspath(tmp_path) + "/smoke.db"  # type: ignore[attr-defined]
+    store = DuckDBStore(db_path=db_path, embedding_provider=provider)
+    await store.initialize()
+
+    seeds = [
+        "DuckDB is a fast in-process analytical database.",
+        "Cosine similarity measures the angle between two vectors.",
+        "The Vancouver waterfront has a seaplane terminal.",
+        "Sourdough bread relies on wild yeast and lactic bacteria.",
+        "ONNX runtime executes neural network graphs across hardware.",
+    ]
+    for s in seeds:
+        await store.store(
+            Entry(
+                content=s,
+                entry_type=EntryType.REFERENCE,
+                source=EntrySource.MANUAL,
+                author="smoke-test",
+                status=EntryStatus.ACTIVE,
+            )
+        )
+
+    hits = await store.search("vector database query speed", filters=None, limit=3)
+    assert len(hits) >= 1
+    top_text = hits[0].entry.content.lower()
+    assert "duckdb" in top_text or "vector" in top_text or "cosine" in top_text


### PR DESCRIPTION
## Summary

The `FastembedProvider` class already ships in `src/distillery/embedding/fastembed.py` with full unit-test coverage (`tests/test_fastembed_provider.py`) and the `[fastembed]` optional dependency group is declared in `pyproject.toml` — but no code path actually constructs the provider. Setting `embedding.provider: fastembed` in a config file currently fails validation, and the two factory functions (`embedding.create_provider` and `mcp.server._create_embedding_provider`) don't map that string to an instance.

This PR adds the three missing branches plus docs, so the feature works end-to-end:

- `src/distillery/embedding/__init__.py` — `create_provider` factory branch + `__all__` export
- `src/distillery/config.py` — include `"fastembed"` in the valid_providers set; refresh `EmbeddingConfig` + `_validate` docstrings to list all four accepted values and note fastembed's relationship to `dimensions` / `api_key_env`
- `src/distillery/mcp/server.py` — factory branch in `_create_embedding_provider`
- `tests/test_smoke_fastembed.py` — `@pytest.mark.integration` smoke test, skipped unless the `[fastembed]` extra is installed. Covers no-key construction and a real 5-entry store+search roundtrip against `bge-small-en-v1.5`.
- `distillery.yaml.example` — Option C block documenting fastembed alongside the existing Jina / OpenAI options (model alias list, dimension table, install hint)
- `README.md` — one-line pointer in Quick Start Step 2 for users who want fully offline operation

After this lands, setting `embedding.provider: fastembed` in `distillery.yaml` boots the server with no API key, downloads the ONNX model on first call into `~/.cache/fastembed`, and produces vectors that flow through the existing DuckDB store unchanged.

## Test plan

- [x] `pytest tests/test_fastembed_provider.py tests/test_config.py tests/test_smoke_fastembed.py` — 122 passed
- [x] `pytest -m unit` — passes (one unrelated `test_skill_coverage` failure caused by local untracked `.claude/skills/investigate/` is not introduced by this PR)
- [x] Booted distillery-mcp locally against a fastembed-configured DuckDB; `/distill` and `/recall` round-trip with no API key set
- [ ] Maintainer: verify `pytest -m integration tests/test_smoke_fastembed.py` passes in CI with `[fastembed]` extra installed (first run downloads ~67 MB ONNX weights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fastembed embedding provider, enabling fully offline operations without API dependencies
  * Users can now install the optional fastembed extra and configure it for local embeddings
  * Documentation updated with offline setup instructions and configuration examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->