### PR TITLE
feeds: content-bearing GitHub releases sync mode (#625)

### DIFF
--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -43,6 +43,7 @@ For `add`, parse:
 - **`--label LABEL`**: human-readable label (optional)
 - **`--interval N`**: poll interval in minutes (default: 60)
 - **`--trust N`**: trust weight in [0.0, 1.0] (default: 1.0)
+- **`--mode MODE`** (github only): content surface to poll. Valid: `releases` (default — one body-bearing entry per release with the changelog notes) or `events` (opt-in contentless events firehose). The default `releases` mode is the high-signal "what shipped" surface.
 
 If `add` is requested without a URL, ask the user before proceeding.
 
@@ -51,7 +52,7 @@ If `add` is requested without a URL, ask the user before proceeding.
 Call `distillery_watch` with the parsed arguments:
 
 - **list**: `distillery_watch(action="list")`
-- **add**: `distillery_watch(action="add", url=..., source_type=..., label=..., poll_interval_minutes=..., trust_weight=...)`
+- **add**: `distillery_watch(action="add", url=..., source_type=..., label=..., poll_interval_minutes=..., trust_weight=..., mode=...)` (`mode` is github-only; omit for `rss`)
 - **remove** (no purge): `distillery_watch(action="remove", url="<url>")`
 - **remove --purge** (requires explicit confirmation):
   1. Explain to the user that `--purge` will archive **all historic entries** previously ingested from `<url>`. This skill's allowlist only includes `mcp__*__distillery_watch`, so the exact count cannot be fetched here — describe the impact in-prompt instead of issuing a `distillery_list` call.

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -222,6 +222,11 @@ class FeedSourceConfig:
             noisy aggregators (HN, Lobsters, Reddit) that ``trust_weight``
             cannot separate from vendor blogs because ``trust_weight`` only
             attenuates downward.
+        mode: Adapter-specific surface selector.  For ``github`` sources this
+            chooses which surface to poll: ``'releases'`` (default,
+            body-bearing release notes) or ``'events'`` (opt-in contentless
+            firehose).  Ignored by ``rss`` sources.  Empty string means
+            "adapter default".
     """
 
     url: str = ""
@@ -230,6 +235,7 @@ class FeedSourceConfig:
     poll_interval_minutes: int = 60
     trust_weight: float = 1.0
     thresholds: FeedSourceThresholdsConfig = field(default_factory=FeedSourceThresholdsConfig)
+    mode: str = ""
 
 
 @dataclass
@@ -815,6 +821,19 @@ def _parse_feed_source(raw: dict[str, Any], index: int) -> FeedSourceConfig:
 
     thresholds = _parse_feed_source_thresholds(raw.get("thresholds"), index)
 
+    mode = str(raw.get("mode", "")).strip().lower()
+    if mode:
+        if source_type != "github":
+            raise ValueError(
+                f"feeds.sources[{index}].mode is only supported for source_type='github', "
+                f"got: {source_type!r}"
+            )
+        valid_modes = {"releases", "events"}
+        if mode not in valid_modes:
+            raise ValueError(
+                f"feeds.sources[{index}].mode must be one of {sorted(valid_modes)}, got: {mode!r}"
+            )
+
     return FeedSourceConfig(
         url=url,
         source_type=source_type,
@@ -822,6 +841,7 @@ def _parse_feed_source(raw: dict[str, Any], index: int) -> FeedSourceConfig:
         poll_interval_minutes=poll_interval,
         trust_weight=trust_weight,
         thresholds=thresholds,
+        mode=mode,
     )
 
 

--- a/src/distillery/feeds/github.py
+++ b/src/distillery/feeds/github.py
@@ -1,11 +1,17 @@
-"""GitHub repository events adapter.
+"""GitHub repository feed adapter.
 
-Polls the GitHub REST API ``GET /repos/{owner}/{repo}/events`` endpoint and
-normalises each event to a :class:`~distillery.feeds.models.FeedItem`.
+Polls a content-bearing GitHub surface and normalises each item to a
+:class:`~distillery.feeds.models.FeedItem`.  Two modes are supported:
+
+- ``"releases"`` (default) — polls ``GET /repos/{owner}/{repo}/releases`` and
+  emits one item per release carrying the release-notes **body**, tag, name,
+  and prerelease flag.  This is the high-signal "what shipped" surface.
+- ``"events"`` (opt-in, back-compat) — polls the contentless public events
+  firehose ``GET /repos/{owner}/{repo}/events``.  Retained only for callers
+  that explicitly request it; it is no longer the default (#625).
 
 The adapter tracks ``last_polled_at`` so that callers can detect stale state
-and implement incremental polling (GitHub returns events in reverse-
-chronological order, newest first).
+and implement incremental polling (GitHub returns items newest-first).
 """
 
 from __future__ import annotations
@@ -46,6 +52,13 @@ _DEFAULT_INCLUDE_EVENT_TYPES: frozenset[str] = frozenset(
         "ReleaseEvent",
     }
 )
+
+# Default sync mode.  "releases" emits body-bearing release-notes entries;
+# the contentless "events" firehose is opt-in only (#625).
+DEFAULT_MODE = "releases"
+
+# Modes the adapter knows how to poll.
+VALID_MODES: frozenset[str] = frozenset({"releases", "events"})
 
 # Pattern that matches a bare "owner/repo" slug so callers may pass either
 # the full URL or the short slug form.
