### PR TITLE
mcp: add distillery_ingest_doc for arbitrary document ingestion (#627)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -42,6 +42,7 @@ from distillery.mcp.tools.configure import _handle_configure
 from distillery.mcp.tools.crud import (
     _handle_correct,
     _handle_get,
+    _handle_ingest_doc,
     _handle_list,
     _handle_store,
     _handle_update,
@@ -83,6 +84,7 @@ __all__ = [
     "_create_embedding_provider",
     "_handle_configure",
     "_handle_store",
+    "_handle_ingest_doc",
     "_handle_get",
     "_handle_update",
     "_handle_correct",
@@ -556,6 +558,80 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                                 "audit_log write failed for distillery_store_batch (ignored)",
                                 exc_info=True,
                             )
+        return result
+
+    @server.tool
+    async def distillery_ingest_doc(  # noqa: PLR0913
+        ctx: Context,
+        text: str,
+        author: str,
+        doctype: str | None = None,
+        source: str | None = None,
+        external_id: str | None = None,
+        title: str | None = None,
+        project: str | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> list[types.TextContent]:
+        """Ingest an arbitrary document (ADR, spec, decision, customer feedback).
+
+        USE WHEN: importing a standalone document — a markdown ADR/spec/RFC, a
+        design decision, or a customer-feedback transcript/doc — so it becomes
+        queryable knowledge with provenance. Distinct from distillery_store
+        (single entry, semantic dedup) and from PreCompact transcripts: this
+        chunks large text into multiple linked entries and deduplicates
+        idempotently by content hash, so re-ingesting identical content adds
+        no second entry.
+
+        PARAMS:
+          - text (str, required): The full document text. Large text is split
+            into multiple linked entries (relation_type="chunk").
+          - author (str, required): Who is ingesting / owns this document.
+          - doctype (str, optional, default="doc"): Document kind. Valid:
+            [adr, spec, decision, feedback, doc]. Applied as both a
+            "doctype/<value>" tag and metadata.doctype for faceted retrieval.
+          - source (str, optional): Provenance label (file path, Drive URL,
+            etc.). Stored in metadata.source.
+          - external_id (str, optional): Explicit dedup key. Defaults to the
+            SHA-256 hash of text, making re-ingest idempotent.
+          - title (str, optional): Human-readable title (stored in metadata.title).
+          - project (str, optional): Project scope.
+          - tags (list[str], optional): Extra namespaced tags.
+          - metadata (dict, optional): Arbitrary extra metadata.
+
+        RETURNS (success): { entry_ids: list[str], count: int, doctype: str,
+            external_id: str, chunked: bool, persisted: bool,
+            dedup_action: "stored" | "skipped" }
+            On re-ingest of identical content, persisted=false,
+            dedup_action="skipped", and entry_ids points at the existing entries.
+        RETURNS (error): { error: true, code: "INVALID_PARAMS" | "INTERNAL", message: "..." }
+
+        RELATED: distillery_store (single entry with semantic dedup),
+        distillery_search (to retrieve ingested documents)
+        """
+        c = _lc(ctx)
+        user = _get_authenticated_user()
+        args: dict[str, Any] = dict(
+            text=text,
+            author=author,
+            **_omit_none(
+                doctype=doctype,
+                source=source,
+                external_id=external_id,
+                title=title,
+                project=project,
+                tags=tags,
+                metadata=metadata,
+            ),
+        )
+        result = await _handle_ingest_doc(
+            store=c["store"], arguments=args, cfg=c["config"], created_by=user
+        )
+        rd = json.loads(result[0].text) if result else {}
+        ids = rd.get("entry_ids") or []
+        await _audit(
+            c, user, "distillery_ingest_doc", ids[0] if ids else "", "store", result
+        )
         return result
 
     @server.tool

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -1093,12 +1093,24 @@ async def _handle_ingest_doc(
         return error_response("INVALID_PARAMS", "Field 'external_id' must be a string.")
 
     # --- idempotency check: already ingested? -------------------------------
+    # Paginate to exhaustion so a re-ingest of a doc that produced >page_size
+    # chunks returns the full entry_ids list (and correct count), not a slice.
     try:
-        existing = await store.list_entries(
-            filters={"metadata.external_id": external_id},
-            limit=500,
-            offset=0,
-        )
+        existing: list[Any] = []
+        page_size = 500
+        offset = 0
+        while True:
+            page = await store.list_entries(
+                filters={"metadata.external_id": external_id},
+                limit=page_size,
+                offset=offset,
+            )
+            if not page:
+                break
+            existing.extend(page)
+            if len(page) < page_size:
+                break
+            offset += page_size
     except Exception:  # noqa: BLE001
         logger.exception("ingest_doc: external_id lookup failed for %r", external_id)
         return error_response("INTERNAL", "Failed to check for existing document")
@@ -1159,8 +1171,9 @@ async def _handle_ingest_doc(
     # --- persist (no semantic dedup; idempotency is handled above) ----------
     try:
         entry_ids = await store.store_batch(entries)
-    except ValueError as exc:
-        return error_response("INVALID_PARAMS", str(exc))
+    except ValueError:
+        logger.exception("ingest_doc: invalid params during batch store")
+        return error_response("INVALID_PARAMS", "Invalid ingestion parameters.")
     except EmbeddingProviderError as exc:
         logger.warning(
             "Upstream embedding provider failed during ingest_doc "

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -10,6 +10,7 @@ Implements the following tools:
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from collections.abc import Mapping
@@ -968,6 +969,232 @@ async def _handle_store_batch(
             entry_ids_out.append(pid)
     return success_response(
         {"entry_ids": entry_ids_out, "results": results, "count": len(persisted_ids)}
+    )
+
+
+# ---------------------------------------------------------------------------
+# _handle_ingest_doc
+# ---------------------------------------------------------------------------
+
+# Valid doctype values for document ingestion.  These drive the
+# ``doctype/<value>`` tag convention and the ``metadata.doctype`` field so
+# specs/ADRs/decisions and customer feedback become faceted, queryable
+# entries without adding a new EntryType enum value (issue #627).
+_VALID_DOCTYPES = {"adr", "spec", "decision", "feedback", "doc"}
+
+# Approximate maximum characters per chunk when a document is split.  Chosen
+# so a chunk comfortably fits a single embedding call and stays well under
+# typical model context windows.  Splitting happens on paragraph boundaries
+# where possible; an oversized paragraph is hard-split.
+_DOC_CHUNK_CHARS = 4000
+
+
+def _content_hash(text: str) -> str:
+    """Return the SHA-256 hex digest of *text* (stable dedup key)."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _chunk_text(text: str, *, max_chars: int = _DOC_CHUNK_CHARS) -> list[str]:
+    """Split *text* into chunks no larger than *max_chars*.
+
+    Paragraph boundaries (blank lines) are preferred so chunks stay
+    semantically coherent.  A single paragraph longer than *max_chars* is
+    hard-split.  Returns at least one chunk for non-empty input.
+    """
+    if len(text) <= max_chars:
+        return [text]
+
+    chunks: list[str] = []
+    current = ""
+    for paragraph in text.split("\n\n"):
+        # Hard-split any single paragraph that exceeds the limit on its own.
+        if len(paragraph) > max_chars:
+            if current:
+                chunks.append(current)
+                current = ""
+            for i in range(0, len(paragraph), max_chars):
+                chunks.append(paragraph[i : i + max_chars])
+            continue
+        candidate = f"{current}\n\n{paragraph}" if current else paragraph
+        if len(candidate) > max_chars:
+            chunks.append(current)
+            current = paragraph
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+async def _handle_ingest_doc(
+    store: Any,
+    arguments: dict[str, Any],
+    cfg: DistilleryConfig | None = None,
+    created_by: str = "",
+) -> list[types.TextContent]:
+    """Ingest an arbitrary document (ADR/spec/decision/feedback) into the store.
+
+    Distinct from ``distillery_store`` (single entry, semantic-similarity
+    dedup) and the PreCompact-transcript path: this takes raw document text
+    plus provenance, chunks large text into multiple linked entries, and
+    deduplicates idempotently by content hash so re-ingesting identical
+    content creates no second entry (issue #627).
+
+    Args:
+        store: Initialised storage backend.
+        arguments: Tool arguments.  Required: ``text`` (str), ``author``
+            (str).  Optional: ``doctype`` (one of ``_VALID_DOCTYPES``,
+            default ``"doc"``), ``source`` (str — provenance label such as a
+            file path or Drive URL), ``external_id`` (str — explicit dedup
+            key; defaults to the content hash), ``title`` (str), ``project``
+            (str), ``tags`` (list[str]), ``metadata`` (dict).
+        cfg: Optional config (reserved for future budget checks; unused here
+            because ingestion runs through ``store_batch`` which has no dedup).
+        created_by: Ownership identifier from the auth layer.
+
+    Returns:
+        MCP content list with ``{entry_ids, count, doctype, external_id,
+        chunked, persisted, dedup_action}``.  On re-ingest of identical
+        content, ``persisted`` is ``False`` and ``dedup_action`` is
+        ``"skipped"`` with the existing ``entry_ids``.
+    """
+    from distillery.models import Entry, EntrySource, EntryType
+
+    err = validate_required(arguments, "text", "author")
+    if err:
+        return error_response("INVALID_PARAMS", err)
+
+    text = arguments["text"]
+    if not isinstance(text, str) or not text.strip():
+        return error_response("INVALID_PARAMS", "Field 'text' must be a non-empty string.")
+
+    doctype = arguments.get("doctype", "doc")
+    if doctype not in _VALID_DOCTYPES:
+        return error_response(
+            "INVALID_PARAMS",
+            f"Invalid doctype {doctype!r}. Must be one of: {', '.join(sorted(_VALID_DOCTYPES))}.",
+        )
+
+    tags_err = validate_type(arguments, "tags", list, "list of strings")
+    if tags_err:
+        return error_response("INVALID_PARAMS", tags_err)
+
+    metadata_err = validate_type(arguments, "metadata", dict, "object")
+    if metadata_err:
+        return error_response("INVALID_PARAMS", metadata_err)
+
+    source_raw = arguments.get("source")
+    title = arguments.get("title")
+
+    # Dedup key: caller-supplied external_id, else the content hash so
+    # re-ingesting identical text is idempotent.
+    external_id = arguments.get("external_id") or _content_hash(text)
+    if not isinstance(external_id, str):
+        return error_response("INVALID_PARAMS", "Field 'external_id' must be a string.")
+
+    # --- idempotency check: already ingested? -------------------------------
+    try:
+        existing = await store.list_entries(
+            filters={"metadata.external_id": external_id},
+            limit=500,
+            offset=0,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("ingest_doc: external_id lookup failed for %r", external_id)
+        return error_response("INTERNAL", "Failed to check for existing document")
+
+    if existing:
+        existing_ids = [e.id for e in existing]
+        return success_response(
+            {
+                "entry_ids": existing_ids,
+                "count": len(existing_ids),
+                "doctype": doctype,
+                "external_id": external_id,
+                "chunked": len(existing_ids) > 1,
+                "persisted": False,
+                "dedup_action": "skipped",
+            }
+        )
+
+    # --- chunk large documents ----------------------------------------------
+    chunks = _chunk_text(text)
+    chunked = len(chunks) > 1
+
+    # ``doctype/<value>`` tag convention + caller tags (deduped, order-stable).
+    base_tags: list[str] = [f"doctype/{doctype}"]
+    for tag in arguments.get("tags") or []:
+        if tag not in base_tags:
+            base_tags.append(tag)
+
+    base_metadata: dict[str, Any] = dict(arguments.get("metadata") or {})
+    base_metadata["doctype"] = doctype
+    base_metadata["external_id"] = external_id
+    if source_raw is not None:
+        base_metadata["source"] = source_raw
+    if title is not None:
+        base_metadata["title"] = title
+
+    project = arguments.get("project")
+
+    entries: list[Entry] = []
+    for idx, chunk in enumerate(chunks):
+        chunk_metadata = dict(base_metadata)
+        if chunked:
+            chunk_metadata["chunk_index"] = idx
+            chunk_metadata["chunk_total"] = len(chunks)
+        entries.append(
+            Entry(
+                content=chunk,
+                entry_type=EntryType.REFERENCE,
+                source=EntrySource.IMPORT,
+                author=arguments["author"],
+                project=project,
+                tags=list(base_tags),
+                metadata=chunk_metadata,
+                created_by=created_by,
+            )
+        )
+
+    # --- persist (no semantic dedup; idempotency is handled above) ----------
+    try:
+        entry_ids = await store.store_batch(entries)
+    except ValueError as exc:
+        return error_response("INVALID_PARAMS", str(exc))
+    except EmbeddingProviderError as exc:
+        logger.warning(
+            "Upstream embedding provider failed during ingest_doc "
+            "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
+            exc.provider,
+            exc.endpoint,
+            exc.status_code,
+            exc.retry_after,
+            exc,
+        )
+        return upstream_error_response(exc)
+    except Exception:  # noqa: BLE001
+        logger.exception("Error ingesting document external_id=%s", external_id)
+        return error_response("INTERNAL", "Failed to ingest document")
+
+    # --- link chunks so they round-trip as one document ---------------------
+    if chunked:
+        head = entry_ids[0]
+        for tail in entry_ids[1:]:
+            try:
+                await store.add_relation(from_id=head, to_id=tail, relation_type="chunk")
+            except Exception:  # noqa: BLE001
+                logger.warning("ingest_doc: failed to link chunk %s -> %s", head, tail)
+
+    return success_response(
+        {
+            "entry_ids": entry_ids,
+            "count": len(entry_ids),
+            "doctype": doctype,
+            "external_id": external_id,
+            "chunked": chunked,
+            "persisted": True,
+            "dedup_action": "stored",
+        }
     )
 
 
@@ -2011,6 +2238,7 @@ async def _handle_correct(
 __all__ = [
     "_handle_store",
     "_handle_store_batch",
+    "_handle_ingest_doc",
     "_handle_get",
     "_handle_update",
     "_handle_correct",

--- a/tests/test_e2e_mcp.py
+++ b/tests/test_e2e_mcp.py
@@ -500,12 +500,13 @@ class TestCallToolDispatcher:
         tools = await server.list_tools()
         tool_names = {t.name for t in tools}
 
-        # 16-tool consolidated API (12 from #196 + store_batch, gh_sync, sync_status, status).
+        # 17-tool consolidated API (16 prior + distillery_ingest_doc from #627).
         # Analytics tools (aggregate, metrics, stale, tag_tree, interests)
         # absorbed into distillery_list via group_by, output="stats", stale_days.
         expected = {
             "distillery_store",
             "distillery_store_batch",
+            "distillery_ingest_doc",
             "distillery_get",
             "distillery_update",
             "distillery_correct",

--- a/tests/test_ingest_doc.py
+++ b/tests/test_ingest_doc.py
@@ -137,6 +137,7 @@ class TestIngestIdempotency:
 
         def _stub(idx: int) -> Entry:
             return Entry(
+                id=f"entry-{idx}",
                 content=f"chunk {idx}",
                 entry_type=EntryType.REFERENCE,
                 source=EntrySource.IMPORT,

--- a/tests/test_ingest_doc.py
+++ b/tests/test_ingest_doc.py
@@ -127,6 +127,45 @@ class TestIngestIdempotency:
         )
         assert len(all_adrs) == 1
 
+    async def test_reingest_paginates_past_first_page(self, store: DuckDBStore) -> None:
+        # A re-ingest of a doc that produced more chunks than one page must
+        # return every existing entry_id, not just the first page's slice.
+        from distillery.mcp.tools import crud as crud_mod
+        from distillery.models import Entry, EntrySource, EntryType
+
+        page_size = 500
+
+        def _stub(idx: int) -> Entry:
+            return Entry(
+                content=f"chunk {idx}",
+                entry_type=EntryType.REFERENCE,
+                source=EntrySource.IMPORT,
+                author="a",
+                metadata={"external_id": "big-doc", "chunk_index": idx},
+            )
+
+        # Page 1: full (page_size rows) -> loop must request page 2.
+        # Page 2: partial (1 row) -> loop stops, but only after accumulating it.
+        all_entries = [_stub(i) for i in range(page_size + 1)]
+
+        async def fake_list_entries(
+            *, filters: object, limit: int, offset: int
+        ) -> list[Entry]:
+            return all_entries[offset : offset + limit]
+
+        # type: ignore[method-assign] — monkeypatch the bound method for this test.
+        store.list_entries = fake_list_entries  # type: ignore[assignment]
+
+        payload = parse_mcp_response(
+            await crud_mod._handle_ingest_doc(
+                store=store,
+                arguments={"text": "x", "author": "a", "external_id": "big-doc"},
+            )
+        )
+        assert payload["persisted"] is False
+        assert payload["count"] == page_size + 1
+        assert len(payload["entry_ids"]) == page_size + 1
+
     async def test_explicit_external_id_dedups(self, store: DuckDBStore) -> None:
         # Different text but same external_id -> treated as same document.
         first = parse_mcp_response(

--- a/tests/test_ingest_doc.py
+++ b/tests/test_ingest_doc.py
@@ -1,0 +1,203 @@
+"""Tests for ``distillery_ingest_doc`` — arbitrary document ingestion (issue #627).
+
+Covers the acceptance criteria:
+
+* A markdown ADR file and a customer-transcript file both become queryable
+  entries carrying provenance (source metadata + doctype).
+* Re-ingesting identical content is idempotent via the dedup key (content
+  hash / external_id) — no second entry is created.
+* Large text is chunked into multiple linked entries.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.mcp.tools.crud import (
+    _DOC_CHUNK_CHARS,
+    _content_hash,
+    _handle_ingest_doc,
+)
+from distillery.store.duckdb import DuckDBStore
+from tests.conftest import parse_mcp_response
+
+pytestmark = pytest.mark.unit
+
+
+_ADR = """# ADR 0007: Adopt DuckDB for the knowledge store
+
+## Status
+Accepted
+
+## Context
+We need an embedded analytical database with vector search support.
+
+## Decision
+Use DuckDB with the VSS extension for HNSW similarity search.
+"""
+
+_TRANSCRIPT = """Customer feedback call — Acme Corp, 2026-06-01
+
+Acme wants faster onboarding and clearer error messages. They were confused
+by the dedup warnings and asked for a way to bulk-import their existing specs.
+"""
+
+
+class TestIngestProvenance:
+    async def test_adr_becomes_queryable_with_provenance(self, store: DuckDBStore) -> None:
+        result = await _handle_ingest_doc(
+            store=store,
+            arguments={
+                "text": _ADR,
+                "author": "alice",
+                "doctype": "adr",
+                "source": "docs/adr/0007-duckdb.md",
+                "title": "Adopt DuckDB",
+                "project": "distillery",
+            },
+        )
+        payload = parse_mcp_response(result)
+        assert payload["persisted"] is True
+        assert payload["dedup_action"] == "stored"
+        assert payload["doctype"] == "adr"
+        assert payload["count"] == 1
+
+        entry_id = payload["entry_ids"][0]
+        entry = await store.get(entry_id)
+        assert entry is not None
+        # Provenance: doctype tag + metadata carry source + doctype + title.
+        assert "doctype/adr" in entry.tags
+        assert entry.metadata["doctype"] == "adr"
+        assert entry.metadata["source"] == "docs/adr/0007-duckdb.md"
+        assert entry.metadata["title"] == "Adopt DuckDB"
+        assert entry.project == "distillery"
+        assert entry.metadata["external_id"] == _content_hash(_ADR)
+
+        # Queryable via metadata filter and via list.
+        listed = await store.list_entries(filters={"metadata.doctype": "adr"}, limit=10, offset=0)
+        assert any(e.id == entry_id for e in listed)
+
+    async def test_customer_transcript_becomes_queryable_feedback(
+        self, store: DuckDBStore
+    ) -> None:
+        result = await _handle_ingest_doc(
+            store=store,
+            arguments={
+                "text": _TRANSCRIPT,
+                "author": "bob",
+                "doctype": "feedback",
+                "source": "drive://acme/2026-06-01-call.txt",
+            },
+        )
+        payload = parse_mcp_response(result)
+        assert payload["persisted"] is True
+        assert payload["doctype"] == "feedback"
+
+        entry = await store.get(payload["entry_ids"][0])
+        assert entry is not None
+        assert "doctype/feedback" in entry.tags
+        assert entry.metadata["doctype"] == "feedback"
+        assert entry.metadata["source"] == "drive://acme/2026-06-01-call.txt"
+
+        # The feedback doc surfaces via semantic search.
+        hits = await store.search(query="onboarding feedback", filters=None, limit=5)
+        assert any(h.entry.id == entry.id for h in hits)
+
+
+class TestIngestIdempotency:
+    async def test_reingest_identical_content_is_idempotent(self, store: DuckDBStore) -> None:
+        args = {
+            "text": _ADR,
+            "author": "alice",
+            "doctype": "adr",
+            "source": "docs/adr/0007-duckdb.md",
+        }
+        first = parse_mcp_response(await _handle_ingest_doc(store=store, arguments=dict(args)))
+        assert first["persisted"] is True
+        assert first["dedup_action"] == "stored"
+
+        second = parse_mcp_response(await _handle_ingest_doc(store=store, arguments=dict(args)))
+        assert second["persisted"] is False
+        assert second["dedup_action"] == "skipped"
+        # Same entry returned, no duplicate row created.
+        assert second["entry_ids"] == first["entry_ids"]
+
+        all_adrs = await store.list_entries(
+            filters={"metadata.external_id": _content_hash(_ADR)}, limit=10, offset=0
+        )
+        assert len(all_adrs) == 1
+
+    async def test_explicit_external_id_dedups(self, store: DuckDBStore) -> None:
+        # Different text but same external_id -> treated as same document.
+        first = parse_mcp_response(
+            await _handle_ingest_doc(
+                store=store,
+                arguments={"text": "version one", "author": "a", "external_id": "spec-42"},
+            )
+        )
+        second = parse_mcp_response(
+            await _handle_ingest_doc(
+                store=store,
+                arguments={"text": "version two", "author": "a", "external_id": "spec-42"},
+            )
+        )
+        assert first["persisted"] is True
+        assert second["persisted"] is False
+        assert second["entry_ids"] == first["entry_ids"]
+
+
+class TestIngestChunking:
+    async def test_large_text_chunks_into_linked_entries(self, store: DuckDBStore) -> None:
+        # Build text well over the chunk limit using paragraph boundaries.
+        paragraph = "This is a paragraph about the design rationale. " * 30
+        big_text = "\n\n".join(paragraph for _ in range(8))
+        assert len(big_text) > _DOC_CHUNK_CHARS
+
+        payload = parse_mcp_response(
+            await _handle_ingest_doc(
+                store=store,
+                arguments={"text": big_text, "author": "alice", "doctype": "spec"},
+            )
+        )
+        assert payload["chunked"] is True
+        assert payload["count"] > 1
+        ids = payload["entry_ids"]
+
+        # Every chunk is a queryable entry carrying chunk provenance.
+        for idx, eid in enumerate(ids):
+            entry = await store.get(eid)
+            assert entry is not None
+            assert entry.metadata["chunk_index"] == idx
+            assert entry.metadata["chunk_total"] == len(ids)
+            assert "doctype/spec" in entry.tags
+
+        # Chunks are linked from the head entry with relation_type="chunk".
+        relations = await store.get_related(ids[0], direction="outgoing", relation_type="chunk")
+        linked_ids = {r["to_id"] for r in relations}
+        assert linked_ids == set(ids[1:])
+
+
+class TestIngestValidation:
+    async def test_missing_text_is_invalid(self, store: DuckDBStore) -> None:
+        payload = parse_mcp_response(
+            await _handle_ingest_doc(store=store, arguments={"author": "a"})
+        )
+        assert payload["error"] is True
+        assert payload["code"] == "INVALID_PARAMS"
+
+    async def test_empty_text_is_invalid(self, store: DuckDBStore) -> None:
+        payload = parse_mcp_response(
+            await _handle_ingest_doc(store=store, arguments={"text": "   ", "author": "a"})
+        )
+        assert payload["error"] is True
+        assert payload["code"] == "INVALID_PARAMS"
+
+    async def test_invalid_doctype_is_rejected(self, store: DuckDBStore) -> None:
+        payload = parse_mcp_response(
+            await _handle_ingest_doc(
+                store=store,
+                arguments={"text": "x", "author": "a", "doctype": "novel"},
+            )
+        )
+        assert payload["error"] is True
+        assert payload["code"] == "INVALID_PARAMS"

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -32,10 +32,11 @@ MCP_HEADERS = {
     "Accept": "application/json, text/event-stream",
 }
 
-# 16-tool API (15 prior + distillery_status from #313).
+# 17-tool API (16 prior + distillery_ingest_doc from #627).
 EXPECTED_TOOLS = {
     "distillery_store",
     "distillery_store_batch",
+    "distillery_ingest_doc",
     "distillery_get",
     "distillery_update",
     "distillery_correct",
@@ -145,7 +146,7 @@ class TestHttpServerStarts:
 
 class TestAllToolsAccessibleOverHttp:
     async def test_all_tools_accessible_over_http(self) -> None:
-        """All 16 tools appear in tools/list response over HTTP."""
+        """All 17 tools appear in tools/list response over HTTP."""
         port = _free_port()
         config = _make_server_config()
         uv_server, task = await _start_http_server(port, config)
@@ -162,7 +163,7 @@ class TestAllToolsAccessibleOverHttp:
             assert "result" in data, f"Expected result in: {data}"
             tools = data["result"]["tools"]
             tool_names = {t["name"] for t in tools}
-            assert len(tool_names) == 16, f"Expected 16 tools, got {len(tool_names)}: {tool_names}"
+            assert len(tool_names) == 17, f"Expected 17 tools, got {len(tool_names)}: {tool_names}"
             assert tool_names == EXPECTED_TOOLS, (
                 f"Tool mismatch.\nExpected: {EXPECTED_TOOLS}\nGot: {tool_names}"
             )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -687,10 +687,11 @@ class TestCreateServer:
         tools = await server.list_tools()
         tool_names = {t.name for t in tools}
 
-        # 16-tool consolidated API (15 prior + distillery_status from #313)
+        # 17-tool consolidated API (16 prior + distillery_ingest_doc from #627)
         expected = {
             "distillery_store",
             "distillery_store_batch",
+            "distillery_ingest_doc",
             "distillery_get",
             "distillery_update",
             "distillery_correct",
@@ -771,13 +772,13 @@ class TestRemovedTools:
             )
 
     async def test_removed_tools_count_unchanged(self) -> None:
-        """Exactly 16 tools must be registered — consolidated analytics tools + status."""
+        """Exactly 17 tools must be registered — 16 prior + distillery_ingest_doc (#627)."""
         config = DistilleryConfig(
             storage=StorageConfig(database_path=":memory:"),
             embedding=EmbeddingConfig(provider="", model="stub", dimensions=4),
         )
         server = create_server(config)
         tools = await server.list_tools()
-        assert len(tools) == 16, (
-            f"Expected 16 registered tools, got {len(tools)}: {sorted(t.name for t in tools)}"
+        assert len(tools) == 17, (
+            f"Expected 17 registered tools, got {len(tools)}: {sorted(t.name for t in tools)}"
         )


### PR DESCRIPTION
## Root cause

`gh_sync` ingests GitHub issues/PRs and the PreCompact path (#199) ingests Claude Code conversation transcripts, but there was no path to ingest arbitrary documents — Google Drive docs, repo markdown specs/ADRs/RFCs, or customer-feedback files. Specs/ADRs could not be put in the store for knowledge-gap detection, and customer feedback could not be tied to the dev process.

## Fix

New additive MCP tool `distillery_ingest_doc` (`src/distillery/mcp/tools/crud.py` `_handle_ingest_doc`, registered in `src/distillery/mcp/server.py`). Distinct from `distillery_store`: it ingests arbitrary `(text, source metadata)` into one or more entries with provenance, chunks large text, and dedups by exact content hash / `external_id` rather than `store`'s single-entry semantic dedup.

- Provenance: `doctype/<value>` tag + `metadata.doctype`, `metadata.source`, `metadata.title`. Valid doctypes: `adr`, `spec`, `decision`, `feedback`, `doc` — no new `EntryType` enum value needed.
- Idempotency: dedup key is caller-supplied `external_id` or SHA-256 of the text; lookup uses the established `metadata.external_id` exact-match mechanism (`json_extract_string`) that `feeds/github_sync.py` already relies on. Re-ingest returns `persisted=False` with the same `entry_ids`.
- Chunking: text over 4000 chars splits on paragraph boundaries (hard-split fallback for oversized paragraphs, no content loss). Chunks are linked via `add_relation(relation_type="chunk")`.
- Errors: missing/empty `text` and invalid `doctype` return `INVALID_PARAMS`; embedding failures surface as upstream errors; the `external_id` lookup is try/except-guarded.

Tool count updated 16 → 17 in every live-server-derived assertion.

## Acceptance

- [x] A markdown ADR and a customer-transcript file both become queryable entries with provenance — `tests/test_ingest_doc.py::TestIngestProvenance::test_adr_becomes_queryable_with_provenance` and `::test_customer_transcript_becomes_queryable_feedback` (assert `doctype/<v>` tag, `metadata.source/doctype/title`, retrieval via `list_entries` filter and semantic search).
- [x] Re-ingest is idempotent via the dedup key — `tests/test_ingest_doc.py::TestIngestIdempotency::test_reingest_identical_content_is_idempotent` (second call `persisted=False`, same `entry_ids`, `len(list_entries by external_id) == 1`) and `::test_explicit_external_id_dedups`.

Additional coverage: chunking + linking (`TestIngestChunking::test_large_text_chunks_into_linked_entries`), validation (`TestIngestValidation::test_missing_text_is_invalid`, `test_empty_text_is_invalid`, `test_invalid_doctype_is_rejected`).

## Test plan

```
PYTHONPATH="$PWD/src" .venv/bin/python -m pytest tests/test_ingest_doc.py tests/test_mcp_server.py tests/test_mcp_http_transport.py tests/test_e2e_mcp.py -q
# 83 passed

PYTHONPATH="$PWD/src" .venv/bin/mypy --strict src/distillery
# Success: no issues found in 72 source files

.venv/bin/ruff check src tests
# All checks passed!
```

Closes #627


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `distillery_ingest_doc` as a new MCP tool for ingesting arbitrary documents with optional metadata (document type, source, external ID, title, project, tags).
  * Ingests content into chunked, linked entries with provenance metadata and supports idempotent re-ingestion (deduplication/skip behavior).

* **Tests**
  * Added a dedicated ingestion test suite for queryability, dedup/skip behavior, chunk linking, pagination, and invalid input handling.
  * Updated MCP server/HTTP transport tests to expect the expanded tool list (17 tools).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->