### PR TITLE
release: v0.6.0 — fastembed as plugin install default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "distillery",
       "source": "./",
       "description": "Knowledge base skills — capture, search, and synthesize project knowledge",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings"],
       "category": "knowledge-management"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "distillery",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Knowledge base skills for Claude Code — capture, search, and synthesize project knowledge",
   "author": {
     "name": "norrietaylor",
@@ -31,7 +31,10 @@
   "mcpServers": {
     "distillery": {
       "command": "uvx",
-      "args": ["distillery-mcp"]
+      "args": ["--from", "distillery-mcp[fastembed]>=0.6.0", "distillery-mcp"],
+      "env": {
+        "DISTILLERY_EMBEDDING_PROVIDER": "fastembed"
+      }
     }
   },
   "hooks": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distillery-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "Persistent shared memory for Claude Code — MCP server with DuckDB vector search, semantic dedup, and ambient intelligence for team knowledge"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.norrietaylor/distillery-mcp",
   "title": "Distillery",
   "description": "Knowledge base for Claude Code with semantic search, feed intelligence, and teams",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repository": {
     "url": "https://github.com/norrietaylor/distillery",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "transport": {
         "type": "streamable-http",
         "url": "https://distillery-mcp.fly.dev/mcp"

--- a/src/distillery/__init__.py
+++ b/src/distillery/__init__.py
@@ -2,5 +2,5 @@
 
 import os
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __build_sha__ = os.environ.get("DISTILLERY_BUILD_SHA", "dev")

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ wheels = [
 
 [[package]]
 name = "distillery-mcp"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

Cuts release v0.6.0. Headline: fastembed becomes the plugin's install-time default embedding provider. New installs require no API keys; embeddings run locally via bge-small-en-v1.5 (384-dim vectors).

## Manifest change

```diff
   "mcpServers": {
     "distillery": {
       "command": "uvx",
-      "args": ["distillery-mcp"]
+      "args": ["--from", "distillery-mcp[fastembed]>=0.6.0", "distillery-mcp"],
+      "env": {
+        "DISTILLERY_EMBEDDING_PROVIDER": "fastembed"
+      }
     }
   }
```

The `>=0.6.0` pin ensures the manifest cannot resolve until the corresponding PyPI publish completes; this turns the pre-release window into a clean install failure rather than a confusing runtime error.

## Version stamps

- `pyproject.toml` — 0.5.0 → 0.6.0
- `src/distillery/__init__.py` — __version__ 0.5.0 → 0.6.0
- `.claude-plugin/plugin.json` — 0.5.0 → 0.6.0 + mcpServers patch
- `.claude-plugin/marketplace.json` — plugin entry 0.5.0 → 0.6.0
- `server.json` — version + packages[*].version → 0.6.0
- `uv.lock` — regenerated

## Quality evidence

Published LongMemEval HEADLINE numbers already use bge-small via fastembed:

| Metric | Value | Source |
|---|---|---|
| R@5 | 0.97 | bench/results/summary_longmemeval_hybrid_session_on_bge-small_20260518T090851Z.json |
| R@10 | 0.99 | same |
| nDCG@10 | 0.885 | same |

This release aligns the install-time UX with the documented benchmark.

## Gate verification (per #548)

- `uvx --from 'distillery-mcp[fastembed]' distillery-mcp` resolves and installs 93 packages including onnxruntime + tokenizers (1.8s first run, 89ms warm)
- Cold-start: fastembed import 2.9s, model download + ONNX load 3.5s, first embed 2ms, subsequent embeds 1ms. Lazy-loaded — MCP server startup pays only the import cost, model download happens on first /recall or /distill.

## What this leaves untouched

- 3 `userConfig` fields (jina_api_key, github_client_id, github_client_secret) stay declared but unwired. Power users who want Jina or team OAuth override via env vars or `claude mcp add --scope user`.
- Hosted demo at `distillery-mcp.fly.dev` — still relevant for users who want a managed stack; the plugin default just no longer requires it for a working install.

## Post-merge sequencing

After this PR merges, immediately tag v0.6.0:

```
git checkout main && git pull
git tag v0.6.0 && git push origin v0.6.0
gh release create v0.6.0 --title "v0.6.0 — Fastembed default" --generate-notes
```

The release triggers `pypi-publish.yml` (PyPI + MCP Registry + Smithery) and `changelog.yml`. Minimize the window between merge and tag — the manifest `>=0.6.0` pin will block installs cleanly during it, but shorter is better.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy --strict`, `pytest -q` green (2685 passed, 88 skipped)
- [x] All version stamp files agree on 0.6.0
- [x] Manifest JSON files parse
- [ ] Post-merge: tag v0.6.0; verify PyPI publish; verify MCP Registry update; smoke-test `claude plugin install distillery@distillery-marketplace` against a fresh Claude Code install

Closes #548. Supersedes #466 (commented separately on that issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.6.0: Updated all package manifests, configurations, and metadata files to reflect the new version
  * Enhanced server startup configuration: Implemented explicit dependency specification in MCP server initialization with environment variable support for flexible provider selection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->