### PR TITLE
fix(store): checkpoint WAL after every write path

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -198,6 +198,7 @@ class DuckDBStore:
         self._initialized: bool = False
         self._vss_available: bool = False
         self._fts_available: bool = False
+        self._checkpoint_failures: int = 0
         self._hybrid_search: bool = hybrid_search
         self._rrf_k: int = rrf_k
         self._recency_window_days: int = recency_window_days
@@ -436,11 +437,25 @@ class DuckDBStore:
         """
         try:
             conn.execute("CHECKPOINT")
+            self._checkpoint_failures = 0
         except duckdb.Error as exc:
             # Non-fatal: the row is already in the WAL.  Log so operators
             # can see repeated failures, but don't raise — the caller has
-            # already observed a successful write.
-            logger.debug("CHECKPOINT after write failed (non-fatal): %s", exc)
+            # already observed a successful write.  A persistent failure
+            # streak means the WAL is accumulating writes (including HNSW
+            # index entries under experimental persistence, whose replay
+            # has crashed on startup in production) — escalate so it is
+            # visible before the WAL becomes unreplayable.
+            self._checkpoint_failures += 1
+            if self._checkpoint_failures >= 3:
+                logger.warning(
+                    "CHECKPOINT after write failed %d times in a row — "
+                    "WAL is accumulating un-flushed writes (non-fatal): %s",
+                    self._checkpoint_failures,
+                    exc,
+                )
+            else:
+                logger.debug("CHECKPOINT after write failed (non-fatal): %s", exc)
 
     def _sync_verify_entries_readable(self, entry_ids: Sequence[str]) -> None:
         """Read-back verification after a bulk rewrite of ``entries`` (issue #584).
@@ -2569,6 +2584,7 @@ class DuckDBStore:
                 "VALUES (?, ?, ?, ?, ?, ?)",
                 [str(_uuid.uuid4()), user_id, tool, entry_id, action, outcome],
             )
+            self._checkpoint_after_write(conn)
 
         try:
             await self._run_sync(_sync)
@@ -2718,6 +2734,7 @@ class DuckDBStore:
             "VALUES (?, ?, ?, ?, ?)"
         )
         conn.execute(sql, [search_id, query, result_entry_ids, result_scores, session_id])
+        self._checkpoint_after_write(conn)
         logger.debug("Logged search id=%s query=%r", search_id, query)
         return search_id
 
@@ -2767,6 +2784,7 @@ class DuckDBStore:
         conn = self.connection
         sql = "INSERT INTO feedback_log (id, search_id, entry_id, signal) VALUES (?, ?, ?, ?)"
         conn.execute(sql, [feedback_id, search_id, entry_id, signal])
+        self._checkpoint_after_write(conn)
         logger.debug(
             "Logged feedback id=%s search_id=%s entry_id=%s signal=%r",
             feedback_id,
@@ -2922,6 +2940,7 @@ class DuckDBStore:
             )
         except duckdb.ConstraintException as exc:
             raise ValueError(f"Feed source with URL {url!r} already exists.") from exc
+        self._checkpoint_after_write(self._conn)
         return {
             "url": url,
             "source_type": source_type,
@@ -2936,7 +2955,10 @@ class DuckDBStore:
         """Remove a feed source by URL. Returns True if it existed."""
         assert self._conn is not None
         result = self._conn.execute("DELETE FROM feed_sources WHERE url = ? RETURNING url", [url])
-        return len(result.fetchall()) > 0
+        removed = len(result.fetchall()) > 0
+        if removed:
+            self._checkpoint_after_write(self._conn)
+        return removed
 
     # Maximum length of a persisted ``last_error`` string.  Longer errors are
     # truncated to keep the liveness payload small and to avoid storing
@@ -2980,7 +3002,10 @@ class DuckDBStore:
             "WHERE url = ? RETURNING url",
             [polled_at_naive, item_count_int, truncated, url],
         )
-        return len(result.fetchall()) > 0
+        updated = len(result.fetchall()) > 0
+        if updated:
+            self._checkpoint_after_write(self._conn)
+        return updated
 
     async def list_feed_sources(self) -> list[dict[str, Any]]:
         """Return all persisted feed sources as dicts."""
@@ -3062,6 +3087,7 @@ class DuckDBStore:
             "ON CONFLICT (key) DO UPDATE SET value = excluded.value",
             [key, value],
         )
+        self._checkpoint_after_write(self._conn)
 
     async def get_metadata(self, key: str) -> str | None:
         """Read a value from the ``_meta`` key-value table."""
@@ -3098,6 +3124,8 @@ class DuckDBStore:
             "RETURNING id",
             [retention_days],
         ).fetchall()