@@ -176,12 +189,84 @@ def _event_to_feed_item(event: dict[str, Any], source_url: str) -> FeedItem:
     )
 
 
-class GitHubAdapter:
-    """Feed adapter that polls GitHub repository events.
+def _release_to_feed_item(release: dict[str, Any], source_url: str, repo_slug: str) -> FeedItem:
+    """Convert a single GitHub releases API response object to a :class:`FeedItem`.
 
-    Uses the GitHub REST API ``GET /repos/{owner}/{repo}/events`` endpoint.
-    An optional personal access token (PAT) can be supplied to increase the
-    rate limit from 60 to 5000 requests/hour.
+    The emitted item carries the release-notes ``body`` (the real changelog
+    text, not an event title) so downstream embedding/search reflects what
+    actually shipped.  ``item_id`` is the stable ``owner/repo@tag`` external id
+    so re-polling the same release is deduped (#625).
+
+    Args:
+        release: Parsed JSON object from the GitHub releases endpoint.
+        source_url: The canonical feed URL (used as ``FeedItem.source_url``).
+        repo_slug: ``owner/repo`` slug used to build the external id.
+
+    Returns:
+        A normalised :class:`FeedItem`.
+    """
+    tag_raw = release.get("tag_name")
+    tag = tag_raw.strip() if isinstance(tag_raw, str) else ""
+    # Fall back to the numeric release id when no tag is present so the
+    # external id stays stable and unique.
+    release_ref = tag or str(release.get("id", ""))
+    external_id = f"{repo_slug}@{release_ref}"
+
+    name_raw = release.get("name")
+    name = name_raw.strip() if isinstance(name_raw, str) and name_raw.strip() else tag
+    # A release with no name and no tag still gets a usable title.
+    title = name or release_ref or repo_slug
+
+    body_raw = release.get("body")
+    body = body_raw.strip() if isinstance(body_raw, str) and body_raw.strip() else None
+
+    author_info: dict[str, Any] = release.get("author") or {}
+    author_login_raw = author_info.get("login")
+    author_login = author_login_raw.strip() if isinstance(author_login_raw, str) else ""
+
+    item_url_raw = release.get("html_url")
+    item_url = item_url_raw if isinstance(item_url_raw, str) and item_url_raw else None
+
+    prerelease = bool(release.get("prerelease", False))
+
+    published_at: datetime | None = None
+    for key in ("published_at", "created_at"):
+        ts_raw = release.get(key)
+        if isinstance(ts_raw, str):
+            try:
+                published_at = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+                break
+            except ValueError:
+                continue
+
+    return FeedItem(
+        source_url=source_url,
+        source_type="github",
+        item_id=external_id,
+        title=title,
+        url=item_url,
+        content=body,
+        author=author_login or None,
+        published_at=published_at,
+        raw=release,
+        extra={
+            "mode": "releases",
+            "repo": repo_slug,
+            "tag": tag,
+            "prerelease": prerelease,
+        },
+    )
+
+
+class GitHubAdapter:
+    """Feed adapter that polls a content-bearing GitHub surface.
+
+    In the default ``"releases"`` mode the adapter uses the GitHub REST API
+    ``GET /repos/{owner}/{repo}/releases`` endpoint and emits one body-bearing
+    item per release.  The opt-in ``"events"`` mode polls the contentless
+    public events firehose ``GET /repos/{owner}/{repo}/events`` (back-compat
+    only — see #625).  An optional personal access token (PAT) can be supplied
+    to increase the rate limit from 60 to 5000 requests/hour.
 
     Parameters
     ----------
@@ -192,12 +277,16 @@ class GitHubAdapter:
         Optional GitHub personal access token.  When omitted the adapter
         checks the ``GITHUB_TOKEN`` environment variable.
     per_page:
-        Number of events to retrieve per API call (1-100).  Defaults to 30.
+        Number of items to retrieve per API call (1-100).  Defaults to 30.
+    mode:
+        Which surface to poll: ``"releases"`` (default) or ``"events"``.
+        An empty/``None`` value falls back to :data:`DEFAULT_MODE`.
 
     Raises
     ------
     ValueError
-        If *url* cannot be parsed as a valid GitHub repository reference.
+        If *url* cannot be parsed as a valid GitHub repository reference, or
+        if *mode* is not one of :data:`VALID_MODES`.
     """
 
     def __init__(
@@ -206,6 +295,7 @@ class GitHubAdapter:
         token: str | None = None,
         per_page: int = _DEFAULT_PER_PAGE,
         include_event_types: frozenset[str] | None = None,
+        mode: str | None = None,
     ) -> None:
         self._owner, self._repo = _parse_github_url(url)
         self._source_url = url
@@ -214,6 +304,13 @@ class GitHubAdapter:
         self._include_event_types = (
             include_event_types if include_event_types is not None else _DEFAULT_INCLUDE_EVENT_TYPES
         )
+        resolved_mode = (mode or DEFAULT_MODE).strip().lower()
+        if resolved_mode not in VALID_MODES:
+            raise ValueError(
+                f"Unsupported GitHub feed mode {mode!r}. "
+                f"Expected one of {sorted(VALID_MODES)}."
+            )
+        self._mode = resolved_mode
         self.last_polled_at: datetime | None = None
 
     # ------------------------------------------------------------------
@@ -235,21 +332,20 @@ class GitHubAdapter:
         """Repository name extracted from *url*."""
         return self._repo
 
-    def fetch(self) -> list[FeedItem]:
-        """Poll the GitHub events endpoint and return normalised items.
+    @property
+    def mode(self) -> str:
+        """The resolved poll mode (``"releases"`` or ``"events"``)."""
+        return self._mode
 
-        Updates :attr:`last_polled_at` on every successful call (even when
-        the response is an empty list).
+    def _get_json(self, api_url: str) -> Any:
+        """Issue a GET against *api_url* and return the parsed JSON body.
 
-        Returns:
-            A list of :class:`~distillery.feeds.models.FeedItem` objects,
-            ordered newest-first as returned by the GitHub API.
+        Updates :attr:`last_polled_at` on every successful call.
 
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
             httpx.RequestError: On network-level failures.
         """
-        api_url = f"{_GITHUB_API_BASE}/repos/{self._owner}/{self._repo}/events"
         params: dict[str, str | int] = {"per_page": self._per_page}
         headers: dict[str, str] = {
             "Accept": "application/vnd.github+json",
@@ -265,8 +361,56 @@ class GitHubAdapter:
             response.raise_for_status()
 
         self.last_polled_at = datetime.now(tz=UTC)
+        return response.json()
 
-        events: list[dict[str, Any]] = response.json()
+    def fetch(self) -> list[FeedItem]:
+        """Poll the configured GitHub surface and return normalised items.
+
+        Dispatches on :attr:`mode`: ``"releases"`` (default) emits one
+        body-bearing item per release; ``"events"`` polls the contentless
+        events firehose (back-compat only).
+
+        Updates :attr:`last_polled_at` on every successful call (even when
+        the response is an empty list).
+
+        Returns:
+            A list of :class:`~distillery.feeds.models.FeedItem` objects,
+            ordered newest-first as returned by the GitHub API.
+
+        Raises:
+            httpx.HTTPStatusError: On non-2xx responses.
+            httpx.RequestError: On network-level failures.
+        """
+        if self._mode == "events":
+            return self._fetch_events()
+        return self._fetch_releases()
+
+    def _fetch_releases(self) -> list[FeedItem]:
+        """Poll ``/repos/{owner}/{repo}/releases`` and normalise each release."""
+        api_url = f"{_GITHUB_API_BASE}/repos/{self._owner}/{self._repo}/releases"
+        repo_slug = f"{self._owner}/{self._repo}"
+        releases = self._get_json(api_url)
+        if not isinstance(releases, list):
+            logger.warning("GitHubAdapter: unexpected response type %s", type(releases).__name__)
+            return []
+
+        items: list[FeedItem] = []
+        for release in releases:
+            try:
+                if not isinstance(release, dict):
+                    continue
+                items.append(_release_to_feed_item(release, self._source_url, repo_slug))
+            except Exception:
+                logger.exception(
+                    "GitHubAdapter: failed to convert release %r",
+                    release.get("id") if isinstance(release, dict) else release,
+                )
+        return items
+
+    def _fetch_events(self) -> list[FeedItem]:
+        """Poll the contentless events firehose (opt-in back-compat mode)."""
+        api_url = f"{_GITHUB_API_BASE}/repos/{self._owner}/{self._repo}/events"
+        events = self._get_json(api_url)
         if not isinstance(events, list):
             logger.warning("GitHubAdapter: unexpected response type %s", type(events).__name__)
             return []

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -194,7 +194,7 @@ def _build_adapter(source: FeedSourceConfig, *, user_agent: str | None = None) -
             logger.debug(
                 "_build_adapter: GitHub adapter using unauthenticated mode for %s", source.url
             )
-        return GitHubAdapter(url=source.url, token=token or None)
+        return GitHubAdapter(url=source.url, token=token or None, mode=source.mode or None)
     elif source.source_type == "rss":
         from distillery.feeds.rss import RSSAdapter
 
@@ -600,7 +600,14 @@ class FeedPoller:
         # that are not part of FeedSourceConfig — filter to the constructor
         # kwargs before instantiation.  Capture which sources have never been
         # polled so the first batch can be flagged as backfill (issue #444).
-        _cfg_fields = {"url", "source_type", "label", "poll_interval_minutes", "trust_weight"}
+        _cfg_fields = {
+            "url",
+            "source_type",
+            "label",
+            "poll_interval_minutes",
+            "trust_weight",
+            "mode",
+        }
         sources: list[FeedSourceConfig] = []
         for s in db_sources:
             kwargs = {k: v for k, v in s.items() if k in _cfg_fields}

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -240,6 +240,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                             trust_weight=src.trust_weight,
                             threshold_alert=src.thresholds.alert,
                             threshold_digest=src.thresholds.digest,
+                            mode=src.mode,
                         )
                 await store.set_metadata("feeds_seeded", "true")
             # Wire the sync-job tracker to the store and reconcile any
@@ -1154,6 +1155,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         purge: bool = False,
         probe: bool = True,
         force: bool = False,
+        mode: str | None = None,
     ) -> list[types.TextContent]:
         """Manage monitored feed sources for ambient intelligence.
 
@@ -1186,6 +1188,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - force (bool, optional, default=false): When adding, persist the source
             even if the reachability probe fails (useful for sites that block HEAD
             but work via the poller).
+          - mode (str, optional, github only): Which content-bearing surface to poll.
+            Valid: [releases, events]. Defaults to "releases" (one body-bearing
+            entry per release). "events" is the opt-in contentless firehose.
 
         RETURNS (success): { sources: list, count: int } (list) or
           { added: dict, sources: list, sync_job?: dict } (add) or
@@ -1212,6 +1217,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                     thresholds=thresholds,
                     sync_history=sync_history or None,
                     purge=purge or None,
+                    mode=mode,
                 ),
             ),
         )

--- a/src/distillery/mcp/tools/feeds.py
+++ b/src/distillery/mcp/tools/feeds.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 from mcp import types
 
 from distillery.config import DistilleryConfig
+from distillery.feeds.github import VALID_MODES as _VALID_GITHUB_MODES
 from distillery.feeds.url_guard import UnsafeURLError, validate_public_url
 from distillery.mcp.tools._common import (
     error_response,
@@ -346,6 +347,27 @@ async def _handle_watch(
         except ValueError as exc:
             return error_response("INVALID_PARAMS", str(exc))
 
+        # Optional ``mode`` selects the content-bearing surface for github
+        # sources (#625). Defaults to '' = adapter default ('releases').
+        mode_raw = arguments.get("mode")
+        if mode_raw is not None and not isinstance(mode_raw, str):
+            return error_response(
+                "INVALID_PARAMS",
+                f"mode must be a string, got: {type(mode_raw).__name__}",
+            )
+        mode = str(mode_raw or "").strip().lower()
+        if mode:
+            if source_type != "github":
+                return error_response(
+                    "INVALID_PARAMS",
+                    f"mode is only supported for source_type='github', got: {source_type!r}",
+                )
+            if mode not in _VALID_GITHUB_MODES:
+                return error_response(
+                    "INVALID_PARAMS",
+                    f"mode must be one of {sorted(_VALID_GITHUB_MODES)}, got: {mode!r}",
+                )
+
         try:
             sync_history = _parse_bool_arg(arguments.get("sync_history"), default=False)
         except ValueError as exc:
@@ -423,6 +445,7 @@ async def _handle_watch(
                 trust_weight=trust_weight,
                 threshold_alert=threshold_alert,
                 threshold_digest=threshold_digest,
+                mode=mode,
             )
             db_sources = await store.list_feed_sources()
         except ValueError:

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2920,7 +2920,7 @@ class DuckDBStore:
         result = conn.execute(
             "SELECT url, source_type, label, poll_interval_minutes, trust_weight, "
             "last_polled_at, last_item_count, last_error, "
-            "threshold_alert, threshold_digest "
+            "threshold_alert, threshold_digest, mode "
             "FROM feed_sources ORDER BY created_at"
         )
         rows = result.fetchall()
@@ -2964,6 +2964,7 @@ class DuckDBStore:
                     "threshold_digest": (
                         float(threshold_digest_raw) if threshold_digest_raw is not None else None
                     ),
+                    "mode": row[10] if row[10] is not None else "",
                 }
             )
         return sources
@@ -2977,6 +2978,7 @@ class DuckDBStore:
         trust_weight: float = 1.0,
         threshold_alert: float | None = None,
         threshold_digest: float | None = None,
+        mode: str = "",
     ) -> dict[str, Any]:
         """Add a feed source. Raises ValueError if URL already exists."""
         assert self._conn is not None
@@ -2984,8 +2986,8 @@ class DuckDBStore:
             self._conn.execute(
                 "INSERT INTO feed_sources "
                 "(url, source_type, label, poll_interval_minutes, trust_weight, "
-                "threshold_alert, threshold_digest) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "threshold_alert, threshold_digest, mode) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 [
                     url,
                     source_type,
@@ -2994,6 +2996,7 @@ class DuckDBStore:
                     trust_weight,
                     threshold_alert,
                     threshold_digest,
+                    mode,
                 ],
             )
         except duckdb.ConstraintException as exc:
@@ -3007,6 +3010,7 @@ class DuckDBStore:
             "trust_weight": trust_weight,
             "threshold_alert": threshold_alert,
             "threshold_digest": threshold_digest,
+            "mode": mode,
         }
 
     def _sync_remove_feed_source(self, url: str) -> bool:
@@ -3080,6 +3084,7 @@ class DuckDBStore:
         trust_weight: float = 1.0,
         threshold_alert: float | None = None,
         threshold_digest: float | None = None,
+        mode: str = "",
     ) -> dict[str, Any]:
         """Add a feed source. Raises ValueError if URL already exists."""
         return await self._run_sync(
@@ -3091,6 +3096,7 @@ class DuckDBStore:
             trust_weight,
             threshold_alert,
             threshold_digest,
+            mode,
         )
 
     async def remove_feed_source(self, url: str) -> bool:

--- a/src/distillery/store/migrations.py
+++ b/src/distillery/store/migrations.py
@@ -574,6 +574,26 @@ def add_relation_attributes(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> N
     logger.info("Migration 15: entry_relations weight/valid_at/invalid_at/metadata columns added")
 
 
+# DuckDB's ALTER TABLE ADD COLUMN does not accept constraints (NOT NULL), so
+# add a plain nullable VARCHAR with a default of '' — matching migration 3's
+# ``created_by``/``last_modified_by`` pattern. The reader coalesces NULL to ''.
+_ADD_FEED_SOURCE_MODE_COLUMN = (
+    "ALTER TABLE feed_sources ADD COLUMN IF NOT EXISTS mode VARCHAR DEFAULT '';"
+)
+
+
+def add_feed_source_mode(conn: duckdb.DuckDBPyConnection, **kwargs: Any) -> None:
+    """Migration 16: Add the ``mode`` column to ``feed_sources``.
+
+    Selects which content-bearing surface a ``github`` source polls
+    (``'releases'`` by default, ``'events'`` opt-in).  Empty string means
+    "adapter default", preserving behaviour for ``rss`` sources and any rows
+    created before the migration ran (#625).
+    """
+    conn.execute(_ADD_FEED_SOURCE_MODE_COLUMN)
+    logger.info("Migration 16: feed_sources mode column added")
+
+
 # ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
@@ -594,6 +614,7 @@ MIGRATIONS: dict[int, MigrationFunc] = {
     13: create_sync_jobs,
     14: add_feed_source_thresholds,
     15: add_relation_attributes,
+    16: add_feed_source_mode,
 }
 """Ordered mapping of schema version to migration function.
 

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -367,10 +367,11 @@ class DistilleryStore(Protocol):
         ``poll_interval_minutes``, ``trust_weight``, ``last_polled_at``
         (ISO 8601 string or ``None``), ``last_item_count`` (int),
         ``last_error`` (str or ``None``), ``next_poll_at``
-        (ISO 8601 string or ``None``), and per-source threshold
+        (ISO 8601 string or ``None``), per-source threshold
         overrides ``threshold_alert`` / ``threshold_digest`` (float in
         ``[0.0, 1.0]`` or ``None`` to fall back to the global
-        ``feeds.thresholds`` values).
+        ``feeds.thresholds`` values), and ``mode`` (adapter surface
+        selector; empty string means "adapter default").
 
         Returns:
             List of feed source dicts ordered by creation time.
@@ -386,6 +387,7 @@ class DistilleryStore(Protocol):
         trust_weight: float = 1.0,
         threshold_alert: float | None = None,
         threshold_digest: float | None = None,
+        mode: str = "",
     ) -> dict[str, Any]:
         """Persist a new feed source and return it as a dict.
 
@@ -401,6 +403,9 @@ class DistilleryStore(Protocol):
             threshold_digest: Optional per-source override of
                 ``feeds.thresholds.digest`` in ``[0.0, 1.0]``.  ``None``
                 falls back to the global value.
+            mode: Adapter-specific surface selector.  For ``github`` sources
+                ``"releases"`` (default) or ``"events"``.  Empty string means
+                "adapter default".
 
         Returns:
             Dict with the stored feed source fields.

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -23,7 +23,12 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from distillery.feeds.github import GitHubAdapter, _event_to_feed_item, _parse_github_url
+from distillery.feeds.github import (
+    GitHubAdapter,
+    _event_to_feed_item,
+    _parse_github_url,
+    _release_to_feed_item,
+)
 from distillery.feeds.models import FeedItem
 from distillery.feeds.rss import RSSAdapter, parse_feed_xml
 
@@ -273,7 +278,7 @@ class TestGitHubAdapter:
             mock_client.get.return_value = mock_response
             mock_client_cls.return_value = mock_client
 
-            adapter = GitHubAdapter("owner/repo")
+            adapter = GitHubAdapter("owner/repo", mode="events")
             items = adapter.fetch()
 
         assert len(items) == 1
@@ -356,7 +361,7 @@ class TestGitHubAdapter:
             mock_client.get.return_value = mock_response
             mock_client_cls.return_value = mock_client
 
-            adapter = GitHubAdapter("owner/repo")
+            adapter = GitHubAdapter("owner/repo", mode="events")
             items = adapter.fetch()
 
         # Only IssuesEvent should pass the default filter
@@ -386,7 +391,9 @@ class TestGitHubAdapter:
             mock_client_cls.return_value = mock_client
 
             # Pass empty frozenset to disable filtering
-            adapter = GitHubAdapter("owner/repo", include_event_types=frozenset())
+            adapter = GitHubAdapter(
+                "owner/repo", include_event_types=frozenset(), mode="events"
+            )
             items = adapter.fetch()
 
         # All events should pass when filter is empty
@@ -423,11 +430,154 @@ class TestGitHubAdapter:
             mock_client_cls.return_value = mock_client
 
             # Only allow WatchEvent
-            adapter = GitHubAdapter("owner/repo", include_event_types=frozenset({"WatchEvent"}))
+            adapter = GitHubAdapter(
+                "owner/repo", include_event_types=frozenset({"WatchEvent"}), mode="events"
+            )
             items = adapter.fetch()
 
         assert len(items) == 1
         assert items[0].item_id == "1"
+
+
+# ---------------------------------------------------------------------------
+# _release_to_feed_item + releases mode (#625)
+# ---------------------------------------------------------------------------
+
+
+def _mock_github_client(payload: object) -> object:
+    """Build a MagicMock httpx.Client whose GET returns *payload* as JSON."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = payload
+    mock_response.raise_for_status.return_value = None
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.return_value = mock_response
+    return mock_client
+
+
+class TestReleaseToFeedItem:
+    _SOURCE_URL = "owner/repo"
+
+    def _make_release(self, **overrides: object) -> dict[str, object]:
+        release: dict[str, object] = {
+            "id": 99,
+            "tag_name": "v1.2.0",
+            "name": "Release 1.2.0",
+            "body": "## Changes\n- shipped a thing",
+            "prerelease": False,
+            "author": {"login": "releaser"},
+            "html_url": "https://github.com/owner/repo/releases/tag/v1.2.0",
+            "published_at": "2024-03-25T09:00:00Z",
+        }
+        release.update(overrides)
+        return release
+
+    def test_external_id_is_repo_at_tag(self) -> None:
+        item = _release_to_feed_item(self._make_release(), self._SOURCE_URL, "owner/repo")
+        assert item.item_id == "owner/repo@v1.2.0"
+
+    def test_content_is_release_body(self) -> None:
+        item = _release_to_feed_item(self._make_release(), self._SOURCE_URL, "owner/repo")
+        assert item.content == "## Changes\n- shipped a thing"
+
+    def test_title_uses_name(self) -> None:
+        item = _release_to_feed_item(self._make_release(), self._SOURCE_URL, "owner/repo")
+        assert item.title == "Release 1.2.0"
+
+    def test_extra_carries_tag_and_prerelease(self) -> None:
+        item = _release_to_feed_item(
+            self._make_release(prerelease=True), self._SOURCE_URL, "owner/repo"
+        )
+        assert item.extra["tag"] == "v1.2.0"
+        assert item.extra["prerelease"] is True
+        assert item.extra["mode"] == "releases"
+
+    def test_source_type_is_github(self) -> None:
+        item = _release_to_feed_item(self._make_release(), self._SOURCE_URL, "owner/repo")
+        assert item.source_type == "github"
+
+    def test_falls_back_to_id_when_no_tag(self) -> None:
+        item = _release_to_feed_item(
+            self._make_release(tag_name=None, name=None), self._SOURCE_URL, "owner/repo"
+        )
+        assert item.item_id == "owner/repo@99"
+
+    def test_empty_body_is_none(self) -> None:
+        item = _release_to_feed_item(self._make_release(body="  "), self._SOURCE_URL, "owner/repo")
+        assert item.content is None
+
+
+class TestGitHubAdapterReleasesMode:
+    def test_default_mode_is_releases(self) -> None:
+        adapter = GitHubAdapter("owner/repo")
+        assert adapter.mode == "releases"
+
+    def test_invalid_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported GitHub feed mode"):
+            GitHubAdapter("owner/repo", mode="bogus")
+
+    def test_fetch_hits_releases_endpoint_by_default(self) -> None:
+        releases = [
+            {
+                "id": 1,
+                "tag_name": "v1.0.0",
+                "name": "First",
+                "body": "Initial release notes",
+                "prerelease": False,
+                "html_url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+                "published_at": "2024-03-25T09:00:00Z",
+            }
+        ]
+        mock_client = _mock_github_client(releases)
+        with patch("distillery.feeds.github.httpx.Client", return_value=mock_client):
+            adapter = GitHubAdapter("owner/repo")
+            items = adapter.fetch()
+
+        # Must have polled the releases endpoint, not events.
+        called_url = mock_client.get.call_args.args[0]
+        assert called_url.endswith("/repos/owner/repo/releases")
+        # One body-bearing entry per release.
+        assert len(items) == 1
+        assert items[0].item_id == "owner/repo@v1.0.0"
+        assert items[0].content == "Initial release notes"
+
+    def test_default_does_not_emit_event_stubs(self) -> None:
+        # Feeding event-shaped payloads to releases mode must not produce the
+        # contentless "*Event by ... on ..." stubs the events firehose emits.
+        events = [
+            {
+                "id": "42",
+                "type": "PushEvent",
+                "actor": {"login": "bot"},
+                "repo": {"name": "owner/repo"},
+                "payload": {},
+            }
+        ]
+        mock_client = _mock_github_client(events)
+        with patch("distillery.feeds.github.httpx.Client", return_value=mock_client):
+            items = GitHubAdapter("owner/repo").fetch()
+        # No item should carry an event-style title.
+        assert all(not (it.title and "Event by" in it.title) for it in items)
+
+    def test_events_mode_is_opt_in(self) -> None:
+        events = [
+            {
+                "id": "42",
+                "type": "PushEvent",
+                "actor": {"login": "bob"},
+                "repo": {"name": "owner/repo"},
+                "payload": {"commits": [{"message": "fix"}]},
+                "created_at": "2024-03-25T09:00:00Z",
+            }
+        ]
+        mock_client = _mock_github_client(events)
+        with patch("distillery.feeds.github.httpx.Client", return_value=mock_client):
+            adapter = GitHubAdapter("owner/repo", mode="events")
+            items = adapter.fetch()
+        called_url = mock_client.get.call_args.args[0]
+        assert called_url.endswith("/repos/owner/repo/events")
+        assert items[0].item_id == "42"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_feeds.py
+++ b/tests/test_mcp_feeds.py
@@ -96,6 +96,7 @@ class FakeSourceStore:
         trust_weight: float = 1.0,
         threshold_alert: float | None = None,
         threshold_digest: float | None = None,
