### PR TITLE
fix(feeds): tighten auto-tagger, persist per-item relevance, normalize namespaces (#628)

### DIFF
--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -21,10 +21,11 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from distillery.feeds.scorer import RelevanceScorer
+from distillery.feeds.tags import normalize_tag
 from distillery.feeds.truncation import truncate_content
 
 if TYPE_CHECKING:
-    from distillery.config import DistilleryConfig, FeedSourceConfig
+    from distillery.config import DistilleryConfig, FeedSourceConfig, TagsConfig
     from distillery.feeds.models import FeedItem
     from distillery.feeds.reader import JinaReaderClient
     from distillery.store.protocol import DistilleryStore
@@ -283,9 +284,14 @@ def build_keyword_map(vocabulary: dict[str, int]) -> dict[str, str]:
     For each tag in *vocabulary*:
 
     - Extracts the leaf segment (the last ``/``-separated part).
-    - Maps the leaf directly to the full tag path.
-    - Splits hyphenated leaves into individual words and maps each word longer
-      than 3 characters to the full tag path.
+    - Maps the **whole leaf phrase** (with hyphens treated as word boundaries)
+      to the full tag path.
+
+    Multi-word leaves are kept as a single phrase key — the individual words
+    are **not** mapped on their own.  This is a deliberate "strong signal"
+    requirement: a leaf like ``package-management`` must only match text that
+    contains the full phrase ``package management`` (in order, contiguous),
+    never a lone generic token like ``management`` (issue #628).
 
     When two tags produce the same keyword, the one with the higher occurrence
     count (or alphabetically first on tie) wins.
@@ -295,18 +301,18 @@ def build_keyword_map(vocabulary: dict[str, int]) -> dict[str, str]:
             by :meth:`~distillery.store.protocol.DistilleryStore.get_tag_vocabulary`.
 
     Returns:
-        A dict mapping lowercase keyword strings to full tag paths.
+        A dict mapping lowercase keyword/phrase strings (words separated by
+        single spaces) to full tag paths.
 
     Example::
 
-        vocab = {"domain/authentication": 5, "supply-chain-security": 2}
+        vocab = {"domain/authentication": 5, "tech/package-management": 2}
         kw_map = build_keyword_map(vocab)
-        # kw_map["authentication"]    == "domain/authentication"
-        # kw_map["supply"]            == "supply-chain-security"
-        # kw_map["chain"]             == "supply-chain-security"
-        # kw_map["security"]          == "supply-chain-security"
+        # kw_map["authentication"]      == "domain/authentication"
+        # kw_map["package management"]  == "tech/package-management"
+        # "management" is NOT a key on its own
     """
-    # keyword -> (full_tag_path, occurrence_count)
+    # keyword/phrase -> (full_tag_path, occurrence_count)
     best: dict[str, tuple[str, int]] = {}
 
     for tag, count in vocabulary.items():
@@ -314,21 +320,18 @@ def build_keyword_map(vocabulary: dict[str, int]) -> dict[str, str]:
         if tag.startswith("source/"):
             continue
         leaf = tag.rsplit("/", 1)[-1]
-        keywords: list[str] = [leaf]
-        # Split hyphenated leaf and keep words longer than 3 chars
-        for word in leaf.split("-"):
-            if len(word) > 3:
-                keywords.append(word)
-
-        for kw in keywords:
-            kw_lower = kw.lower()
-            if kw_lower not in best:
+        # Treat hyphens as word boundaries and normalise to a single-spaced
+        # phrase so matching can require the whole phrase (contiguous tokens).
+        kw_lower = " ".join(w for w in leaf.lower().split("-") if w)
+        if not kw_lower:
+            continue
+        if kw_lower not in best:
+            best[kw_lower] = (tag, count)
+        else:
+            existing_tag, existing_count = best[kw_lower]
+            # Higher count wins; alphabetical ordering breaks ties
+            if count > existing_count or (count == existing_count and tag < existing_tag):
                 best[kw_lower] = (tag, count)
-            else:
-                existing_tag, existing_count = best[kw_lower]
-                # Higher count wins; alphabetical ordering breaks ties
-                if count > existing_count or (count == existing_count and tag < existing_tag):
-                    best[kw_lower] = (tag, count)
 
     return {kw: tag for kw, (tag, _) in best.items()}
 
@@ -337,24 +340,45 @@ def match_topic_tags(text: str, keyword_map: dict[str, str]) -> list[str]:
     """Match feed item text against a keyword map to derive topic tags.
 
     Tokenises *text* into lowercase words (splitting on any non-alphanumeric
-    character) and looks each token up in *keyword_map*.  Duplicate tag paths
-    are collapsed so the returned list contains at most one entry per tag.
+    character) and looks each keyword/phrase up in *keyword_map*.  A
+    single-word keyword matches when that whole token is present; a multi-word
+    phrase matches only when its tokens appear contiguously, in order, as a
+    sub-sequence of the text tokens.  This whole-token / whole-phrase rule
+    avoids substring false-positives (e.g. a lone ``management`` token does
+    not fire ``tech/package-management``; see issue #628).  Duplicate tag
+    paths are collapsed so the returned list contains at most one entry per
+    tag.
 
     Args:
         text: The combined title + content text of a feed item.
-        keyword_map: A mapping of lowercase keyword → full tag path, as
+        keyword_map: A mapping of lowercase keyword/phrase → full tag path, as
             produced by :func:`build_keyword_map`.
 
     Returns:
         A deduplicated list of matched full tag paths; empty if nothing matched.
     """
+    if not keyword_map:
+        return []
+
+    tokens = [t for t in re.split(r"[^a-z0-9]+", text.lower()) if t]
+    if not tokens:
+        return []
+
+    token_set = set(tokens)
+    text_joined = " ".join(tokens)
+
     seen: set[str] = set()
     matched: list[str] = []
-    for token in re.split(r"[^a-z0-9]+", text.lower()):
-        if not token:
+    for keyword, full_tag in keyword_map.items():
+        if full_tag in seen:
             continue
-        full_tag = keyword_map.get(token)
-        if full_tag is not None and full_tag not in seen:
+        if " " in keyword:
+            # Multi-word phrase: require contiguous, in-order tokens.  Wrap in
+            # spaces so the match respects token boundaries (no partial-word hits).
+            if f" {keyword} " in f" {text_joined} ":
+                seen.add(full_tag)
+                matched.append(full_tag)
+        elif keyword in token_set:
             seen.add(full_tag)
             matched.append(full_tag)
 
@@ -365,6 +389,8 @@ def derive_all_tags(
     item: FeedItem,
     source_type: str,
     keyword_map: dict[str, str],
+    *,
+    tags_config: TagsConfig | None = None,
 ) -> list[str]:
     """Derive the complete tag list for a feed item.
 
@@ -376,6 +402,10 @@ def derive_all_tags(
         source_type: The adapter type string (e.g. ``'rss'``, ``'github'``).
         keyword_map: A mapping of lowercase keyword → full tag path as
             produced by :func:`build_keyword_map`.
+        tags_config: Optional :class:`~distillery.config.TagsConfig`.  When it
+            has ``enforce_namespaces=True``, reserved-prefix tags are
+            normalised on ingest so variant spellings collapse to one
+            canonical form (issue #628).
 
     Returns:
         A deduplicated list of validated tag paths; Tier-1 tags appear first.
@@ -385,13 +415,18 @@ def derive_all_tags(
     text = _item_text(item)
     topic_tags = match_topic_tags(text, keyword_map)
 
-    # Deduplicate preserving order (source tags first)
-    seen: set[str] = set(source_tags)
-    combined = list(source_tags)
-    for tag in topic_tags:
-        if tag not in seen:
-            seen.add(tag)
-            combined.append(tag)
+    # Deduplicate preserving order (source tags first), applying reserved-prefix
+    # normalisation when namespace enforcement is enabled so variant spellings
+    # collapse before dedup (issue #628).
+    normalize = bool(tags_config and tags_config.enforce_namespaces)
+    reserved = tags_config.reserved_prefixes if tags_config else []
+    seen: set[str] = set()
+    combined: list[str] = []
+    for tag in (*source_tags, *topic_tags):
+        canonical = normalize_tag(tag, reserved) if normalize else tag
+        if canonical not in seen:
+            seen.add(canonical)
+            combined.append(canonical)
 
     return combined
 
@@ -404,6 +439,7 @@ def _item_to_entry_kwargs(
     enriched_content: str | None = None,
     is_backfill: bool = False,
     is_alert: bool = False,
+    tags_config: TagsConfig | None = None,
 ) -> dict[str, Any]:
     """Convert a :class:`~distillery.feeds.models.FeedItem` to Entry constructor kwargs.
 
@@ -433,6 +469,9 @@ def _item_to_entry_kwargs(
             digest-eligible only.  See issue #472.  A downstream alert
             consumer (e.g. notification sink) is intentionally out of scope
             for this fix and is left to a follow-up.
+        tags_config: Optional :class:`~distillery.config.TagsConfig`.  When it
+            has ``enforce_namespaces=True``, reserved-prefix tags are
+            normalised so variant spellings collapse on ingest (issue #628).
 
     Returns:
         A dict of keyword arguments for :class:`~distillery.models.Entry`.
@@ -468,9 +507,18 @@ def _item_to_entry_kwargs(
         text = _item_text(item)
 
     if keyword_map is not None:
-        tags = derive_all_tags(item, item.source_type, keyword_map)
+        tags = derive_all_tags(item, item.source_type, keyword_map, tags_config=tags_config)
     else:
         tags = _derive_source_tags(item, item.source_type)
+        if tags_config and tags_config.enforce_namespaces:
+            seen: set[str] = set()
+            normalized: list[str] = []
+            for tag in tags:
+                canonical = normalize_tag(tag, tags_config.reserved_prefixes)
+                if canonical not in seen:
+                    seen.add(canonical)
+                    normalized.append(canonical)
+            tags = normalized
 
     # Use real author from source payload when available; fall back to tool name.
     # Treat None, empty, and whitespace-only authors as missing (#302).
@@ -554,6 +602,28 @@ class FeedPoller:
         # only logs once per poller instance instead of per item.
         self._alert_threshold_warning_emitted = False
         self._reader = reader
+        # Resolve the tags config once.  Reserved-prefix normalisation only
+        # activates when ``enforce_namespaces`` is a real ``True`` bool and
+        # ``reserved_prefixes`` is a real list — guards against MagicMock
+        # configs in unit tests (issue #628).
+        self._tags_config = self._resolve_tags_config(config)
+
+    @staticmethod
+    def _resolve_tags_config(config: DistilleryConfig) -> TagsConfig | None:
+        """Return ``config.tags`` only when it is usable for normalisation.
+
+        Reserved-prefix normalisation (issue #628) runs on the ingest hot path,
+        so a malformed ``tags`` section (or a ``MagicMock`` config in unit
+        tests) must never break stores.  Returns ``None`` unless
+        ``enforce_namespaces`` is a genuine ``True`` and ``reserved_prefixes``
+        is a genuine ``list`` — i.e. normalisation is both requested and safe.
+        """
+        tags = getattr(config, "tags", None)
+        enforce = getattr(tags, "enforce_namespaces", None)
+        prefixes = getattr(tags, "reserved_prefixes", None)
+        if enforce is True and isinstance(prefixes, list):
+            return tags
+        return None
 
     def _resolve_digest_threshold(self, source: FeedSourceConfig) -> float:
         """Return the effective digest threshold for *source*.
@@ -943,6 +1013,7 @@ class FeedPoller:
                     enriched_content=enriched,
                     is_backfill=is_backfill,
                     is_alert=is_alert,
+                    tags_config=self._tags_config,
                 )
                 entry = Entry(**kwargs)
                 await self._store.store(entry)

--- a/src/distillery/feeds/tags.py
+++ b/src/distillery/feeds/tags.py
@@ -26,3 +26,43 @@ def sanitise_label(label: str) -> str | None:
     candidate = label.lower().replace(" ", "-").replace("_", "-")
     candidate = re.sub(r"-+", "-", candidate).strip("-")
     return candidate if _TAG_RE.fullmatch(candidate) else None
+
+
+def normalize_tag(tag: str, reserved_prefixes: list[str]) -> str:
+    """Collapse variant spellings of a reserved-prefix tag to a canonical form.
+
+    When namespace enforcement is enabled (``tags.enforce_namespaces``), tags
+    that share a reserved top-level prefix but differ only in how their
+    sub-segments are separated should resolve to a single canonical tag so the
+    same concept does not fragment across spellings (issue #628).  Examples
+    (with ``reserved_prefixes`` containing ``"source"`` / ``"entity"``)::
+
+        source/slack/links   -> source/slack-links
+        source/slack-links   -> source/slack-links   (already canonical)
+        source/slack-dms     -> source/slack-dms     (distinct concept, kept)
+        entity/cloudflare/workers -> entity/cloudflare-workers
+
+    The canonical form keeps the reserved top-level prefix verbatim and flattens
+    everything after it into a single hyphen-joined leaf, treating ``/`` and
+    ``-`` as equivalent separators.  Tags whose top-level segment is not a
+    reserved prefix, or that have no sub-segment, are returned unchanged.
+
+    Args:
+        tag: The full tag path (already lowercased / sanitised).
+        reserved_prefixes: Top-level prefixes eligible for normalisation, from
+            :class:`~distillery.config.TagsConfig.reserved_prefixes`.
+
+    Returns:
+        The canonical tag string (unchanged when no normalisation applies).
+    """
+    if "/" not in tag:
+        return tag
+    top, remainder = tag.split("/", 1)
+    if top not in reserved_prefixes or not remainder:
+        return tag
+    # Treat '/' and '-' after the prefix as equivalent separators; collapse the
+    # remainder into a single hyphen-joined leaf so variant spellings converge.
+    leaf = "-".join(seg for seg in re.split(r"[/-]+", remainder) if seg)
+    if not leaf:
+        return tag
+    return f"{top}/{leaf}"

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -947,25 +947,25 @@ class TestBuildKeywordMap:
         kw_map = build_keyword_map({"domain/authentication": 5})
         assert kw_map.get("authentication") == "domain/authentication"
 
-    def test_hyphenated_leaf_splits_long_words(self) -> None:
-        """Hyphenated leaf segments produce individual words > 3 chars."""
+    def test_hyphenated_leaf_maps_whole_phrase(self) -> None:
+        """Hyphenated leaves map as a single spaced phrase, not individual words (#628)."""
         from distillery.feeds.poller import build_keyword_map
 
         kw_map = build_keyword_map({"security/supply-chain": 3})
-        # leaf = "supply-chain"; both "supply" and "chain" are > 3 chars
-        assert kw_map.get("supply") == "security/supply-chain"
-        assert kw_map.get("chain") == "security/supply-chain"
+        # leaf = "supply-chain" -> phrase key "supply chain"; the bare words
+        # "supply"/"chain" must NOT be standalone keys.
+        assert kw_map.get("supply chain") == "security/supply-chain"
+        assert "supply" not in kw_map
+        assert "chain" not in kw_map
 
-    def test_short_words_not_mapped(self) -> None:
-        """Words of 3 chars or fewer from hyphenated leaves are not mapped."""
+    def test_hyphenated_leaf_uses_space_separated_key(self) -> None:
+        """The whole hyphenated leaf maps via a single-spaced phrase key (#628)."""
         from distillery.feeds.poller import build_keyword_map
 
         kw_map = build_keyword_map({"ops/ci-cd": 1})
-        # leaf = "ci-cd"; "ci" (2 chars) and "cd" (2 chars) skipped
-        # The whole leaf "ci-cd" should still map
-        assert "ci" not in kw_map
-        assert "cd" not in kw_map
-        assert kw_map.get("ci-cd") == "ops/ci-cd"
+        # leaf = "ci-cd" -> phrase key "ci cd"; no hyphenated key.
+        assert "ci-cd" not in kw_map
+        assert kw_map.get("ci cd") == "ops/ci-cd"
 
     def test_higher_count_wins_on_collision(self) -> None:
         """When two tags produce the same keyword, the higher-count tag wins."""
@@ -1063,6 +1063,36 @@ class TestMatchTopicTags:
 
         result = match_topic_tags("authentication security python", {})
         assert result == []
+
+    def test_lone_generic_token_does_not_fire_phrase_tag(self) -> None:
+        """A lone 'management' token must NOT apply tech/package-management (#628)."""
+        from distillery.feeds.poller import build_keyword_map, match_topic_tags
+
+        kw_map = build_keyword_map({"tech/package-management": 3})
+        result = match_topic_tags("Effective management of remote teams", kw_map)
+        assert "tech/package-management" not in result
+
+    def test_full_phrase_fires_phrase_tag(self) -> None:
+        """The full 'package management' phrase DOES apply the tag (#628)."""
+        from distillery.feeds.poller import build_keyword_map, match_topic_tags
+
+        kw_map = build_keyword_map({"tech/package-management": 3})
+        # Both the spaced and hyphenated spellings tokenise to "package management".
+        assert "tech/package-management" in match_topic_tags(
+            "A guide to package management with uv", kw_map
+        )
+        assert "tech/package-management" in match_topic_tags(
+            "A guide to package-management with uv", kw_map
+        )
+
+    def test_phrase_requires_contiguous_in_order_tokens(self) -> None:
+        """Phrase tokens present but not contiguous/in-order do not match (#628)."""
+        from distillery.feeds.poller import build_keyword_map, match_topic_tags
+
+        kw_map = build_keyword_map({"tech/package-management": 3})
+        # "management" and "package" both present but reversed / non-adjacent.
+        result = match_topic_tags("management of every npm package", kw_map)
+        assert "tech/package-management" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -1312,6 +1342,209 @@ class TestPollCycleTopicTagIntegration:
         assert "source/rss" in stored_tags
         # No topic tags since vocabulary fetch failed
         assert "domain/authentication" not in stored_tags
+
+
+# ---------------------------------------------------------------------------
+# Reserved-prefix namespace normalisation on ingest (issue #628)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeTag:
+    """Unit tests for normalize_tag() reserved-prefix canonicalisation (#628)."""
+
+    def test_slash_and_hyphen_variants_collapse(self) -> None:
+        from distillery.feeds.tags import normalize_tag
+
+        reserved = ["source"]
+        # Both spellings collapse to one canonical form.
+        assert normalize_tag("source/slack/links", reserved) == "source/slack-links"
+        assert normalize_tag("source/slack-links", reserved) == "source/slack-links"
+
+    def test_distinct_leaves_stay_distinct(self) -> None:
+        from distillery.feeds.tags import normalize_tag
+
+        reserved = ["source"]
+        assert normalize_tag("source/slack-dms", reserved) == "source/slack-dms"
+        assert normalize_tag("source/slack-links", reserved) != normalize_tag(
+            "source/slack-dms", reserved
+        )
+
+    def test_cloudflare_entity_variants_collapse(self) -> None:
+        from distillery.feeds.tags import normalize_tag
+
+        reserved = ["entity"]
+        assert normalize_tag("entity/cloudflare/workers", reserved) == "entity/cloudflare-workers"
+        assert normalize_tag("entity/cloudflare-workers", reserved) == "entity/cloudflare-workers"
+
+    def test_non_reserved_prefix_unchanged(self) -> None:
+        from distillery.feeds.tags import normalize_tag
+
+        reserved = ["source"]
+        assert normalize_tag("entity/cloudflare/workers", reserved) == "entity/cloudflare/workers"
+
+    def test_flat_tag_unchanged(self) -> None:
+        from distillery.feeds.tags import normalize_tag
+
+        assert normalize_tag("python", ["source"]) == "python"
+
+
+class TestEnforceNamespaceNormalizationOnIngest:
+    """derive_all_tags collapses variant spellings when enforce_namespaces=True (#628)."""
+
+    @staticmethod
+    def _make_item(content: str) -> FeedItem:
+        return FeedItem(
+            source_url="https://example.com/rss",
+            source_type="rss",
+            item_id="ns-1",
+            title="",
+            content=content,
+        )
+
+    def test_topic_tag_variants_collapse_under_enforcement(self) -> None:
+        from distillery.config import TagsConfig
+        from distillery.feeds.poller import build_keyword_map, derive_all_tags
+
+        # Vocabulary holds the slashed spelling; the keyword map yields the same
+        # slashed tag path, which normalisation flattens to one canonical form.
+        # ('source/' tags are excluded from the keyword map, so use 'entity/'.)
+        kw_map = build_keyword_map({"entity/cloudflare/workers": 5})
+        item = self._make_item("a post about cloudflare workers and more")
+        cfg = TagsConfig(enforce_namespaces=True, reserved_prefixes=["entity"])
+        tags = derive_all_tags(item, "rss", kw_map, tags_config=cfg)
+        assert "entity/cloudflare-workers" in tags
+        assert "entity/cloudflare/workers" not in tags
+
+    def test_no_normalization_when_disabled(self) -> None:
+        from distillery.config import TagsConfig
+        from distillery.feeds.poller import build_keyword_map, derive_all_tags
+
+        kw_map = build_keyword_map({"entity/cloudflare/workers": 5})
+        item = self._make_item("a post about cloudflare workers and more")
+        cfg = TagsConfig(enforce_namespaces=False, reserved_prefixes=["entity"])
+        tags = derive_all_tags(item, "rss", kw_map, tags_config=cfg)
+        # Off-by-default: the variant spelling is preserved verbatim.
+        assert "entity/cloudflare/workers" in tags
+
+    def test_item_to_entry_kwargs_normalizes_source_tags(self) -> None:
+        from distillery.config import TagsConfig
+        from distillery.feeds.poller import _item_to_entry_kwargs
+
+        # Source tags are already canonical; confirm enforcement path is safe
+        # and dedupes when keyword_map is None (source-only branch).
+        item = self._make_item("nothing topical here")
+        cfg = TagsConfig(enforce_namespaces=True, reserved_prefixes=["source"])
+        kwargs = _item_to_entry_kwargs(item, 0.5, None, tags_config=cfg)
+        assert "source/rss" in kwargs["tags"]
+
+
+# ---------------------------------------------------------------------------
+# relevance_score is computed and persisted per item (issue #628)
+# ---------------------------------------------------------------------------
+
+
+class TestRelevanceScorePersistedPerItem:
+    """The poll-ingest path stores the computed per-item score, not a 1.0 sentinel."""
+
+    @pytest.mark.asyncio
+    async def test_scored_batch_relevance_scores_vary(self) -> None:
+        """A scored batch yields varying relevance_score values (not all 1.0) (#628)."""
+        from distillery.config import (
+            ClassificationConfig,
+            DistilleryConfig,
+            EmbeddingConfig,
+            StorageConfig,
+        )
+        from distillery.feeds.poller import FeedPoller, _item_text
+        from distillery.models import Entry, EntrySource, EntryType
+        from distillery.store.duckdb import DuckDBStore
+        from tests.conftest import ControlledEmbeddingProvider
+
+        emb = ControlledEmbeddingProvider()
+        # One anchor entry the items will be scored against.
+        anchor_text = "Anchor: oauth authentication and session security"
+        emb.register(anchor_text, [1, 0, 0, 0, 0, 0, 0, 0])
+
+        store = DuckDBStore(db_path=":memory:", embedding_provider=emb)
+        await store.initialize()
+        await store.store(
+            Entry(
+                content=anchor_text,
+                entry_type=EntryType.REFERENCE,
+                source=EntrySource.MANUAL,
+                author="tester",
+            )
+        )
+
+        # Three feed items at deliberately different similarities to the anchor.
+        items = [
+            FeedItem(
+                source_url="https://example.com/rss",
+                source_type="rss",
+                item_id="hi",
+                title="High match",
+                content="hi-text",
+            ),
+            FeedItem(
+                source_url="https://example.com/rss",
+                source_type="rss",
+                item_id="mid",
+                title="Mid match",
+                content="mid-text",
+            ),
+            FeedItem(
+                source_url="https://example.com/rss",
+                source_type="rss",
+                item_id="lo",
+                title="Low match",
+                content="lo-text",
+            ),
+        ]
+        # Register embeddings for each item's combined title+content text.
+        emb.register(_item_text(items[0]), [0.95, 0.31, 0, 0, 0, 0, 0, 0])
+        emb.register(_item_text(items[1]), [0.6, 0.8, 0, 0, 0, 0, 0, 0])
+        emb.register(_item_text(items[2]), [0.1, 0.99, 0, 0, 0, 0, 0, 0])
+
+        config = DistilleryConfig(
+            storage=StorageConfig(database_path=":memory:"),
+            embedding=EmbeddingConfig(provider="", model="stub", dimensions=8),
+            classification=ClassificationConfig(confidence_threshold=0.6),
+        )
+        # Store everything regardless of score so the whole batch lands.
+        config.feeds.thresholds.digest = 0.0
+        config.feeds.thresholds.alert = 1.0
+
+        # Register the source in the store so poll() picks it up.
+        await store.add_feed_source(
+            url="https://example.com/rss",
+            source_type="rss",
+            poll_interval_minutes=60,
+            trust_weight=1.0,
+        )
+
+        with patch("distillery.feeds.poller._build_adapter") as mock_build_adapter:
+            mock_adapter = MagicMock()
+            mock_adapter.fetch.return_value = items
+            mock_build_adapter.return_value = mock_adapter
+
+            poller = FeedPoller(store=store, config=config)
+            summary = await poller.poll()
+
+        assert summary.total_stored == 3
+
+        # Pull the stored feed entries back and inspect their persisted scores.
+        feed_entries = await store.list_entries(
+            {"entry_type": "feed"}, limit=100, offset=0
+        )
+        scores = sorted(e.metadata["relevance_score"] for e in feed_entries)
+        assert len(scores) == 3
+        # The scores must vary — not all pinned at the 1.0 sentinel.
+        assert len(set(scores)) > 1
+        assert not all(s == 1.0 for s in scores)
+        # And they must be usable for ordering (strictly increasing once sorted).
+        assert scores[0] < scores[-1]
+
+        await store.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

1. **Auto-tagger over-application.** `build_keyword_map` split each hyphenated tag leaf into individual words and mapped every word > 3 chars to the full tag path. So `tech/package-management` registered `management` as a standalone key, and `entity/build-sandbox` registered `build` and `sandbox`. `match_topic_tags` then fired the tag on any single token hit, producing the observed mass over-tagging (`entity/build-sandbox` on 3,651 entries, `tech/cloud-hypervisor` on 1,157).

2. **`relevance_score` stuck at `1.0`.** This was a scope-finding: the poll path already computes and persists a per-item `adjusted_score = score * trust_weight` into `metadata.relevance_score` (`poller.py:1009-1017`). There was no end-to-end test proving real, varying scores reach storage, so the regression had no guard.

3. **Namespace fragmentation.** With `enforce_namespaces: false`, variant spellings (`source/slack/links` vs `source/slack-links`, four `entity/cloudflare*` spellings) never converged. There was no normalization step on ingest.

## Fix

**`feeds/poller.py` — strong-signal matcher.** `build_keyword_map` now maps the **whole leaf phrase** (hyphens treated as word boundaries, normalized to a single-spaced key) and never the individual words:

    # kw_map["package management"] == "tech/package-management"
    # "management" is NOT a key on its own

`match_topic_tags` matches a single-word key only on a whole token, and a multi-word phrase only when its tokens appear contiguously and in order (` {keyword} ` wrapped in a spaced join). A lone `build` token no longer fires `entity/build-sandbox`; only the contiguous phrase `build sandbox` does.

**`feeds/tags.py` — `normalize_tag(tag, reserved_prefixes)`.** Collapses variant spellings of a reserved-prefix tag to a canonical hyphen-joined leaf, treating `/` and `-` as equivalent separators after the prefix. No-op on flat tags, non-reserved prefixes, and already-canonical tags.

**`feeds/poller.py` — wire normalization through ingest.** `derive_all_tags` and `_item_to_entry_kwargs` take an optional `tags_config`; normalization runs only when `enforce_namespaces=True`. `FeedPoller._resolve_tags_config` resolves `config.tags` once and returns `None` unless `enforce_namespaces is True` and `reserved_prefixes` is a genuine `list` (MagicMock-safe guard for unit tests).

Feature is off by default (`enforce_namespaces=False`; default `reserved_prefixes=["kind"]`), so existing behavior is unchanged unless explicitly opted in.

## Acceptance

- [x] **Spot-check: `entity/build-sandbox` entries are on-topic.** Over-tagging eliminated at the source — `match_topic_tags` no longer fires on lone generic tokens. Proven by `test_lone_generic_token_does_not_fire_phrase_tag`, `test_full_phrase_fires_phrase_tag`, `test_phrase_requires_contiguous_in_order_tokens`, and `build_keyword_map` tests `test_hyphenated_leaf_maps_whole_phrase` / `test_hyphenated_leaf_uses_space_separated_key`.
- [x] **`relevance_score` varies across feed entries and is usable for sort/threshold.** End-to-end regression (real `DuckDBStore`, real poll, read-back) asserts 3 distinct sorted `metadata.relevance_score` values rather than the `1.0` sentinel.
- [x] **Namespace normalization (`enforce_namespaces: true` + reserved-prefix map).** `test_slash_and_hyphen_variants_collapse`, `test_cloudflare_entity_variants_collapse`, `test_distinct_leaves_stay_distinct`, `test_non_reserved_prefix_unchanged`, `test_flat_tag_unchanged`, `test_topic_tag_variants_collapse_under_enforcement`, `test_item_to_entry_kwargs_normalizes_source_tags`, and `test_no_normalization_when_disabled` (flag-OFF preserves current behavior).

## Test plan

    PYTHONPATH="$PWD/src" .venv/bin/python -m pytest tests/test_feeds.py tests/test_poller.py -q
    # 177 passed, 2 warnings (pre-existing AsyncMock artifacts in untouched test_poller.py)

    PYTHONPATH="$PWD/src" .venv/bin/mypy --strict src/distillery
    # Success: no issues found in 72 source files

    .venv/bin/ruff check src tests
    # All checks passed!

## Related

Shares files with sibling PRs in this batch (`feeds/poller.py`, `store/duckdb.py`, and/or `config.py`) and may conflict on merge. Merge the smaller/independent PRs first and rebase this one; resolve semantically so both issues' behavior coexists.

Closes #628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topic tag matching precision to prevent unintended partial-word matches in feed content.

* **New Features**
  * Added support for reserved-prefix tag namespace enforcement to normalize tag formats.
  * Enhanced tag matching with better phrase and keyword boundary handling.

* **Tests**
  * Expanded test coverage for tag matching, namespace normalization, and relevance score persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->