### PR TITLE
ci: hermetic default test suite + grype r2 pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: mypy --strict src/
 
       - name: Test (pytest + coverage)
-        run: pytest --cov=src/distillery --cov-report=xml --cov-report=term-missing --cov-fail-under=80
+        run: pytest -m "not bench" --cov=src/distillery --cov-report=xml --cov-report=term-missing --cov-fail-under=80
 
       - name: Upload coverage report
         if: always()

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -34,15 +34,15 @@ ignore:
   # Active suppressions — confirmed against the CI scan of the python-3.14
   # runtime image (SBOM: python-3.14.4-r4 + glibc 2.43-r7, Chainguard
   # distroless `cgr.dev/chainguard/python` base, which is built on Wolfi).
-  # Refreshed: 2026-05-15 (issue #271, checking for new CVEs; individual CVE review dates in each entry's reason field).
+  # Refreshed: 2026-06-03 (issue #271, checking for new CVEs; individual CVE review dates in each entry's reason field).
   # ---------------------------------------------------------------------
 
   - vulnerability: CVE-2026-7210
     package:
       name: python-3.14
-      version: 3.14.5-r1
+      version: 3.14.5-r2
       type: apk
-    reason: "CPython 3.14.5-r1 — CVSS Critical; libexpat hash-flooding: xml.parsers.expat and xml.etree.ElementTree use insufficient entropy for hash-flooding protection, so a crafted XML document can trigger a hash-collision DoS.  Distillery parses feed XML, so this is a real but DoS-only exposure; defusedxml guards XXE / entity expansion but not expat's hash entropy.  No upstream fix available: full mitigation requires libexpat >= 2.8.0 plus a CPython patch, and neither Wolfi nor CPython has released a fixed python-3.14 build.  Grype matched via NVD CPE with no version constraint.  Revisit on the next Chainguard base-image rebuild.  Reviewed: 2026-05-17"
+    reason: "CPython 3.14.5-r2 — CVSS Critical; base image bumped python-3.14 r1->r2 (Chainguard rebuild); same libexpat hash-flooding CVE, still DoS-only, still no upstream fix.  libexpat hash-flooding: xml.parsers.expat and xml.etree.ElementTree use insufficient entropy for hash-flooding protection, so a crafted XML document can trigger a hash-collision DoS.  Distillery parses feed XML, so this is a real but DoS-only exposure; defusedxml guards XXE / entity expansion but not expat's hash entropy.  No upstream fix available: full mitigation requires libexpat >= 2.8.0 plus a CPython patch, and neither Wolfi nor CPython has released a fixed python-3.14 build.  Grype matched via NVD CPE with no version constraint.  Revisit on the next Chainguard base-image rebuild.  Reviewed: 2026-06-03"
 
 
 # Fail on critical and high severity vulnerabilities.

--- a/tests/eval/test_dataset_loader.py
+++ b/tests/eval/test_dataset_loader.py
@@ -6,10 +6,11 @@ Two tiers:
   against a hand-crafted fixture in ``tests/fixtures/longmemeval_mini.json``.
   No network, no HF SDK invocation. Designed for the regular CI unit suite.
 
-* ``@pytest.mark.integration`` — hits the real HuggingFace API on the first
-  run, downloads ~265 MB into the user-supplied cache, and verifies the file
-  SHA against :data:`DATASET_FILE_SHA256`. The second call exercises the
-  warm-cache offline path. Skipped under ``pytest -m unit``.
+* ``@pytest.mark.bench`` — opt-in, heavy: hits the real HuggingFace API on the
+  first run, downloads ~265 MB into the user-supplied cache, and verifies the
+  file SHA against :data:`DATASET_FILE_SHA256`. The second call exercises the
+  warm-cache offline path. Excluded from default CI (``pytest -m "not bench"``);
+  run by the dedicated ``bench-*.yml`` nightly workflows.
 """
 
 from __future__ import annotations
@@ -218,6 +219,41 @@ def test_load_and_verify_corrupt_file_e2e(tmp_path: Path, monkeypatch: pytest.Mo
 
 
 @pytest.mark.unit
+async def test_load_longmemeval_mocked_download_verifies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive the public ``load_longmemeval`` entry point without touching HF.
+
+    Mocks ``snapshot_download`` to lay the shipped fixture down in HF's
+    canonical snapshot layout and patches the expected digest to the fixture's
+    own SHA, exercising the download -> verify -> schema-validate path that the
+    opt-in ``bench`` network tests cover live. Keeps that path in the default
+    (hermetic) CI suite after the network tests moved to ``-m bench``.
+    """
+    fixture_sha = _sha256_bytes(FIXTURE_PATH.read_bytes())
+    monkeypatch.setattr(
+        "distillery.eval.longmemeval_dataset.DATASET_FILE_SHA256",
+        fixture_sha,
+    )
+
+    def fake_snapshot_download(*_args: Any, **_kwargs: Any) -> str:
+        snapshot_dir = tmp_path / "snapshots" / DATASET_REVISION_SHA
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(FIXTURE_PATH, snapshot_dir / DATASET_FILENAME)
+        return str(snapshot_dir)
+
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        fake_snapshot_download,
+    )
+
+    questions = await load_longmemeval(cache_dir=tmp_path)
+    assert isinstance(questions, list)
+    assert len(questions) >= 1
+    assert REQUIRED_QUESTION_KEYS.issubset(questions[0].keys())
+
+
+@pytest.mark.unit
 def test_pinned_constants_are_concrete() -> None:
     """Guard against shipping placeholder SHAs (rule 5)."""
     assert len(DATASET_REVISION_SHA) == 40, "Revision SHA must be a full 40-char hex"
