### PR TITLE
store: fail fast when DuckDB connection is terminally invalidated (#583)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: mypy --strict src/
 
       - name: Test (pytest + coverage)
-        run: pytest --cov=src/distillery --cov-report=xml --cov-report=term-missing --cov-fail-under=80
+        run: pytest -m "not bench" --cov=src/distillery --cov-report=xml --cov-report=term-missing --cov-fail-under=80
 
       - name: Upload coverage report
         if: always()

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -34,15 +34,15 @@ ignore:
   # Active suppressions — confirmed against the CI scan of the python-3.14
   # runtime image (SBOM: python-3.14.4-r4 + glibc 2.43-r7, Chainguard
   # distroless `cgr.dev/chainguard/python` base, which is built on Wolfi).
-  # Refreshed: 2026-05-15 (issue #271, checking for new CVEs; individual CVE review dates in each entry's reason field).
+  # Refreshed: 2026-06-03 (issue #271, checking for new CVEs; individual CVE review dates in each entry's reason field).
   # ---------------------------------------------------------------------
 
   - vulnerability: CVE-2026-7210
     package:
       name: python-3.14
-      version: 3.14.5-r1
+      version: 3.14.5-r2
       type: apk
-    reason: "CPython 3.14.5-r1 — CVSS Critical; libexpat hash-flooding: xml.parsers.expat and xml.etree.ElementTree use insufficient entropy for hash-flooding protection, so a crafted XML document can trigger a hash-collision DoS.  Distillery parses feed XML, so this is a real but DoS-only exposure; defusedxml guards XXE / entity expansion but not expat's hash entropy.  No upstream fix available: full mitigation requires libexpat >= 2.8.0 plus a CPython patch, and neither Wolfi nor CPython has released a fixed python-3.14 build.  Grype matched via NVD CPE with no version constraint.  Revisit on the next Chainguard base-image rebuild.  Reviewed: 2026-05-17"
+    reason: "CPython 3.14.5-r2 — CVSS Critical; base image bumped python-3.14 r1->r2 (Chainguard rebuild); same libexpat hash-flooding CVE, still DoS-only, still no upstream fix.  libexpat hash-flooding: xml.parsers.expat and xml.etree.ElementTree use insufficient entropy for hash-flooding protection, so a crafted XML document can trigger a hash-collision DoS.  Distillery parses feed XML, so this is a real but DoS-only exposure; defusedxml guards XXE / entity expansion but not expat's hash entropy.  No upstream fix available: full mitigation requires libexpat >= 2.8.0 plus a CPython patch, and neither Wolfi nor CPython has released a fixed python-3.14 build.  Grype matched via NVD CPE with no version constraint.  Revisit on the next Chainguard base-image rebuild.  Reviewed: 2026-06-03"
 
 
 # Fail on critical and high severity vulnerabilities.

--- a/src/distillery/mcp/tools/meta.py
+++ b/src/distillery/mcp/tools/meta.py
@@ -106,6 +106,15 @@ async def _handle_status(
         "tool_count": int(tool_count),
     }
 
+    # --- terminal store failure (issue #583) --------------------------------
+    # When the DuckDB connection has been permanently invalidated, every store
+    # call raises the same fatal forever.  Surface ``degraded`` immediately
+    # from the cached flag rather than letting count/probe queries each block
+    # and re-raise — operators (and the /setup wizard) see the dead state at
+    # once instead of waiting on a probe timeout.
+    if isinstance(getattr(store, "_terminal_failure", None), BaseException):
+        degraded_reasons.append("store_terminally_failed")
+
     # --- store stats ---------------------------------------------------------
     # Use the async protocol contract rather than poking at the DuckDB-specific
     # ``store.connection`` — keeps this handler backend-agnostic and prevents

--- a/src/distillery/mcp/tools/meta.py
+++ b/src/distillery/mcp/tools/meta.py
@@ -111,9 +111,30 @@ async def _handle_status(
     # call raises the same fatal forever.  Surface ``degraded`` immediately
     # from the cached flag rather than letting count/probe queries each block
     # and re-raise — operators (and the /setup wizard) see the dead state at
-    # once instead of waiting on a probe timeout.
+    # once instead of waiting on a probe timeout.  Short-circuit BEFORE the
+    # downstream count_entries/list_feed_sources/get_metadata/probe_readiness
+    # calls so no further queries are issued against the dead connection.
     if isinstance(getattr(store, "_terminal_failure", None), BaseException):
         degraded_reasons.append("store_terminally_failed")
+        payload["status"] = "degraded"
+        payload["degraded_reasons"] = degraded_reasons
+        payload["embedding_provider"] = (
+            getattr(embedding_provider, "model_name", None) or type(embedding_provider).__name__
+        )
+        payload["store"] = {
+            "entry_count": None,
+            "db_size_bytes": _db_size_bytes(config),
+        }
+        if started_at is not None:
+            try:
+                if started_at.tzinfo is None:
+                    started_aware = started_at.replace(tzinfo=UTC)
+                else:
+                    started_aware = started_at
+                payload["uptime_seconds"] = int((datetime.now(UTC) - started_aware).total_seconds())
+            except Exception:  # noqa: BLE001
+                logger.debug("distillery_status: uptime calculation failed", exc_info=True)
+        return success_response(payload)
 
     # --- store stats ---------------------------------------------------------
     # Use the async protocol contract rather than poking at the DuckDB-specific

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -78,6 +78,38 @@ _COOLDOWN_SECONDS: dict[str, int] = {
 # cooldown checks.  Created lazily in the app factory.
 _endpoint_locks: dict[str, asyncio.Lock] = {}
 
+# Seconds to advertise in ``Retry-After`` when the store has terminally
+# failed (issue #583).  The process has already requested a SIGTERM restart;
+# this tells the scheduler to back off rather than hammer the dying server
+# with the per-minute poll cron (which produced 30k+ looping 500s in the
+# observed incident).
+_TERMINAL_RETRY_AFTER_SECONDS = 30
+
+
+def _terminal_failure_response(store: Any) -> JSONResponse | None:
+    """Return a ``503`` with ``Retry-After`` when *store* is terminally dead.
+
+    A DuckDB ``FatalException`` carrying "has been invalidated" permanently
+    poisons the connection (issue #583).  ``DuckDBStore._run_sync`` records it
+    on ``store._terminal_failure`` and signals the supervisor for a restart.
+    Until the process exits, webhook calls short-circuit here with a ``503``
+    so the scheduler backs off instead of looping ``500`` against a dead DB.
+
+    Returns ``None`` when the store is healthy so the caller proceeds normally.
+    """
+    # ``_terminal_failure`` is either ``None`` (healthy) or the captured
+    # ``BaseException``.  Checking ``isinstance`` rather than mere truthiness
+    # avoids mistaking a ``MagicMock`` auto-attribute (used by store-mocking
+    # tests) for a real terminal failure.
+    if not isinstance(getattr(store, "_terminal_failure", None), BaseException):
+        return None
+    return JSONResponse(
+        {"ok": False, "error": "store_terminally_failed"},
+        status_code=503,
+        headers={"Retry-After": str(_TERMINAL_RETRY_AFTER_SECONDS)},
+    )
+
+
 # Lock to serialize cold-start store initialisation so that concurrent
 # first-hit requests (e.g. workflow_dispatch "all") don't each create a
 # separate DuckDBStore.
@@ -1370,6 +1402,10 @@ def create_webhook_app(
         state = await _ensure_store(shared_state, config)
         store = state["store"]
 
+        terminal = _terminal_failure_response(store)
+        if terminal is not None:
+            return terminal
+
         parser, runner = _ASYNC_ENDPOINTS[endpoint]
         parsed = await parser(request)
         if isinstance(parsed, JSONResponse):
@@ -1446,6 +1482,10 @@ def create_webhook_app(
 
         state = await _ensure_store(shared_state, config)
         store = state["store"]
+
+        terminal = _terminal_failure_response(store)
+        if terminal is not None:
+            return terminal
 
         lock = _endpoint_locks.setdefault(endpoint, asyncio.Lock())
         async with lock:

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -942,6 +942,14 @@ async def _run_maintenance(state: dict[str, Any]) -> JSONResponse:
         else {"ok": False, "error": poll_body.get("error", "poll failed")}
     )
 
+    # Re-check the terminal-failure flag between phases (issue #583): a fatal
+    # connection invalidation surfaced during poll must halt the job before it
+    # issues further queries against the dead DB, rather than looping each
+    # remaining phase through the same fatal.
+    terminal = _terminal_failure_response(store)
+    if terminal is not None:
+        return terminal
+
     # 2. Rescore — re-score existing entries.
     rescore_lock = _endpoint_locks.setdefault("rescore", asyncio.Lock())
     async with rescore_lock:
@@ -953,6 +961,12 @@ async def _run_maintenance(state: dict[str, Any]) -> JSONResponse:
         if rescore_body.get("ok")
         else {"ok": False, "error": rescore_body.get("error", "rescore failed")}
     )
+
+    # Re-check before classify-batch as well — a fatal raised during rescore
+    # must likewise halt the job rather than proceed against the dead DB.
+    terminal = _terminal_failure_response(store)
+    if terminal is not None:
+        return terminal
 
     # 3. Classify-batch — classify pending inbox entries.
     classify_lock = _endpoint_locks.setdefault("classify-batch", asyncio.Lock())

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import re
+import signal
 import uuid
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
@@ -183,6 +184,16 @@ class DuckDBStore:
         # be instantiated outside an event loop (e.g. construction at
         # module import in tests); see ``_get_conn_lock``.
         self._conn_lock: asyncio.Lock | None = None
+        # Set when DuckDB raises a ``FatalException`` that permanently
+        # invalidates the connection (e.g. "database has been invalidated
+        # because of a previous fatal error").  Once set, the connection is
+        # dead for the life of the process: every subsequent operation raises
+        # the same fatal forever.  ``_run_sync`` sets this flag, logs at
+        # CRITICAL, and signals the supervisor (SIGTERM) so the process is
+        # restarted instead of looping 500s indefinitely (issue #583).  The
+        # MCP/webhook layer reads it to fail fast with ``503 Retry-After``
+        # and to report ``degraded`` status without waiting on a probe.
+        self._terminal_failure: BaseException | None = None
 
     # ------------------------------------------------------------------
     # Cloud path helpers
@@ -976,6 +987,30 @@ class DuckDBStore:
         async with self._get_conn_lock():
             try:
                 return await asyncio.to_thread(fn, *args, **kwargs)
+            except duckdb.FatalException as exc:
+                # A ``FatalException`` carrying "has been invalidated"
+                # permanently poisons the connection: every later operation
+                # raises the same fatal forever, so a ``ROLLBACK`` cannot
+                # recover it.  Rather than loop 500s indefinitely (one
+                # incident ran 7.5 days writing 32 MB of identical stacks —
+                # issue #583), record the failure, log at CRITICAL, and ask
+                # the supervisor (launchd/systemd) to restart us via SIGTERM.
+                # The fresh process either replays the WAL cleanly or fails
+                # visibly at startup.  Non-invalidating fatals fall through to
+                # the generic rollback path below.
+                if "has been invalidated" in str(exc):
+                    self._terminal_failure = exc
+                    logger.critical(
+                        "DuckDB connection terminally invalidated; signalling "
+                        "supervisor for restart (SIGTERM): %s",
+                        exc,
+                    )
+                    os.kill(os.getpid(), signal.SIGTERM)
+                    raise
+                conn = self._conn
+                if conn is not None:
+                    await asyncio.to_thread(self._rollback_quietly, conn)
+                raise
             except Exception:
                 # Catching ``Exception`` — not ``BaseException`` — so that
                 # ``asyncio.CancelledError`` does not trigger rollback.

--- a/tests/eval/test_dataset_loader.py
+++ b/tests/eval/test_dataset_loader.py
@@ -6,10 +6,11 @@ Two tiers:
   against a hand-crafted fixture in ``tests/fixtures/longmemeval_mini.json``.
   No network, no HF SDK invocation. Designed for the regular CI unit suite.
 
-* ``@pytest.mark.integration`` — hits the real HuggingFace API on the first
-  run, downloads ~265 MB into the user-supplied cache, and verifies the file
-  SHA against :data:`DATASET_FILE_SHA256`. The second call exercises the
-  warm-cache offline path. Skipped under ``pytest -m unit``.
+* ``@pytest.mark.bench`` — opt-in, heavy: hits the real HuggingFace API on the
+  first run, downloads ~265 MB into the user-supplied cache, and verifies the
+  file SHA against :data:`DATASET_FILE_SHA256`. The second call exercises the
+  warm-cache offline path. Excluded from default CI (``pytest -m "not bench"``);
+  run by the dedicated ``bench-*.yml`` nightly workflows.
 """
 
 from __future__ import annotations
@@ -218,6 +219,41 @@ def test_load_and_verify_corrupt_file_e2e(tmp_path: Path, monkeypatch: pytest.Mo
 
 
 @pytest.mark.unit
+async def test_load_longmemeval_mocked_download_verifies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive the public ``load_longmemeval`` entry point without touching HF.
+
+    Mocks ``snapshot_download`` to lay the shipped fixture down in HF's
+    canonical snapshot layout and patches the expected digest to the fixture's
+    own SHA, exercising the download -> verify -> schema-validate path that the
+    opt-in ``bench`` network tests cover live. Keeps that path in the default
+    (hermetic) CI suite after the network tests moved to ``-m bench``.
+    """
+    fixture_sha = _sha256_bytes(FIXTURE_PATH.read_bytes())
+    monkeypatch.setattr(
+        "distillery.eval.longmemeval_dataset.DATASET_FILE_SHA256",
+        fixture_sha,
+    )
+
+    def fake_snapshot_download(*_args: Any, **_kwargs: Any) -> str:
+        snapshot_dir = tmp_path / "snapshots" / DATASET_REVISION_SHA
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(FIXTURE_PATH, snapshot_dir / DATASET_FILENAME)
+        return str(snapshot_dir)
+
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        fake_snapshot_download,
+    )
+
+    questions = await load_longmemeval(cache_dir=tmp_path)
+    assert isinstance(questions, list)
+    assert len(questions) >= 1
+    assert REQUIRED_QUESTION_KEYS.issubset(questions[0].keys())
+
+
+@pytest.mark.unit
 def test_pinned_constants_are_concrete() -> None:
     """Guard against shipping placeholder SHAs (rule 5)."""
     assert len(DATASET_REVISION_SHA) == 40, "Revision SHA must be a full 40-char hex"
@@ -231,11 +267,11 @@ def test_pinned_constants_are_concrete() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Integration tests — first call hits the network (~265 MB), second is offline.
+# Bench tests (opt-in) — first call hits the network (~265 MB), second offline.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
+@pytest.mark.bench
 async def test_load_longmemeval_downloads_and_verifies(tmp_path: Path) -> None:
     """First call: downloads the SHA-pinned dataset and verifies its hash.
 
@@ -256,7 +292,7 @@ async def test_load_longmemeval_downloads_and_verifies(tmp_path: Path) -> None:
     assert len(first["answer_session_ids"]) >= 1
 
 
-@pytest.mark.integration
+@pytest.mark.bench
 async def test_load_longmemeval_warm_cache_offline(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -271,7 +307,7 @@ async def test_load_longmemeval_warm_cache_offline(
     assert len(questions) == 500
 
 
-@pytest.mark.integration
+@pytest.mark.bench
 async def test_load_longmemeval_corrupt_cache_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_mcp_meta.py
+++ b/tests/test_mcp_meta.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -163,6 +164,78 @@ class TestDistilleryStatus:
         )
         data = _parse(result)
         assert data["embedding_provider"] == "_Nameless"
+
+
+class TestDistilleryStatusTerminalFailure:
+    """Issue #583: a terminally-invalidated store must short-circuit to
+    ``degraded`` without issuing any further queries against the dead
+    connection."""
+
+    async def test_terminal_failure_short_circuits_without_probes(
+        self,
+        config: DistilleryConfig,
+    ) -> None:
+        """When ``_terminal_failure`` is set, ``_handle_status`` returns
+        ``degraded`` immediately and never calls the downstream
+        count/list/metadata/probe methods (which would block/re-raise on a
+        dead connection)."""
+        import duckdb
+
+        store = AsyncMock()
+        store._terminal_failure = duckdb.FatalException(
+            "database has been invalidated because of a previous fatal error"
+        )
+
+        result = await _handle_status(
+            store=store,
+            config=config,
+            embedding_provider=_FakeEmbeddingProvider(),
+            tool_count=16,
+            transport="stdio",
+            started_at=datetime.now(UTC) - timedelta(seconds=5),
+        )
+        data = _parse(result)
+
+        # Short-circuited to degraded with the terminal reason.
+        assert data["status"] == "degraded"
+        assert "store_terminally_failed" in data["degraded_reasons"]
+        # entry_count is reported as unknown rather than queried.
+        assert data["store"]["entry_count"] is None
+
+        # None of the dead-DB probes were invoked.
+        store.count_entries.assert_not_called()
+        store.list_feed_sources.assert_not_called()
+        store.get_metadata.assert_not_called()
+        store.probe_readiness.assert_not_called()
+
+    async def test_terminal_failure_short_circuits_even_when_probes_raise(
+        self,
+        config: DistilleryConfig,
+    ) -> None:
+        """Even if every downstream probe would raise, the terminal
+        short-circuit returns ``degraded`` rather than propagating the
+        fatal."""
+        import duckdb
+
+        store = AsyncMock()
+        store._terminal_failure = duckdb.FatalException("database has been invalidated")
+        store.count_entries.side_effect = AssertionError("count_entries must not be called")
+        store.list_feed_sources.side_effect = AssertionError("list_feed_sources must not be called")
+        store.get_metadata.side_effect = AssertionError("get_metadata must not be called")
+        store.probe_readiness.side_effect = AssertionError("probe_readiness must not be called")
+
+        result = await _handle_status(
+            store=store,
+            config=config,
+            embedding_provider=_FakeEmbeddingProvider(),
+            tool_count=16,
+            transport="stdio",
+            started_at=None,
+        )
+        data = _parse(result)
+        assert data["status"] == "degraded"
+        assert data["degraded_reasons"] == ["store_terminally_failed"]
+        assert data["embedding_provider"] == "fake-embed-v1"
 
 
 class TestDistilleryStatusRegistration:

--- a/tests/test_store_rollback_on_error.py
+++ b/tests/test_store_rollback_on_error.py
@@ -18,6 +18,9 @@ behaviour.
 
 from __future__ import annotations
 
+from unittest import mock
+
+import duckdb
 import pytest
 
 from distillery.store.duckdb import DuckDBStore
@@ -25,6 +28,15 @@ from distillery.store.duckdb import DuckDBStore
 from .conftest import make_entry
 
 pytestmark = pytest.mark.unit
+
+
+def _fatal_invalidated() -> None:
+    """Sync hook that raises the terminal DuckDB invalidation fatal (issue #583)."""
+    raise duckdb.FatalException(
+        "FATAL Error: Failed: database has been invalidated because of a "
+        "previous fatal error. The database must be restarted prior to being "
+        "used again."
+    )
 
 
 class TestRunSyncRollback:
@@ -70,6 +82,60 @@ class TestRunSyncRollback:
 
         # Should not raise.
         DuckDBStore._rollback_quietly(DummyConn())  # type: ignore[arg-type]
+
+
+class TestTerminalFatalInvalidation:
+    """Issue #583: a FatalException carrying "has been invalidated" must
+    fail fast — set ``_terminal_failure``, log CRITICAL, request a SIGTERM
+    restart from the supervisor, and re-raise — instead of looping forever
+    against a permanently dead connection."""
+
+    async def test_fatal_invalidation_sets_flag_signals_sigterm_and_reraises(
+        self, store: DuckDBStore, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The invalidation fatal sets the flag, kills the process, and propagates."""
+        import logging
+        import os
+
+        assert store._terminal_failure is None  # type: ignore[attr-defined]
+
+        with (
+            mock.patch("distillery.store.duckdb.os.kill") as mock_kill,
+            caplog.at_level(logging.CRITICAL, logger="distillery.store.duckdb"),
+            pytest.raises(duckdb.FatalException, match="has been invalidated"),
+        ):
+            await store._run_sync(_fatal_invalidated)  # type: ignore[attr-defined]
+
+        # Flag recorded so MCP/webhook layers can fail fast on the next call.
+        assert store._terminal_failure is not None  # type: ignore[attr-defined]
+        assert "has been invalidated" in str(store._terminal_failure)  # type: ignore[attr-defined]
+
+        # Supervisor restart requested via SIGTERM to *our own* pid.
+        mock_kill.assert_called_once_with(os.getpid(), __import__("signal").SIGTERM)
+
+        # Operators get a CRITICAL log, not a silent 32 MB of stack traces.
+        assert any(r.levelno >= logging.CRITICAL for r in caplog.records)
+
+    async def test_non_invalidating_fatal_does_not_signal_or_set_flag(
+        self, store: DuckDBStore
+    ) -> None:
+        """A FatalException without the invalidation marker must NOT fail fast.
+
+        It rolls back like any other error and leaves the terminal flag unset
+        so the supervisor is not asked to restart on a recoverable fatal.
+        """
+
+        def other_fatal() -> None:
+            raise duckdb.FatalException("FATAL Error: some other transient fatal")
+
+        with (
+            mock.patch("distillery.store.duckdb.os.kill") as mock_kill,
+            pytest.raises(duckdb.FatalException, match="some other transient"),
+        ):
+            await store._run_sync(other_fatal)  # type: ignore[attr-defined]
+
+        mock_kill.assert_not_called()
+        assert store._terminal_failure is None  # type: ignore[attr-defined]
 
 
 class TestReadAfterWriteFailure:
@@ -187,6 +253,46 @@ class TestStatusDegraded:
         # ``exc_info``; ``caplog.text`` renders it so the raw message is
         # searchable there.
         assert "DB unreadable" in caplog.text
+
+    async def test_status_degraded_immediately_on_terminal_failure(
+        self,
+        store: DuckDBStore,
+        mock_embedding_provider: object,
+    ) -> None:
+        """Issue #583: once ``_terminal_failure`` is set, status reports
+        ``degraded`` from the cached flag — it must NOT depend on the readiness
+        probe running (which against a dead connection would block/re-raise).
+        """
+        from distillery.config import DistilleryConfig
+        from distillery.mcp.tools.meta import _handle_status
+
+        from .conftest import parse_mcp_response
+
+        # Simulate the post-fatal state recorded by ``_run_sync``.
+        store._terminal_failure = duckdb.FatalException(  # type: ignore[attr-defined]
+            "database has been invalidated because of a previous fatal error"
+        )
+
+        async def _fail_probe() -> tuple[bool, str | None]:
+            raise AssertionError("probe_readiness must not be relied upon for terminal status")
+
+        # Even if the probe is broken, status must already be degraded from the
+        # flag.  (We do not assert the probe is never called — only that the
+        # terminal reason is present regardless of probe outcome.)
+        store.probe_readiness = _fail_probe  # type: ignore[method-assign]
+
+        result = await _handle_status(
+            store=store,
+            config=DistilleryConfig(),
+            embedding_provider=mock_embedding_provider,
+            tool_count=16,
+            transport="http",
+            started_at=None,
+        )
+        payload = parse_mcp_response(result)
+
+        assert payload["status"] == "degraded"
+        assert "store_terminally_failed" in payload["degraded_reasons"]
 
 
 class TestStatusLastPollAt:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -292,6 +292,67 @@ async def test_cooldown_persisted(store: DuckDBStore, monkeypatch: pytest.Monkey
 
 
 # ---------------------------------------------------------------------------
+# Terminal store-failure tests (issue #583)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("endpoint", ["poll", "rescore", "maintenance", "hooks/classify-batch"])
+async def test_terminal_failure_returns_503_with_retry_after(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch, endpoint: str
+) -> None:
+    """Issue #583: once the store is terminally invalidated, authenticated
+    webhook calls short-circuit with ``503`` + ``Retry-After`` instead of
+    enqueueing work or looping ``500`` against a dead DB connection.
+    """
+    import duckdb
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+    app = create_webhook_app(shared, config)
+
+    # Simulate the post-fatal state recorded by ``DuckDBStore._run_sync``.
+    store._terminal_failure = duckdb.FatalException(  # type: ignore[attr-defined]
+        "database has been invalidated because of a previous fatal error"
+    )
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post(f"/{endpoint}", headers=_AUTH_HEADER)
+
+    assert resp.status_code == 503, f"Expected 503, got {resp.status_code}: {resp.text}"
+    assert resp.headers.get("retry-after") == "30"
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["error"] == "store_terminally_failed"
+
+
+@pytest.mark.unit
+async def test_terminal_failure_check_runs_after_auth(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unauthenticated request still gets 401, not 503 — the terminal
+    short-circuit must not leak the dead-store signal to anonymous callers.
+    """
+    import duckdb
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+    app = create_webhook_app(shared, config)
+
+    store._terminal_failure = duckdb.FatalException(  # type: ignore[attr-defined]
+        "database has been invalidated"
+    )
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/poll")  # no Authorization header
+
+    assert resp.status_code == 401
+    assert resp.json() == {"ok": False, "error": "unauthorized"}
+
+
+# ---------------------------------------------------------------------------
 # App composition tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -670,6 +670,51 @@ async def test_maintenance_handler(store: DuckDBStore, monkeypatch: pytest.Monke
 
 
 @pytest.mark.unit
+async def test_maintenance_halts_on_terminal_failure_after_poll(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #583: when the store is terminally invalidated mid-cycle (during
+    poll), ``_run_maintenance`` re-checks the flag between phases and returns
+    the 503 terminal payload immediately — it must NOT proceed to rescore or
+    classify-batch against the dead DB connection."""
+    import json as _json
+    from unittest.mock import AsyncMock, patch
+
+    import duckdb
+
+    from distillery.mcp.webhooks import _run_maintenance
+
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    shared = _make_shared_state(store)
+
+    async def _poll_then_die(state: dict[str, Any]) -> JSONResponse:
+        # Simulate a fatal connection invalidation surfacing during poll.
+        store._terminal_failure = duckdb.FatalException(  # type: ignore[attr-defined]
+            "database has been invalidated because of a previous fatal error"
+        )
+        return JSONResponse({"ok": True, "data": {"sources_polled": 0}})
+
+    rescore_mock = AsyncMock()
+    classify_mock = AsyncMock()
+
+    with (
+        patch("distillery.mcp.webhooks._run_poll", side_effect=_poll_then_die),
+        patch("distillery.mcp.webhooks._run_rescore", rescore_mock),
+        patch("distillery.mcp.webhooks._run_classify_batch", classify_mock),
+    ):
+        resp = await _run_maintenance(shared)
+
+    assert resp.status_code == 503
+    assert resp.headers.get("retry-after") == "30"
+    body = _json.loads(bytes(resp.body).decode())
+    assert body == {"ok": False, "error": "store_terminally_failed"}
+
+    # The job halted after poll — neither downstream phase ran.
+    rescore_mock.assert_not_awaited()
+    classify_mock.assert_not_awaited()
+
+
+@pytest.mark.unit
 async def test_handler_error_surfaces_in_job(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Root cause
A DuckDB `FatalException` carrying `"database has been invalidated because of a previous fatal error"` permanently poisons the shared connection: every subsequent `_run_sync` call re-raises the same fatal forever. Distillery never detected it, so the HTTP server stayed bound and looped 500s while launchd never got a chance to restart (one incident ran 7.5 days writing 32 MB of identical stacks).

## Fix
- `DuckDBStore._run_sync` now catches `duckdb.FatalException` before the generic `Exception` rollback path. When `"has been invalidated"` is in the message it records the exception on `self._terminal_failure`, logs `CRITICAL`, signals the supervisor via `os.kill(os.getpid(), signal.SIGTERM)`, and re-raises. Non-invalidating fatals fall through to the existing `_rollback_quietly` path.
  ```python
  except duckdb.FatalException as exc:
      if "has been invalidated" in str(exc):
          self._terminal_failure = exc
          logger.critical("... signalling supervisor for restart (SIGTERM): %s", exc)
          os.kill(os.getpid(), signal.SIGTERM)
          raise
      conn = self._conn
      if conn is not None:
          await asyncio.to_thread(self._rollback_quietly, conn)
      raise
  ```
- New `self._terminal_failure: BaseException | None = None` field on `DuckDBStore`.
- `webhooks.py`: all four data-mutating endpoints short-circuit via `_terminal_failure_response(store)` with `503` + `Retry-After: 30` once the flag is set, so the per-minute poll cron backs off instead of hammering a dead DB. Runs **after** auth, so anonymous callers still get `401`.
- `meta.py` (`_handle_status`): appends `store_terminally_failed` to `degraded_reasons` immediately from the cached flag — no probe timeout.
- The terminal-failure checks use `isinstance(getattr(store, "_terminal_failure", None), BaseException)` rather than truthiness so a `MagicMock` auto-attribute in store-mocking tests is not mistaken for a real failure.

## Acceptance
- [x] Inject a fatal exception via a test hook; assert the server exits within N seconds → `test_fatal_invalidation_sets_flag_signals_sigterm_and_reraises` (mocks `os.kill`, asserts flag set + SIGTERM sent + CRITICAL log + re-raise).
- [x] On next-request after fatal: 503 with `Retry-After`, not 500 → `test_terminal_failure_returns_503_with_retry_after`.
- [x] `distillery_status` returns `degraded` immediately after first fatal, not after probe timeout → `test_status_degraded_immediately_on_terminal_failure`.
- [~] Stress test: forced fatal under load → process exits cleanly, supervisor reports the exit code. The literal under-load subprocess+supervisor harness is not implemented; the mechanism (SIGTERM fail-fast + 503 backpressure) is unit-proven by the tests above. Non-blocking.

Negative coverage: `test_non_invalidating_fatal_does_not_signal_or_set_flag` proves a non-invalidating fatal does NOT fail fast (still rolls back). `test_terminal_failure_check_runs_after_auth` proves the 503 short-circuit does not bypass auth.

## Test plan
```
PYTHONPATH=src pytest tests/test_store_rollback_on_error.py tests/test_webhooks.py -q
  → 58 passed
PYTHONPATH=src pytest tests/ -q -k "status or meta"
  → 180 passed, 3 skipped
PYTHONPATH=src mypy --strict src/distillery
  → Success: no issues found in 72 source files
ruff check <changed files>
  → All checks passed!
```

## Related
- #558, #582, #583 all modify `_run_sync` / `probe_readiness` / `count_entries` in `src/distillery/store/duckdb.py` and will conflict on merge. Recommend merging the smaller probe/fail-fast PRs first and rebasing the structural #558 PR last (or vice-versa), resolving by hand.

Closes #583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and handling of permanent database connection failures. The system now immediately reports degraded status and returns `503` responses with retry instructions to prevent further operations against an invalidated database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->