### PR TITLE
release: v0.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "distillery",
       "source": "./",
       "description": "Knowledge base skills — capture, search, and synthesize project knowledge",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings"],
       "category": "knowledge-management"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "distillery",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Knowledge base skills for Claude Code — capture, search, and synthesize project knowledge",
   "author": {
     "name": "norrietaylor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distillery-mcp"
-version = "0.6.1"
+version = "0.6.2"
 description = "Persistent shared memory for Claude Code — MCP server with DuckDB vector search, semantic dedup, and ambient intelligence for team knowledge"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.norrietaylor/distillery-mcp",
   "title": "Distillery",
   "description": "Knowledge base for Claude Code with semantic search, feed intelligence, and teams",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "repository": {
     "url": "https://github.com/norrietaylor/distillery",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "transport": {
         "type": "streamable-http",
         "url": "https://distillery-mcp.fly.dev/mcp"

--- a/src/distillery/__init__.py
+++ b/src/distillery/__init__.py
@@ -2,5 +2,5 @@
 
 import os
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __build_sha__ = os.environ.get("DISTILLERY_BUILD_SHA", "dev")

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ wheels = [
 
 [[package]]
 name = "distillery-mcp"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
Version bump 0.6.1 → 0.6.2. Bug-fix release.

## Version files bumped (per RELEASING.md)
- \`pyproject.toml\`, \`src/distillery/__init__.py\`
- \`.claude-plugin/plugin.json\`, \`.claude-plugin/marketplace.json\`
- \`server.json\` (top-level + both \`packages[*].version\`)
- \`uv.lock\` (regenerated via \`uv lock\`)

No new MCP tools or skills, so the plugin SessionStart echo and skill \`min_server_version\` fields are unchanged.

## Included since v0.6.1
Store reliability + supply-chain hardening:
- store: \`distillery_status\` no longer blocks behind embedding HTTP calls (#558)
- store: \`probe_readiness\` materializes a row, detects data-page corruption that \`COUNT(*)\` missed (#582)
- store: fail fast + SIGTERM on terminally invalidated DuckDB connection (#583)
- store: read-back integrity verification after dedup merge bulk-rewrite (#584)
- mcp: schema-validation rejections return \`INVALID_PARAMS\`, not masked \`INTERNAL\` (#559)
- feeds: background \`gh_sync\` over HTTP via lifespan-decoupled store (#588)

Together #582/#583/#584 close the silent-corruption-undetected-for-30-days gap.

## Verification
- \`main\` is green on the merge gates: CI, CodeQL, Supply Chain Security.
- All version strings consistent at 0.6.2; \`uv.lock\` regenerated.

## After merge (held for owner)
Publish a GitHub Release tagged \`v0.6.2\` → triggers \`pypi-publish.yml\` (PyPI + MCP Registry + Smithery) and \`changelog.yml\` (git-cliff CHANGELOG PR). CHANGELOG is auto-generated; not edited here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.6.2 Release

* **Chores**
  * Version bumped to 0.6.2 across all package manifests and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->