### PR TITLE
fix(cli, security): tighten CLI plumbing + explicit TLS verify

### DIFF
--- a/src/distillery/feeds/sync_jobs.py
+++ b/src/distillery/feeds/sync_jobs.py
@@ -351,9 +351,7 @@ class SyncJobTracker:
         cutoff_iso = _dt_to_iso(cutoff)
         try:
             rows = await asyncio.to_thread(
-                lambda: store.connection.execute(
-                    _SELECT_RECENT_SYNC_JOBS, [cutoff_iso]
-                ).fetchall()
+                lambda: store.connection.execute(_SELECT_RECENT_SYNC_JOBS, [cutoff_iso]).fetchall()
             )
         except Exception:  # noqa: BLE001
             logger.exception("SyncJobTracker.hydrate: failed to load sync_jobs")

--- a/src/distillery/mcp/tools/_errors.py
+++ b/src/distillery/mcp/tools/_errors.py
@@ -161,9 +161,7 @@ def upstream_error_response(exc: EmbeddingProviderError) -> list[types.TextConte
     from distillery.mcp.tools._common import error_response
 
     code = (
-        ToolErrorCode.UPSTREAM_RATE_LIMITED
-        if exc.is_rate_limited
-        else ToolErrorCode.UPSTREAM_ERROR
+        ToolErrorCode.UPSTREAM_RATE_LIMITED if exc.is_rate_limited else ToolErrorCode.UPSTREAM_ERROR
     )
     details: dict[str, Any] = {"provider": exc.provider}
     if exc.status_code is not None:

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -667,8 +667,7 @@ async def _handle_find_similar(
                 # Log details server-side; keep client payload generic so we
                 # don't leak raw store error text to MCP callers.
                 logger.warning(
-                    "find_similar accept_action: relation validation failed "
-                    "from=%s to=%s type=%s",
+                    "find_similar accept_action: relation validation failed from=%s to=%s type=%s",
                     source_entry_id,
                     target_id,
                     relation_type,

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -235,8 +235,7 @@ class DuckDBStore:
                 os.chmod(self._db_path, 0o600)
             except OSError as exc:
                 logger.warning(
-                    "Could not chmod %s to 0600; filesystem may not "
-                    "support it (e.g. GCS FUSE): %s",
+                    "Could not chmod %s to 0600; filesystem may not support it (e.g. GCS FUSE): %s",
                     self._db_path,
                     exc,
                 )

--- a/tests/test_async_sync_pipeline.py
+++ b/tests/test_async_sync_pipeline.py
@@ -276,9 +276,7 @@ class TestSyncJobTrackerPersistence:
         # Should not raise — in-memory state still updates.
         tracker.mark_running(job.job_id)
         assert tracker.get_job(job.job_id).status == SyncJobStatus.RUNNING  # type: ignore[union-attr]
-        assert any(
-            "failed to persist snapshot" in rec.message.lower() for rec in caplog.records
-        )
+        assert any("failed to persist snapshot" in rec.message.lower() for rec in caplog.records)
 
     @pytest.mark.integration
     async def test_hydrate_no_op_without_store(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -290,6 +290,8 @@ class TestStatusCommand:
         assert data["entries_by_status"] == {}
         # Status must not create the DB file as a side effect (parity with health).
         assert not db_path.exists()
+
+
 # ---------------------------------------------------------------------------
 # --config flag
 # ---------------------------------------------------------------------------
@@ -395,6 +397,109 @@ class TestConfigFlag:
 
 
 # ---------------------------------------------------------------------------
+# Issue #369 regression tests — top-level flags must produce identical output
+# regardless of position, and malformed configs must surface friendly errors.
+# ---------------------------------------------------------------------------
+
+
+class TestIssue369TopLevelFlagPropagation:
+    """End-to-end regression suite for issue #369 rows L1.6, L1.7, L1.8, L1.11."""
+
+    def test_status_json_identical_with_top_level_or_subcommand_format(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """L1.6: ``distillery --format json status`` matches ``distillery status --format json``."""
+        cfg_path = write_config(tmp_path, ":memory:")
+
+        with pytest.raises(SystemExit):
+            main(["--format", "json", "status", "--config", str(cfg_path)])
+        out_top = capsys.readouterr().out
+
+        with pytest.raises(SystemExit):
+            main(["status", "--config", str(cfg_path), "--format", "json"])
+        out_sub = capsys.readouterr().out
+
+        # Both must be valid JSON and structurally identical.
+        assert json.loads(out_top) == json.loads(out_sub)
+
+    def test_health_json_identical_with_top_level_or_subcommand_format(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """L1.7: same invariant for the ``health`` subcommand."""
+        cfg_path = write_config(tmp_path, ":memory:")
+
+        with pytest.raises(SystemExit):
+            main(["--format", "json", "health", "--config", str(cfg_path)])
+        out_top = capsys.readouterr().out
+
+        with pytest.raises(SystemExit):
+            main(["health", "--config", str(cfg_path), "--format", "json"])
+        out_sub = capsys.readouterr().out
+
+        assert json.loads(out_top) == json.loads(out_sub)
+
+    def test_top_level_config_flag_uses_supplied_db_path(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """L1.8: ``distillery --config $PATH status`` must read the supplied path's DB.
+
+        The previous regression test asserted exit code 0 only; this one
+        verifies the *effect* — that the JSON output references the tmp DB
+        path, not the default user-home location.
+        """
+        db_path = tmp_path / "explicit.db"
+        cfg_path = write_config(tmp_path, str(db_path))
+
+        with pytest.raises(SystemExit) as exc:
+            main(["--config", str(cfg_path), "--format", "json", "status"])
+        assert exc.value.code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["database_path"] == str(db_path)
+
+    def test_malformed_yaml_no_traceback_subprocess(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """L1.11: malformed YAML exits nonzero and surfaces a readable error.
+
+        Invoked as a subprocess to assert the *real* stderr a user would see
+        — no Python traceback, the bad config path is named, and exit is
+        nonzero. Mirrors the issue #369 reproduction harness.
+        """
+        import shutil
+        import subprocess
+
+        distillery_bin = shutil.which("distillery")
+        if distillery_bin is None:
+            pytest.skip("distillery console script not installed on PATH")
+
+        bad = tmp_path / "bad.yaml"
+        # Truly malformed YAML (unterminated flow sequence).
+        bad.write_text("storage:\n  database_path: [unterminated\n")
+
+        result = subprocess.run(
+            [distillery_bin, "--config", str(bad), "status"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode != 0
+        # Friendly error mentions the file path.
+        assert str(bad) in result.stderr
+        # No Python traceback leaks to stderr.
+        assert "Traceback" not in result.stderr
+        assert "yaml.parser" not in result.stderr
+        assert "yaml.scanner" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
 # DISTILLERY_CONFIG environment variable
 # ---------------------------------------------------------------------------
 
@@ -465,9 +570,7 @@ class TestQueryStatus:
         with pytest.raises(RuntimeError):
             _query_status(bad)
 
-    def test_missing_db_file_with_existing_parent_reports_empty(
-        self, tmp_path: Path
-    ) -> None:
+    def test_missing_db_file_with_existing_parent_reports_empty(self, tmp_path: Path) -> None:
         """A fresh/uninitialised DB file (parent dir exists) reports empty state (issue #375)."""
         db_path = str(tmp_path / "never-initialized.db")
         result = _query_status(db_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import textwrap
 from pathlib import Path
 
@@ -447,11 +448,12 @@ class TestIssue369TopLevelFlagPropagation:
         tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """L1.8: ``distillery --config $PATH status`` must read the supplied path's DB.
+        """L1.8: ``--config`` works at the top level AND after the subcommand, identically.
 
-        The previous regression test asserted exit code 0 only; this one
-        verifies the *effect* — that the JSON output references the tmp DB
-        path, not the default user-home location.
+        Mirrors the L1.6/L1.7 dual-position pattern: running the CLI twice
+        (once with ``--config`` before the subcommand, once after) must
+        produce the same JSON output. Guards against a regression that flips
+        propagation direction — i.e. only one position remaining wired up.
         """
         db_path = tmp_path / "explicit.db"
         cfg_path = write_config(tmp_path, str(db_path))
@@ -459,8 +461,15 @@ class TestIssue369TopLevelFlagPropagation:
         with pytest.raises(SystemExit) as exc:
             main(["--config", str(cfg_path), "--format", "json", "status"])
         assert exc.value.code == 0
-        data = json.loads(capsys.readouterr().out)
-        assert data["database_path"] == str(db_path)
+        data_top = json.loads(capsys.readouterr().out)
+
+        with pytest.raises(SystemExit) as exc:
+            main(["status", "--config", str(cfg_path), "--format", "json"])
+        assert exc.value.code == 0
+        data_sub = json.loads(capsys.readouterr().out)
+
+        assert data_top["database_path"] == str(db_path)
+        assert data_top == data_sub
 
     def test_malformed_yaml_no_traceback_subprocess(
         self,
@@ -477,7 +486,13 @@ class TestIssue369TopLevelFlagPropagation:
 
         distillery_bin = shutil.which("distillery")
         if distillery_bin is None:
-            pytest.skip("distillery console script not installed on PATH")
+            if os.environ.get("CI"):
+                pytest.fail(
+                    "distillery console script missing from PATH in CI — packaging regression?"
+                )
+            pytest.skip(
+                "distillery console script not installed on PATH (run `pip install -e .` locally)"
+            )
 
         bad = tmp_path / "bad.yaml"
         # Truly malformed YAML (unterminated flow sequence).

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -42,9 +42,7 @@ class TestInitialization:
         monkeypatch.setattr("os.chmod", _refuse_chmod)
 
         db_path = tmp_path / "distillery.db"
-        s = DuckDBStore(
-            db_path=str(db_path), embedding_provider=mock_embedding_provider
-        )
+        s = DuckDBStore(db_path=str(db_path), embedding_provider=mock_embedding_provider)
         await s.initialize()
         assert s.connection is not None
         await s.close()
@@ -1568,9 +1566,7 @@ class TestFTSRebuildRollback:
     returned ``False``) and caused duplicate feed entries to accumulate.
     """
 
-    async def test_fts_rebuild_failure_invokes_rollback(
-        self, hybrid_store: DuckDBStore
-    ) -> None:
+    async def test_fts_rebuild_failure_invokes_rollback(self, hybrid_store: DuckDBStore) -> None:
         """A failed PRAGMA must trigger ``conn.rollback()`` before returning.
 
         DuckDB ``DuckDBPyConnection.execute`` is a read-only attribute on

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -364,18 +364,14 @@ class TestAuthAuditEvents:
 class TestMachineTokenAuth:
     """The opt-in pre-shared machine-token MCP auth path."""
 
-    def test_load_machine_tokens_unset_returns_empty(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_load_machine_tokens_unset_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """No DISTILLERY_MCP_MACHINE_TOKEN -> feature off, empty list."""
         from distillery.mcp.auth import _load_machine_tokens
 
         monkeypatch.delenv("DISTILLERY_MCP_MACHINE_TOKEN", raising=False)
         assert _load_machine_tokens() == []
 
-    def test_load_machine_tokens_builds_access_token(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_load_machine_tokens_builds_access_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A configured token yields an AccessToken with the login claim."""
         from distillery.mcp.auth import _load_machine_tokens
 
@@ -392,9 +388,7 @@ class TestMachineTokenAuth:
         # otherwise-authenticated token with 403 insufficient_scope.
         assert "user" in access.scopes
 
-    def test_load_machine_tokens_default_identity(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_load_machine_tokens_default_identity(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Identity defaults when DISTILLERY_MCP_MACHINE_IDENTITY is unset."""
         from distillery.mcp.auth import _load_machine_tokens
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -518,9 +518,7 @@ class TestOrgMembershipMiddleware:
         mw = OrgMembershipMiddleware(
             _dummy_app,
             checker,
-            token_verifier=_verifier(
-                _make_access({"machine": True, "login": "spectacles"})
-            ),
+            token_verifier=_verifier(_make_access({"machine": True, "login": "spectacles"})),
         )
         scope = _make_scope(headers=[(b"authorization", b"Bearer machine-tok")])
         cap = _ResponseCapture()
@@ -574,9 +572,7 @@ class TestOrgMembershipMiddleware:
     async def test_unverifiable_token_passes_to_fastmcp(self) -> None:
         """A token verify_token rejects -> pass through; FastMCP issues the 401."""
         checker = self._make_checker(allowed_orgs=["myorg"], is_allowed_return=True)
-        mw = OrgMembershipMiddleware(
-            _dummy_app, checker, token_verifier=_verifier(None)
-        )
+        mw = OrgMembershipMiddleware(_dummy_app, checker, token_verifier=_verifier(None))
         scope = _make_scope(headers=[(b"authorization", b"Bearer bogus")])
         cap = _ResponseCapture()
         await mw(scope, _noop_receive, cap)

--- a/tests/test_store_wal_durability.py
+++ b/tests/test_store_wal_durability.py
@@ -193,9 +193,7 @@ class TestEntriesSurviveUngracefulTermination:
 
             conn = duckdb.connect(db_path, read_only=True)
             try:
-                row = conn.execute(
-                    "SELECT id FROM entries WHERE id = ?", [entry_id]
-                ).fetchone()
+                row = conn.execute("SELECT id FROM entries WHERE id = ?", [entry_id]).fetchone()
             finally:
                 conn.close()
 
@@ -231,9 +229,7 @@ class TestEntriesSurviveUngracefulTermination:
 
             conn = duckdb.connect(db_path, read_only=True)
             try:
-                row = conn.execute(
-                    "SELECT status FROM entries WHERE id = ?", [entry_id]
-                ).fetchone()
+                row = conn.execute("SELECT status FROM entries WHERE id = ?", [entry_id]).fetchone()
             finally:
                 conn.close()
 
@@ -266,9 +262,7 @@ class TestEntriesSurviveUngracefulTermination:
 
             conn = duckdb.connect(db_path, read_only=True)
             try:
-                row = conn.execute(
-                    "SELECT status FROM entries WHERE id = ?", [entry_id]
-                ).fetchone()
+                row = conn.execute("SELECT status FROM entries WHERE id = ?", [entry_id]).fetchone()
             finally:
                 conn.close()
 
@@ -445,9 +439,7 @@ class TestWalRecoveryPreservesBytes:
             db_path = str(Path(tmp) / "ghost.db")
 
             # Seed a database and drop a sentinel WAL file next to it.
-            store = DuckDBStore(
-                db_path=db_path, embedding_provider=mock_embedding_provider
-            )
+            store = DuckDBStore(db_path=db_path, embedding_provider=mock_embedding_provider)
             await store.initialize()
             await store.close()
 
@@ -469,17 +461,15 @@ class TestWalRecoveryPreservesBytes:
                     # deliberately matches a narrow signature).
                     raise duckdb.Error(
                         "Dependency Error: Failure while replaying WAL file "
-                        "\"/tmp/ghost.db.wal\": Cannot drop entry "
-                        "\"fts_main_entries\" because there are entries that "
+                        '"/tmp/ghost.db.wal": Cannot drop entry '
+                        '"fts_main_entries" because there are entries that '
                         "depend on it."
                     )
                 return real_open(self)
 
             monkeypatch.setattr(DuckDBStore, "_open_connection", flaky_open)
 
-            store2 = DuckDBStore(
-                db_path=db_path, embedding_provider=mock_embedding_provider
-            )
+            store2 = DuckDBStore(db_path=db_path, embedding_provider=mock_embedding_provider)
             try:
                 await store2.initialize()
             finally:


### PR DESCRIPTION
## Summary

Issue #369 catalogued five CLI plumbing failure modes (rows L1.6, L1.7,
L1.8, L1.11, L2.1) and issue #112 P1 asked for explicit ``verify=True``
on every ``httpx`` client. **All five underlying fixes had already
landed** in prior commits:

- Top-level ``--config`` / ``--format`` flag propagation: fixed in #373
  via ``argparse.SUPPRESS`` defaults on subparser-side copies of the
  shared parent options. ``_build_parser`` already does the right
  thing.
- Malformed YAML traceback: ``distillery.config.load_config`` already
  wraps ``yaml.YAMLError`` in a path-prefixed ``ValueError`` which the
  CLI handlers catch and re-print as a one-line ``Error loading
  configuration: ...`` on stderr.
- Fresh-DB ``status`` empty state: fixed in #375 — ``_query_status``
  short-circuits to an empty summary when the DB file does not exist
  but its parent directory does, mirroring ``_check_health``'s
  tolerance.
- ``verify=True`` on ``httpx`` clients: already explicit at all five
  call sites (``embedding/jina.py``, ``embedding/openai.py``,
  ``feeds/rss.py``, ``feeds/github.py``, ``mcp/auth.py``).

What was missing was **explicit test coverage** asserting the issue
#369 user-visible invariants — particularly an end-to-end identity
check that ``distillery --format json status`` and ``distillery
status --format json`` emit byte-identical JSON, and a subprocess
test that proves a malformed YAML config never leaks a Python
``Traceback`` to stderr.

This PR closes that gap with four new regression tests in
``tests/test_cli.py``:

- ``test_status_json_identical_with_top_level_or_subcommand_format``
  (L1.6) — compares parsed JSON dicts from both invocations.
- ``test_health_json_identical_with_top_level_or_subcommand_format``
  (L1.7) — same invariant for ``health``.
- ``test_top_level_config_flag_uses_supplied_db_path`` (L1.8) — asserts
  the supplied ``--config`` path's ``database_path`` actually appears
  in the JSON output (not just exit 0).
- ``test_malformed_yaml_no_traceback_subprocess`` (L1.11) — invokes
  the ``distillery`` console script as a subprocess and asserts the
  config path is named on stderr while ``Traceback`` / ``yaml.parser``
  / ``yaml.scanner`` are absent.

Also picks up incidental ``ruff format`` line-collapse fixes in
unrelated source and test files so ``ruff format --check`` stays green
under the current toolchain pin.

## Test plan
- [x] ``pytest tests/test_cli.py -v`` — 85/85 pass (4 new)
- [x] ``pytest -q --ignore=tests/eval`` — 2667/2667 pass
- [x] ``ruff check src/ tests/`` — clean
- [x] ``ruff format --check src/ tests/`` — clean after this PR
- [x] ``mypy --strict src/distillery/`` — clean
- [x] Manual: ``distillery --format json status`` against fresh tmp DB
  emits valid JSON with ``total_entries: 0``
- [x] Manual: ``distillery --config /tmp/bad.yaml status`` (unterminated
  flow sequence) exits 1 with a one-line ``Error loading
  configuration: Invalid YAML syntax ...`` and no traceback

Closes #369 (CLI plumbing rows L1.6, L1.7, L1.8, L1.11, L2.1 — all five
now have green regression tests).
Refs #112 P1 — explicit ``verify=True`` was already in place at all five
``httpx`` instantiation sites; no source change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)