### PR TITLE
release: v0.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "distillery",
       "source": "./",
       "description": "Knowledge base skills — capture, search, and synthesize project knowledge",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings"],
       "category": "knowledge-management"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "distillery",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Knowledge base skills for Claude Code — capture, search, and synthesize project knowledge",
   "author": {
     "name": "norrietaylor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distillery-mcp"
-version = "0.6.0"
+version = "0.6.1"
 description = "Persistent shared memory for Claude Code — MCP server with DuckDB vector search, semantic dedup, and ambient intelligence for team knowledge"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.norrietaylor/distillery-mcp",
   "title": "Distillery",
   "description": "Knowledge base for Claude Code with semantic search, feed intelligence, and teams",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "url": "https://github.com/norrietaylor/distillery",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "transport": {
         "type": "streamable-http",
         "url": "https://distillery-mcp.fly.dev/mcp"

--- a/src/distillery/__init__.py
+++ b/src/distillery/__init__.py
@@ -2,5 +2,5 @@
 
 import os
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __build_sha__ = os.environ.get("DISTILLERY_BUILD_SHA", "dev")

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ wheels = [
 
 [[package]]
 name = "distillery-mcp"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

Patch release rolling up three PRs landed against v0.6.0. No manifest content changes — fastembed remains the install-time default from v0.6.0.

## What's in v0.6.1

- **#552** — Docs refresh for v0.6.0 install UX (README, CLAUDE.md, RELEASING, distillery.yaml.example, docs/getting-started/*, docs/architecture.md). Aligns install copy with fastembed default; preserves Jina/OpenAI as documented overrides.
- **#527** — SSRF hardening for RSS fetcher:
  - DNS rebinding prevention via scoped `socket.getaddrinfo` pinning in the redirect loop
  - `socket.gaierror` errno-strict handling — only `EAI_NONAME`/`EAI_NODATA` get the silent-return; `EAI_AGAIN` and friends now reject closed
  - Stable validation message for clients (no `str(exc)` leak)
  - Bounded `OrgMembershipChecker` caches (1024 entries, FIFO eviction)
- **#520** — Wikilink edge population — `[[entry-<8-hex>]]` references now create `link` rows in `entry_relations` via the existing reconcile action. Mechanism #8 of #496; mechanisms 3-7 remain open.

## Version stamps

- `pyproject.toml` — 0.6.0 → 0.6.1
- `src/distillery/__init__.py` — __version__ → 0.6.1
- `.claude-plugin/plugin.json` — 0.6.0 → 0.6.1
- `.claude-plugin/marketplace.json` — plugin entry 0.6.0 → 0.6.1
- `server.json` — version + packages[*].version → 0.6.1
- `uv.lock` — regenerated

## Post-merge sequencing

After this PR merges, tag immediately:

```
git checkout main && git pull
git tag v0.6.1 && git push origin v0.6.1
gh release create v0.6.1 --title "v0.6.1 — Security + docs + wikilink edges" --generate-notes
```

Triggers `pypi-publish.yml` (PyPI + MCP Registry + Smithery) and `changelog.yml`.

## Test plan

- [x] ruff check, mypy --strict clean
- [x] pytest -q full suite green (2745 passed, 88 skipped)
- [x] All manifest JSON files parse
- [x] All 6 version stamp files agree on 0.6.1
- [ ] Note: `ruff format --check` flags `tests/test_relations_backfill_on_write.py` (pre-existing from PR #520; CI does not run `--check`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.6.1 across all manifest and configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norrietaylor/distillery/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->