### PR TITLE
fix(skills): align allowed-tools with what each skill actually uses

### DIFF
--- a/skills/bookmark/SKILL.md
+++ b/skills/bookmark/SKILL.md
@@ -2,6 +2,7 @@
 name: bookmark
 description: "Save a URL with an auto-generated summary to the knowledge base"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_store"
   - "mcp__*__distillery_find_similar"
   - "WebFetch"

--- a/skills/briefing/SKILL.md
+++ b/skills/briefing/SKILL.md
@@ -2,6 +2,7 @@
 name: briefing
 description: "Produce a knowledge dashboard with recent entries, corrections, expiring soon, stale knowledge, and unresolved items. In team mode, also shows team activity, related entries from teammates, and the review queue."
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_list"
   - "mcp__*__distillery_relations"
   - "mcp__*__distillery_search"

--- a/skills/classify/SKILL.md
+++ b/skills/classify/SKILL.md
@@ -2,10 +2,12 @@
 name: classify
 description: "Classify knowledge entries by type and manage the manual review queue"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_classify"
   - "mcp__*__distillery_resolve_review"
   - "mcp__*__distillery_get"
   - "mcp__*__distillery_list"
+  - "Read"
 effort: medium
 ---
 

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -2,6 +2,7 @@
 name: digest
 description: "Generate a structured summary of internal team activity over a time window"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_list"
   - "mcp__*__distillery_search"
   - "mcp__*__distillery_store"

--- a/skills/distill/SKILL.md
+++ b/skills/distill/SKILL.md
@@ -2,6 +2,7 @@
 name: distill
 description: "Capture decisions, insights, and action items from the current session into the knowledge base"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_store"
   - "mcp__*__distillery_find_similar"
   - "mcp__*__distillery_update"

--- a/skills/gh-sync/SKILL.md
+++ b/skills/gh-sync/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-sync
 description: "Sync GitHub issues and pull requests into the Distillery knowledge base as searchable, linkable entries"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_gh_sync"
   - "mcp__*__distillery_sync_status"
 context: fork

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -2,6 +2,7 @@
 name: investigate
 description: "Compile deep context on a topic by combining semantic search with relationship traversal across 4 retrieval phases"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_search"
   - "mcp__*__distillery_get"
   - "mcp__*__distillery_relations"

--- a/skills/minutes/SKILL.md
+++ b/skills/minutes/SKILL.md
@@ -2,6 +2,7 @@
 name: minutes
 description: "Capture meeting notes or append updates to an existing meeting record"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_store"
   - "mcp__*__distillery_find_similar"
   - "mcp__*__distillery_search"

--- a/skills/pour/SKILL.md
+++ b/skills/pour/SKILL.md
@@ -2,6 +2,7 @@
 name: pour
 description: "Synthesize multiple knowledge entries into a cohesive narrative with citations"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_search"
   - "mcp__*__distillery_get"
   - "mcp__*__distillery_store"

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -2,6 +2,7 @@
 name: radar
 description: "Generate an ambient intelligence digest from recent feed activity with source suggestions"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_search"
   - "mcp__*__distillery_list"
   - "mcp__*__distillery_store"

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -2,6 +2,7 @@
 name: recall
 description: "Search the knowledge base using natural language and return matching entries with provenance"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_search"
   - "mcp__*__distillery_get"
 effort: low

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -13,6 +13,10 @@ allowed-tools:
   - "Bash(mkdir:*)"
   - "Bash(cp:*)"
   - "Bash(chmod:*)"
+  - "Read"
+  - "Edit(~/.claude/settings.json)"
+  - "Edit(.claude/settings.json)"
+  - "Edit(.claude/settings.local.json)"
 effort: low
 ---
 

--- a/skills/tune/SKILL.md
+++ b/skills/tune/SKILL.md
@@ -2,6 +2,7 @@
 name: tune
 description: "Display and adjust feed relevance thresholds for alerts and digests"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_configure"
 effort: low
 model: haiku

--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -2,6 +2,7 @@
 name: watch
 description: "Add, remove, or list monitored feed sources (RSS and GitHub)"
 allowed-tools:
+  - "mcp__*__distillery_status"
   - "mcp__*__distillery_watch"
 disable-model-invocation: true
 effort: medium


### PR DESCRIPTION
## Problem

Running an installed skill prompts the user to approve tools the skill legitimately needs but never declared in its `allowed-tools`. Because `allowed-tools` pre-authorizes only the tools it lists, every first invocation interrupts the user for approval of, e.g., the MCP health check or reading the skill's own bundled reference files. (Reported as: "running an installed skill then granting access to its files is cumbersome.")

This PR audits every `skills/*/SKILL.md` against its documented procedure and `skills/CONVENTIONS.md`, and widens `allowed-tools` to match actual usage.

## Changes

- **`distillery_status` → all 13 skills that lacked it.** `CONVENTIONS.md` ("MCP Health Check") requires *every* skill to call `distillery_status()` on the first invocation in a conversation, yet only `setup` declared it. Any skill can be the first one invoked, so all need it.
- **`classify`: add `Read`.** It reads `references/modes.md` for help text and confidence-level thresholds (per the references-on-demand convention).
- **`setup`: add `Read` + scoped `Edit`.** It reads `references/*.md`, `plugin.json`, and settings files for transport/scope detection, and merges the `SessionStart` hook into the scope-appropriate settings file. `Edit` is scoped to the three files it may target: `~/.claude/settings.json`, `.claude/settings.json`, `.claude/settings.local.json`.

## Deliberate non-changes

- **`watch`** keeps only `distillery_watch` — its body explicitly describes `--purge` impact in-prompt *instead of* issuing a `distillery_list` call, so no `distillery_list` grant is added.
- **Fork-context skills** (`briefing`, `digest`, `gh-sync`, `investigate`, `pour`, `radar`) get only the `distillery_status` MCP grant — no `Bash`/`WebFetch` — per the fork-safety convention (forked contexts must not shell out).
- **`ToolSearch` / `AskUserQuestion`** are intentionally not added; they are not permission-gated.
- No existing declarations were pruned (this PR only widens).

## Notes / open questions

- `Read` is added unscoped for `classify`/`setup` because the reference reads use skill-relative paths (`references/<file>.md`) that resolve against the plugin-cache dir at runtime, which a portable path-scoped rule can't easily target. Happy to scope these down if maintainers prefer.
- `setup` uses `Edit` (merge into existing settings); if a target settings file may not exist yet, a matching `Write(...)` grant could be added.

## Test plan

- Invoke any skill as the first in a fresh conversation → no prompt for `distillery_status`.
- Run `/classify` → no prompt when it reads `references/modes.md`.
- Run `/setup` → no prompts reading references/settings or merging the SessionStart hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced multiple skills with status-checking capabilities to provide improved monitoring and diagnostics.
  * Extended the setup skill with configuration file read and edit permissions for enhanced customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->