### PR TITLE
fix(feeds): handle null comment user in gh-sync content builder

### DIFF
--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -225,7 +225,11 @@ def _build_content(
     if body and body.strip():
         parts.append(body.strip())
     for comment in comments[:_MAX_COMMENTS]:
-        author = comment.get("user", {}).get("login", "unknown")
+        # GitHub returns ``"user": null`` for comments by deleted/ghost
+        # accounts; ``.get("user", {})`` yields ``None`` (the key exists), so
+        # coerce a missing/null user object to an empty dict before lookup.
+        user = comment.get("user") or {}
+        author = user.get("login", "unknown")
         comment_body = comment.get("body", "")
         if comment_body and comment_body.strip():
             parts.append(f"**{author}**: {comment_body.strip()}")

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -139,6 +139,21 @@ class TestBuildContent:
         assert "user9" in result
         assert "user10" not in result
 
+    @pytest.mark.unit
+    def test_comment_with_null_user(self) -> None:
+        # GitHub returns ``"user": null`` for comments by deleted/ghost
+        # accounts.  ``dict.get("user", {})`` returns ``None`` (not the
+        # default) because the key exists, so a naive ``.get("login")``
+        # crashes the whole sync for that issue/PR.
+        comments = [
+            {"user": None, "body": "Orphaned comment"},
+            {"user": {"login": "alice"}, "body": "Live comment"},
+        ]
+        result = _build_content("Title", "Body", comments)
+        assert "Orphaned comment" in result
+        assert "**unknown**: Orphaned comment" in result
+        assert "**alice**: Live comment" in result
+
 
 # ---------------------------------------------------------------------------
 # Mock GitHub API responses


### PR DESCRIPTION
## Root cause

GitHub's REST API returns `"user": null` for issue/PR comments authored by deleted or *ghost* accounts. In `_build_content` (`src/distillery/feeds/github_sync.py`), the comment author was read with:

```python
author = comment.get("user", {}).get("login", "unknown")
```

`dict.get("user", {})` only returns the `{}` default when the key is **absent**. When the key is present with a `null`/`None` value, it returns `None`, so `None.get("login", ...)` raises `AttributeError`. This propagated out of `_build_content` → `_issue_to_entry`, crashing the sync for the affected issue/PR (both `sync()` and `sync_batched()` paths).

## Fix

Coerce a missing or null `user` object to an empty dict before the lookup:

```python
user = comment.get("user") or {}
author = user.get("login", "unknown")
```

Comments from ghost accounts now attribute to `"unknown"` instead of aborting the sync. Surgical one-line change plus a clarifying comment.

## Acceptance

- New unit test `TestBuildContent::test_comment_with_null_user` reproduces the crash (fails with `AttributeError` before the fix) and passes after.
- Full `tests/test_github_sync.py` and `tests/test_feeds.py` suites pass (171 tests).
- `ruff check` and `mypy --strict` clean on the touched source file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub comment rendering to properly handle comments from deleted or ghosted user accounts, now displaying "unknown" as the author instead of potential errors.

* **Tests**
  * Added test coverage for comments from deleted GitHub user accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->