### PR TITLE
fix(skills): stop auto-installing MCP server; remove 30-prompt distill nudge

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,15 +28,6 @@
       "sensitive": true
     }
   },
-  "mcpServers": {
-    "distillery": {
-      "command": "uvx",
-      "args": ["--from", "distillery-mcp[fastembed]>=0.6.0", "distillery-mcp"],
-      "env": {
-        "DISTILLERY_EMBEDDING_PROVIDER": "fastembed"
-      }
-    }
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ claude plugin marketplace add norrietaylor/distillery
 claude plugin install distillery
 ```
 
-This installs all 14 skills and configures the MCP server to run **locally** via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp` — a private, self-contained knowledge base on your machine, with on-device `fastembed` embeddings as the install-time default (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/) (install: `curl -LsSf https://astral.sh/uv/install.sh | sh`).
+This installs all 14 skills. The plugin **does not configure an MCP server automatically** — run `/setup` (below) to add one. The recommended setup runs **locally** via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp` — a private, self-contained knowledge base on your machine, with on-device `fastembed` embeddings (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/) (install: `curl -LsSf https://astral.sh/uv/install.sh | sh`).
 
 ### Step 2 (Optional): Use Jina or OpenAI Instead
 
@@ -100,7 +100,7 @@ Restart Claude Code and run the onboarding wizard:
 
 ### Try the Hosted Demo (Opt-In)
 
-Want to evaluate without installing anything locally? Override the plugin default with the hosted demo at `distillery-mcp.fly.dev`:
+Want to evaluate without installing anything locally? Configure the hosted demo at `distillery-mcp.fly.dev` instead of a local server:
 
 ```bash
 claude mcp add distillery --scope user --transport http --url https://distillery-mcp.fly.dev/mcp

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -12,10 +12,10 @@ claude plugin marketplace add norrietaylor/distillery
 claude plugin install distillery
 ```
 
-This installs the skill definitions globally and configures the MCP server to run **locally** via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp` — a private, self-contained knowledge base on your machine, with on-device `fastembed` embeddings as the install-time default (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/) on your `PATH`.
+This installs the skill definitions globally. The plugin **does not configure an MCP server automatically** — run `/setup` (next step) to add one. The recommended setup is a private, self-contained local knowledge base via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp`, with on-device `fastembed` embeddings (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/) on your `PATH`.
 
 !!! tip "Install uv"
-    `curl -LsSf https://astral.sh/uv/install.sh | sh` — or use `pip install 'distillery-mcp[fastembed]'` and override the plugin's default `command` to `distillery-mcp` (see [Troubleshooting](mcp-setup.md#troubleshooting)).
+    `curl -LsSf https://astral.sh/uv/install.sh | sh` — or use `pip install 'distillery-mcp[fastembed]'` and set the server `command` to `distillery-mcp` (see [Troubleshooting](mcp-setup.md#troubleshooting)).
 
 After installation, restart Claude Code and run the onboarding wizard:
 
@@ -23,7 +23,7 @@ After installation, restart Claude Code and run the onboarding wizard:
 /setup
 ```
 
-This verifies MCP connectivity, detects your transport, and configures auto-poll for ambient intelligence.
+This verifies MCP connectivity, prompts you to configure an MCP server if none is connected, detects your transport, and configures auto-poll for ambient intelligence.
 
 !!! note "Hosted demo (opt-in)"
     Want a zero-install evaluation? You can opt into the hosted demo at `distillery-mcp.fly.dev` instead — see [MCP Configuration](#mcp-configuration) below. The demo server is for **evaluation only**; do not store sensitive or confidential data.
@@ -62,11 +62,11 @@ ln -s ~/.claude/distillery/skills/setup     ~/.claude/skills/setup
 
 ## MCP Configuration
 
-The skills require the Distillery MCP server. The plugin's **default** is local stdio via `uvx distillery-mcp`. Hosted demo and self-hosted HTTP are opt-in alternatives.
+The skills require the Distillery MCP server, which you configure yourself — the plugin ships skills only. The **recommended** setup is local stdio via `uvx distillery-mcp`. Hosted demo and self-hosted HTTP are opt-in alternatives.
 
-### Default — Local stdio with uvx (fastembed)
+### Recommended — Local stdio with uvx (fastembed)
 
-`claude plugin install distillery` registers this configuration automatically. The plugin manifest declares:
+`/setup` prompts to add this when no server is connected, or add it manually to `~/.claude.json` (user scope) or `.mcp.json` (this project):
 
 ```json
 {

--- a/docs/home.md
+++ b/docs/home.md
@@ -46,7 +46,7 @@ claude plugin marketplace add norrietaylor/distillery
 claude plugin install distillery
 ```
 
-This installs all 14 skills and configures the MCP server to run **locally** via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp` — a private, self-contained knowledge base on your machine, with on-device `fastembed` embeddings as the install-time default (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/).
+This installs all 14 skills. The plugin **does not configure an MCP server automatically** — run `/setup` to add one. The recommended setup runs **locally** via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp` — a private, self-contained knowledge base on your machine, with on-device `fastembed` embeddings (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/).
 
 !!! tip "Install uv"
     `curl -LsSf https://astral.sh/uv/install.sh | sh`
@@ -69,7 +69,7 @@ Restart Claude Code and run `/setup` to complete onboarding.
 
 ### Try the Hosted Demo (Opt-In)
 
-Want to evaluate without installing locally? Override the plugin default with the hosted demo at `distillery-mcp.fly.dev`:
+Want to evaluate without installing locally? Configure the hosted demo at `distillery-mcp.fly.dev` instead of a local server:
 
 ```bash
 claude mcp add distillery --scope user --transport http --url https://distillery-mcp.fly.dev/mcp

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,8 +77,7 @@
 - [x] Extended `EntrySource` — added inference, documentation, external provenance values
 
 ### Session Hooks
-- [x] Hook dispatcher script (`distillery-hooks.sh`) — routes UserPromptSubmit, SessionStart, PreCompact
-- [x] Memory nudge — periodic reminder to `/distill` every 30 prompts
+- [x] Hook dispatcher script (`distillery-hooks.sh`) — routes SessionStart, PreCompact
 - [x] SessionStart briefing — automatic context injection via HTTP MCP
 - [x] Scope-aware `/setup` hook configuration — detects plugin install scope (user/project)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,7 +77,7 @@
 - [x] Extended `EntrySource` — added inference, documentation, external provenance values
 
 ### Session Hooks
-- [x] Hook dispatcher script (`distillery-hooks.sh`) — routes SessionStart, PreCompact
+- [x] Hook dispatcher script (`distillery-hooks.sh`) — routes SessionStart
 - [x] SessionStart briefing — automatic context injection via HTTP MCP
 - [x] Scope-aware `/setup` hook configuration — detects plugin install scope (user/project)
 

--- a/docs/skills/setup.md
+++ b/docs/skills/setup.md
@@ -74,19 +74,18 @@ Routines run automatically in the background when Claude Code is active. They wo
 
 Configures session lifecycle hooks in the appropriate `settings.json` based on your plugin installation scope.
 
-!!! note "Plugin Hooks Limitation"
-    Plugin manifest hooks (`plugin.json`) support `SessionStart` and `Stop` events but **not** `UserPromptSubmit`. To enable the memory nudge and full session lifecycle hooks, they must be configured in `settings.json` via `/setup`.
+!!! note "Why settings.json"
+    The dispatcher resolves sibling scripts by absolute path, so `/setup` registers it in the scope-appropriate `settings.json` (user or project) where the briefing handler can locate `session-start-briefing.sh`.
 
 The wizard:
 
 1. **Detects plugin scope** — checks `enabledPlugins` in user (`~/.claude/settings.json`) or project (`.claude/settings.json`) settings
 2. **Locates the dispatcher** — finds `scripts/hooks/distillery-hooks.sh` in the repo or plugin cache
-3. **Checks existing hooks** — skips if both `UserPromptSubmit` and `SessionStart` already reference the dispatcher
+3. **Checks existing hooks** — skips if `SessionStart` already references the dispatcher
 4. **Installs hooks** — merges hook config into the scope-appropriate settings file
 
 | Hook | Behaviour |
 |------|-----------|
-| **UserPromptSubmit** | Memory nudge every 30 prompts — reminds you to `/distill` |
 | **SessionStart** | Injects a condensed briefing with recent entries and stale items |
 
 ### Step 6: Summary

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -15,14 +15,12 @@ installation scope (user or project) and configures hooks in the appropriate
 ## distillery-hooks.sh
 
 A single **dispatcher script** that routes Claude Code hook events to the
-appropriate Distillery handler. Register this one script for `SessionStart`
-(and `PreCompact`) — no need to manage multiple hook entries.
+appropriate Distillery handler. Register this one script for `SessionStart`.
 
 ### Hook Events
 
 | Hook Event | Behaviour |
 |---|---|
-| `PreCompact` | Placeholder — silently exits (future spec) |
 | `SessionStart` | Delegates to `session-start-briefing.sh` for briefing injection |
 
 ### Prerequisites
@@ -110,8 +108,6 @@ export DISTILLERY_MCP_COMMAND="env DISTILLERY_CONFIG=/path/to/distillery.yaml di
 > these values. The hook scripts themselves contain no credentials.
 
 ### Expected Behaviour
-
-**PreCompact:** Silently exits. Auto-extraction is planned for a future spec.
 
 **SessionStart:** Delegates to `session-start-briefing.sh` in the same directory.
 If that script is not present or not executable, exits silently with no output.

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -8,21 +8,20 @@ Run `/setup` after installing the Distillery plugin. It detects your plugin
 installation scope (user or project) and configures hooks in the appropriate
 `settings.json` automatically.
 
-> **Why not plugin.json?** Plugin manifest hooks only support `SessionStart`
-> and `Stop` events. `UserPromptSubmit` is silently ignored by the plugin
-> system, so these hooks must be registered in `settings.json`.
+> **Why settings.json?** The dispatcher resolves sibling scripts by absolute
+> path and is registered in the scope-appropriate `settings.json` (user or
+> project) so the briefing handler can locate `session-start-briefing.sh`.
 
 ## distillery-hooks.sh
 
-A single **dispatcher script** that routes all Claude Code hook events to the
-appropriate Distillery handler. Register this one script for `UserPromptSubmit`,
-`PreCompact`, and `SessionStart` — no need to manage multiple hook entries.
+A single **dispatcher script** that routes Claude Code hook events to the
+appropriate Distillery handler. Register this one script for `SessionStart`
+(and `PreCompact`) — no need to manage multiple hook entries.
 
 ### Hook Events
 
 | Hook Event | Behaviour |
 |---|---|
-| `UserPromptSubmit` | Outputs a memory nudge every N prompts (default 30) |
 | `PreCompact` | Placeholder — silently exits (future spec) |
 | `SessionStart` | Delegates to `session-start-briefing.sh` for briefing injection |
 
@@ -30,7 +29,6 @@ appropriate Distillery handler. Register this one script for `UserPromptSubmit`,
 
 - **HTTP mode**: Distillery MCP server running at a reachable URL (must be pre-started; the hook connects to it)
 - **stdio mode**: `distillery-mcp` installed and on PATH (the hook launches it as a subprocess — no pre-running server required)
-  _(required only for the `SessionStart` briefing; the `UserPromptSubmit` nudge works offline)_
 - Python 3.11+ available on the system PATH (for `SessionStart` briefing)
 - Claude Code with hook support
 
@@ -57,16 +55,6 @@ Choose the appropriate file based on desired scope:
 ```json
 {
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash /absolute/path/to/distillery/scripts/hooks/distillery-hooks.sh"
-          }
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "hooks": [
@@ -90,8 +78,7 @@ installation.
 distillery-mcp --transport http --port 8000
 ```
 
-If the MCP server is not running, `SessionStart` exits silently and `UserPromptSubmit`
-nudges still work independently.
+If the MCP server is not running, `SessionStart` exits silently.
 
 ### Configuration
 
@@ -102,14 +89,12 @@ Configure all hooks via environment variables. Set these in your shell profile
 |---|---|---|
 | `DISTILLERY_MCP_URL` | _(auto-detect)_ | MCP HTTP endpoint URL (skips auto-detection) |
 | `DISTILLERY_MCP_COMMAND` | _(auto-detect)_ | MCP stdio command (skips auto-detection) |
-| `DISTILLERY_NUDGE_INTERVAL` | `30` | Prompts between memory nudge outputs |
 | `DISTILLERY_BRIEFING_LIMIT` | `5` | Recent entries in SessionStart briefing |
 | `DISTILLERY_BEARER_TOKEN` | _(empty)_ | Bearer token if OAuth is enabled |
 
-Example — nudge every 20 prompts, custom hosted URL:
+Example — custom hosted URL:
 
 ```bash
-export DISTILLERY_NUDGE_INTERVAL=20
 export DISTILLERY_MCP_URL="https://distillery-mcp.fly.dev/mcp"
 ```
 
@@ -126,27 +111,12 @@ export DISTILLERY_MCP_COMMAND="env DISTILLERY_CONFIG=/path/to/distillery.yaml di
 
 ### Expected Behaviour
 
-**UserPromptSubmit:** On each prompt, the dispatcher increments a per-session
-counter in `/tmp/distillery-prompt-count-<session_id>`. Every `DISTILLERY_NUDGE_INTERVAL`
-prompts it writes a reminder to stdout:
-
-```text
-[Distillery] You've exchanged 30 messages this session. Consider whether any decisions, insights, or corrections from this conversation should be stored with /distill.
-```
-
-All other prompts produce no output. The counter file is created automatically
-on the first prompt and cleaned up on reboot (lives in `/tmp`).
-
 **PreCompact:** Silently exits. Auto-extraction is planned for a future spec.
 
 **SessionStart:** Delegates to `session-start-briefing.sh` in the same directory.
 If that script is not present or not executable, exits silently with no output.
 
 ### Troubleshooting
-
-**Nudge never fires:**
-- Check `/tmp/distillery-prompt-count-<session_id>` exists and increments
-- Verify `DISTILLERY_NUDGE_INTERVAL` is a positive integer (non-zero, non-empty)
 
 **SessionStart produces no output:**
 - **HTTP transport**: Check the MCP server accepts JSON-RPC probes — the hook

--- a/scripts/hooks/distillery-hooks.sh
+++ b/scripts/hooks/distillery-hooks.sh
@@ -3,14 +3,13 @@
 #
 # Single dispatcher script that routes Claude Code hook events to the
 # appropriate handler based on hook_event_name. Register this script for
-# all three hook events in ~/.claude/settings.json (see scripts/hooks/README.md).
+# the SessionStart hook in ~/.claude/settings.json (see scripts/hooks/README.md).
 #
 # Usage: register in ~/.claude/settings.json (see README.md)
 # Input: hook JSON on stdin (hook_event_name, session_id, cwd, transcript_path)
-# Output: hook-specific output on stdout (nudge text, briefing, etc.)
+# Output: hook-specific output on stdout (briefing, etc.)
 #
 # Configuration (environment variables):
-#   DISTILLERY_NUDGE_INTERVAL  Prompts between memory nudges (default: 30)
 #   DISTILLERY_BEARER_TOKEN    Optional bearer token if OAuth is enabled
 
 # ── Silent error handler ──────────────────────────────────────────────────────
@@ -19,50 +18,18 @@ trap 'exit 0' ERR
 
 set -euo pipefail
 
-# ── Configuration ────────────────────────────────────────────────────────────
-NUDGE_INTERVAL="${DISTILLERY_NUDGE_INTERVAL:-30}"
-if ! [[ "$NUDGE_INTERVAL" =~ ^[1-9][0-9]*$ ]]; then
-  NUDGE_INTERVAL=30
-fi
-
 # ── Read hook input ───────────────────────────────────────────────────────────
 HOOK_JSON="$(cat)" || exit 0
 
 # Parse fields from hook JSON (no jq dependency — portable grep/sed)
 # Patterns allow optional whitespace around the colon for flexibility
 HOOK_EVENT="$(echo "$HOOK_JSON" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/"hook_event_name"[[:space:]]*:[[:space:]]*"//;s/"//')" || true
-SESSION_ID="$(echo "$HOOK_JSON" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/"session_id"[[:space:]]*:[[:space:]]*"//;s/"//')" || true
 CWD="$(echo "$HOOK_JSON" | grep -oE '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/"cwd"[[:space:]]*:[[:space:]]*"//;s/"//')" || true
 
 # Fall back to current directory if cwd not found
 if [[ -z "${CWD:-}" ]]; then
   CWD="$(pwd)"
 fi
-
-# ── Handler: UserPromptSubmit ─────────────────────────────────────────────────
-handle_user_prompt_submit() {
-  # Require a session_id to scope the counter file
-  if [[ -z "${SESSION_ID:-}" ]]; then
-    return 0
-  fi
-
-  local counter_file="/tmp/distillery-prompt-count-${SESSION_ID}"
-  local count=0
-
-  # Read current count (file may not exist yet on first prompt)
-  if [[ -f "$counter_file" ]]; then
-    count="$(cat "$counter_file" 2>/dev/null || echo 0)"
-    [[ "$count" =~ ^[0-9]+$ ]] || count=0
-  fi
-
-  count=$((count + 1))
-  echo "$count" > "$counter_file"
-
-  # Output nudge at interval boundary
-  if (( count % NUDGE_INTERVAL == 0 )); then
-    echo "[Distillery] You've exchanged ${count} messages this session. Consider whether any decisions, insights, or corrections from this conversation should be stored with /distill."
-  fi
-}
 
 # ── Handler: PreCompact ───────────────────────────────────────────────────────
 handle_pre_compact() {
@@ -86,9 +53,6 @@ handle_session_start() {
 
 # ── Dispatch ──────────────────────────────────────────────────────────────────
 case "${HOOK_EVENT:-}" in
-  UserPromptSubmit)
-    handle_user_prompt_submit
-    ;;
   PreCompact)
     handle_pre_compact
     ;;

--- a/scripts/hooks/distillery-hooks.sh
+++ b/scripts/hooks/distillery-hooks.sh
@@ -31,13 +31,6 @@ if [[ -z "${CWD:-}" ]]; then
   CWD="$(pwd)"
 fi
 
-# ── Handler: PreCompact ───────────────────────────────────────────────────────
-handle_pre_compact() {
-  # PreCompact auto-extraction is deferred to a future spec.
-  # Placeholder: exits silently.
-  return 0
-}
-
 # ── Handler: SessionStart ─────────────────────────────────────────────────────
 handle_session_start() {
   # Delegate to the spec-14 briefing hook script.
@@ -53,9 +46,6 @@ handle_session_start() {
 
 # ── Dispatch ──────────────────────────────────────────────────────────────────
 case "${HOOK_EVENT:-}" in
-  PreCompact)
-    handle_pre_compact
-    ;;
   SessionStart)
     handle_session_start
     ;;

--- a/scripts/hooks/test-hooks.sh
+++ b/scripts/hooks/test-hooks.sh
@@ -36,15 +36,6 @@ fail() {
   FAIL=$((FAIL + 1))
 }
 
-assert_eq() {
-  local name="$1" expected="$2" actual="$3"
-  if [[ "$actual" == "$expected" ]]; then
-    pass "$name"
-  else
-    fail "$name" "expected $(printf '%q' "$expected") got $(printf '%q' "$actual")"
-  fi
-}
-
 assert_empty() {
   local name="$1" actual="$2"
   if [[ -z "$actual" ]]; then
@@ -72,24 +63,6 @@ assert_exit_zero() {
   fi
 }
 
-assert_file_exists() {
-  local name="$1" path="$2"
-  if [[ -f "$path" ]]; then
-    pass "$name"
-  else
-    fail "$name" "file not found: ${path}"
-  fi
-}
-
-assert_file_absent() {
-  local name="$1" path="$2"
-  if [[ ! -f "$path" ]]; then
-    pass "$name"
-  else
-    fail "$name" "file should not exist: ${path}"
-  fi
-}
-
 # ── Helper: emit hook JSON ────────────────────────────────────────────────────
 hook_json() {
   local event="$1" session="${2:-test-session-$$}" cwd="${3:-/tmp}"
@@ -104,100 +77,6 @@ BASE_SESSION="test-$$"
 echo ""
 echo "distillery-hooks.sh — integration tests"
 echo "========================================"
-
-# ── T1: Counter file created on first prompt ──────────────────────────────────
-echo ""
-echo "T1: Counter file lifecycle"
-
-SESSION1="${BASE_SESSION}-t1"
-COUNTER1="/tmp/distillery-prompt-count-${SESSION1}"
-rm -f "$COUNTER1"
-
-hook_json UserPromptSubmit "$SESSION1" \
-  | DISTILLERY_NUDGE_INTERVAL=30 bash "$DISPATCHER" >/dev/null 2>&1
-
-assert_file_exists "counter file created on first prompt" "$COUNTER1"
-
-COUNT_VAL="$(cat "$COUNTER1" 2>/dev/null || echo "")"
-assert_eq "counter starts at 1" "1" "$COUNT_VAL"
-
-# Cleanup
-rm -f "$COUNTER1"
-assert_file_absent "counter file removed after cleanup" "$COUNTER1"
-
-# ── T2: Counter increments across prompts ─────────────────────────────────────
-echo ""
-echo "T2: Counter increments"
-
-SESSION2="${BASE_SESSION}-t2"
-COUNTER2="/tmp/distillery-prompt-count-${SESSION2}"
-rm -f "$COUNTER2"
-
-for i in 1 2 3; do
-  hook_json UserPromptSubmit "$SESSION2" \
-    | DISTILLERY_NUDGE_INTERVAL=30 bash "$DISPATCHER" >/dev/null 2>&1
-done
-
-FINAL_COUNT="$(cat "$COUNTER2" 2>/dev/null || echo "")"
-assert_eq "counter increments correctly (3 prompts -> 3)" "3" "$FINAL_COUNT"
-
-rm -f "$COUNTER2"
-
-# ── T3: Non-nudge prompts produce no output ───────────────────────────────────
-echo ""
-echo "T3: Non-nudge prompts are silent"
-
-SESSION3="${BASE_SESSION}-t3"
-COUNTER3="/tmp/distillery-prompt-count-${SESSION3}"
-rm -f "$COUNTER3"
-
-OUTPUT3="$(hook_json UserPromptSubmit "$SESSION3" \
-  | DISTILLERY_NUDGE_INTERVAL=30 bash "$DISPATCHER" 2>/dev/null)"
-
-assert_empty "first prompt (non-nudge) produces no stdout" "$OUTPUT3"
-
-rm -f "$COUNTER3"
-
-# ── T4: Nudge fires at configured interval ────────────────────────────────────
-echo ""
-echo "T4: Nudge fires at interval boundary"
-
-SESSION4="${BASE_SESSION}-t4"
-COUNTER4="/tmp/distillery-prompt-count-${SESSION4}"
-rm -f "$COUNTER4"
-
-# Use interval=3: first two prompts silent, third fires nudge
-OUTPUT4_1="$(hook_json UserPromptSubmit "$SESSION4" \
-  | DISTILLERY_NUDGE_INTERVAL=3 bash "$DISPATCHER" 2>/dev/null)"
-OUTPUT4_2="$(hook_json UserPromptSubmit "$SESSION4" \
-  | DISTILLERY_NUDGE_INTERVAL=3 bash "$DISPATCHER" 2>/dev/null)"
-OUTPUT4_3="$(hook_json UserPromptSubmit "$SESSION4" \
-  | DISTILLERY_NUDGE_INTERVAL=3 bash "$DISPATCHER" 2>/dev/null)"
-
-assert_empty "prompt 1 of 3 produces no output" "$OUTPUT4_1"
-assert_empty "prompt 2 of 3 produces no output" "$OUTPUT4_2"
-assert_contains "prompt 3 of 3 fires nudge" "[Distillery]" "$OUTPUT4_3"
-assert_contains "nudge mentions message count" "3 messages" "$OUTPUT4_3"
-
-rm -f "$COUNTER4"
-
-# ── T5: Interval=1 fires on every prompt ─────────────────────────────────────
-echo ""
-echo "T5: Interval=1 fires on every prompt"
-
-SESSION5="${BASE_SESSION}-t5"
-COUNTER5="/tmp/distillery-prompt-count-${SESSION5}"
-rm -f "$COUNTER5"
-
-OUTPUT5_1="$(hook_json UserPromptSubmit "$SESSION5" \
-  | DISTILLERY_NUDGE_INTERVAL=1 bash "$DISPATCHER" 2>/dev/null)"
-OUTPUT5_2="$(hook_json UserPromptSubmit "$SESSION5" \
-  | DISTILLERY_NUDGE_INTERVAL=1 bash "$DISPATCHER" 2>/dev/null)"
-
-assert_contains "interval=1, prompt 1 fires nudge" "[Distillery]" "$OUTPUT5_1"
-assert_contains "interval=1, prompt 2 fires nudge" "[Distillery]" "$OUTPUT5_2"
-
-rm -f "$COUNTER5"
 
 # ── T6: Unknown hook events exit 0 silently ───────────────────────────────────
 echo ""
@@ -239,17 +118,6 @@ elif [[ "$OUTPUT8" == *"[Distillery]"* ]]; then
 else
   fail "SessionStart output is non-empty but malformed: ${OUTPUT8:0:100}"
 fi
-
-# ── T9: Missing session_id handled gracefully ─────────────────────────────────
-echo ""
-echo "T9: Missing session_id handled gracefully"
-
-OUTPUT9="$(printf '{"hook_event_name":"UserPromptSubmit"}' \
-  | bash "$DISPATCHER" 2>/dev/null)"
-EXIT9=$?
-
-assert_exit_zero "UserPromptSubmit with no session_id exits 0" "$EXIT9"
-assert_empty "UserPromptSubmit with no session_id produces no output" "$OUTPUT9"
 
 # ── T10: Empty input handled gracefully ──────────────────────────────────────
 echo ""

--- a/scripts/hooks/test-hooks.sh
+++ b/scripts/hooks/test-hooks.sh
@@ -89,17 +89,6 @@ EXIT6=$?
 assert_exit_zero "unknown event exits 0" "$EXIT6"
 assert_empty "unknown event produces no output" "$OUTPUT6"
 
-# ── T7: PreCompact exits 0 silently ──────────────────────────────────────────
-echo ""
-echo "T7: PreCompact exits 0 silently"
-
-OUTPUT7="$(hook_json PreCompact "${BASE_SESSION}-t7" \
-  | bash "$DISPATCHER" 2>/dev/null)"
-EXIT7=$?
-
-assert_exit_zero "PreCompact exits 0" "$EXIT7"
-assert_empty "PreCompact produces no output" "$OUTPUT7"
-
 # ── T8: SessionStart delegates or skips gracefully ───────────────────────────
 echo ""
 echo "T8: SessionStart delegates or skips gracefully"

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -77,13 +77,7 @@ Display:
 Distillery MCP Server Not Available
 
 The Distillery MCP server is not configured or not running.
-
-Quickest setup — install the plugin (configures local stdio by default):
-
-  claude plugin marketplace add norrietaylor/distillery
-  claude plugin install distillery
-
-Or add manually to ~/.claude.json:
+The plugin does not configure an MCP server automatically — add one now:
 
   {
     "mcpServers": {
@@ -96,6 +90,9 @@ Or add manually to ~/.claude.json:
       }
     }
   }
+
+Add this to ~/.claude.json (user scope, all projects) or .mcp.json
+(this project only).
 
 Get a free Jina API key at https://jina.ai
 Then restart Claude Code and run /setup again.
@@ -168,7 +165,7 @@ Scheduled tasks: skipped
 
 ### Step 5: Configure Session Hooks
 
-Plugin manifest hooks do not support `UserPromptSubmit` events. Manifest hooks support `SessionStart` and `Stop`, so `UserPromptSubmit` must be configured in `settings.json`. To enable the memory nudge (every 30 prompts) and full session lifecycle hooks via the dispatcher, the script must be configured in the appropriate settings.json based on plugin installation scope.
+The dispatcher provides `SessionStart` briefing context injection. To wire it via the dispatcher, the script must be configured in the appropriate settings.json based on plugin installation scope.
 
 **5a. Detect plugin installation scope:**
 
@@ -204,13 +201,12 @@ Skip to Step 6.
 
 **5c. Check existing hooks:**
 
-Read `SCOPE_FILE` and check whether **both** `hooks.UserPromptSubmit` and `hooks.SessionStart` reference `distillery-hooks.sh` (same dispatcher path).
+Read `SCOPE_FILE` and check whether `hooks.SessionStart` references `distillery-hooks.sh` (the dispatcher path).
 
-If both are already configured:
+If already configured:
 
 ```text
 Session hooks: active (<SCOPE_LABEL> scope)
-  Memory nudge:  every 30 prompts
   Session start: briefing context injection
 ```
 
@@ -222,7 +218,6 @@ Ask the user:
 
 ```text
 Enable session hooks? This configures hooks in <SCOPE_FILE> (<SCOPE_LABEL> scope).
-  • Memory nudge — reminder to /distill every 30 prompts
   • Session start — briefing context injection
 (yes / no)
 ```
@@ -232,16 +227,6 @@ If yes, merge the following hooks into `SCOPE_FILE` (do not overwrite other sett
 ```json
 {
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash <absolute-path-to>/scripts/hooks/distillery-hooks.sh"
-          }
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "hooks": [
@@ -262,7 +247,6 @@ Display:
 Session hooks installed:
   Config:        <SCOPE_FILE> (<SCOPE_LABEL> scope)
   Dispatcher:    <absolute-path-to>/scripts/hooks/distillery-hooks.sh
-  Memory nudge:  every 30 prompts
   Session start: briefing context injection
 ```
 
@@ -291,7 +275,6 @@ Distillery Setup Complete
     KB maintenance:    <active (weekly routine) | inactive>
 
   Session Hooks:   <SCOPE_LABEL> scope
-    Memory nudge:  <active (every 30 prompts) | inactive | skipped>
     Session start: <active | inactive | skipped>
 
 Available skills:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -165,7 +165,6 @@ class TestPluginManifestMetadata:
             "homepage",
             "repository",
             "keywords",
-            "mcpServers",
         }
         for key in required_keys:
             assert key in manifest, f"Required key '{key}' missing from .claude-plugin/plugin.json"
@@ -210,49 +209,20 @@ class TestPluginSkills:
 # ---------------------------------------------------------------------------
 
 
-class TestPluginMCPServers:
-    def test_mcp_servers_key_present(self) -> None:
-        """mcpServers field must be present."""
-        manifest = load_plugin_manifest()
-        assert "mcpServers" in manifest
+class TestPluginNoMCPServers:
+    """The plugin must NOT auto-declare an MCP server.
 
-    def test_distillery_server_declared(self) -> None:
-        """The 'distillery' MCP server must be declared."""
-        manifest = load_plugin_manifest()
-        assert "distillery" in manifest["mcpServers"]
+    Installing the plugin ships skills and the SessionStart briefing hook only.
+    The MCP server is configured by the user during /setup (or added manually),
+    so no server is silently registered on plugin install.
+    """
 
-    def test_distillery_server_uses_stdio_transport(self) -> None:
-        """The distillery server must use stdio transport (command, no url)."""
+    def test_no_mcp_servers_declared(self) -> None:
+        """plugin.json must not declare an mcpServers block."""
         manifest = load_plugin_manifest()
-        server = manifest["mcpServers"]["distillery"]
-        assert "command" in server, "stdio transport requires a 'command' field"
-        assert "url" not in server, "stdio transport must not include a 'url' field"
-
-    def test_distillery_server_command_is_uvx(self) -> None:
-        """The distillery server must launch via 'uvx distillery-mcp'."""
-        manifest = load_plugin_manifest()
-        server = manifest["mcpServers"]["distillery"]
-        assert server["command"] == "uvx"
-        assert "distillery-mcp" in server.get("args", [])
-
-    def test_distillery_server_no_url_field(self) -> None:
-        """The distillery server must not declare a hosted URL.
-
-        The plugin default is local stdio. Hosted demo is opt-in via:
-        claude mcp add distillery --scope user --transport http \
-            --url https://distillery-mcp.fly.dev/mcp
-        """
-        manifest = load_plugin_manifest()
-        server = manifest["mcpServers"]["distillery"]
-        assert "url" not in server
-
-    def test_distillery_server_no_unsupported_fields(self) -> None:
-        """The distillery server must not contain fields unsupported by the plugin schema."""
-        manifest = load_plugin_manifest()
-        server = manifest["mcpServers"]["distillery"]
-        unsupported = {"required", "description", "setup", "transports", "default_transport"}
-        found = unsupported & set(server.keys())
-        assert not found, f"Unsupported fields in mcpServers.distillery: {found}"
+        assert "mcpServers" not in manifest, (
+            "Plugin must not auto-configure an MCP server; configuration is /setup-driven"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two behavior changes to the plugin installer.

## 1. No default MCP server

Removed the `mcpServers` block from `.claude-plugin/plugin.json`. Installing the plugin now ships skills + the SessionStart briefing hook only — it no longer registers an MCP server automatically.

`/setup` already distinguishes **connected / needs-auth / not-connected / not-configured**. On "Not Configured" it now prompts the user to add a server (local stdio via `uvx`, hosted demo, or self-hosted HTTP) instead of claiming the plugin did it. Corrected the same auto-config claim in `README.md`, `docs/home.md`, `docs/getting-started/plugin-install.md`.

## 2. Removed the every-30-prompts distill nudge

The `UserPromptSubmit` memory nudge is deleted, not just unwired:

- `scripts/hooks/distillery-hooks.sh` — dropped `handle_user_prompt_submit`, the `UserPromptSubmit` dispatch case, `NUDGE_INTERVAL` config, and the now-orphaned `session_id` parse.
- `skills/setup/SKILL.md` — Step 5 installs only the `SessionStart` briefing hook; nudge removed from the install prompt and Step 6 summary.
- `scripts/hooks/test-hooks.sh` — removed T1–T5 and T9 (nudge tests) plus the now-unused `assert_eq` / `assert_file_exists` / `assert_file_absent` helpers.
- `scripts/hooks/README.md`, `docs/skills/setup.md`, `docs/roadmap.md` — dropped nudge documentation.

**The `SessionStart` briefing hook is unchanged** — only the 30-prompt nudge is gone.

## Verification

- `bash scripts/hooks/test-hooks.sh` → 21/21 passed
- `mkdocs build --strict` → clean
- `plugin.json` valid JSON; `bash -n` clean on both scripts
- Repo-wide sweep: zero residual `nudge` / `UserPromptSubmit` / `NUDGE_INTERVAL` references outside historical `docs/specs/` and `CHANGELOG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that installing the plugin only installs skills and does not configure an MCP server automatically; users must run `/setup` to add one.
  * Updated setup and quick-start guides to emphasize the hosted/self-hosted options and the required configuration flow.
  * Revised session hook guidance to focus on `SessionStart` briefing context.
* **Bug Fixes**
  * Removed the periodic “memory nudge” reminder behavior.
  * Streamlined session hooks to route only `SessionStart`, ignoring other hook events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->