### PR TITLE
fix(store): exclude archived entries from find_similar

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2167,17 +2167,28 @@ class DuckDBStore:
         def _sync() -> list[SearchResult]:
             conn = self.connection
 
+            # Exclude archived (soft-deleted) entries: find_similar drives
+            # pre-store deduplication, so a conceptually-removed entry must not
+            # be returned as a near-duplicate match (which would recommend
+            # SKIP/MERGE/LINK against dead content). Mirrors _sync_get's default.
             sql = (
                 f"SELECT {self._ENTRY_COLUMNS}, "
                 f"array_cosine_similarity(embedding, ?::FLOAT[{self._embedding_provider.dimensions}]) AS score "
                 f"FROM entries "
-                f"WHERE array_cosine_similarity(embedding, ?::FLOAT[{self._embedding_provider.dimensions}]) >= ? "
+                f"WHERE status != ? "
+                f"AND array_cosine_similarity(embedding, ?::FLOAT[{self._embedding_provider.dimensions}]) >= ? "
                 f"ORDER BY score DESC "
                 f"LIMIT ?"
             )
             # Convert normalized [0, 1] threshold to raw [-1, 1] for SQL comparison
             raw_threshold = threshold * 2.0 - 1.0
-            params: list[Any] = [embedding, embedding, raw_threshold, limit]
+            params: list[Any] = [
+                embedding,
+                EntryStatus.ARCHIVED.value,
+                embedding,
+                raw_threshold,
+                limit,
+            ]
             result = conn.execute(sql, params)
             col_names = [desc[0] for desc in result.description]
 

--- a/tests/test_store_integration.py
+++ b/tests/test_store_integration.py
@@ -310,6 +310,32 @@ class TestFindSimilarIntegration:
         results = await store.find_similar("similar item", threshold=0.0, limit=3)
         assert len(results) <= 3
 
+    async def test_find_similar_excludes_archived(
+        self,
+        store: DuckDBStore,
+        embedding_provider: DeterministicEmbeddingProvider,
+    ) -> None:
+        """Soft-deleted (archived) entries must not surface in find_similar.
+
+        find_similar drives pre-store deduplication: an archived entry is
+        conceptually removed, so it must not be returned as a near-duplicate
+        match (which would recommend SKIP/MERGE/LINK against dead content).
+        """
+        dup_vec = [1.0, 0.0, 0.0, 0.0]
+        text = "knowledge that will be archived"
+        embedding_provider.register(text, dup_vec)
+
+        entry = make_entry(content=text)
+        entry_id = await store.store(entry)
+
+        # Soft-delete it (sets status to archived).
+        assert await store.delete(entry_id) is True
+
+        # An archived entry must not be returned as a similarity match.
+        results = await store.find_similar(text, threshold=0.9, limit=10)
+        result_ids = [r.entry.id for r in results]
+        assert entry_id not in result_ids
+
 
 # ---------------------------------------------------------------------------
 # Full lifecycle: store -> update -> search reflects changes


### PR DESCRIPTION
## Root cause

`DuckDBStore.find_similar` (`src/distillery/store/duckdb.py`) is documented as the pre-store deduplication primitive — it powers `DeduplicationChecker.check`, which maps the highest similarity score to a SKIP / MERGE / LINK recommendation. But its SQL queried `entries` with **no status filter**:

```sql
SELECT ... FROM entries
WHERE array_cosine_similarity(embedding, ?) >= ?
ORDER BY score DESC LIMIT ?
```

Soft-deleted (archived) entries — those `delete()` sets to `status = 'archived'` — were therefore still returned as near-duplicate matches. A user who archived an entry and then re-distilled equivalent content would get a SKIP/MERGE/LINK recommendation pointing at a conceptually-removed entry. This diverges from `get()` (excludes archived by default) and `get_tag_vocabulary()` (excludes archived), both of which treat archived as deleted.

## Fix

Add a `status != 'archived'` predicate to the `find_similar` query (using `EntryStatus.ARCHIVED.value`, already imported), mirroring `_sync_get`'s default behavior. Surgical one-clause change; no API or signature change.

## Acceptance

- New test `test_find_similar_excludes_archived` in `tests/test_store_integration.py`: stores an entry, soft-deletes it, asserts `find_similar` no longer returns it. Fails before the fix (archived id present), passes after.
- Full store + dedup + conflict + search suites pass (612 passed, 19 skipped).
- `ruff check` and `mypy --strict` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Similarity search now properly excludes archived entries from results, preventing soft-deleted content from appearing as near-duplicate suggestions
  * Updated query logic to respect archived status when identifying matches

* **Tests**
  * Added integration test to validate archived entries are excluded from similarity search results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->