### PR TITLE
fix(skills): remove orphaned userConfig from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,25 +9,6 @@
   "homepage": "https://github.com/norrietaylor/distillery",
   "repository": "https://github.com/norrietaylor/distillery",
   "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings", "distillery"],
-  "userConfig": {
-    "jina_api_key": {
-      "title": "Jina API Key",
-      "description": "Jina AI embedding API key. Obtain from https://jina.ai/api-key/",
-      "type": "string",
-      "sensitive": true
-    },
-    "github_client_id": {
-      "title": "GitHub Client ID",
-      "description": "GitHub OAuth app client ID for team access. Create at Settings > Developer settings > OAuth Apps",
-      "type": "string"
-    },
-    "github_client_secret": {
-      "title": "GitHub Client Secret",
-      "description": "GitHub OAuth app client secret for team access. Found alongside the client ID in your OAuth App settings",
-      "type": "string",
-      "sensitive": true
-    }
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -71,7 +71,13 @@ Skills that exceed 150 lines should move detailed or mode-specific content into 
 
 ## API Key Configuration
 
-API keys required by Distillery (embedding provider, GitHub OAuth) are supplied to the MCP server via environment variables: `JINA_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`. Set them in the MCP server's `env` block (added during `/setup` or manually in `~/.claude.json`) or export them in the deployment environment.
+API keys required by Distillery (embedding provider, GitHub OAuth) are supplied to the MCP server via environment variables: `JINA_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`.
+
+**Recommended (local):** run `/setup`, which configures the MCP server and writes its `env` block to `~/.claude.json` (see `skills/setup/SKILL.md`).
+
+**Manual (local):** edit the MCP server's `env` block in `~/.claude.json` directly.
+
+**Hosted/CI:** export the variables in the deployment environment (container, cloud runtime, CI secrets) that runs `distillery-mcp`.
 
 The plugin no longer bundles or auto-configures an MCP server, so it declares no `userConfig` keys.
 

--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -71,11 +71,9 @@ Skills that exceed 150 lines should move detailed or mode-specific content into 
 
 ## API Key Configuration
 
-API keys required by Distillery (embedding provider, GitHub OAuth) are declared in `plugin.json` under `userConfig`. Keys marked `sensitive: true` are stored in the OS keychain (macOS Keychain, Windows Credential Manager, Linux Secret Service) via Claude Code's secure config system.
+API keys required by Distillery (embedding provider, GitHub OAuth) are supplied to the MCP server via environment variables: `JINA_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`. Set them in the MCP server's `env` block (added during `/setup` or manually in `~/.claude.json`) or export them in the deployment environment.
 
-**Preferred method:** `userConfig` in `plugin.json` — keys are prompted on first use and stored securely.
-
-**Fallback:** Environment variables (`JINA_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`) for CI or environments without keychain access.
+The plugin no longer bundles or auto-configures an MCP server, so it declares no `userConfig` keys.
 
 ## Author & Project Resolution
 


### PR DESCRIPTION
## Root cause
The plugin stopped bundling an MCP server in 2c4f008 (the `mcpServers` block was removed). The `userConfig` keys that fed that server — `jina_api_key`, `github_client_id`, `github_client_secret` — were left behind as dead metadata, still prompting installers for credentials nothing consumes.

## Fix
- `.claude-plugin/plugin.json`: remove the `userConfig` block.
- `skills/CONVENTIONS.md`: rewrite "API Key Configuration" to document env-var config (`JINA_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`) on the `/setup`-configured MCP server, drop the `userConfig` references.

## Acceptance
- `plugin.json` is valid JSON.
- `tests/test_plugin.py`: 46/46 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API credential configuration guidance to use environment variables only for embedding and GitHub OAuth, removing reliance on configurable plugin settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->