### PR TITLE
fix(mcp): use per-call cursors in budget to avoid DuckDB result-set race

### DIFF
--- a/src/distillery/mcp/budget.py
+++ b/src/distillery/mcp/budget.py
@@ -73,19 +73,24 @@ def increment_usage(conn: Any, count: int = 1) -> int:
     Returns:
         The new total for today.
     """
+    with _write_lock:
+        return _increment_locked(conn, count)
+
+
+def _increment_locked(conn: Any, count: int) -> int:
+    """Upsert today's counter and return the new total.  Caller holds ``_write_lock``."""
     key = _today_key()
     # Use a per-call cursor so concurrent callers don't invalidate each
-    # other's result sets on the shared connection, and hold the write lock
-    # so concurrent upserts of the same row don't conflict.
-    with _write_lock:
-        cur = conn.cursor()
-        cur.execute(
-            "INSERT INTO _meta (key, value) VALUES (?, ?) "
-            "ON CONFLICT (key) DO UPDATE SET "
-            "value = CAST(CAST(_meta.value AS INTEGER) + ? AS VARCHAR)",
-            [key, str(count), count],
-        )
-        row = cur.execute("SELECT value FROM _meta WHERE key = ?", [key]).fetchone()
+    # other's result sets on the shared connection; the write lock keeps
+    # concurrent upserts of the same row from conflicting.
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO _meta (key, value) VALUES (?, ?) "
+        "ON CONFLICT (key) DO UPDATE SET "
+        "value = CAST(CAST(_meta.value AS INTEGER) + ? AS VARCHAR)",
+        [key, str(count), count],
+    )
+    row = cur.execute("SELECT value FROM _meta WHERE key = ?", [key]).fetchone()
     return int(row[0]) if row else count
 
 
@@ -126,5 +131,11 @@ def record_and_check(conn: Any, daily_limit: int, count: int = 1) -> int:
     """
     if daily_limit <= 0:
         return increment_usage(conn, count)  # unlimited, still track
-    check_budget(conn, daily_limit, count)
-    return increment_usage(conn, count)
+    # Check and increment under one lock: a check that releases the lock
+    # before the increment lets concurrent callers all pass the read and
+    # collectively overspend the cap.
+    with _write_lock:
+        used = get_daily_usage(conn)
+        if used + count > daily_limit:
+            raise EmbeddingBudgetError(used, daily_limit)
+        return _increment_locked(conn, count)

--- a/src/distillery/mcp/budget.py
+++ b/src/distillery/mcp/budget.py
@@ -16,9 +16,15 @@ from __future__ import annotations
 
 import datetime
 import logging
+import threading
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Serializes counter writes.  Per-call cursors are separate DuckDB
+# connections, so unserialized concurrent upserts of the same row hit
+# optimistic-concurrency conflicts ("Conflict on update!" / duplicate key).
+_write_lock = threading.Lock()
 
 
 class EmbeddingBudgetError(Exception):
@@ -48,7 +54,9 @@ def get_daily_usage(conn: Any) -> int:
         The number of embedding calls made today.
     """
     key = _today_key()
-    row = conn.execute("SELECT value FROM _meta WHERE key = ?", [key]).fetchone()
+    # Use a per-call cursor: another execute() on the shared connection would
+    # invalidate a pending result set ("No open result set") under concurrency.
+    row = conn.cursor().execute("SELECT value FROM _meta WHERE key = ?", [key]).fetchone()
     return int(row[0]) if row else 0
 
 
