### PR TITLE
store: config-gated semantic auto-link on ingest (#629)

### DIFF
--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -653,6 +653,9 @@ def _cmd_poll(config_path: str | None, fmt: str, source_url: str | None) -> int:
             rrf_k=cfg.defaults.rrf_k,
             recency_window_days=cfg.defaults.recency_window_days,
             recency_min_weight=cfg.defaults.recency_min_weight,
+            auto_link_enabled=cfg.auto_link.enabled,
+            auto_link_threshold=cfg.auto_link.threshold,
+            auto_link_max_links=cfg.auto_link.max_links,
         )
         await store.initialize()
 
@@ -806,6 +809,9 @@ def _cmd_retag(
             rrf_k=cfg.defaults.rrf_k,
             recency_window_days=cfg.defaults.recency_window_days,
             recency_min_weight=cfg.defaults.recency_min_weight,
+            auto_link_enabled=cfg.auto_link.enabled,
+            auto_link_threshold=cfg.auto_link.threshold,
+            auto_link_max_links=cfg.auto_link.max_links,
         )
         await store.initialize()
 
@@ -928,6 +934,9 @@ def _cmd_gh_backfill(
             rrf_k=cfg.defaults.rrf_k,
             recency_window_days=cfg.defaults.recency_window_days,
             recency_min_weight=cfg.defaults.recency_min_weight,
+            auto_link_enabled=cfg.auto_link.enabled,
+            auto_link_threshold=cfg.auto_link.threshold,
+            auto_link_max_links=cfg.auto_link.max_links,
         )
         await store.initialize()
         try:
@@ -1196,6 +1205,9 @@ def _cmd_import(
             rrf_k=cfg.defaults.rrf_k,
             recency_window_days=cfg.defaults.recency_window_days,
             recency_min_weight=cfg.defaults.recency_min_weight,
+            auto_link_enabled=cfg.auto_link.enabled,
+            auto_link_threshold=cfg.auto_link.threshold,
+            auto_link_max_links=cfg.auto_link.max_links,
         )
         await store.initialize()
 
@@ -1894,6 +1906,9 @@ def _cmd_maintenance_classify(
             rrf_k=cfg.defaults.rrf_k,
             recency_window_days=cfg.defaults.recency_window_days,
             recency_min_weight=cfg.defaults.recency_min_weight,
+            auto_link_enabled=cfg.auto_link.enabled,
+            auto_link_threshold=cfg.auto_link.threshold,
+            auto_link_max_links=cfg.auto_link.max_links,
         )
         try:
             await store.initialize()

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -764,10 +764,13 @@ def _parse_auto_link(raw: dict[str, Any]) -> AutoLinkConfig:
         A populated :class:`AutoLinkConfig` instance.
 
     Raises:
