### PR TITLE
fix(auth): don't cache transient org-membership check failures

### DIFF
--- a/src/distillery/mcp/org_membership.py
+++ b/src/distillery/mcp/org_membership.py
@@ -82,6 +82,18 @@ class _CacheEntry:
     expires_at: float  # monotonic timestamp
 
 
+class _IndeterminateMembershipError(Exception):
+    """Raised when membership cannot be determined (transient/unknown error).
+
+    Distinguishes a *definitive* "not a member" (GitHub 404) from a
+    fail-closed denial caused by a transient condition — a network error or
+    an unexpected status such as 5xx / rate-limit.  The caller treats both as
+    "deny" for the current request, but only definitive results are cached:
+    caching a transient denial would lock a legitimate member out for the
+    full TTL after GitHub recovers.
+    """
+
+
 # ---------------------------------------------------------------------------
 # OrgMembershipChecker
 # ---------------------------------------------------------------------------
@@ -218,8 +230,14 @@ class OrgMembershipChecker:
                 )
                 return entry.is_member
 
-        # Fetch outside the lock to avoid blocking other coroutines.
-        result = await self._fetch_membership(token, username, org)
+        # Fetch outside the lock to avoid blocking other coroutines.  A
+        # transient/unknown error fails closed (deny) for *this* request but
+        # must NOT be cached — otherwise a momentary GitHub blip would lock a
+        # legitimate member out for the full TTL.
+        try:
+            result = await self._fetch_membership(token, username, org)
+        except _IndeterminateMembershipError:
+            return False
 
         async with self._lock:
             self._cache[key] = _CacheEntry(
@@ -254,7 +272,9 @@ class OrgMembershipChecker:
         * 302 — the token is not seen as an org member, so GitHub will only
           answer the public-membership endpoint; follow there via
           :meth:`_fetch_public_member`.
-        * anything else / network error — fail closed (deny).
+        * anything else / network error — indeterminate; raise
+          :class:`_IndeterminateMembershipError` so the caller fails closed for
+          this request *without* caching the denial.
         """
         headers: dict[str, str] = {
             "Accept": "application/vnd.github+json",
@@ -286,7 +306,7 @@ class OrgMembershipChecker:
                 username,
                 org,
             )
-            return False
+            raise _IndeterminateMembershipError
         except httpx.HTTPError as exc:
             logger.error(
                 "GitHub membership API error for %s in %s: %s",
@@ -294,7 +314,7 @@ class OrgMembershipChecker:
                 org,
                 exc,
             )
-            return False
+            raise _IndeterminateMembershipError from exc
 
     async def _fetch_public_member(self, username: str, org: str) -> bool:
         """Call ``GET /orgs/{org}/public_members/{username}``.
@@ -307,7 +327,9 @@ class OrgMembershipChecker:
         * 404 — not a public member. A *private* membership is invisible
           here; to gate private members, set ``GITHUB_ORG_CHECK_TOKEN`` (a
           ``read:org`` PAT) so the members endpoint answers 204/404 directly.
-        * anything else / network error — fail closed (deny).
+        * anything else / network error — indeterminate; raise
+          :class:`_IndeterminateMembershipError` so the caller fails closed for
+          this request *without* caching the denial.
         """
         headers = {
             "Accept": "application/vnd.github+json",
@@ -331,7 +353,7 @@ class OrgMembershipChecker:
                 username,
                 org,
             )
-            return False
+            raise _IndeterminateMembershipError
         except httpx.HTTPError as exc:
             logger.error(
                 "GitHub public_members API error for %s in %s: %s",
@@ -339,4 +361,4 @@ class OrgMembershipChecker:
                 org,
                 exc,
             )
-            return False
+            raise _IndeterminateMembershipError from exc

--- a/tests/test_mcp_org_membership.py
+++ b/tests/test_mcp_org_membership.py
@@ -369,6 +369,65 @@ class TestOrgMembershipCaching:
         assert second is False
         assert api_call_count == 1
 
+    async def test_transient_error_is_not_cached(self) -> None:
+        """A fail-closed transient error must NOT poison the cache.
+
+        A momentary GitHub outage (network error or 5xx) makes the check
+        fail closed (deny) for that request, which is correct.  But the
+        denial must not be cached: once GitHub recovers, a legitimate org
+        member must be admitted on the very next request rather than being
+        locked out for the full cache TTL.
+        """
+        import httpx
+
+        checker = OrgMembershipChecker(allowed_orgs=["acme"], cache_ttl_seconds=3600)
+        call_count = 0
+
+        async def fake_get(url: str, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First check: GitHub is briefly unreachable -> fail closed.
+                raise httpx.ConnectError("timeout")
+            # GitHub has recovered: alice is a member.
+            return _mock_response(204)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = _make_async_client_mock()
+            mock_client.get = fake_get
+            mock_client_cls.return_value = mock_client
+
+            first = await checker.is_allowed("alice", hint_token="tok")
+            second = await checker.is_allowed("alice", hint_token="tok")
+
+        assert first is False  # transient error -> fail closed
+        assert second is True  # recovered -> member admitted (not stuck on cached False)
+        assert call_count == 2  # second request must re-hit the API, not the cache
+
+    async def test_unexpected_status_is_not_cached(self) -> None:
+        """A 5xx from the members endpoint must not be cached either."""
+        checker = OrgMembershipChecker(allowed_orgs=["acme"], cache_ttl_seconds=3600)
+        call_count = 0
+
+        async def fake_get(url: str, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_response(503)  # transient upstream error
+            return _mock_response(204)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = _make_async_client_mock()
+            mock_client.get = fake_get
+            mock_client_cls.return_value = mock_client
+
+            first = await checker.is_allowed("alice", hint_token="tok")
+            second = await checker.is_allowed("alice", hint_token="tok")
+
+        assert first is False
+        assert second is True
+        assert call_count == 2
+
 
 # ---------------------------------------------------------------------------
 # Config parsing


### PR DESCRIPTION
## Root cause

`OrgMembershipChecker._check_org` (`src/distillery/mcp/org_membership.py`) caches the result of every membership lookup keyed by `(username, org)` for the configured TTL (default 1 hour). The underlying `_fetch_membership` / `_fetch_public_member` helpers **fail closed** — they return `False` not only for a definitive GitHub `404` (genuinely not a member) but also for transient conditions: a network error (`httpx.HTTPError`) or an unexpected status such as `5xx` / rate-limit.

Because `_check_org` cached that `False` unconditionally, a momentary GitHub outage during a single request would lock a legitimate org member out for the **full TTL** — every subsequent request returned the cached denial even after GitHub recovered. Failing closed for the *current* request is correct; persisting that denial is not.

## Fix

Introduce a private `_IndeterminateMembershipError` raised on the transient/unknown paths in `_fetch_membership` and `_fetch_public_member` (network error and unexpected status), distinct from the definitive `404 -> False`. `_check_org` catches it, returns `False` for the current request (still fail-closed), and **skips the cache write** so the next request re-hits the GitHub API. Definitive results (`204 -> True`, `404 -> False`) are cached exactly as before.

Surgical change confined to `org_membership.py`; no public API or signature changes.

## Acceptance

- New tests in `tests/test_mcp_org_membership.py`:
  - `test_transient_error_is_not_cached` — network error then recovery: first request denies (fail-closed), second request admits the member and re-hits the API.
  - `test_unexpected_status_is_not_cached` — same for a `503` from the members endpoint.
- Both tests fail on `main` (cached `False` → second request returns `False`, API hit once) and pass with the fix.
- Existing behavior preserved: `test_negative_result_is_cached` (real `404` still cached), `test_network_error_fails_closed`, `test_unexpected_status_returns_false`, and the full 45-test `test_mcp_org_membership.py` suite pass.
- `test_middleware.py`, `test_mcp_auth.py`, `test_mcp_http_transport.py` all pass (130 total).
- `ruff check` and `mypy --strict` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced organization membership verification to properly distinguish between transient failures (network errors, rate limiting, temporary service errors) and permanent denials, preventing transient conditions from being inappropriately cached and blocking future access requests.

* **Tests**
  * Added comprehensive test coverage ensuring organization membership checks correctly retry after transient errors instead of relying on cached failure states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->