@@ -231,11 +267,11 @@ def test_pinned_constants_are_concrete() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Integration tests — first call hits the network (~265 MB), second is offline.
+# Bench tests (opt-in) — first call hits the network (~265 MB), second offline.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
+@pytest.mark.bench
 async def test_load_longmemeval_downloads_and_verifies(tmp_path: Path) -> None:
     """First call: downloads the SHA-pinned dataset and verifies its hash.
 
@@ -256,7 +292,7 @@ async def test_load_longmemeval_downloads_and_verifies(tmp_path: Path) -> None:
     assert len(first["answer_session_ids"]) >= 1
 
 
-@pytest.mark.integration
+@pytest.mark.bench
 async def test_load_longmemeval_warm_cache_offline(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -271,7 +307,7 @@ async def test_load_longmemeval_warm_cache_offline(
     assert len(questions) == 500
 
 
-@pytest.mark.integration
+@pytest.mark.bench
 async def test_load_longmemeval_corrupt_cache_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Root cause (two pre-existing main failures hitting every PR)

Two failures live on `main` in files no feature PR touches, so they turn CI + supply-chain RED on every open PR:

1. **CI flake (mismarked network tests).** `tests/eval/test_dataset_loader.py` had three tests marked `@pytest.mark.integration` that download ~265 MB from HuggingFace over the real network (`test_load_longmemeval_downloads_and_verifies`, `test_load_longmemeval_warm_cache_offline`, `test_load_longmemeval_corrupt_cache_raises`). `ci.yml` ran `pytest --cov ... --cov-fail-under=80` with **no marker filter**, so these heavy network tests ran in PR CI and flaked per-runner — one matrix cell red per run. The repo design reserves heavy LongMemEval tests for the opt-in `bench` marker, run by dedicated `bench-*.yml` nightly workflows.

2. **Supply chain (Grype).** The Grype scan fails the build (`fail-on-severity: high`). The Chainguard/Wolfi base image bumped the `python-3.14` apk build `r1 -> r2`, so the exact-version suppression of `CVE-2026-7210` (pinned to `3.14.5-r1`) no longer matched and the Critical re-failed. Repo policy requires exact name+version pinning, so the fix is to update the pin, not drop the version.

## Fix (the two changes)

- **Tests:** re-marked the three HF-download tests `@pytest.mark.integration` -> `@pytest.mark.bench` (opt-in), updated the module docstring's two-tier description, and changed the CI test step to `pytest -m "not bench" --cov=src/distillery --cov-report=xml --cov-report=term-missing --cov-fail-under=80` (all existing flags preserved; only `-m "not bench"` added). The `@pytest.mark.unit` fixture tests are untouched. To keep `load_longmemeval`'s download->verify->schema-validate path covered in the hermetic default suite, added a `@pytest.mark.unit` test that mocks `snapshot_download` to return the shipped `tests/fixtures/longmemeval_mini.json` and patches the expected SHA to the fixture digest. The 80% gate was not lowered.
- **Grype:** bumped the `CVE-2026-7210` suppression from `version: 3.14.5-r1` to `3.14.5-r2`, refreshed the header `Refreshed:` and entry `Reviewed:` dates to 2026-06-03, and noted the base-image rebuild in the reason. Same libexpat hash-flooding CVE, still DoS-only, still no upstream fix. Other entries and policy comments untouched.

## Acceptance

- [x] default CI excludes HF-download tests (`-m "not bench"`; the three are deselected, 0 network downloads)
- [x] Grype passes with the r2-pinned suppression (`CVE-2026-7210` now matches `python-3.14 3.14.5-r2 apk`)
- [x] coverage gate still >=80% at 85.68% (module `longmemeval_dataset.py` restored 74% -> 90% by the hermetic test)

## Test plan

```
PYTHONPATH="$PWD/src" .venv/bin/python -m pytest -m "not bench" \
  --cov=src/distillery --cov-report=term-missing --cov-fail-under=80 -q
```

Result: `2854 passed, 91 skipped, 3 deselected` — `Required test coverage of 80% reached. Total coverage: 85.68%`. `ruff check src tests`, `ruff format --check tests/eval/test_dataset_loader.py`, and `mypy --strict src/distillery` all pass.

This unblocks PRs #590-#595.

Refs #271 (grype suppression audit policy).