### PR TITLE
fix(classification): guard against empty content in dedup check

### DIFF
--- a/src/distillery/classification/dedup.py
+++ b/src/distillery/classification/dedup.py
@@ -123,7 +123,8 @@ class DeduplicationChecker:
         # Results are sorted by descending score; first is highest.
         highest = similar[0]
         score = highest.score
-        first_line = highest.entry.content.splitlines()[0][:80]
+        content_lines = highest.entry.content.splitlines()
+        first_line = content_lines[0][:80] if content_lines else ""
 
         action, reasoning = self._decide(score, first_line)
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -391,3 +391,23 @@ class TestHighestScore:
         result = await checker.check("Content")
 
         assert result.action == DeduplicationAction.MERGE
+
+
+# ---------------------------------------------------------------------------
+# Empty-content match does not crash
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyContentMatch:
+    """A similar entry whose content is empty must not raise IndexError."""
+
+    async def test_empty_content_match_returns_result(self) -> None:
+        # An existing entry with empty content can be returned by find_similar.
+        # Extracting its first line must not crash the dedup check.
+        store = _make_mock_store([_make_search_result(0.97, content="")])
+        checker = _make_checker(store)
+
+        result = await checker.check("Some content")
+
+        assert result.action == DeduplicationAction.SKIP
+        assert result.highest_score == pytest.approx(0.97)


### PR DESCRIPTION
## Root cause

`DeduplicationChecker.check()` in `src/distillery/classification/dedup.py` extracted the first line of the most similar entry's content via:

```python
first_line = highest.entry.content.splitlines()[0][:80]
```

When the most similar entry returned by `find_similar` has empty content, `"".splitlines()` returns `[]`, so indexing `[0]` raises `IndexError: list index out of range`. `Entry` performs no validation forbidding empty content, so such an entry can legitimately exist in the store and be returned as a near-duplicate match, crashing the entire dedup check (and any caller, e.g. the `distillery_store` MCP tool).

## Fix

Guard the index access:

```python
content_lines = highest.entry.content.splitlines()
first_line = content_lines[0][:80] if content_lines else ""
```

When content is empty, `first_line` becomes `""` and the reasoning string degrades gracefully instead of raising. Surgical, single-spot change; action selection and all other behavior are unchanged.

## Acceptance

- New test `TestEmptyContentMatch::test_empty_content_match_returns_result` in `tests/test_dedup.py` reproduces the crash (fails with `IndexError` before the fix) and passes after.
- Full dedup/classification test area green: `tests/test_dedup.py`, `tests/test_classification_engine.py`, `tests/test_classification/`, `tests/test_mcp_dedup.py`, `tests/test_store_dedup_response.py` (119 passed).
- `ruff check` and `mypy --strict` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed a crash that occurred during deduplication when processing empty content. The deduplication process now handles empty content gracefully without raising errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->