+        mode: str = "",
     ) -> dict[str, Any]:
         if any(s["url"] == url for s in self._sources):
             raise ValueError(f"Feed source with URL {url!r} already exists.")
@@ -111,6 +112,7 @@ class FakeSourceStore:
             "next_poll_at": None,
             "threshold_alert": threshold_alert,
             "threshold_digest": threshold_digest,
+            "mode": mode,
         }
         self._sources.append(entry)
         return entry

--- a/tests/test_mcp_watch.py
+++ b/tests/test_mcp_watch.py
@@ -48,6 +48,7 @@ class FakeSourceStore:
         trust_weight: float = 1.0,
         threshold_alert: float | None = None,
         threshold_digest: float | None = None,
+        mode: str = "",
     ) -> dict[str, Any]:
         if any(s["url"] == url for s in self._sources):
             raise ValueError(f"Feed source with URL {url!r} already exists.")
@@ -59,6 +60,7 @@ class FakeSourceStore:
             "trust_weight": trust_weight,
             "threshold_alert": threshold_alert,
             "threshold_digest": threshold_digest,
+            "mode": mode,
         }
         self._sources.append(entry)
         return entry
@@ -153,6 +155,75 @@ class TestInvalidUrlRejected:
                 "action": "add",
                 "url": "owner/repo",
                 "source_type": "rss",