+        if result:
+            self._checkpoint_after_write(self._conn)
         return len(result)
 
     async def prune_search_log(self, retention_days: int) -> int:
@@ -3327,6 +3355,8 @@ class DuckDBStore:
                     f"UPDATE entry_relations SET {', '.join(set_parts)} WHERE id = ?",
                     [*set_params, relation_id],
                 )
+            if set_parts:
+                self._checkpoint_after_write(self._conn)
             logger.debug(
                 "Relation already exists id=%s from=%s to=%s type=%s (attrs upserted=%d)",
                 relation_id,
@@ -3352,6 +3382,7 @@ class DuckDBStore:
                 metadata_json,
             ],
         )
+        self._checkpoint_after_write(self._conn)
         logger.debug(
             "Added relation id=%s from=%s to=%s type=%s",
             relation_id,
@@ -3487,8 +3518,11 @@ class DuckDBStore:
                 conn.execute("ROLLBACK")
             raise
 
-        # Rebuild FTS index outside the transaction (non-critical).
+        # Rebuild FTS index outside the transaction (non-critical).  The
+        # rebuild checkpoints when FTS is available; checkpoint explicitly
+        # too so the correction's write set is flushed either way.
         self._rebuild_fts_index(conn)
+        self._checkpoint_after_write(conn)
         logger.debug(
             "Applied correction: new=%s original=%s (archived)",
             new_entry.id,
@@ -3612,6 +3646,7 @@ class DuckDBStore:
         deleted = result.fetchall()
         found = len(deleted) > 0
         if found:
+            self._checkpoint_after_write(self._conn)
             logger.debug("Removed relation id=%s", relation_id)
         return found
 

--- a/tests/test_store_wal_durability.py
+++ b/tests/test_store_wal_durability.py
@@ -484,3 +484,135 @@ class TestWalRecoveryPreservesBytes:
                 "recovery path appears to have deleted the WAL outright."
             )
             assert backups[0].read_bytes() == b"pretend this is a dirty WAL"
+
+
+# ---------------------------------------------------------------------------
+# WAL stays flushed across every write path
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundWritesFlushWal:
+    """Every write path must flush the WAL, not just entry CRUD.
+
+    The 2026-06-12 local incident: ``search_log`` / ``feedback_log`` /
+    ``feed_sources`` / ``entry_relations`` / ``_meta`` / ``audit_log``
+    writes bypassed :meth:`DuckDBStore._checkpoint_after_write`, so a
+    server doing mostly background work (feed polls, search logging)
+    accumulated a multi-megabyte WAL.  With
+    ``hnsw_enable_experimental_persistence`` the WAL also carries HNSW
+    index entries, and replaying such a WAL on startup segfaulted DuckDB
+    — taking the database (and a day of backups) with it.  Checkpointing
+    after every write keeps the WAL near-empty so there is never a large
+    replay to poison.
+
+    A successful CHECKPOINT removes the ``.wal`` sidecar entirely, so the
+    assertion after each operation is simply that the sidecar is gone (or
+    empty).
+    """
+
+    async def test_background_write_paths_leave_no_wal(
+        self, tmp_path: Path, mock_embedding_provider
+    ) -> None:
+        from datetime import UTC, datetime
+
+        db_path = tmp_path / "flush.db"
+        store = DuckDBStore(db_path=str(db_path), embedding_provider=mock_embedding_provider)
+        await store.initialize()
+        wal = tmp_path / "flush.db.wal"
+
+        def wal_bytes() -> int:
+            return wal.stat().st_size if wal.exists() else 0
+
+        try:
+            e1 = make_entry(content="wal flush A")
+            e2 = make_entry(content="wal flush B")
+            await store.store(e1)
+            await store.store(e2)
+
+            await store.log_search("prune me", [e1.id], [0.5])
+            await store.prune_search_log(0)
+            assert wal_bytes() == 0, "prune_search_log left writes in the WAL"
+
+            search_id = await store.log_search("q", [e1.id], [0.9])
+            assert wal_bytes() == 0, "log_search left writes in the WAL"
+
+            await store.log_feedback(search_id, e1.id, "click")
+            assert wal_bytes() == 0, "log_feedback left writes in the WAL"
+
+            await store.add_feed_source("https://example.com/feed.xml", "rss")
+            assert wal_bytes() == 0, "add_feed_source left writes in the WAL"
+
+            await store.record_poll_status(
+                "https://example.com/feed.xml",
+                polled_at=datetime.now(tz=UTC),
+                item_count=3,
+                error=None,
+            )
+            assert wal_bytes() == 0, "record_poll_status left writes in the WAL"
+
+            await store.remove_feed_source("https://example.com/feed.xml")
+            assert wal_bytes() == 0, "remove_feed_source left writes in the WAL"
+
+            await store.set_metadata("wal-test-key", "value")
+            assert wal_bytes() == 0, "set_metadata left writes in the WAL"
+
+            relation_id = await store.add_relation(e1.id, e2.id, "link")
+            assert wal_bytes() == 0, "add_relation left writes in the WAL"
+
+            await store.add_relation(e1.id, e2.id, "link", weight=0.5)  # upsert path
+            assert wal_bytes() == 0, "add_relation upsert left writes in the WAL"
+
+            await store.remove_relation(relation_id)
+            assert wal_bytes() == 0, "remove_relation left writes in the WAL"
+
+            await store.write_audit_log("user", "tool", e1.id, "create", "ok")
+            assert wal_bytes() == 0, "write_audit_log left writes in the WAL"
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Persistent checkpoint failures are surfaced
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointFailureEscalation:
+    """Swallowed checkpoint failures escalate to WARNING after a streak.
+
+    ``_checkpoint_after_write`` deliberately never raises — but logging
+    every failure at DEBUG hid the 2026-06-12 incident's WAL growth until
+    replay was already poisoned.  Three consecutive failures now log at
+    WARNING; any success resets the streak.
+    """
+
+    class _FailingConn:
+        def execute(self, sql: str) -> None:
+            raise duckdb.Error("checkpoint refused")
+
+    class _OkConn:
+        def execute(self, sql: str) -> None:
+            return None
+
+    def test_warns_after_three_consecutive_failures(
+        self, mock_embedding_provider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        store = DuckDBStore(db_path=":memory:", embedding_provider=mock_embedding_provider)
+        with caplog.at_level(logging.DEBUG, logger="distillery.store.duckdb"):
+            store._checkpoint_after_write(self._FailingConn())  # type: ignore[arg-type]
+            store._checkpoint_after_write(self._FailingConn())  # type: ignore[arg-type]
+            warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+            assert warnings == [], "warned before the streak threshold"
+            store._checkpoint_after_write(self._FailingConn())  # type: ignore[arg-type]
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warnings) == 1
+        assert "3 times in a row" in warnings[0].message
+
+    def test_success_resets_failure_streak(self, mock_embedding_provider) -> None:
+        store = DuckDBStore(db_path=":memory:", embedding_provider=mock_embedding_provider)
+        store._checkpoint_after_write(self._FailingConn())  # type: ignore[arg-type]
+        store._checkpoint_after_write(self._FailingConn())  # type: ignore[arg-type]
+        assert store._checkpoint_failures == 2
+        store._checkpoint_after_write(self._OkConn())  # type: ignore[arg-type]
+        assert store._checkpoint_failures == 0


### PR DESCRIPTION
## Root cause

`_checkpoint_after_write` (issue [#346](https://github.com/norrietaylor/distillery/issues/346)) covers entry CRUD only. `_sync_log_search`, `_sync_log_feedback`, `_sync_add_feed_source`, `_sync_remove_feed_source`, `_sync_record_poll_status`, `_sync_set_metadata`, `_sync_prune_search_log`, `_sync_add_relation`, `_sync_remove_relation`, `_sync_apply_correction`, and `write_audit_log` write without flushing. A deployment doing mostly background work (feed polls, search logging) accumulates an unbounded WAL.

With `hnsw_enable_experimental_persistence = true` the WAL also carries HNSW index entries. On 2026-06-12 a local deployment's 2.3 MB WAL segfaulted DuckDB on startup WAL replay (SIGSEGV in-container, SIGBUS reproduced with host duckdb 1.5.1 on a copy), and the base db file ended up with bitpacking block corruption — recovery required restoring a day-old backup. Second occurrence of this failure mode (first: 2026-06-01).

Checkpoint failures were also swallowed at DEBUG, so a persistent failure streak (and the resulting WAL growth) was invisible.

## Fix

- Route every remaining write path through `_checkpoint_after_write`. CHECKPOINT is a no-op on an empty WAL; delete paths checkpoint only when rows were affected.
- `_checkpoint_after_write` escalates to WARNING after 3 consecutive failures; any success resets the streak.

## Acceptance

- `TestBackgroundWritesFlushWal`: file-backed store; after each write path the `.wal` sidecar is gone (a successful CHECKPOINT removes it).
- `TestCheckpointFailureEscalation`: WARNING exactly once at the 3rd consecutive failure; success resets the counter.
- Full suite 2951 passed, `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced data durability by ensuring write operations consistently flush to the main database file, reducing potential data loss in unexpected shutdowns
  * Improved checkpoint failure handling by tracking consecutive failures and escalating from debug to warning messages after three consecutive failures
  * Added comprehensive test coverage to verify durability across all write operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->