### PR TITLE
docs(skills): classify setup transport from status, not config parsing

### DIFF
--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -2,6 +2,7 @@
 name: setup
 description: "Onboarding wizard — verify MCP connectivity, detect transport, and configure scheduled tasks via Claude Code routines"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_list"
   - "mcp__*__distillery_watch"
   - "Bash(test:*)"
@@ -38,7 +39,9 @@ This step determines the MCP server state: **connected**, **needs authentication
 
 Read `references/transport-detection.md` for server detection logic and the "Needs Authentication" auth flow instructions.
 
-Use `ToolSearch` to check whether any `distillery` MCP tools are available. Also read the plugin manifest (`.claude-plugin/plugin.json` in the plugin directory) and any `.mcp.json` or `~/.claude/settings.json` entries to determine if a Distillery MCP server is configured.
+Use `ToolSearch` to check whether any `distillery` MCP tools are available. If they are, call `distillery_status` / `distillery_list(limit=1)` and treat their success as proof the server is configured and connected — do NOT inspect any config files in that case.
+
+Only when the MCP tools are ABSENT, fall back to checking whether a server is merely configured-but-down: read (with the `Read` tool, not a shell or JSON-parsing script) the plugin manifest (`.claude-plugin/plugin.json`) and any `.mcp.json` or `~/.claude/settings.json` entries to determine if a Distillery MCP server is configured.
 
 **1b. Attempt connection:**
 

--- a/skills/setup/references/transport-detection.md
+++ b/skills/setup/references/transport-detection.md
@@ -38,7 +38,15 @@ Then skip to Step 6 (Summary) with `MCP Server: needs authentication`.
 
 ## Step 2: Transport Classification Table
 
-Read the `.mcp.json` file in the project root (or `~/.claude.json` if `.mcp.json` does not exist) to determine the Distillery MCP server configuration.
+Classify the transport from the `transport` field already returned by `distillery_status` in Step 1 — do NOT re-read or parse any config files for this.
+
+| `distillery_status.transport` | Transport | Mode |
+|-------------------------------|-----------|------|
+| `stdio` | Local | `local` |
+| `http` | Hosted **or** Team HTTP (see below) | `hosted`/`team` |
+| `unknown` / missing | unknown | — |
+
+The hosted-vs-team distinction is **cosmetic** and needs the server URL. It is optional: only resolve it if the URL is available with a single `Read` of one config file. Do NOT write shell pipelines or `python`/`jq`/`grep` one-liners to extract it — use the `Read` tool, and if the entry isn't obvious in one read, label it `Hosted/Team HTTP` and move on.
 
 | URL Pattern | Transport | Mode |
 |-------------|-----------|------|


### PR DESCRIPTION
## Problem

The `/setup` wizard's **Step 2 (transport classification)** instructed the agent to read raw `.mcp.json` / `~/.claude.json` config to determine the transport — even when the MCP server is already connected. In practice this invites agents to shell out with ad-hoc `python`/`jq`/`grep` JSON parsing to dig the server URL out of config, an opaque and unnecessary detour: `distillery_status` already returns a `transport` field, so classification needs **zero** config reads in the connected case.

## Change

- **`references/transport-detection.md`** — classify the transport directly from `distillery_status.transport` (`stdio` → Local, `http` → Hosted/Team). The hosted-vs-team split is cosmetic (needs the URL); it's now an optional, single `Read` of one config file, explicitly *not* a shell/parsing pipeline. The original URL-pattern table is retained as the tiebreaker.
- **`SKILL.md`** — scope config-file inspection to the branch where it's actually needed (MCP tools *absent* → server configured-but-down), and mandate the `Read` tool over shell/JSON parsing.
- **`SKILL.md`** — add `distillery_status` to `allowed-tools` (now referenced by Step 1/2).

No behavior change for users; this tightens the wizard's instructions so a connected server is classified from the in-protocol status field instead of by parsing config files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)