+                "probe": False,
+            },
+        )
+        data = _parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+
+
+# ---------------------------------------------------------------------------
+# github mode param (#625)
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubModeParam:
+    async def test_mode_releases_persisted(self) -> None:
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "owner/repo",
+                "source_type": "github",
+                "mode": "releases",
+            },
+        )
+        data = _parse(result)
+        assert "error" not in data
+        assert data["added"]["mode"] == "releases"
+
+    async def test_mode_defaults_to_empty_when_omitted(self) -> None:
+        # Omitting mode persists '' so the adapter applies its own default
+        # (releases). The contentless events firehose is never the default.
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "owner/repo",
+                "source_type": "github",
+            },
+        )
+        data = _parse(result)
+        assert data["added"]["mode"] == ""
+
+    async def test_invalid_mode_rejected(self) -> None:
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "owner/repo",
+                "source_type": "github",
+                "mode": "bogus",
+            },
+        )
+        data = _parse(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert await store.list_feed_sources() == []
+
+    async def test_mode_rejected_for_rss(self) -> None:
+        store = FakeSourceStore()
+        result = await _handle_watch(
+            store=store,
+            arguments={
+                "action": "add",
+                "url": "https://example.com/feed",
+                "source_type": "rss",
+                "mode": "releases",
                 "probe": False,
             },
         )

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1430,3 +1430,115 @@ class TestReaderEnrichment:
 
         assert summary.total_items_enriched == 0
         assert reader.calls == []  # filtered out by candidate predicate
+
+
+# ---------------------------------------------------------------------------
+# GitHub releases mode — end-to-end against the real store + adapter (#625)
+# ---------------------------------------------------------------------------
+
+
+def _mock_releases_client(payload: object) -> MagicMock:
+    """Build a MagicMock httpx.Client whose GET returns *payload* as JSON."""
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    client = MagicMock()
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    client.get.return_value = response
+    return client
+
+
+_RELEASES_PAYLOAD = [
+    {
+        "id": 1,
+        "tag_name": "v1.0.0",
+        "name": "First release",
+        "body": "Initial release notes body text.",
+        "prerelease": False,
+        "author": {"login": "releaser"},
+        "html_url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+        "published_at": "2024-03-25T09:00:00Z",
+    },
+    {
+        "id": 2,
+        "tag_name": "v0.9.0",
+        "name": "Prerelease",
+        "body": "Earlier prerelease notes.",
+        "prerelease": True,
+        "author": {"login": "releaser"},
+        "html_url": "https://github.com/owner/repo/releases/tag/v0.9.0",
+        "published_at": "2024-03-20T09:00:00Z",
+    },
+]
+
+
+@pytest.mark.integration
+class TestGitHubReleasesPollEndToEnd:
+    """End-to-end: real DuckDB store + real GitHubAdapter, httpx mocked."""
+
+    async def _run_poll(self, store: object) -> object:
+        cfg = _make_config(sources=[], digest_threshold=0.0)
+        poller = FeedPoller(store=store, config=cfg)  # type: ignore[arg-type]
+        return await poller.poll()
+
+    async def test_releases_mode_yields_one_body_bearing_entry_per_release(
+        self, store: object
+    ) -> None:
+        await store.add_feed_source(  # type: ignore[attr-defined]
+            url="owner/repo", source_type="github", mode="releases"
+        )
+
+        with patch(
+            "distillery.feeds.github.httpx.Client",
+            return_value=_mock_releases_client(_RELEASES_PAYLOAD),
+        ):
+            summary = await self._run_poll(store)
+
+        assert summary.total_fetched == 2
+        assert summary.total_stored == 2
+
+        entries = await store.list_entries(  # type: ignore[attr-defined]
+            filters=None, limit=100, offset=0
+        )
+        ext_ids = {e.metadata.get("external_id") for e in entries}
+        assert ext_ids == {"owner/repo@v1.0.0", "owner/repo@v0.9.0"}
+        # Each entry carries the real release-notes body, not an event title.
+        bodies = {e.metadata.get("external_id"): e.content for e in entries}
+        assert "Initial release notes body text." in bodies["owner/repo@v1.0.0"]
+        # No contentless "*Event by ... on ..." stub titles.
+        assert all("Event by" not in (e.metadata.get("title") or "") for e in entries)
+
+    async def test_repoll_is_deduped(self, store: object) -> None:
+        await store.add_feed_source(  # type: ignore[attr-defined]
+            url="owner/repo", source_type="github", mode="releases"
+        )
+
+        with patch(
+            "distillery.feeds.github.httpx.Client",
+            return_value=_mock_releases_client(_RELEASES_PAYLOAD),
+        ):
+            first = await self._run_poll(store)
+            second = await self._run_poll(store)
+
+        assert first.total_stored == 2
+        # Re-poll of the same releases stores nothing new and skips via dedup.
+        assert second.total_stored == 0
+        assert second.total_skipped_dedup == 2
+
+        entries = await store.list_entries(  # type: ignore[attr-defined]
+            filters=None, limit=100, offset=0
+        )
+        assert len(entries) == 2  # no duplicates
+
+    async def test_default_mode_polls_releases_not_events(self, store: object) -> None:
+        # No explicit mode -> adapter default (releases). Verify the releases
+        # endpoint is hit and no event-stub entries are produced.
+        await store.add_feed_source(url="owner/repo", source_type="github")  # type: ignore[attr-defined]
+
+        client = _mock_releases_client(_RELEASES_PAYLOAD)
+        with patch("distillery.feeds.github.httpx.Client", return_value=client):
+            await self._run_poll(store)
+
+        called_url = client.get.call_args.args[0]
+        assert called_url.endswith("/repos/owner/repo/releases")

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -39,6 +39,7 @@ class FakeSourceStore:
         trust_weight: float = 1.0,
         threshold_alert: float | None = None,
         threshold_digest: float | None = None,
+        mode: str = "",
     ) -> dict[str, Any]:
         if any(s["url"] == url for s in self._sources):
             raise ValueError(f"Feed source with URL {url!r} already exists.")
