### PR TITLE
ci(automerge): enable bot auto-merge for Dependabot and benchmark PRs

### DIFF
--- a/.github/workflows/bench-graph-regression-cell.yml
+++ b/.github/workflows/bench-graph-regression-cell.yml
@@ -527,6 +527,7 @@ jobs:
           git reset
 
       - name: Open auto-PR
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -554,3 +555,11 @@ jobs:
           labels: benchmark
           add-paths: bench/results/graph_regression_cell_a.json
           delete-branch: true
+
+      # Bench PRs are data-only (allowlisted paths above); merge immediately.
+      - name: Auto-merge bench PR
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge "$PR_NUM" --merge --delete-branch

--- a/.github/workflows/bench-longmemeval.yml
+++ b/.github/workflows/bench-longmemeval.yml
@@ -399,6 +399,7 @@ jobs:
       # Only the allowlisted paths are passed to `add-paths`, which is a
       # second layer of defence on top of the verify-paths step above.
       - name: Create auto-PR
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -430,3 +431,13 @@ jobs:
             bench/badge_ndcg10.json
             docs/benchmarks.md
           delete-branch: true
+
+      # Bench PRs are data-only (paths gated by verify-paths above) and
+      # GITHUB_TOKEN-created PRs do not cascade other workflows, so there
+      # is nothing to wait on — merge directly.
+      - name: Auto-merge bench PR
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge "$PR_NUM" --merge --delete-branch

--- a/.github/workflows/bench-variance-gate.yml
+++ b/.github/workflows/bench-variance-gate.yml
@@ -373,6 +373,7 @@ jobs:
           git reset
 
       - name: Open auto-PR
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -401,3 +402,11 @@ jobs:
           labels: benchmark
           add-paths: bench/results/variance_baseline.json
           delete-branch: true
+
+      # Bench PRs are data-only (allowlisted paths above); merge immediately.
+      - name: Auto-merge bench PR
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge "$PR_NUM" --merge --delete-branch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.4.0
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+# Auto-merge Dependabot PRs for patch and minor updates once required
+# checks pass. Major updates are deliberately excluded so a human still
+# reviews them. Dependabot PRs trigger workflows normally (they are not
+# subject to the GITHUB_TOKEN recursion guard that affects bot-authored
+# PRs created via peter-evans/create-pull-request), so a top-level
+# pull_request trigger is sufficient here.
+
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: contains(fromJSON('["version-update:semver-patch","version-update:semver-minor"]'), steps.meta.outputs.update-type)
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --merge --delete-branch "$PR_URL"


### PR DESCRIPTION
## Summary
- New `.github/workflows/dependabot-auto-merge.yml` — fires on `pull_request`, gates on `author == dependabot[bot]`, uses `dependabot/fetch-metadata` to enable auto-merge only for `semver-patch` and `semver-minor` (major updates still require human review). Merges with `--merge --delete-branch`.
- Patched 3 bench workflows (`bench-longmemeval.yml`, `bench-graph-regression-cell.yml`, `bench-variance-gate.yml`) — added `id: cpr` to the `peter-evans/create-pull-request` step and a follow-up `gh pr merge "$PR_NUM" --merge --delete-branch` step.
- Repo setting `allow_auto_merge=true` already applied via `gh api -X PATCH` (out of tree).

## Why two patterns
Dependabot PRs cascade workflows normally — a top-level `pull_request` trigger works. Bench PRs are created by `peter-evans/create-pull-request@v6` with `GITHUB_TOKEN`, which hits GitHub's recursion guard: downstream workflows (including any top-level auto-merge workflow) do NOT fire. Inline merge in the same job is the simplest fix. Bench PRs are data-only (paths allowlisted by the existing verify-paths step), so there is nothing to wait on — merge directly.

## Test plan
- [ ] Wait for next Dependabot PR (patch/minor) — confirm the workflow enables auto-merge and the PR merges once `ci (3.11..3.14)` go green.
- [ ] Wait for next bench cron run (`bench-longmemeval` nightly UTC) — confirm the auto-PR is created and immediately merged.
- [ ] Confirm a major-version Dependabot PR is NOT auto-merged (left open for human review).

## Risks
- `allow_auto_merge=true` is repo-wide; affects any future PR if `--auto` is invoked manually.
- No branch protection on `main` means there are no required checks to gate Dependabot's `--auto` flag; merges fire as soon as the CI matrix completes. If a check is added later it will start gating automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflows to automatically merge benchmark-related pull requests
  * Added automatic merging for Dependabot dependency updates (patch and minor version updates)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->