### PR TITLE
feat(store): temporal + weighted edge metadata on relations

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1234,6 +1234,10 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         tags: list[str] | None = None,
         date_from: str | None = None,
         date_to: str | None = None,
+        weight: float | None = None,
+        valid_at: str | None = None,
+        invalid_at: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> list[types.TextContent]:
         """Manage typed relations between knowledge entries.
 
@@ -1249,6 +1253,11 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - relation_type (str, required for add, optional for get/traverse): Relation type.
             Valid: [link, corrects, supersedes, related, blocks, depends_on, citation,
             duplicate, merge_source, sync_source].
+          - weight (float, optional for add): Edge strength (e.g. interest/engagement
+            magnitude). On a re-assert of an existing edge, supplied attributes are upserted.
+          - valid_at / invalid_at (str ISO 8601, optional for add): Bi-temporal validity
+            window — when the relationship became / stopped being true (invalid_at null = current).
+          - metadata (object, optional for add): Arbitrary per-edge attributes (JSON).
           - entry_id (str, required for get/traverse, required for metrics scope='ego'):
             Entry UUID to query relations for (BFS root for traverse / ego-graph).
           - direction (str, optional for get/traverse, default="both"): Filter direction.
@@ -1265,7 +1274,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - project / tags / date_from / date_to (optional, metrics global scope):
             restrict the entries whose relations participate in the graph.
 
-        RETURNS (success): { relation_id: str, from_id: str, to_id: str, relation_type: str } (add) or
+        RETURNS (success): { relation_id: str, from_id: str, to_id: str, relation_type: str,
+          weight: float | null, valid_at: str | null, invalid_at: str | null,
+          metadata: object | null } (add) or
           { entry_id: str, relations: list, count: int } (get) or
           { relation_id: str, removed: bool } (remove) or
           { action: "traverse", root: str, hops: int, direction: str, relation_type: str | null,
@@ -1298,6 +1309,10 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                     tags=tags,
                     date_from=date_from,
                     date_to=date_to,
+                    weight=weight,
+                    valid_at=valid_at,
+                    invalid_at=invalid_at,
+                    metadata=metadata,
                 ),
             ),
         )

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -121,8 +121,39 @@ async def _handle_relations(
                 f"Must be one of: {', '.join(sorted(_VALID_RELATION_TYPES))}.",
             )
 
+        # Optional edge attributes (migration 15): weight, bi-temporal validity,
+        # arbitrary metadata. All default to None ("unspecified").
+        weight_raw = arguments.get("weight")
+        weight: float | None = None
+        if weight_raw is not None:
+            if isinstance(weight_raw, bool) or not isinstance(weight_raw, (int, float)):
+                return error_response("INVALID_PARAMS", "weight must be a number")
+            weight = float(weight_raw)
+
+        valid_at, err = _validate_optional_timestamp(arguments, "valid_at")
+        if err is not None:
+            return err
+        invalid_at, err = _validate_optional_timestamp(arguments, "invalid_at")
+        if err is not None:
+            return err
+
+        metadata_raw = arguments.get("metadata")
+        metadata: dict[str, Any] | None = None
+        if metadata_raw is not None:
+            if not isinstance(metadata_raw, dict):
+                return error_response("INVALID_PARAMS", "metadata must be an object")
+            metadata = metadata_raw
+
         try:
-            relation_id = await store.add_relation(from_id, to_id, relation_type)
+            relation_id = await store.add_relation(
+                from_id,
+                to_id,
+                relation_type,
+                weight=weight,
+                valid_at=valid_at,
+                invalid_at=invalid_at,
+                metadata=metadata,
+            )
         except ValueError as exc:
             return error_response(
                 "NOT_FOUND",
@@ -138,6 +169,10 @@ async def _handle_relations(
                 "from_id": from_id,
                 "to_id": to_id,
                 "relation_type": relation_type,
+                "weight": weight,
+                "valid_at": valid_at,
+                "invalid_at": invalid_at,
+                "metadata": metadata,
             }
         )
 
@@ -389,6 +424,31 @@ def _validate_optional_str(
         )
     stripped = raw.strip()
     return (stripped or None), None
+
+
+def _validate_optional_timestamp(
+    arguments: dict[str, Any], field: str
+) -> tuple[str | None, list[types.TextContent] | None]:
+    """Return (ISO-8601-str-or-None, error-or-None) for an optional timestamp field."""
+    raw = arguments.get(field)
+    if raw is None:
+        return None, None
+    if not isinstance(raw, str):
+        return None, error_response(
+            "INVALID_PARAMS",
+            f"{field} must be an ISO 8601 string, got: {type(raw).__name__}",
+        )
+    stripped = raw.strip()
+    if not stripped:
+        return None, None
+    try:
+        datetime.fromisoformat(stripped)
+    except ValueError:
+        return None, error_response(
+            "INVALID_PARAMS",
+            f"{field} must be a valid ISO 8601 timestamp, got: {raw!r}",
+        )
+    return stripped, None
 
 
 def _validate_optional_str_list(

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -3232,7 +3232,32 @@ class DuckDBStore:
 
         return diag
 
-    def _sync_add_relation(self, from_id: str, to_id: str, relation_type: str) -> str:
+    @staticmethod
+    def _coerce_relation_timestamp(value: str | datetime | None) -> datetime | None:
+        """Coerce a relation timestamp input to a tz-aware datetime (or None).
+
+        Accepts ``datetime`` objects, ISO 8601 strings (naive strings are
+        treated as UTC), or ``None``.
+        """
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+
+    def _sync_add_relation(
+        self,
+        from_id: str,
+        to_id: str,
+        relation_type: str,
+        weight: float | None = None,
+        valid_at: str | datetime | None = None,
+        invalid_at: str | datetime | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
         """Synchronous implementation of add_relation(); called via asyncio.to_thread."""
         assert self._conn is not None
         # Validate that both entries exist (including archived — preserves historical links).
@@ -3259,19 +3284,57 @@ class DuckDBStore:
             "SELECT id FROM entry_relations WHERE from_id = ? AND to_id = ? AND relation_type = ?",
             [from_id, to_id, relation_type],
         ).fetchone()
+        valid_at_dt = self._coerce_relation_timestamp(valid_at)
+        invalid_at_dt = self._coerce_relation_timestamp(invalid_at)
+        metadata_json = json.dumps(metadata) if metadata is not None else None
         if existing is not None:
+            relation_id = str(existing[0])
+            # Re-asserting an edge with fresh attributes upserts the supplied
+            # (non-None) fields onto the existing row; the (from,to,type) triple
+            # stays idempotent.
+            set_parts: list[str] = []
+            set_params: list[Any] = []
+            if weight is not None:
+                set_parts.append("weight = ?")
+                set_params.append(weight)
+            if valid_at_dt is not None:
+                set_parts.append("valid_at = ?")
+                set_params.append(valid_at_dt)
+            if invalid_at_dt is not None:
+                set_parts.append("invalid_at = ?")
+                set_params.append(invalid_at_dt)
+            if metadata_json is not None:
+                set_parts.append("metadata = ?")
+                set_params.append(metadata_json)
+            if set_parts:
+                self._conn.execute(
+                    f"UPDATE entry_relations SET {', '.join(set_parts)} WHERE id = ?",
+                    [*set_params, relation_id],
+                )
             logger.debug(
-                "Relation already exists id=%s from=%s to=%s type=%s",
-                existing[0],
+                "Relation already exists id=%s from=%s to=%s type=%s (attrs upserted=%d)",
+                relation_id,
                 from_id,
                 to_id,
                 relation_type,
+                len(set_parts),
             )
-            return str(existing[0])
+            return relation_id
         relation_id = str(uuid.uuid4())
         self._conn.execute(
-            "INSERT INTO entry_relations (id, from_id, to_id, relation_type) VALUES (?, ?, ?, ?)",
-            [relation_id, from_id, to_id, relation_type],
+            "INSERT INTO entry_relations "
+            "(id, from_id, to_id, relation_type, weight, valid_at, invalid_at, metadata) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                relation_id,
+                from_id,
+                to_id,
+                relation_type,
+                weight,
+                valid_at_dt,
+                invalid_at_dt,
+                metadata_json,
+            ],
         )
         logger.debug(
             "Added relation id=%s from=%s to=%s type=%s",
@@ -3287,18 +3350,30 @@ class DuckDBStore:
         from_id: str,
         to_id: str,
         relation_type: str,
+        weight: float | None = None,
+        valid_at: str | datetime | None = None,
+        invalid_at: str | datetime | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> str:
         """Create a typed relation between two entries and return its UUID.
 
         The method is idempotent: if a relation with the same ``(from_id,
         to_id, relation_type)`` triple already exists, its existing UUID is
