### PR TITLE
fix(embedding): sort Jina embeddings by index to preserve input order

### DIFF
--- a/src/distillery/embedding/jina.py
+++ b/src/distillery/embedding/jina.py
@@ -278,8 +278,19 @@ class JinaEmbeddingProvider:
                 f"Jina API returned {len(items)} embeddings, expected {expected_count}."
             )
 
+        # The API does not guarantee ``data`` is returned in request order;
+        # each item carries an ``index`` field. Sort by it so the returned
+        # vectors line up with the input texts (mirrors the OpenAI provider).
+        # Items without a usable ``index`` fall back to their array position.
+        items = sorted(
+            enumerate(items),
+            key=lambda pair: pair[1].get("index", pair[0])
+            if isinstance(pair[1], dict)
+            else pair[0],
+        )
+
         embeddings: list[list[float]] = []
-        for i, item in enumerate(items):
+        for i, (_, item) in enumerate(items):
             if "embedding" not in item:
                 raise RuntimeError(
                     f"Jina API response item {i} missing 'embedding' field. "

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -351,6 +351,38 @@ class TestJinaRateLimitRetry:
         assert result[0] == [0.1, 0.2, 0.3, 0.4]
         assert result[1] == [0.5, 0.6, 0.7, 0.8]
 
+    def test_embed_batch_reorders_out_of_order_response(self) -> None:
+        """Embeddings are reordered by ``index`` to match input order.
+
+        The Jina API (like OpenAI's) does not guarantee the ``data`` array is
+        returned in request order; each item carries an ``index`` field. If the
+        provider trusts array order, a stored entry can silently receive another
+        entry's embedding, corrupting vector search.
+        """
+        vec_first = [0.1, 0.1, 0.1, 0.1]
+        vec_second = [0.9, 0.9, 0.9, 0.9]
+        # API returns the second input's embedding first (index out of order).
+        out_of_order_payload = {
+            "data": [
+                {"embedding": vec_second, "index": 1},
+                {"embedding": vec_first, "index": 0},
+            ]
+        }
+        good_response = _mock_httpx_response(200, out_of_order_payload)
+        good_response.raise_for_status.return_value = None
+
+        provider = JinaEmbeddingProvider(api_key="test-key", dimensions=4)
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = good_response
+
+            result = provider.embed_batch(["first", "second"])
+
+        assert result[0] == vec_first
+        assert result[1] == vec_second
+
     def test_exhausted_5xx_raises_embedding_provider_error(self) -> None:
         """Exhausted 5xx retries raise EmbeddingProviderError (not rate limited).
 


### PR DESCRIPTION
## Root cause

`JinaEmbeddingProvider._parse_response` (`src/distillery/embedding/jina.py`) extracted embedding vectors by iterating the API's `data` array in array order:

```python
for i, item in enumerate(items):
    ...
    embeddings.append([float(v) for v in embedding])
```

The Jina Embeddings API — like OpenAI's — does **not** guarantee the `data` array is returned in request order; each item carries an `index` field for exactly this reason. The OpenAI provider already sorts by `index` ("Sort results by index to guarantee order matches input"), but the Jina provider ignored it.

When Jina returns embeddings out of order, `embed_batch` returns vectors mismatched to their input texts. In a batch store/index operation each entry would silently receive another entry's embedding, corrupting vector (HNSW) search results with no error raised.

## Fix

Sort the response items by their `index` field before extracting vectors, mirroring the OpenAI provider. Items lacking a usable `index` fall back to their array position, preserving the existing tolerant parsing behavior. The change is confined to `_parse_response`; the count-mismatch guard and per-item validation are unchanged.

## Acceptance

- New test `TestJinaRateLimitRetry::test_embed_batch_reorders_out_of_order_response` feeds an out-of-order response (`index` 1 before `index` 0) and asserts vectors are reordered to match input order. It fails before the fix and passes after.
- Full embedding suite: 70 passed (+1 fastembed skip).
- `ruff check` clean and `mypy --strict` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured embeddings are returned in the correct order matching input texts, regardless of upstream service response order.

* **Tests**
  * Added test coverage for embedding reordering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->