@@ -50,6 +51,7 @@ class FakeSourceStore:
             "trust_weight": trust_weight,
             "threshold_alert": threshold_alert,
             "threshold_digest": threshold_digest,
+            "mode": mode,
         }
         self._sources.append(d)
         return d


### PR DESCRIPTION
## Root cause

The `github` watch source polled the contentless public **events** firehose (`GET /repos/{owner}/{repo}/events`): rows titled `IssuesEvent`/`PullRequestEvent`/`PushEvent`/... where `content == title`, no body, mostly bot-authored. On a live instance this was 39,099 entries = 75.6% of a 51,724-entry store, buried signal, and stored the same item up to 4x.

## Fix

`src/distillery/feeds/github.py` — `GitHubAdapter` now defaults to `mode="releases"`:

- `DEFAULT_MODE = "releases"`, `VALID_MODES = {"releases", "events"}`.
- `releases` polls `GET /repos/{owner}/{repo}/releases` and emits one body-bearing `FeedItem` per release carrying the release-notes body, tag, name, and prerelease flag, with `item_id = "{owner}/{repo}@{tag}"` (`github.py:213,245`).
- The `events` firehose is preserved as opt-in only (explicit `mode="events"`).

Plumbing for the new per-source selector:

- `src/distillery/config.py` — `FeedSourceConfig.mode` field; `_parse_feed_source` validates `mode` is only set on `github` sources and is one of `{releases, events}`.
- `src/distillery/store/migrations.py` — migration 16 adds nullable `mode VARCHAR DEFAULT ''` to `feed_sources` (mirrors migration 3's `created_by` pattern; reader coalesces NULL to '').
- `src/distillery/store/{duckdb.py,protocol.py}` — persist/read `mode` through the feed-source store API.
- `src/distillery/feeds/poller.py` — pass the configured `mode` to the adapter.
- `src/distillery/mcp/{server.py,tools/feeds.py}` and `skills/watch/SKILL.md` — extend the existing `distillery_watch` tool with one optional `mode` param (additive; no new MCP tool).

Dedup is genuine: `github` is in `_AUTHORITATIVE_EXTERNAL_ID_TYPES`, and `item_id` flows to `metadata.external_id`, checked via `_has_external_id`.

## Acceptance

- [x] A repo added in `releases` mode yields one entry per release with the changelog body, deduped — `tests/test_poller.py::TestGitHubReleasesPollEndToEnd::test_releases_mode_yields_one_body_bearing_entry_per_release` (real DuckDB store + real adapter, httpx mocked; asserts `len(entries)==2` with real body text) and `test_repoll_is_deduped` (asserts `total_skipped_dedup==2` on re-poll).
- [x] The contentless events firehose is no longer ingested by default — `tests/test_poller.py::...::test_default_mode_polls_releases_not_events` asserts the `/releases` endpoint is hit, not `/events`.
- [x] On a fresh instance, `source/github` volume is dominated by body-bearing entries — follows directly: the default surface now emits one body-bearing release entry instead of contentless `*Event` stubs.

## Test plan

```
PYTHONPATH="$PWD/src" .venv/bin/python -m pytest tests/test_feeds.py tests/test_poller.py tests/test_mcp_watch.py tests/test_mcp_feeds.py tests/test_watch.py -q
# 297 passed, 2 warnings (pre-existing, unrelated)

.venv/bin/ruff check src tests          # All checks passed!
PYTHONPATH="$PWD/src" .venv/bin/mypy --strict src/distillery   # Success: no issues found in 72 source files
```

## Related

Shares files with sibling PRs in this batch (`feeds/poller.py`, `store/duckdb.py`, `config.py`) and may conflict on merge. Merge the smaller/independent PRs first and rebase this one; resolve semantically so both issues' behavior coexists.

Closes #625


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub feed sources now support an optional `mode` parameter to select between `releases` (new default) or `events` polling
  * `distillery_watch` tool extended with GitHub-only `--mode` option when adding feeds

* **Documentation**
  * Updated `watch` skill documentation for the new `--mode` parameter

* **Tests**
  * Added comprehensive test coverage for releases mode polling and mode validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->