### PR TITLE
store: AND-match multi-tag filter (intersection) (#626)

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1810,7 +1810,8 @@ class DuckDBStore:
         - ``entry_type`` (str | list[str])
         - ``author`` (str)
         - ``project`` (str)
-        - ``tags`` (list[str]) -- matches entries containing *any* listed tag
+        - ``tags`` (list[str]) -- matches entries containing *all* listed tags
+          (AND / intersection)
         - ``status`` (str)
         - ``verification`` (str) -- one of "unverified", "testing", "verified"
         - ``source`` (str) -- entry origin (e.g. "claude-code", "manual", "inference", etc.)
@@ -1850,10 +1851,12 @@ class DuckDBStore:
         if "tags" in filters:
             tag_list = filters["tags"]
             if tag_list:
-                # list_has_any checks whether the tags array shares any
-                # element with the provided list.
-                clauses.append("list_has_any(tags, ?)")
-                params.append(tag_list)
+                # AND semantics: an entry matches only if its tags array
+                # contains *every* requested tag (intersection, not union).
+                # One list_contains clause per tag, ANDed together.
+                for tag in tag_list:
+                    clauses.append("list_contains(tags, ?)")
+                    params.append(tag)
 
         if "status" in filters:
             val = filters["status"]

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1851,6 +1851,10 @@ class DuckDBStore:
         if "tags" in filters:
             tag_list = filters["tags"]
             if tag_list:
+                if not isinstance(tag_list, list) or not all(
+                    isinstance(t, str) for t in tag_list
+                ):
+                    raise ValueError("tags filter must be a list[str]")
                 # AND semantics: an entry matches only if its tags array
                 # contains *every* requested tag (intersection, not union).
                 # One list_contains clause per tag, ANDed together.

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -164,7 +164,8 @@ class DistilleryStore(Protocol):
             - ``entry_type`` (str | list[str])
             - ``author`` (str)
             - ``project`` (str)
-            - ``tags`` (list[str]) -- matches entries containing *any* tag
+            - ``tags`` (list[str]) -- matches entries containing *all* listed
+              tags (AND / intersection)
             - ``status`` (str)
             - ``verification`` (str) -- one of ``"unverified"``, ``"testing"``, ``"verified"``
             - ``date_from`` (datetime | str) -- inclusive lower bound on ``created_at``
@@ -248,8 +249,9 @@ class DistilleryStore(Protocol):
 
         Parameters:
             filters: Optional metadata constraints. Supported keys:
-                ``entry_type``, ``author``, ``project``, ``tags`` (matches any
-                tag), ``status`` (str or list[str] — a list matches any of the
+                ``entry_type``, ``author``, ``project``, ``tags`` (matches
+                entries containing all listed tags — AND / intersection),
+                ``status`` (str or list[str] — a list matches any of the
                 listed statuses via SQL ``IN``), ``verification`` (one of
                 "unverified", "testing", "verified"), ``date_from``, ``date_to``.
             limit: Maximum number of entries (or groups) to return.

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -585,6 +585,11 @@ class TestListEntries:
             assert "tag-a" in e.tags
             assert "tag-b" in e.tags
 
+    async def test_list_entries_tags_filter_rejects_non_list(self, store: DuckDBStore) -> None:
+        """A bare string tags filter must raise rather than iterate characters (#626)."""
+        with pytest.raises(ValueError, match="tags filter must be a list"):
+            await store.list_entries(filters={"tags": "tag-a"}, limit=10, offset=0)
+
     async def test_list_entries_filter_by_status(self, store: DuckDBStore) -> None:
         await store.store(make_entry(content="active", status=EntryStatus.ACTIVE))
         pending = make_entry(content="pending", status=EntryStatus.PENDING_REVIEW)

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -400,6 +400,21 @@ class TestSearch:
         for r in results:
             assert "important" in r.entry.tags
 
+    async def test_search_filter_by_multiple_tags_is_intersection(
+        self, store: DuckDBStore
+    ) -> None:
+        """Multi-tag search ANDs the tags: only entries with *both* match (#626)."""
+        await store.store(make_entry(content="entry only a", tags=["tag-a"]))
+        await store.store(make_entry(content="entry only b", tags=["tag-b"]))
+        await store.store(make_entry(content="entry both", tags=["tag-a", "tag-b"]))
+        results = await store.search("entry", filters={"tags": ["tag-a", "tag-b"]}, limit=10)
+        # Per-tag counts are 2 (tag-a) and 2 (tag-b); AND must return <= min == 2,
+        # and specifically only the single entry carrying both tags.
+        assert len(results) == 1
+        for r in results:
+            assert "tag-a" in r.entry.tags
+            assert "tag-b" in r.entry.tags
+
     async def test_search_filter_by_status(self, store: DuckDBStore) -> None:
         active_entry = make_entry(content="active entry", status=EntryStatus.ACTIVE)
         pending_entry = make_entry(content="pending entry", status=EntryStatus.PENDING_REVIEW)
@@ -550,6 +565,25 @@ class TestListEntries:
         result = await store.list_entries(filters={"tags": ["critical"]}, limit=10, offset=0)
         for e in result:
             assert "critical" in e.tags
+
+    async def test_list_entries_filter_by_multiple_tags_is_intersection(
+        self, store: DuckDBStore
+    ) -> None:
+        """Multi-tag list ANDs the tags: only entries with *both* match (#626)."""
+        await store.store(make_entry(content="only a", tags=["tag-a"]))
+        await store.store(make_entry(content="only a too", tags=["tag-a"]))
+        await store.store(make_entry(content="only b", tags=["tag-b"]))
+        await store.store(make_entry(content="both", tags=["tag-a", "tag-b"]))
+        result = await store.list_entries(
+            filters={"tags": ["tag-a", "tag-b"]}, limit=10, offset=0
+        )
+        # Per-tag counts: tag-a == 3, tag-b == 2; AND must return <= min == 2 and
+        # in fact only the single entry carrying both tags (proves intersection,
+        # not the union of 4 that the old list_has_any produced).
+        assert len(result) == 1
+        for e in result:
+            assert "tag-a" in e.tags
+            assert "tag-b" in e.tags
 
     async def test_list_entries_filter_by_status(self, store: DuckDBStore) -> None:
         await store.store(make_entry(content="active", status=EntryStatus.ACTIVE))


### PR DESCRIPTION
## Root cause

The shared `_build_filter_clauses` helper in `store/duckdb.py` emitted a single

```python
clauses.append("list_has_any(tags, ?)")
params.append(tag_list)
```

`list_has_any` is set-intersection-nonempty, i.e. UNION: an entry matched if its
`tags` array shared *any* element with the requested list. So
`tags=["source/github","entity/build-sandbox"]` returned ~39,099 + 3,651 - overlap
= 40,033 rather than the intersection. Every filtering path (`search`,
`list_entries`, `find_similar` candidate filtering, `count_entries`,
`aggregate_entries`) routes through this one helper, so all of them were affected.

## Fix

Emit one `list_contains(tags, ?)` clause per requested tag, ANDed together:

```python
for tag in tag_list:
    clauses.append("list_contains(tags, ?)")
    params.append(tag)
```

An entry now matches only if its `tags` array contains *every* requested tag
(intersection). Single-tag behavior is unchanged (one clause, identical result).
Docstring updated from "any listed tag" to "all listed tags (AND / intersection)".

## Acceptance

- [x] The 2-tag repro returns <= min of the per-tag counts. With per-tag counts of
  3 (`tag-a`) and 2 (`tag-b`), the AND filter now returns the single entry carrying
  both, not the union of 4. Covered by `test_list_entries_filter_by_multiple_tags_is_intersection`
  and `test_search_filter_by_multiple_tags_is_intersection` in `tests/test_duckdb_store.py`.
- [x] Documented behavior and actual behavior agree. The docstring now states
  "AND / intersection"; `server.py` already documents `tags` as "AND match".

No new MCP tool added (`tags_any` is not required for acceptance) — additive
evolution honored.

## Test plan

```
PYTHONPATH="$PWD/src" .venv/bin/python -m pytest tests/test_duckdb_store.py -q -k "tag or filter or search or list_entries"
  -> 55 passed, 74 deselected

PYTHONPATH="$PWD/src" .venv/bin/mypy --strict src/distillery
  -> Success: no issues found in 72 source files

.venv/bin/ruff check src tests
  -> All checks passed!
```

The new tests were verified non-vacuous: reverting the source to the old
`list_has_any` makes both fail (list test returns 4 = union vs expected 1).

## Related

Shares `store/duckdb.py` with sibling PRs in this batch and may conflict on merge.
Merge the smaller/independent PRs first and rebase this one.

Closes #626


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected metadata tag filtering to use intersection/AND semantics: when multiple tags are provided, entries must contain **all** requested tags (not just any).

* **Tests**
  * Added integration/regression coverage to confirm multi-tag filtering returns only entries matching **all** tags and that returned results include both tags.
  * Added validation to ensure the `tags` filter rejects non-list inputs (e.g., a bare string).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->