### PR TITLE
store: categorize budget-check failures into distinct codes (#557)

### DIFF
--- a/src/distillery/mcp/tools/_errors.py
+++ b/src/distillery/mcp/tools/_errors.py
@@ -44,6 +44,13 @@ class ToolErrorCode(StrEnum):
             operation (e.g., ownership violation).
         BUDGET_EXCEEDED: A rate-limit or budget has been exhausted (e.g.,
             daily embedding budget, database size limit).
+        STORE_TRANSIENT: A transient storage fault (aborted/rolled-back
+            transaction, lock contention, IO error) that the caller should
+            retry with backoff. Distinct from ``INTERNAL`` so clients can
+            safely retry instead of treating it as a permanent failure.
+        EMBEDDING_PROVIDER_UNAVAILABLE: The embedding provider failed (HTTP
+            error, timeout) while recording the budget counter. Retryable
+            with backoff.
         RATE_LIMITED: The request was rejected due to rate limiting.
         UPSTREAM_RATE_LIMITED: An upstream dependency (e.g. embedding
             provider) rate-limited the request after internal retries were
@@ -61,6 +68,8 @@ class ToolErrorCode(StrEnum):
     INTERNAL = "INTERNAL"
     FORBIDDEN = "FORBIDDEN"
     BUDGET_EXCEEDED = "BUDGET_EXCEEDED"
+    STORE_TRANSIENT = "STORE_TRANSIENT"
+    EMBEDDING_PROVIDER_UNAVAILABLE = "EMBEDDING_PROVIDER_UNAVAILABLE"
     RATE_LIMITED = "RATE_LIMITED"
     UPSTREAM_RATE_LIMITED = "UPSTREAM_RATE_LIMITED"
     UPSTREAM_ERROR = "UPSTREAM_ERROR"

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+import duckdb
 from mcp import types
 
 from distillery.config import DistilleryConfig
@@ -47,6 +48,52 @@ def _normalize_db_path(raw: str) -> str:
     if _is_remote_db_path(raw):
         return raw
     return os.path.expanduser(raw)
+
+
+async def _budget_check_error_response(
+    exc: BaseException, store: Any, context: str
+) -> list[types.TextContent]:
+    """Categorize a non-budget failure from the embedding-budget check (issue #557).
+
+    ``record_and_check`` touches the shared writer connection, so any of three
+    distinct conditions can surface here.  Collapsing them all to one opaque
+    ``INTERNAL`` (with a misleading "budget" message) hid retryable faults from
+    clients.  Branch on the concrete exception type so clients can react:
+
+    * ``duckdb.OperationalError`` (aborted/rolled-back transaction, lock
+      contention, IO faults — all subclass it) -> ``STORE_TRANSIENT`` (retry
+      with backoff).
+    * :class:`~distillery.embedding.errors.EmbeddingProviderError` (provider
+      HTTP/timeout surfacing in the counter path) ->
+      ``EMBEDDING_PROVIDER_UNAVAILABLE`` (retry with backoff).
+    * anything else -> ``INTERNAL``.
+
+    ``EmbeddingBudgetError`` is handled by the caller before this is reached and
+    must not be passed here.  The connection is rolled back (best effort) for
+    every category so a poisoned write transaction doesn't break the next
+    request.
+    """
+    logger.exception("Embedding budget check failed (%s)", context)
+    rollback = getattr(store, "rollback", None)
+    if callable(rollback):
+        try:
+            await rollback()
+        except Exception:  # noqa: BLE001
+            logger.debug("post-budget rollback skipped", exc_info=True)
+
+    if isinstance(exc, duckdb.OperationalError):
+        return error_response(
+            "STORE_TRANSIENT",
+            "Storage temporarily unavailable (db transient: aborted/locked "
+            "transaction). Retry with backoff.",
+        )
+    if isinstance(exc, EmbeddingProviderError):
+        return error_response(
+            "EMBEDDING_PROVIDER_UNAVAILABLE",
+            "Embedding provider unavailable while recording usage. "
+            "Retry with backoff.",
+        )
+    return error_response("INTERNAL", f"Embedding budget check failed ({context}).")
 
 
 # ---------------------------------------------------------------------------
@@ -359,19 +406,12 @@ async def _handle_store(
             )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
-        except Exception:  # noqa: BLE001
-            # Any non-budget failure here (e.g. TransactionContext aborted on a
-            # shared connection — see issue #363) would otherwise propagate as
-            # a raw DuckDB message.  Roll back the connection and return a
-            # sanitised INTERNAL response so clients see a stable contract.
-            logger.exception("Embedding budget check failed")
-            rollback = getattr(store, "rollback", None)
-            if callable(rollback):
-                try:
-                    await rollback()
-                except Exception:  # noqa: BLE001
-                    logger.debug("post-budget rollback skipped", exc_info=True)
-            return error_response("INTERNAL", "Failed to check embedding budget")
+        except Exception as exc:  # noqa: BLE001
+            # Non-budget failures (aborted txn on the shared connection — see
+            # issue #363, provider faults in the counter path) are categorized
+            # into distinct retryable codes rather than one opaque INTERNAL
+            # (issue #557).
+            return await _budget_check_error_response(exc, store, "store")
 
     # --- parse verification ---------------------------------------------------
     verification_val = VerificationStatus.UNVERIFIED
@@ -910,15 +950,8 @@ async def _handle_store_batch(
             )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
-        except Exception:  # noqa: BLE001
-            logger.exception("Embedding budget check failed (store_batch)")
-            rollback = getattr(store, "rollback", None)
-            if callable(rollback):
-                try:
-                    await rollback()
-                except Exception:  # noqa: BLE001
-                    logger.debug("post-budget rollback skipped", exc_info=True)
-            return error_response("INTERNAL", "Failed to check embedding budget")
+        except Exception as exc:  # noqa: BLE001
+            return await _budget_check_error_response(exc, store, "store_batch")
 
     # --- persist ------------------------------------------------------------
     try:
@@ -1972,15 +2005,8 @@ async def _handle_correct(
             record_and_check(store.connection, cfg.rate_limit.embedding_budget_daily, count=1)
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
-        except Exception:  # noqa: BLE001
-            logger.exception("Embedding budget check failed (correct)")
-            rollback = getattr(store, "rollback", None)
-            if callable(rollback):
-                try:
-                    await rollback()
-                except Exception:  # noqa: BLE001
-                    logger.debug("post-budget rollback skipped", exc_info=True)
-            return error_response("INTERNAL", "Failed to check embedding budget")
+        except Exception as exc:  # noqa: BLE001
+            return await _budget_check_error_response(exc, store, "correct")
 
     # --- atomically persist entry, relation, and archive original -----------
     try:

--- a/tests/test_mcp_coverage_gaps.py
+++ b/tests/test_mcp_coverage_gaps.py
@@ -463,6 +463,152 @@ class TestStoreGaps:
         assert "error" not in data2
 
 
+class TestStoreBudgetErrorCategorization:
+    """Issue #557: distinct codes for budget vs transient-DB vs provider faults.
+
+    The budget check (``record_and_check``) touches the shared writer
+    connection, so transient DB faults and provider failures used to collapse
+    into one opaque ``INTERNAL: Failed to check embedding budget`` — even when
+    the budget was unlimited.  These tests pin the categorization.
+    """
+
+    async def test_distinct_codes_per_failure_mode(
+        self,
+        store: DuckDBStore,
+        config: DistilleryConfig,
+        budget_config: DistilleryConfig,
+    ) -> None:
+        """budget-exceeded vs DB-transient vs provider-unavailable map to 3 codes."""
+        import duckdb
+
+        from distillery.embedding.errors import EmbeddingProviderError
+        from distillery.mcp.budget import record_and_check
+
+        # 1) Genuine budget exhaustion -> BUDGET_EXCEEDED (unchanged behavior).
+        record_and_check(store.connection, budget_config.rate_limit.embedding_budget_daily)
+        budget_resp = await _handle_store(
+            store,
+            {"content": "over budget", "entry_type": "inbox", "author": "bob"},
+            cfg=budget_config,
+        )
+        budget_code = parse_mcp_response(budget_resp)["code"]
+
+        # 2) Transient DB fault (aborted/locked txn) -> STORE_TRANSIENT.
+        #    config has the default unlimited budget (embedding_budget_daily=0).
+        aborted = duckdb.TransactionException(
+            "TransactionContext Error: Current transaction is aborted (please ROLLBACK)"
+        )
+        with patch("distillery.mcp.budget.record_and_check", side_effect=aborted):
+            transient_resp = await _handle_store(
+                store,
+                {"content": "transient", "entry_type": "inbox", "author": "bob"},
+                cfg=config,
+            )
+        transient_code = parse_mcp_response(transient_resp)["code"]
+
+        # 3) Provider failure inside the counter path -> EMBEDDING_PROVIDER_UNAVAILABLE.
+        provider_exc = EmbeddingProviderError("timeout", provider="jina")
+        with patch("distillery.mcp.budget.record_and_check", side_effect=provider_exc):
+            provider_resp = await _handle_store(
+                store,
+                {"content": "provider down", "entry_type": "inbox", "author": "bob"},
+                cfg=config,
+            )
+        provider_code = parse_mcp_response(provider_resp)["code"]
+
+        assert budget_code == "BUDGET_EXCEEDED"
+        assert transient_code == "STORE_TRANSIENT"
+        assert provider_code == "EMBEDDING_PROVIDER_UNAVAILABLE"
+        assert len({budget_code, transient_code, provider_code}) == 3
+
+    async def test_poisoned_connection_returns_store_transient(
+        self, store: DuckDBStore, config: DistilleryConfig
+    ) -> None:
+        """A real aborted-transaction fault on the connection -> STORE_TRANSIENT.
+
+        Closing the connection makes ``record_and_check`` raise a genuine
+        ``duckdb.ConnectionException`` (a ``duckdb.OperationalError`` subclass,
+        the same family as an aborted/locked transaction).
+        """
+        import duckdb
+
+        from distillery.mcp.budget import record_and_check
+
+        store.connection.close()  # poison: connection-level transient fault
+        # Sanity-check the poison yields a genuine OperationalError (the family
+        # that includes aborted/locked transactions) before the handler runs.
+        with pytest.raises(duckdb.OperationalError):
+            record_and_check(store.connection, 0)
+
+        response = await _handle_store(
+            store,
+            {"content": "poisoned", "entry_type": "inbox", "author": "bob"},
+            cfg=config,
+        )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["code"] == "STORE_TRANSIENT"
+        assert "budget" not in data["message"].lower()
+
+    async def test_provider_failure_returns_provider_unavailable(
+        self, store: DuckDBStore, config: DistilleryConfig
+    ) -> None:
+        """Provider HTTP/timeout surfacing in the counter path -> EMBEDDING_PROVIDER_UNAVAILABLE."""
+        from distillery.embedding.errors import EmbeddingProviderError
+
+        provider_exc = EmbeddingProviderError("read timeout", provider="openai")
+        with patch("distillery.mcp.budget.record_and_check", side_effect=provider_exc):
+            response = await _handle_store(
+                store,
+                {"content": "provider", "entry_type": "inbox", "author": "bob"},
+                cfg=config,
+            )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["code"] == "EMBEDDING_PROVIDER_UNAVAILABLE"
+
+    async def test_opaque_string_gone_for_non_budget_failure(
+        self, store: DuckDBStore, config: DistilleryConfig
+    ) -> None:
+        """Non-budget failures never emit the misleading 'budget' string (unlimited budget)."""
+        from distillery.mcp.budget import record_and_check
+
+        # A genuine non-OperationalError fault: drop the counter table so the
+        # upsert hits a CatalogException -> INTERNAL fallback (not "budget").
+        store.connection.execute("DROP TABLE _meta")
+        with pytest.raises(Exception):  # noqa: B017,PT011 — proves the table is gone
+            record_and_check(store.connection, 0)
+
+        response = await _handle_store(
+            store,
+            {"content": "no meta", "entry_type": "inbox", "author": "bob"},
+            cfg=config,
+        )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["code"] == "INTERNAL"
+        assert "Failed to check embedding budget" not in data["message"]
+
+    async def test_batch_path_categorizes_transient(
+        self, store: DuckDBStore, config: DistilleryConfig
+    ) -> None:
+        """The store_batch path uses the same categorization (STORE_TRANSIENT)."""
+        import duckdb
+
+        from distillery.mcp.tools.crud import _handle_store_batch
+
+        aborted = duckdb.TransactionException("Current transaction is aborted")
+        with patch("distillery.mcp.budget.record_and_check", side_effect=aborted):
+            response = await _handle_store_batch(
+                store,
+                {"entries": [{"content": "batch transient", "author": "bob"}]},
+                cfg=config,
+            )
+        data = parse_mcp_response(response)
+        assert data["error"] is True
+        assert data["code"] == "STORE_TRANSIENT"
+
+
 class TestGetGaps:
     """Cover feedback logging in _handle_get."""
 

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -39,9 +39,9 @@ class TestToolErrorCode:
         assert str(code) == "INVALID_PARAMS"
 
     def test_all_codes_listed(self) -> None:
-        """Verify there are exactly 9 codes (no accidental additions)."""
+        """Verify there are exactly 11 codes (no accidental additions)."""
         codes = list(ToolErrorCode)
-        assert len(codes) == 9
+        assert len(codes) == 11
         assert set(codes) == {
             ToolErrorCode.INVALID_PARAMS,
             ToolErrorCode.NOT_FOUND,
@@ -49,6 +49,8 @@ class TestToolErrorCode:
             ToolErrorCode.INTERNAL,
             ToolErrorCode.FORBIDDEN,
             ToolErrorCode.BUDGET_EXCEEDED,
+            ToolErrorCode.STORE_TRANSIENT,
+            ToolErrorCode.EMBEDDING_PROVIDER_UNAVAILABLE,
             ToolErrorCode.RATE_LIMITED,
             ToolErrorCode.UPSTREAM_RATE_LIMITED,
             ToolErrorCode.UPSTREAM_ERROR,


### PR DESCRIPTION
## Root cause

`distillery_store`, `distillery_store_batch`, and `distillery_correct` collapsed every non-budget failure inside the embedding-budget check into one opaque response:

```python
except Exception:  # noqa: BLE001
    logger.exception("Embedding budget check failed")
    ...
    return error_response("INTERNAL", "Failed to check embedding budget")
```

`record_and_check` touches the shared writer connection, so three distinct conditions surfaced here with the same `INTERNAL` code and a misleading "budget" message:

1. Genuine budget exhaustion (already had its own `BUDGET_EXCEEDED` branch).
2. Transient DB faults (aborted/rolled-back transaction, lock contention, IO error on the shared connection — see #363).
3. Provider unavailability (embedding API timeout/HTTP error in the counter path).

Clients could not distinguish a retryable fault from a permanent one, and logs said "budget" even when the budget was unlimited.

## Fix

Added a shared async helper `_budget_check_error_response(exc, store, context)` in `src/distillery/mcp/tools/crud.py` that branches on the concrete exception type:

| Cause | Code | Retry? |
|---|---|---|
| `duckdb.OperationalError` (aborted/locked txn, IO) | `STORE_TRANSIENT` | Yes, backoff |
| `EmbeddingProviderError` | `EMBEDDING_PROVIDER_UNAVAILABLE` | Yes, backoff |
| anything else | `INTERNAL` | Maybe |

`EmbeddingBudgetError` is still caught first at every call site and returns `BUDGET_EXCEEDED` (unchanged). All four DuckDB transient faults named in the issue subclass `OperationalError`; non-transient faults (Catalog/Binder) subclass `ProgrammingError` and correctly fall through to `INTERNAL`. The lock-protected best-effort rollback (#416) and `logger.exception` traceback capture are preserved for every category and now live inside the helper. The three call sites (`_handle_store`, `_handle_store_batch`, `_handle_correct`) delegate to it.

Two new error codes added to the existing `ToolErrorCode` enum in `src/distillery/mcp/tools/_errors.py`: `STORE_TRANSIENT`, `EMBEDDING_PROVIDER_UNAVAILABLE`. Additive evolution — no new MCP tool.

## Acceptance

- [x] Distinct codes returned for budget-exceeded vs DB-transient vs provider-unavailable failures — `test_distinct_codes_per_failure_mode` asserts `BUDGET_EXCEEDED`, `STORE_TRANSIENT`, `EMBEDDING_PROVIDER_UNAVAILABLE` for the three modes.
- [x] `Failed to check embedding budget` string no longer appears when the budget is unlimited/under-used — `test_poisoned_connection_returns_store_transient` asserts `"budget" not in message.lower()`; `test_mcp_errors.py::test_all_codes_listed` enforces the exact code set.
- [x] Unit test: poison the connection (force an aborted txn), call store, assert `STORE_TRANSIENT` — `test_poisoned_connection_returns_store_transient` uses a real closed-connection `ConnectionException` (with a `pytest.raises` sanity pre-check).
- [x] Unit test: stub provider to raise, assert `EMBEDDING_PROVIDER_UNAVAILABLE` — `test_provider_failure_returns_provider_unavailable` raises a real `EmbeddingProviderError` in the counter path.

## Test plan

```
PYTHONPATH=src python -m pytest tests/test_mcp_coverage_gaps.py tests/test_mcp_errors.py -q
  -> 187 passed
mypy --strict src/distillery
  -> Success: no issues found in 72 source files
ruff check src tests
  -> All checks passed!
```

Closes #557


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for embedding operations by introducing distinct error codes for transient storage issues and embedding provider unavailability, enabling improved retry behavior and more accurate error reporting.

* **Tests**
  * Added comprehensive test coverage for embedding budget error categorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->