@@ -66,12 +74,18 @@ def increment_usage(conn: Any, count: int = 1) -> int:
         The new total for today.
     """
     key = _today_key()
-    conn.execute(
-        "INSERT INTO _meta (key, value) VALUES (?, ?) "
-        "ON CONFLICT (key) DO UPDATE SET value = CAST(CAST(_meta.value AS INTEGER) + ? AS VARCHAR)",
-        [key, str(count), count],
-    )
-    row = conn.execute("SELECT value FROM _meta WHERE key = ?", [key]).fetchone()
+    # Use a per-call cursor so concurrent callers don't invalidate each
+    # other's result sets on the shared connection, and hold the write lock
+    # so concurrent upserts of the same row don't conflict.
+    with _write_lock:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO _meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT (key) DO UPDATE SET "
+            "value = CAST(CAST(_meta.value AS INTEGER) + ? AS VARCHAR)",
+            [key, str(count), count],
+        )
+        row = cur.execute("SELECT value FROM _meta WHERE key = ?", [key]).fetchone()
     return int(row[0]) if row else count
 
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -121,6 +121,78 @@ class TestRecordAndCheck:
 
 
 # ---------------------------------------------------------------------------
+# Unit tests: concurrency (issue #608)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConcurrentAccess:
+    """Regression tests for the DuckDB result-set race (issue #608).
+
+    DuckDB invalidates a connection's pending result set when another
+    ``execute()`` runs on the same connection, so concurrent execute+fetch
+    on a shared connection raised ``InvalidInputException: No open result
+    set``.  Per-call cursors give each caller its own result set.
+    """
+
+    def test_concurrent_reads_and_writes_do_not_raise(
+        self, conn: duckdb.DuckDBPyConnection
+    ) -> None:
+        """Concurrent check/read/record calls on one shared connection succeed."""
+        import threading
+
+        n_threads = 8
+        iterations = 25
+        barrier = threading.Barrier(n_threads)
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            barrier.wait()
+            try:
+                for _ in range(iterations):
+                    check_budget(conn, daily_limit=10_000_000)
+                    get_daily_usage(conn)
+                    record_and_check(conn, daily_limit=10_000_000)
+            except Exception as exc:  # pragma: no cover - only on regression
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"concurrent budget calls raised: {errors!r}"
+        assert get_daily_usage(conn) == n_threads * iterations
+
+    def test_concurrent_increments_count_correctly(self, conn: duckdb.DuckDBPyConnection) -> None:
+        """The _meta counter reflects every concurrent increment exactly once."""
+        import threading
+
+        n_threads = 6
+        iterations = 20
+        barrier = threading.Barrier(n_threads)
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            barrier.wait()
+            try:
+                for _ in range(iterations):
+                    increment_usage(conn)
+            except Exception as exc:  # pragma: no cover - only on regression
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"concurrent increments raised: {errors!r}"
+        assert get_daily_usage(conn) == n_threads * iterations
+
+
+# ---------------------------------------------------------------------------
 # Unit tests: config
 # ---------------------------------------------------------------------------
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -191,6 +191,43 @@ class TestConcurrentAccess:
         assert errors == [], f"concurrent increments raised: {errors!r}"
         assert get_daily_usage(conn) == n_threads * iterations
 
+    def test_concurrent_record_and_check_cannot_overspend(
+        self, conn: duckdb.DuckDBPyConnection
+    ) -> None:
+        """Concurrent record_and_check calls never push usage past daily_limit."""
+        import threading
+
+        daily_limit = 10
+        n_threads = 8
+        iterations = 5  # 40 attempted calls against a limit of 10
+        barrier = threading.Barrier(n_threads)
+        errors: list[Exception] = []
+        successes: list[int] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            barrier.wait()
+            for _ in range(iterations):
+                try:
+                    record_and_check(conn, daily_limit=daily_limit)
+                except EmbeddingBudgetError:
+                    pass  # expected once the cap is reached
+                except Exception as exc:  # pragma: no cover - only on regression
+                    errors.append(exc)
+                else:
+                    with lock:
+                        successes.append(1)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"concurrent record_and_check raised: {errors!r}"
+        assert len(successes) == daily_limit
+        assert get_daily_usage(conn) == daily_limit
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: config


### PR DESCRIPTION
## Root cause

`get_daily_usage` / `increment_usage` in `src/distillery/mcp/budget.py` ran execute+fetch on the shared module-level DuckDB connection. DuckDB invalidates a connection's pending result set when another `execute()` runs on the same connection, so under concurrent tool calls the loser's `fetchone()` raised `InvalidInputException: Invalid Input Error: No open result set`. Reproducing the race against the pre-fix code also segfaulted the interpreter (exit 139).

## Fix

- `get_daily_usage`: read via a per-call `conn.cursor()` so each caller owns its result set.
- `increment_usage`: run the upsert and the follow-up read on a per-call cursor, serialized by a module-level `threading.Lock`. Cursors are separate connections, so unserialized concurrent upserts of the same `_meta` row hit DuckDB optimistic-concurrency errors (`Conflict on update!`, duplicate-key) — the lock keeps the counter exact.
- `check_budget` / `record_and_check` are covered transitively (they only touch the connection through the two functions above).

These are the only call sites that pass the shared connection into budget code (`tools/search.py`, `tools/crud.py`, `tools/analytics.py` all go through `budget.py` functions).

## Acceptance

- New `TestConcurrentAccess` regression tests in `tests/test_budget.py`: 8 threads x 25 iterations of `check_budget` + `get_daily_usage` + `record_and_check` on one shared connection — no exceptions, and the `_meta` counter lands at exactly 200; plus a concurrent-increment exactness test. Against the pre-fix code this repro raises `No open result set` variants or crashes the process.
- `pytest tests/test_budget.py`: 22 passed.
- `ruff check` / `ruff format --check` clean on touched files; `mypy --strict src/distillery/` clean.

Fixes [#608](https://github.com/norrietaylor/distillery/issues/608)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved "No open result set" exceptions during concurrent budget tracking operations.

* **Tests**
  * Added regression tests for concurrent embedding budget tracker access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->