-        returned instead of creating a duplicate row.
+        returned.  When edge attributes are supplied on a re-assert, the
+        provided (non-None) ``weight`` / ``valid_at`` / ``invalid_at`` /
+        ``metadata`` fields are upserted onto the existing row.
 
         Args:
             from_id: UUID string of the source entry.
             to_id: UUID string of the target entry.
             relation_type: Freeform label for the relation (e.g. ``"link"``,
                 ``"blocks"``, ``"related"``).
+            weight: Optional edge strength (e.g. interest/engagement magnitude).
+            valid_at: Optional instant the relationship became true (datetime or
+                ISO 8601 string; naive strings treated as UTC).
+            invalid_at: Optional instant it stopped being true (NULL = still
+                valid) — the bi-temporal validity window.
+            metadata: Optional arbitrary per-edge attributes (JSON-serialisable).
 
         Returns:
             The UUID string of the relation row (existing or newly created).
@@ -3307,7 +3382,16 @@ class DuckDBStore:
             ValueError: If either ``from_id`` or ``to_id`` does not exist in
                 the store.
         """
-        return await self._run_sync(self._sync_add_relation, from_id, to_id, relation_type)
+        return await self._run_sync(
+            self._sync_add_relation,
+            from_id,
+            to_id,
+            relation_type,
+            weight=weight,
+            valid_at=valid_at,
+            invalid_at=invalid_at,
+            metadata=metadata,
+        )
 
     def _sync_apply_correction(
         self,
@@ -3407,6 +3491,44 @@ class DuckDBStore:
         """
         return await self._run_sync(self._sync_apply_correction, new_entry, wrong_entry_id)
 