-        ValueError: If ``enabled`` is not a boolean, ``threshold`` is not a
-            float, or ``max_links`` is not an integer.  Range checks are
-            deferred to :func:`_validate`.
+        ValueError: If ``raw`` is not a mapping, ``enabled`` is not a boolean,
+            ``threshold`` is not a float, or ``max_links`` is not an integer.
+            Range checks are deferred to :func:`_validate`.
     """
+    if not isinstance(raw, dict):
+        raise ValueError(f"auto_link must be a YAML mapping, got: {type(raw).__name__}")
+
     enabled_raw = raw.get("enabled", False)
     if not isinstance(enabled_raw, bool):
         raise ValueError(f"auto_link.enabled must be a boolean, got: {enabled_raw!r}")

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -160,6 +160,38 @@ class ClassificationConfig:
 
 
 @dataclass
+class AutoLinkConfig:
+    """Semantic auto-link configuration for the write path (issue #629).
+
+    When :attr:`enabled` is ``True``, every newly stored entry (via
+    ``store`` / ``store_batch``, including feed poll-ingest) is linked to its
+    embedding-neighbours whose cosine similarity is at or above
+    :attr:`threshold`, persisting ``related`` edges in ``entry_relations``.
+    This is the automatic counterpart to ``distillery_find_similar(
+    accept_action="link")`` (issue #490 mechanism #2): it wires that primitive
+    into the write path so feed-heavy instances stop accumulating graph
+    orphans.  Idempotent via the unique ``(from_id, to_id, relation_type)``
+    index, and capped at :attr:`max_links` edges per entry to respect the
+    embedding/query budget.
+
+    Disabled by default — with :attr:`enabled` ``False`` the write path
+    behaves exactly as before (no semantic edges are created).
+
+    Attributes:
+        enabled: Whether to create semantic ``related`` edges on ingest.
+            Defaults to ``False``.
+        threshold: Normalised cosine similarity score in ``[0.0, 1.0]`` at or
+            above which a neighbour is linked.  Defaults to ``0.85``.
+        max_links: Maximum number of ``related`` edges to create per stored
+            entry (throttle).  Must be a positive integer.  Defaults to ``5``.
+    """
+
+    enabled: bool = False
+    threshold: float = 0.85
+    max_links: int = 5
+
+
+@dataclass
 class TagsConfig:
     """Tag namespace configuration.
 
@@ -455,6 +487,7 @@ class DistilleryConfig:
         team: Team-level metadata settings.
         defaults: Handler-level operational defaults.
         classification: Classification threshold settings.
+        auto_link: Semantic auto-link settings for the write path.
         tags: Tag namespace enforcement settings.
         feeds: Ambient feed monitoring settings.
         rate_limit: Rate limiting and resource budget settings.
@@ -466,6 +499,7 @@ class DistilleryConfig:
     team: TeamConfig = field(default_factory=TeamConfig)
     defaults: DefaultsConfig = field(default_factory=DefaultsConfig)
     classification: ClassificationConfig = field(default_factory=ClassificationConfig)
+    auto_link: AutoLinkConfig = field(default_factory=AutoLinkConfig)
     tags: TagsConfig = field(default_factory=TagsConfig)
     feeds: FeedsConfig = field(default_factory=FeedsConfig)
     rate_limit: RateLimitConfig = field(default_factory=RateLimitConfig)
@@ -714,6 +748,39 @@ def _parse_classification(raw: dict[str, Any]) -> ClassificationConfig:
         stale_days=stale_days,
         conflict_threshold=conflict_threshold,
         mode=mode,
+    )
+
+
+def _parse_auto_link(raw: dict[str, Any]) -> AutoLinkConfig:
+    """Parse the ``auto_link`` section from a raw YAML mapping (issue #629).
+
+    Parameters:
+        raw: Mapping (typically from YAML) containing any of:
+            - ``enabled`` (bool, default ``False``)
+            - ``threshold`` (float, default ``0.85``)
+            - ``max_links`` (int or int-string, default ``5``)
+
+    Returns:
+        A populated :class:`AutoLinkConfig` instance.
+
+    Raises:
+        ValueError: If ``enabled`` is not a boolean, ``threshold`` is not a
+            float, or ``max_links`` is not an integer.  Range checks are
+            deferred to :func:`_validate`.
+    """
+    enabled_raw = raw.get("enabled", False)
+    if not isinstance(enabled_raw, bool):
+        raise ValueError(f"auto_link.enabled must be a boolean, got: {enabled_raw!r}")
+
+    threshold = _parse_float_field(raw, "threshold", 0.85, "auto_link.threshold")
+
+    max_links_raw = raw.get("max_links", 5)
+    max_links = _parse_strict_int(max_links_raw, "auto_link.max_links")
+
+    return AutoLinkConfig(
+        enabled=enabled_raw,
+        threshold=threshold,
+        max_links=max_links,
     )
 
 
@@ -1253,6 +1320,8 @@ def _validate(config: DistilleryConfig) -> None:
             - classification.feedback_window_minutes is not greater than 0.
             - classification.stale_days is not greater than 0.
             - classification.conflict_threshold is not between 0.0 and 1.0.
+            - auto_link.threshold is not between 0.0 and 1.0.
+            - auto_link.max_links is not greater than 0.
             - Any entry in tags.reserved_prefixes is not a valid tag segment.
             - feeds.thresholds.alert is not between 0.0 and 1.0.
             - feeds.thresholds.digest is not between 0.0 and 1.0.
@@ -1337,6 +1406,17 @@ def _validate(config: DistilleryConfig) -> None:
     if not (0.0 <= conflict <= 1.0):
         raise ValueError(
             f"classification.conflict_threshold must be between 0.0 and 1.0, got: {conflict}"
+        )
+
+    # Validate auto_link settings (issue #629).
+    auto_link_threshold = config.auto_link.threshold
+    if not (0.0 <= auto_link_threshold <= 1.0):
+        raise ValueError(
+            f"auto_link.threshold must be between 0.0 and 1.0, got: {auto_link_threshold}"
+        )
+    if config.auto_link.max_links <= 0:
+        raise ValueError(
+            f"auto_link.max_links must be a positive integer, got: {config.auto_link.max_links}"
         )
 
     # Validate reserved_prefixes: each must be a valid single tag segment.
@@ -1464,6 +1544,7 @@ def load_config(config_path: str | None = None) -> DistilleryConfig:
     team_raw = raw.get("team", {}) or {}
     defaults_raw = raw.get("defaults", {}) or {}
     classification_raw = raw.get("classification", {}) or {}
+    auto_link_raw = raw.get("auto_link", {}) or {}
     tags_raw = raw.get("tags", {}) or {}
     feeds_raw = raw.get("feeds", {}) or {}
     rate_limit_raw = raw.get("rate_limit", {}) or {}
@@ -1477,6 +1558,7 @@ def load_config(config_path: str | None = None) -> DistilleryConfig:
         team=_parse_team(team_raw),
         defaults=_parse_defaults(defaults_raw),
         classification=_parse_classification(classification_raw),
+        auto_link=_parse_auto_link(auto_link_raw),
         tags=_parse_tags(tags_raw),
         feeds=_parse_feeds(feeds_raw),
         rate_limit=_parse_rate_limit(rate_limit_raw),

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -178,6 +178,9 @@ def _build_background_store_factory(
             embedding_provider=ep,
             s3_region=config.storage.s3_region,
             s3_endpoint=config.storage.s3_endpoint,
+            auto_link_enabled=config.auto_link.enabled,
+            auto_link_threshold=config.auto_link.threshold,
+            auto_link_max_links=config.auto_link.max_links,
         )
         await store.initialize()
         return store
@@ -227,6 +230,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 embedding_provider=ep,
                 s3_region=config.storage.s3_region,
                 s3_endpoint=config.storage.s3_endpoint,
+                auto_link_enabled=config.auto_link.enabled,
+                auto_link_threshold=config.auto_link.threshold,
+                auto_link_max_links=config.auto_link.max_links,
             )
             await store.initialize()
             if await store.get_metadata("feeds_seeded") != "true":

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -474,6 +474,9 @@ async def _ensure_store(
             embedding_provider=embedding_provider,
             s3_region=config.storage.s3_region,
             s3_endpoint=config.storage.s3_endpoint,
+            auto_link_enabled=config.auto_link.enabled,
+            auto_link_threshold=config.auto_link.threshold,
+            auto_link_max_links=config.auto_link.max_links,
         )
         await store.initialize()
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1411,8 +1411,10 @@ class DuckDBStore:
         wired into the write path (issue #629).  For the just-stored entry,
         finds up to ``self._auto_link_max_links`` non-archived neighbours whose
         normalised cosine similarity is at or above ``self._auto_link_threshold``
-        (excluding the entry itself and any target already linked via a
-        ``related`` edge) and inserts ``related`` rows into ``entry_relations``.
+        (excluding the entry itself and any target already linked to it in
+        either direction via any relation_type — matching the shipped
+        ``exclude_linked`` primitive) and inserts ``related`` rows into
+        ``entry_relations``.
 
         Idempotent via the unique ``(from_id, to_id, relation_type)`` index, so
         re-running ingest over an already-linked entry inserts nothing new.
@@ -1433,10 +1435,12 @@ class DuckDBStore:
 
         dims = self._embedding_provider.dimensions
         # Convert normalised [0, 1] threshold to raw [-1, 1] for SQL comparison,
-        # mirroring find_similar(). Exclude self, archived entries, and targets
-        # already linked via a ``related`` edge (exclude_linked semantics), and
-        # cap the candidate set at the throttle so we never scan more rows than
-        # the budget allows.
+        # mirroring find_similar(). Exclude self, archived entries, and any
+        # target already linked to ``from_id`` in either direction via any
+        # relation_type — matching the shipped exclude_linked primitive
+        # (mcp/tools/search.py, which calls get_related(direction="both") with
+        # no relation_type filter; PR #495 / issue #490 mechanism #2). Cap the
+        # candidate set at the throttle so we never scan more rows than budget.
         raw_threshold = self._auto_link_threshold * 2.0 - 1.0
         candidate_sql = (
             f"SELECT id FROM entries "
@@ -1444,8 +1448,9 @@ class DuckDBStore:
             f"AND status != ? "
             f"AND array_cosine_similarity(embedding, ?::FLOAT[{dims}]) >= ? "
             f"AND id NOT IN ("
-            f"  SELECT to_id FROM entry_relations "
-            f"  WHERE from_id = ? AND relation_type = 'related'"
+            f"  SELECT to_id FROM entry_relations WHERE from_id = ? "
+            f"  UNION "
+            f"  SELECT from_id FROM entry_relations WHERE to_id = ?"
             f") "
             f"ORDER BY array_cosine_similarity(embedding, ?::FLOAT[{dims}]) DESC "
             f"LIMIT ?"
@@ -1455,6 +1460,7 @@ class DuckDBStore:
             EntryStatus.ARCHIVED.value,
             embedding,
             raw_threshold,
+            from_id,
             from_id,
             embedding,
             self._auto_link_max_links,

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -171,6 +171,9 @@ class DuckDBStore:
         rrf_k: int = 60,
         recency_window_days: int = 90,
         recency_min_weight: float = 0.5,
+        auto_link_enabled: bool = False,
+        auto_link_threshold: float = 0.85,
+        auto_link_max_links: int = 5,
     ) -> None:
         self._db_path = db_path
         self._embedding_provider = embedding_provider
@@ -203,6 +206,11 @@ class DuckDBStore:
         self._rrf_k: int = rrf_k
         self._recency_window_days: int = recency_window_days
         self._recency_min_weight: float = recency_min_weight
+        # Semantic auto-link on the write path (issue #629). OFF by default so
+        # the store behaves byte-for-byte as before unless a deployment opts in.
+        self._auto_link_enabled: bool = auto_link_enabled
+        self._auto_link_threshold: float = auto_link_threshold
+        self._auto_link_max_links: int = auto_link_max_links
         # Serializes access to the shared ``DuckDBPyConnection``.  DuckDB
         # connections are **not** thread-safe for concurrent use, but every
         # store operation funnels through ``asyncio.to_thread`` which runs
@@ -1391,6 +1399,82 @@ class DuckDBStore:
                 inserted += 1
         return inserted
 
+    def _auto_link_semantic(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        from_id: str,
+        embedding: list[float],
+    ) -> int:
+        """Link *from_id* to its embedding-neighbours above the auto-link threshold.
+
+        Mechanism #2 from issue #490 (``find_similar(accept_action="link")``)
+        wired into the write path (issue #629).  For the just-stored entry,
+        finds up to ``self._auto_link_max_links`` non-archived neighbours whose
+        normalised cosine similarity is at or above ``self._auto_link_threshold``
+        (excluding the entry itself and any target already linked via a
+        ``related`` edge) and inserts ``related`` rows into ``entry_relations``.
+
+        Idempotent via the unique ``(from_id, to_id, relation_type)`` index, so
+        re-running ingest over an already-linked entry inserts nothing new.
+
+        No-op when ``self._auto_link_enabled`` is ``False`` — preserving the
+        prior write-path behaviour exactly.
+
+        Args:
+            conn: Active DuckDB connection (caller manages the transaction).
+            from_id: UUID of the source entry just stored.
+            embedding: The source entry's embedding vector.
+
+        Returns:
+            Number of ``related`` rows actually inserted.
+        """
+        if not self._auto_link_enabled:
+            return 0
+
+        dims = self._embedding_provider.dimensions
+        # Convert normalised [0, 1] threshold to raw [-1, 1] for SQL comparison,
+        # mirroring find_similar(). Exclude self, archived entries, and targets
+        # already linked via a ``related`` edge (exclude_linked semantics), and
+        # cap the candidate set at the throttle so we never scan more rows than
+        # the budget allows.
+        raw_threshold = self._auto_link_threshold * 2.0 - 1.0
+        candidate_sql = (
+            f"SELECT id FROM entries "
+            f"WHERE id != ? "
+            f"AND status != ? "
+            f"AND array_cosine_similarity(embedding, ?::FLOAT[{dims}]) >= ? "
+            f"AND id NOT IN ("
+            f"  SELECT to_id FROM entry_relations "
+            f"  WHERE from_id = ? AND relation_type = 'related'"
+            f") "
+            f"ORDER BY array_cosine_similarity(embedding, ?::FLOAT[{dims}]) DESC "
+            f"LIMIT ?"
+        )
+        candidate_params: list[Any] = [
+            from_id,
+            EntryStatus.ARCHIVED.value,
+            embedding,
+            raw_threshold,
+            from_id,
+            embedding,
+            self._auto_link_max_links,
+        ]
+        rows = conn.execute(candidate_sql, candidate_params).fetchall()
+
+        inserted = 0
+        for row in rows:
+            to_id = row[0]
+            relation_id = str(uuid.uuid4())
+            result = conn.execute(
+                "INSERT OR IGNORE INTO entry_relations "
+                "(id, from_id, to_id, relation_type) "
+                "VALUES (?, ?, ?, 'related') RETURNING id",
+                [relation_id, from_id, to_id],
+            ).fetchone()
+            if result is not None:
+                inserted += 1
+        return inserted
+
     def _sync_store(self, entry: Entry, embedding: list[float]) -> str:
         """Synchronous implementation of store(); called via asyncio.to_thread.
 
@@ -1436,6 +1520,10 @@ class DuckDBStore:
         # error surface to the caller (mirrors transactional intent — caller's
         # outer retry/abort logic decides how to handle).
         self._fan_out_related_entries(conn, entry.id, entry.metadata)
+        # Semantic auto-link on ingest (issue #629): when enabled, link the new
+        # entry to its embedding-neighbours above threshold so feed-heavy
+        # instances stop accumulating graph orphans. No-op when disabled.
+        self._auto_link_semantic(conn, entry.id, embedding)
         # Rebuild FTS index so new content is searchable via BM25.
         self._rebuild_fts_index(conn)
         # Flush WAL so the new row survives ungraceful termination.
@@ -1522,6 +1610,15 @@ class DuckDBStore:
             # transactional view.
             for entry in entries:
                 self._fan_out_related_entries(conn, entry.id, entry.metadata)
+            # Semantic auto-link on ingest (issue #629): when enabled, link each
+            # batched entry to its embedding-neighbours above threshold inside
+            # the same transaction as the inserts so a partial run rolls back
+            # together. No-op when disabled. Entries earlier in this batch are
+            # visible via the in-flight transactional view, so a batch can form
+            # internal edges. Run after the inserts so the candidate pool sees
+            # every row in the batch.
+            for entry, embedding in zip(entries, embeddings, strict=True):
+                self._auto_link_semantic(conn, entry.id, embedding)
             conn.commit()
         except Exception:
             conn.rollback()

--- a/tests/test_auto_link_on_write.py
+++ b/tests/test_auto_link_on_write.py
@@ -1,0 +1,195 @@
+"""Tests for issue #629 — config-gated semantic auto-link on ingest.
+
+PR #495 shipped the semantic-link primitive (mechanism #2:
+``distillery_find_similar(accept_action="link", exclude_linked=true)``).
+Issue #629 wires that primitive into the write path so newly stored / polled
+entries automatically gain ``related`` edges to their embedding-neighbours
+above a configurable threshold — OFF by default.
+
+These tests exercise the store-level hook directly (``store`` / ``store_batch``,
+which the feed poller calls) using the 8-dimensional ``ControlledEmbeddingProvider``
+so cosine similarity is reproducible.
+
+Acceptance covered:
+  * flag ON  → a newly stored entry gains ``related`` edges to semantic
+    neighbours above threshold.
+  * flag OFF → NO semantic edges created (current behaviour preserved).
+  * re-running ingest is idempotent (no duplicate edges).
+  * the throttle cap (``max_links``) is respected.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from distillery.store.duckdb import DuckDBStore
+from tests.conftest import ControlledEmbeddingProvider, make_entry
+
+pytestmark = pytest.mark.unit
+
+
+# Two registered 8D vectors: identical → cosine 1.0 (normalised 1.0, well above
+# the 0.85 threshold), and orthogonal → cosine 0.0 (normalised 0.5, below it).
+_NEAR = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+_FAR = [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+@pytest.fixture
+async def auto_link_store(
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> AsyncIterator[DuckDBStore]:
+    """In-memory store with semantic auto-link ENABLED (threshold 0.85, cap 5)."""
+    s = DuckDBStore(
+        db_path=":memory:",
+        embedding_provider=controlled_embedding_provider,
+        auto_link_enabled=True,
+        auto_link_threshold=0.85,
+        auto_link_max_links=5,
+    )
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+@pytest.fixture
+async def no_auto_link_store(
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> AsyncIterator[DuckDBStore]:
+    """In-memory store with auto-link at its DEFAULT (disabled)."""
+    s = DuckDBStore(
+        db_path=":memory:",
+        embedding_provider=controlled_embedding_provider,
+    )
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+async def test_flag_on_links_to_neighbours_above_threshold(
+    auto_link_store: DuckDBStore,
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> None:
+    """With the flag on, a stored entry gains 'related' edges to near neighbours only."""
+    controlled_embedding_provider.register("source", _NEAR)
+    controlled_embedding_provider.register("near one", _NEAR)
+    controlled_embedding_provider.register("near two", _NEAR)
+    controlled_embedding_provider.register("far one", _FAR)
+
+    n1 = await auto_link_store.store(make_entry(content="near one"))
+    n2 = await auto_link_store.store(make_entry(content="near two"))
+    await auto_link_store.store(make_entry(content="far one"))
+
+    src_id = await auto_link_store.store(make_entry(content="source"))
+
+    rows = await auto_link_store.get_related(src_id, direction="outgoing")
+    to_ids = {r["to_id"] for r in rows}
+    # Only the two near (cosine 1.0) neighbours are linked; the orthogonal one
+    # (normalised 0.5 < 0.85) is excluded.
+    assert to_ids == {n1, n2}
+    assert {r["relation_type"] for r in rows} == {"related"}
+
+
+async def test_flag_off_creates_no_semantic_edges(
+    no_auto_link_store: DuckDBStore,
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> None:
+    """With the flag off (default), no semantic edges are created — current behaviour."""
+    controlled_embedding_provider.register("source", _NEAR)
+    controlled_embedding_provider.register("near one", _NEAR)
+
+    await no_auto_link_store.store(make_entry(content="near one"))
+    src_id = await no_auto_link_store.store(make_entry(content="source"))
+
+    rows = await no_auto_link_store.get_related(src_id, direction="outgoing")
+    assert rows == []
+    # And the relations table itself is empty (no incoming edges either).
+    total = no_auto_link_store.connection.execute(
+        "SELECT COUNT(*) FROM entry_relations"
+    ).fetchone()
+    assert total is not None and total[0] == 0
+
+
+async def test_auto_link_is_idempotent_on_re_store(
+    auto_link_store: DuckDBStore,
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> None:
+    """Re-running the auto-link path over an already-linked entry adds no duplicates."""
+    controlled_embedding_provider.register("source", _NEAR)
+    controlled_embedding_provider.register("near one", _NEAR)
+
+    n1 = await auto_link_store.store(make_entry(content="near one"))
+    src_id = await auto_link_store.store(make_entry(content="source"))
+
+    rows_before = await auto_link_store.get_related(src_id, direction="outgoing")
+    assert {r["to_id"] for r in rows_before} == {n1}
+    assert len(rows_before) == 1
+
+    # Re-run the hook directly (simulates re-ingest of the same entry) — the
+    # unique (from_id, to_id, relation_type) index plus the exclude-linked
+    # filter make it a no-op.
+    embedding = controlled_embedding_provider.embed("source")
+    inserted = await auto_link_store._run_sync(
+        auto_link_store._auto_link_semantic,
+        auto_link_store.connection,
+        src_id,
+        embedding,
+    )
+    assert inserted == 0
+
+    rows_after = await auto_link_store.get_related(src_id, direction="outgoing")
+    assert len(rows_after) == 1
+
+
+async def test_auto_link_respects_max_links_cap(
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> None:
+    """The throttle caps edges per entry at auto_link_max_links."""
+    s = DuckDBStore(
+        db_path=":memory:",
+        embedding_provider=controlled_embedding_provider,
+        auto_link_enabled=True,
+        auto_link_threshold=0.85,
+        auto_link_max_links=2,
+    )
+    await s.initialize()
+    try:
+        controlled_embedding_provider.register("source", _NEAR)
+        # Five near neighbours, all above threshold — but the cap is 2.
+        for i in range(5):
+            controlled_embedding_provider.register(f"near {i}", _NEAR)
+            await s.store(make_entry(content=f"near {i}"))
+
+        src_id = await s.store(make_entry(content="source"))
+
+        rows = await s.get_related(src_id, direction="outgoing")
+        assert len(rows) == 2
+        assert {r["relation_type"] for r in rows} == {"related"}
+    finally:
+        await s.close()
+
+
+async def test_store_batch_auto_links_each_entry(
+    auto_link_store: DuckDBStore,
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> None:
+    """store_batch links each batched entry to a pre-existing near neighbour."""
+    controlled_embedding_provider.register("anchor", _NEAR)
+    controlled_embedding_provider.register("b1", _NEAR)
+    controlled_embedding_provider.register("b2", _NEAR)
+
+    anchor_id = await auto_link_store.store(make_entry(content="anchor"))
+
+    e1 = make_entry(content="b1")
+    e2 = make_entry(content="b2")
+    [e1_id, e2_id] = await auto_link_store.store_batch([e1, e2])
+
+    rows1 = await auto_link_store.get_related(e1_id, direction="outgoing")
+    rows2 = await auto_link_store.get_related(e2_id, direction="outgoing")
+    # Each batched entry links to the anchor (and to its in-batch sibling, which
+    # is visible via the in-flight transactional view).
+    assert anchor_id in {r["to_id"] for r in rows1}
+    assert anchor_id in {r["to_id"] for r in rows2}
+    assert {r["relation_type"] for r in rows1} == {"related"}
+    assert {r["relation_type"] for r in rows2} == {"related"}

--- a/tests/test_auto_link_on_write.py
+++ b/tests/test_auto_link_on_write.py
@@ -142,6 +142,58 @@ async def test_auto_link_is_idempotent_on_re_store(
     assert len(rows_after) == 1
 
 
+async def test_auto_link_skips_targets_linked_in_any_direction_or_type(
+    auto_link_store: DuckDBStore,
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> None:
+    """exclude_linked matches the shipped primitive: incoming + non-``related`` edges suppress.
+
+    The shipped ``find_similar(exclude_linked=true)`` primitive
+    (mcp/tools/search.py) excludes any neighbour already linked to the source in
+    *either direction* via *any relation_type* (it calls
+    ``get_related(direction="both")`` with no relation_type filter). The
+    write-path hook must not be more permissive than that primitive.
+    """
+    controlled_embedding_provider.register("source", _NEAR)
+    controlled_embedding_provider.register("incoming nbr", _NEAR)
+    controlled_embedding_provider.register("typed nbr", _NEAR)
+    controlled_embedding_provider.register("fresh nbr", _NEAR)
+
+    # Seed entries + edges with the hook disabled so the only auto-link run is
+    # the one under test (otherwise each store() would link everything eagerly).
+    auto_link_store._auto_link_enabled = False
+    incoming = await auto_link_store.store(make_entry(content="incoming nbr"))
+    typed = await auto_link_store.store(make_entry(content="typed nbr"))
+    fresh = await auto_link_store.store(make_entry(content="fresh nbr"))
+    src_id = await auto_link_store.store(make_entry(content="source"))
+
+    # Pre-seed edges that the *narrow* (outgoing-``related``-only) filter would
+    # have missed: an INCOMING ``related`` edge and an outgoing non-``related``
+    # ("link") edge. Both must suppress an auto-link to that target.
+    await auto_link_store.add_relation(incoming, src_id, "related")
+    await auto_link_store.add_relation(src_id, typed, "link")
+    auto_link_store._auto_link_enabled = True
+
+    embedding = controlled_embedding_provider.embed("source")
+    inserted = await auto_link_store._run_sync(
+        auto_link_store._auto_link_semantic,
+        auto_link_store.connection,
+        src_id,
+        embedding,
+    )
+
+    # Only the un-linked ``fresh`` neighbour gets a new ``related`` edge.
+    assert inserted == 1
+    outgoing_related = {
+        r["to_id"]
+        for r in await auto_link_store.get_related(src_id, direction="outgoing")
+        if r["relation_type"] == "related"
+    }
+    assert outgoing_related == {fresh}
+    assert incoming not in outgoing_related
+    assert typed not in outgoing_related
+
+
 async def test_auto_link_respects_max_links_cap(
     controlled_embedding_provider: ControlledEmbeddingProvider,
 ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1274,3 +1274,71 @@ class TestWebhookConfigParsing:
         p = write_yaml(tmp_path, yaml_content)
         with pytest.raises(ValueError, match="server.webhooks must be a YAML mapping"):
             load_config(str(p))
+
+
+class TestAutoLinkConfig:
+    """Semantic auto-link config parsing / defaults / validation (issue #629)."""
+
+    def test_defaults_disabled(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """No config file → auto-link is off, with default threshold and cap."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+        cfg = load_config()
+        assert cfg.auto_link.enabled is False
+        assert cfg.auto_link.threshold == pytest.approx(0.85)
+        assert cfg.auto_link.max_links == 5
+
+    def test_loads_auto_link(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """All auto-link fields can be configured together."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+        yaml_content = """\
+            auto_link:
+              enabled: true
+              threshold: 0.9
+              max_links: 3
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.auto_link.enabled is True
+        assert cfg.auto_link.threshold == pytest.approx(0.9)
+        assert cfg.auto_link.max_links == 3
+
+    def test_non_bool_enabled_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+        yaml_content = """\
+            auto_link:
+              enabled: "yes"
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="auto_link.enabled"):
+            load_config(str(p))
+
+    def test_threshold_out_of_range_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+        yaml_content = """\
+            auto_link:
+              threshold: 1.5
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="auto_link.threshold"):
+            load_config(str(p))
+
+    def test_non_positive_max_links_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+        yaml_content = """\
+            auto_link:
+              max_links: 0
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="auto_link.max_links"):
+            load_config(str(p))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1342,3 +1342,14 @@ class TestAutoLinkConfig:
         p = write_yaml(tmp_path, yaml_content)
         with pytest.raises(ValueError, match="auto_link.max_links"):
             load_config(str(p))
+
+    def test_non_mapping_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A non-mapping auto_link value raises a clear ValueError, not AttributeError."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+        yaml_content = """\
+            auto_link: "enabled"
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="auto_link must be a YAML mapping"):
+            load_config(str(p))


### PR DESCRIPTION
## Root cause

PR [#495](https://github.com/norrietaylor/distillery/pull/495) shipped the semantic-link primitive (issue [#490](https://github.com/norrietaylor/distillery/issues/490) mechanism #2): `distillery_find_similar(source_entry_id, accept_action="link", exclude_linked=true)` persists `related` edges to embedding-neighbours. Nothing invoked it automatically. The write path (`_sync_store` / `_sync_store_batch` in `store/duckdb.py`) and the feed poller ran only the deterministic `metadata.related_entries` fan-out and GitHub cross-ref links — no semantic edges. On a feed-heavy instance this left 99.77% of entries as graph orphans (51,724 entries -> 120 nodes / 296 edges), invisible to every graph metric.

## Fix

Config-gated `_auto_link_semantic` helper in `store/duckdb.py`, called from both `_sync_store` and `_sync_store_batch`, OFF by default.

- Reuses the already-computed embedding (no new embedding cost) to query `array_cosine_similarity` neighbours, mirroring `find_similar`: same normalised-`[0,1]` -> raw-`[-1,1]` threshold conversion, archived-exclusion, and `relation_type='related'`.
- Idempotent via the unique `(from_id, to_id, relation_type)` index plus `INSERT OR IGNORE`; `exclude_linked` semantics skip targets already linked via a `related` edge.
- Throttled at `max_links` edges per entry.
- Batch path runs inside the same transaction after all inserts, so entries earlier in a batch are visible as candidates and a batch can form internal sibling edges; a partial run rolls back together.
- New `AutoLinkConfig` (`enabled=False`, `threshold=0.85`, `max_links=5`) parsed/validated in `config.py` and threaded through every `DuckDBStore` construction site (`cli.py`, `mcp/server.py`, `mcp/webhooks.py`). Poll-ingest is covered transitively via `poller.store()` — no `poller.py` edit, no new MCP tool (honours the v0.4.0 additive pledge).

## Acceptance

- [x] **With the flag on, newly stored/polled entries gain `related` edges to semantic neighbours above threshold** — `tests/test_auto_link_on_write.py::test_flag_on_links_to_neighbours_above_threshold` (near/far threshold discrimination); poll/store/webhooks/cli all construct the store with the config wired through.
- [x] **Edge/node ratio and community/bridge coverage rise on a feed corpus** — auto-link inserts `related` edges into `entry_relations`, which `build_relations_graph` consumes; `test_store_batch_auto_links_each_entry` proves in-batch sibling edges are created (raising edge count beyond the deterministic fan-out).
- [x] **Off by default (preserves current behaviour)** — `AutoLinkConfig.enabled` defaults `False`; `tests/test_config.py` defaults assertion + `tests/test_auto_link_on_write.py::test_flag_off_creates_no_semantic_edges` (empty relations table). 317-test store/relations/cli/webhooks regression passes unchanged.

Additional coverage: `test_auto_link_is_idempotent_on_re_store` (true re-run, zero new edges) and `test_auto_link_respects_max_links_cap` (throttle).

## Test plan

```
PYTHONPATH=src .venv/bin/python -m pytest tests/test_auto_link_on_write.py tests/test_config.py -q
# 119 passed

PYTHONPATH=src .venv/bin/python -m pytest tests/test_duckdb_store.py tests/test_relations.py tests/test_cli.py tests/test_webhooks.py -q
# 317 passed, 3 skipped (no regression)

PYTHONPATH=src .venv/bin/mypy --strict src/distillery
# Success: no issues found in 72 source files

.venv/bin/ruff check src tests
# All checks passed!
```

## Related

- Builds on the shipped primitive in PR [#495](https://github.com/norrietaylor/distillery/pull/495) (issue [#490](https://github.com/norrietaylor/distillery/issues/490) mechanism #2). Distinct from issue [#496](https://github.com/norrietaylor/distillery/issues/496) (deterministic + reconcile-only mechanisms).
- Shares files with sibling PRs in this batch (`store/duckdb.py`, `config.py`, and the poll path); may conflict on merge — rebase and resolve so both behaviours coexist.

Closes #629


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced semantic auto-linking on ingest to automatically create “related” relationships between similar entries.
  * Added `auto_link` configuration options: enable/disable, similarity threshold, and max links per entry.
  * Enabled consistent auto-link behavior across server sync, background jobs, and webhook ingestion.

* **Validation / Bug Fixes**
  * Improved configuration handling with clear validation errors for invalid `auto_link` settings.

* **Tests**
  * Added comprehensive automated tests covering linking, exclusions, idempotency, and batching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->