+    # Column list shared by get_related / list_relations so both return the same
+    # shape. created_at / valid_at / invalid_at are TIMESTAMPTZ rendered as true
+    # UTC ISO 8601 with a 'Z' suffix (`AT TIME ZONE 'UTC'` normalises off the
+    # session tz before formatting; NULL -> NULL -> None); metadata is parsed
+    # from its JSON column.
+    _RELATION_SELECT_COLUMNS = (
+        "id, from_id, to_id, relation_type, "
+        "strftime(created_at AT TIME ZONE 'UTC', '%Y-%m-%dT%H:%M:%S') || 'Z', "
+        "weight, "
+        "strftime(valid_at AT TIME ZONE 'UTC', '%Y-%m-%dT%H:%M:%S') || 'Z', "
+        "strftime(invalid_at AT TIME ZONE 'UTC', '%Y-%m-%dT%H:%M:%S') || 'Z', "
+        "metadata"
+    )
+
+    @staticmethod
+    def _relation_row_to_dict(row: tuple[Any, ...]) -> dict[str, Any]:
+        """Map a row selected with ``_RELATION_SELECT_COLUMNS`` to a result dict."""
+        metadata_raw = row[8]
+        metadata: dict[str, Any] | None = None
+        if metadata_raw is not None:
+            try:
+                metadata = (
+                    json.loads(metadata_raw) if isinstance(metadata_raw, str) else metadata_raw
+                )
+            except (json.JSONDecodeError, TypeError):
+                metadata = None
+        return {
+            "id": row[0],
+            "from_id": row[1],
+            "to_id": row[2],
+            "relation_type": row[3],
+            "created_at": row[4],
+            "weight": row[5],
+            "valid_at": row[6],
+            "invalid_at": row[7],
+            "metadata": metadata,
+        }
+
     def _sync_get_related(
         self,
         entry_id: str,
@@ -3437,22 +3559,11 @@ class DuckDBStore:
 
         where_clause = " AND ".join(conditions)
         sql = (
-            f"SELECT id, from_id, to_id, relation_type, "
-            f"strftime(created_at, '%Y-%m-%dT%H:%M:%S') || 'Z' "
+            f"SELECT {self._RELATION_SELECT_COLUMNS} "
             f"FROM entry_relations WHERE {where_clause} ORDER BY created_at ASC"
         )
         result = self._conn.execute(sql, params)
-        rows = result.fetchall()
-        return [
-            {
-                "id": row[0],
-                "from_id": row[1],
-                "to_id": row[2],
-                "relation_type": row[3],
-                "created_at": row[4],
-            }
-            for row in rows
-        ]
+        return [self._relation_row_to_dict(row) for row in result.fetchall()]
 
     async def get_related(
         self,
@@ -3470,7 +3581,9 @@ class DuckDBStore:
 
         Returns:
             List of dicts with keys: ``id``, ``from_id``, ``to_id``,
-            ``relation_type``, ``created_at`` (ISO 8601 str).
+            ``relation_type``, ``created_at`` (ISO 8601 str), ``weight``
+            (float | None), ``valid_at`` / ``invalid_at`` (ISO 8601 str | None),
+            ``metadata`` (dict | None).
         """
         return await self._run_sync(self._sync_get_related, entry_id, direction, relation_type)
 
@@ -3501,20 +3614,9 @@ class DuckDBStore:
         """Synchronous implementation of list_relations(); called via asyncio.to_thread."""
         assert self._conn is not None
         rows = self._conn.execute(
-            "SELECT id, from_id, to_id, relation_type, "
-            "strftime(created_at, '%Y-%m-%dT%H:%M:%S') || 'Z' "
-            "FROM entry_relations ORDER BY created_at ASC"
+            f"SELECT {self._RELATION_SELECT_COLUMNS} FROM entry_relations ORDER BY created_at ASC"
         ).fetchall()
-        return [
-            {
-                "id": row[0],
-                "from_id": row[1],
-                "to_id": row[2],
-                "relation_type": row[3],
-                "created_at": row[4],
-            }
-            for row in rows
-        ]
+        return [self._relation_row_to_dict(row) for row in rows]
 
     async def list_relations(self) -> list[dict[str, Any]]:
         """Return every row from ``entry_relations`` as a list of dicts.
@@ -3527,8 +3629,9 @@ class DuckDBStore:
 
         Returns:
             List of dicts with keys: ``id``, ``from_id``, ``to_id``,
-            ``relation_type``, ``created_at`` (ISO 8601 str).  Ordered by
-            ascending ``created_at``.
+            ``relation_type``, ``created_at`` (ISO 8601 str), ``weight``
+            (float | None), ``valid_at`` / ``invalid_at`` (ISO 8601 str | None),
+            ``metadata`` (dict | None).  Ordered by ascending ``created_at``.
         """
         return await self._run_sync(self._sync_list_relations)
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -3242,7 +3242,7 @@ class DuckDBStore:
         if value is None:
             return None
         if isinstance(value, datetime):
-            return value
+            return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
         dt = datetime.fromisoformat(value)
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=UTC)
@@ -3286,6 +3286,11 @@ class DuckDBStore:
         ).fetchone()
         valid_at_dt = self._coerce_relation_timestamp(valid_at)
         invalid_at_dt = self._coerce_relation_timestamp(invalid_at)
+        if valid_at_dt is not None and invalid_at_dt is not None and invalid_at_dt < valid_at_dt:
+            raise ValueError(
+                f"invalid_at must be greater than or equal to valid_at "
+                f"(valid_at={valid_at!r}, invalid_at={invalid_at!r})"
+            )
         metadata_json = json.dumps(metadata) if metadata is not None else None
         if existing is not None:
             relation_id = str(existing[0])

--- a/src/distillery/store/migrations.py
+++ b/src/distillery/store/migrations.py
@@ -544,6 +544,36 @@ def add_feed_source_thresholds(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -
     logger.info("Migration 14: feed_sources threshold override columns added")
 
 
+_ADD_ENTRY_RELATION_ATTRIBUTE_COLUMNS = [
+    "ALTER TABLE entry_relations ADD COLUMN IF NOT EXISTS weight DOUBLE;",
+    "ALTER TABLE entry_relations ADD COLUMN IF NOT EXISTS valid_at TIMESTAMPTZ;",
+    "ALTER TABLE entry_relations ADD COLUMN IF NOT EXISTS invalid_at TIMESTAMPTZ;",
+    "ALTER TABLE entry_relations ADD COLUMN IF NOT EXISTS metadata JSON;",
+]
+
+
+def add_relation_attributes(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
+    """Migration 15: Add weight, temporal validity, and metadata to ``entry_relations``.
+
+    Adds four nullable columns so edges can carry strength and a bi-temporal
+    validity window in addition to their type:
+
+    - ``weight`` (DOUBLE) — edge strength (e.g. interest/engagement magnitude).
+    - ``valid_at`` (TIMESTAMPTZ) — when the relationship became true.
+    - ``invalid_at`` (TIMESTAMPTZ) — when it stopped being true (NULL = still
+      valid).
+    - ``metadata`` (JSON) — arbitrary per-edge attributes, mirroring
+      ``entries.metadata``.
+
+    All columns are nullable with no default, so existing edges and the
+    metadata/wikilink backfill paths (which omit them) remain valid; NULL means
+    "unspecified", preserving pre-migration behaviour.
+    """
+    for stmt in _ADD_ENTRY_RELATION_ATTRIBUTE_COLUMNS:
+        conn.execute(stmt)
+    logger.info("Migration 15: entry_relations weight/valid_at/invalid_at/metadata columns added")
+
+
 # ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
@@ -563,6 +593,7 @@ MIGRATIONS: dict[int, MigrationFunc] = {
     12: add_feed_source_liveness,
     13: create_sync_jobs,
     14: add_feed_source_thresholds,
+    15: add_relation_attributes,
 }
 """Ordered mapping of schema version to migration function.
 

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -473,6 +473,10 @@ class DistilleryStore(Protocol):
         from_id: str,
         to_id: str,
         relation_type: str,
+        weight: float | None = None,
+        valid_at: str | datetime | None = None,
+        invalid_at: str | datetime | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> str:
         """Create a typed relation between two entries and return its UUID.
 
@@ -481,9 +485,17 @@ class DistilleryStore(Protocol):
             to_id: UUID string of the target entry.
             relation_type: Freeform label for the relation (e.g. ``"link"``,
                 ``"blocks"``, ``"related"``).
+            weight: Optional edge strength (e.g. interest/engagement magnitude).
+            valid_at: Optional instant the relationship became true (datetime or
+                ISO 8601 string).
+            invalid_at: Optional instant it stopped being true (``None`` = still
+                valid) — the bi-temporal validity window.
+            metadata: Optional arbitrary per-edge attributes (JSON-serialisable).
 
         Returns:
-            The UUID string of the newly created relation row.
+            The UUID string of the relation row.  Idempotent on the
+            ``(from_id, to_id, relation_type)`` triple; on a re-assert the
+            supplied (non-``None``) attributes are upserted onto the existing row.
 
         Raises:
             ValueError: If either ``from_id`` or ``to_id`` does not exist in
@@ -528,7 +540,9 @@ class DistilleryStore(Protocol):
 
         Returns:
             List of dicts, each containing keys: ``id``, ``from_id``,
-            ``to_id``, ``relation_type``, ``created_at`` (ISO 8601 str).
+            ``to_id``, ``relation_type``, ``created_at`` (ISO 8601 str),
+            ``weight`` (float | None), ``valid_at`` / ``invalid_at`` (ISO 8601
+            str | None), ``metadata`` (dict | None).
             Ordered by ascending ``created_at``.
         """
         ...
@@ -554,8 +568,9 @@ class DistilleryStore(Protocol):
 
         Returns:
             List of dicts with keys: ``id``, ``from_id``, ``to_id``,
-            ``relation_type``, ``created_at`` (ISO 8601 str).  Ordered by
-            ascending ``created_at``.
+            ``relation_type``, ``created_at`` (ISO 8601 str), ``weight``
+            (float | None), ``valid_at`` / ``invalid_at`` (ISO 8601 str | None),
+            ``metadata`` (dict | None).  Ordered by ascending ``created_at``.
         """
         ...
 

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -369,15 +369,29 @@ async def test_add_relation_edge_attributes_round_trip(store) -> None:  # type: 
 
 
 @pytest.mark.unit
+async def test_add_relation_rejects_inverted_validity_window(store) -> None:  # type: ignore[no-untyped-def]
+    """invalid_at earlier than valid_at is rejected."""
+    a = await _store_entry(store, content="entry A")
+    b = await _store_entry(store, content="entry B")
+
+    with pytest.raises(ValueError, match="invalid_at must be greater than or equal to valid_at"):
+        await store.add_relation(
+            a,
+            b,
+            "related",
+            valid_at="2026-06-01T00:00:00",
+            invalid_at="2026-01-01T00:00:00",
+        )
+
+
+@pytest.mark.unit
 async def test_add_relation_reassert_upserts_attributes(store) -> None:  # type: ignore[no-untyped-def]
     """Re-asserting an existing edge upserts supplied attrs, stays idempotent on the triple."""
     a = await _store_entry(store, content="entry A")
     b = await _store_entry(store, content="entry B")
 
     first = await store.add_relation(a, b, "related", weight=0.1)
-    second = await store.add_relation(
-        a, b, "related", weight=0.9, invalid_at="2026-06-01T00:00:00"
-    )
+    second = await store.add_relation(a, b, "related", weight=0.9, invalid_at="2026-06-01T00:00:00")
 
     assert first == second  # same row, no duplicate
     (row,) = await store.get_related(a)
@@ -410,6 +424,7 @@ async def test_relations_tool_add_with_edge_attributes(store) -> None:  # type: 
 
     (row,) = await store.get_related(a)
     assert row["weight"] == 2.5
+    assert row["valid_at"] == "2026-03-01T00:00:00Z"
     assert row["metadata"] == {"k": "v"}
 
 
@@ -427,8 +442,13 @@ async def test_relations_tool_add_rejects_bad_attributes(store) -> None:  # type
 
     bad_ts = await _handle_relations(
         store,
-        {"action": "add", "from_id": a, "to_id": b, "relation_type": "link",
-         "valid_at": "not-a-date"},
+        {
+            "action": "add",
+            "from_id": a,
+            "to_id": b,
+            "relation_type": "link",
+            "valid_at": "not-a-date",
+        },
     )
     assert json.loads(bad_ts[0].text)["code"] == "INVALID_PARAMS"
 

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -317,12 +317,120 @@ async def test_get_related_row_structure(store) -> None:  # type: ignore[no-unty
     results = await store.get_related(a)
     assert len(results) == 1
     row = results[0]
-    assert set(row.keys()) == {"id", "from_id", "to_id", "relation_type", "created_at"}
+    assert set(row.keys()) == {
+        "id",
+        "from_id",
+        "to_id",
+        "relation_type",
+        "created_at",
+        "weight",
+        "valid_at",
+        "invalid_at",
+        "metadata",
+    }
     assert row["id"] == relation_id
     assert row["from_id"] == a
     assert row["to_id"] == b
     assert row["relation_type"] == "link"
     assert isinstance(row["created_at"], str)
+    # New edge attributes default to None when unspecified.
+    assert row["weight"] is None
+    assert row["valid_at"] is None
+    assert row["invalid_at"] is None
+    assert row["metadata"] is None
+
+
+@pytest.mark.unit
+async def test_add_relation_edge_attributes_round_trip(store) -> None:  # type: ignore[no-untyped-def]
+    """weight, valid_at, invalid_at, and metadata persist and read back."""
+    a = await _store_entry(store, content="entry A")
+    b = await _store_entry(store, content="entry B")
+
+    await store.add_relation(
+        a,
+        b,
+        "related",
+        weight=0.75,
+        valid_at="2026-01-01T00:00:00",
+        invalid_at="2026-06-01T12:30:00",
+        metadata={"source": "spike", "n": 3},
+    )
+
+    (row,) = await store.get_related(a)
+    assert row["weight"] == 0.75
+    assert row["valid_at"] == "2026-01-01T00:00:00Z"
+    assert row["invalid_at"] == "2026-06-01T12:30:00Z"
+    assert row["metadata"] == {"source": "spike", "n": 3}
+
+    # list_relations returns the same shape.
+    (listed,) = await store.list_relations()
+    assert listed["weight"] == 0.75
+    assert listed["metadata"] == {"source": "spike", "n": 3}
+
+
+@pytest.mark.unit
+async def test_add_relation_reassert_upserts_attributes(store) -> None:  # type: ignore[no-untyped-def]
+    """Re-asserting an existing edge upserts supplied attrs, stays idempotent on the triple."""
+    a = await _store_entry(store, content="entry A")
+    b = await _store_entry(store, content="entry B")
+
+    first = await store.add_relation(a, b, "related", weight=0.1)
+    second = await store.add_relation(
+        a, b, "related", weight=0.9, invalid_at="2026-06-01T00:00:00"
+    )
+
+    assert first == second  # same row, no duplicate
+    (row,) = await store.get_related(a)
+    assert row["weight"] == 0.9  # upserted
+    assert row["invalid_at"] == "2026-06-01T00:00:00Z"
+
+
+@pytest.mark.unit
+async def test_relations_tool_add_with_edge_attributes(store) -> None:  # type: ignore[no-untyped-def]
+    """The MCP add action accepts and echoes weight/valid_at/invalid_at/metadata."""
+    a = await _store_entry(store, content="entry A")
+    b = await _store_entry(store, content="entry B")
+
+    result = await _handle_relations(
+        store,
+        {
+            "action": "add",
+            "from_id": a,
+            "to_id": b,
+            "relation_type": "link",
+            "weight": 2.5,
+            "valid_at": "2026-03-01T00:00:00",
+            "metadata": {"k": "v"},
+        },
+    )
+    payload = json.loads(result[0].text)
+    assert payload["weight"] == 2.5
+    assert payload["valid_at"] == "2026-03-01T00:00:00"
+    assert payload["metadata"] == {"k": "v"}
+
+    (row,) = await store.get_related(a)
+    assert row["weight"] == 2.5
+    assert row["metadata"] == {"k": "v"}
+
+
+@pytest.mark.unit
+async def test_relations_tool_add_rejects_bad_attributes(store) -> None:  # type: ignore[no-untyped-def]
+    """Non-numeric weight and unparseable timestamps are rejected with INVALID_PARAMS."""
+    a = await _store_entry(store, content="entry A")
+    b = await _store_entry(store, content="entry B")
+
+    bad_weight = await _handle_relations(
+        store,
+        {"action": "add", "from_id": a, "to_id": b, "relation_type": "link", "weight": "heavy"},
+    )
+    assert json.loads(bad_weight[0].text)["code"] == "INVALID_PARAMS"
+
+    bad_ts = await _handle_relations(
+        store,
+        {"action": "add", "from_id": a, "to_id": b, "relation_type": "link",
+         "valid_at": "not-a-date"},
+    )
+    assert json.loads(bad_ts[0].text)["code"] == "INVALID_PARAMS"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds edge attributes to `entry_relations` so relationships carry strength and a bi-temporal validity window, not just a type. Closes the "relations carry no weight/timestamp column" gap surfaced by the graph post-recommendation spikes (#605).

## Migration 15
Four nullable columns on `entry_relations`:
- `weight` DOUBLE — edge strength (interest/engagement magnitude)
- `valid_at` TIMESTAMPTZ — when the relationship became true
- `invalid_at` TIMESTAMPTZ — when it stopped being true (NULL = still valid)
- `metadata` JSON — arbitrary per-edge attributes

Fully additive: existing edges and the metadata/wikilink backfill paths keep working; NULL means "unspecified".

## API
- `add_relation(from, to, type, weight=, valid_at=, invalid_at=, metadata=)` — all optional. Re-asserting an existing `(from, to, type)` triple **upserts** the supplied non-None attrs while staying idempotent on the row.
- `get_related` / `list_relations` return the new fields. Timestamps now render as **true UTC** via `AT TIME ZONE 'UTC'`, fixing a latent `created_at` local-time-labelled-`Z` mislabel.
- `distillery_relations` MCP `action="add"` accepts and echoes the new fields, validating `weight` (number) and ISO 8601 timestamps.

## Tests
- Edge-attribute round-trip through `get_related` + `list_relations`
- Re-assert upserts attrs, no duplicate row
- MCP add accepts/echoes attrs; rejects non-numeric weight and unparseable timestamps
- Updated `test_get_related_row_structure` for the additive key set

Full suite green (2930 passed), `mypy --strict` clean on all of `src`, ruff clean.

## Follow-ups (not in this PR)
- Temporal-aware reads (e.g. `get_related(as_of=...)` filtering on the validity window)
- Weight-ordered traversal / weighted graph metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended relation definitions to support optional weight, temporal validity timestamps (valid_at/invalid_at), and custom metadata attributes on edges.
  * Re-asserting an existing relation now upserts the provided attributes without creating duplicate entries.

* **Tests**
  * Added comprehensive coverage for edge attribute persistence, validation, timestamp parsing, metadata round-tripping, and MCP tool integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->