### PR TITLE
cli: filtered export by type/tag/source/status (#634)

### DIFF
--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -205,6 +205,39 @@ def _build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Path to write the exported JSON file",
     )
+    export_parser.add_argument(
+        "--type",
+        dest="entry_types",
+        metavar="ENTRY_TYPE",
+        action="append",
+        default=None,
+        help="Only export entries of this type (repeatable; ORed across values)",
+    )
+    export_parser.add_argument(
+        "--tag",
+        dest="tags",
+        metavar="TAG",
+        action="append",
+        default=None,
+        help="Only export entries carrying this tag (repeatable; ANDed across values)",
+    )
+    export_parser.add_argument(
+        "--source",
+        dest="sources",
+        metavar="ORIGIN|FEED_URL",
+        action="append",
+        default=None,
+        help=(
+            "Only export entries from this origin or feed URL, and limit feed "
+            "sources to matching URLs (repeatable; ORed across values)"
+        ),
+    )
+    export_parser.add_argument(
+        "--status",
+        choices=["active", "archived", "any"],
+        default="any",
+        help="Filter entries by status (default: any — current whole-store behaviour)",
+    )
 
     import_parser = subparsers.add_parser(
         "import",
@@ -963,12 +996,32 @@ def _cmd_gh_backfill(
 # ---------------------------------------------------------------------------
 
 
-def _cmd_export(config_path: str | None, fmt: str, output_path: str) -> int:
+def _cmd_export(
+    config_path: str | None,
+    fmt: str,
+    output_path: str,
+    entry_types: list[str] | None = None,
+    tags: list[str] | None = None,
+    sources: list[str] | None = None,
+    status: str = "any",
+) -> int:
     """Implement the ``export`` subcommand.
 
-    Queries all entries, feed sources, and _meta from the database and writes
-    a portable JSON snapshot to *output_path*.  Embeddings are omitted so the
+    Queries entries, feed sources, and _meta from the database and writes a
+    portable JSON snapshot to *output_path*.  Embeddings are omitted so the
     file can be safely imported on any instance.
+
+    Optional filters are ANDed together; when none are supplied the entire
+    store is exported (back-compatible behaviour):
+
+    - *entry_types*: keep entries whose ``entry_type`` is one of these values.
+    - *tags*: keep entries whose ``tags`` array contains *all* listed tags
+      (AND / intersection — mirrors the store ``list_entries`` semantics).
+    - *sources*: keep entries whose ``source`` column or
+      ``metadata.source_url`` matches one of these values, and limit the
+      exported feed sources to rows whose ``url`` matches one of them.
+    - *status*: ``"active"`` or ``"archived"`` restricts by status;
+      ``"any"`` (default) applies no status filter.
 
     Returns:
         Exit code (0 on success, 1 on error).
@@ -995,6 +1048,30 @@ def _cmd_export(config_path: str | None, fmt: str, output_path: str) -> int:
         if not resolved.exists():
             raise RuntimeError(f"Database file not found: {db_path}")
 
+        # Build the entry filter WHERE clause. Each group is ANDed; sources
+        # are ORed within their group so any matching origin/feed URL keeps
+        # the row.
+        entry_clauses: list[str] = []
+        entry_params: list[Any] = []
+        if entry_types:
+            placeholders = ", ".join("?" for _ in entry_types)
+            entry_clauses.append(f"entry_type IN ({placeholders})")
+            entry_params.extend(entry_types)
+        if tags:
+            for tag in tags:
+                entry_clauses.append("list_contains(tags, ?)")
+                entry_params.append(tag)
+        if sources:
+            ors: list[str] = []
+            for src in sources:
+                ors.append("(source = ? OR json_extract_string(metadata, '$.source_url') = ?)")
+                entry_params.extend([src, src])
+            entry_clauses.append("(" + " OR ".join(ors) + ")")
+        if status != "any":
+            entry_clauses.append("status = ?")
+            entry_params.append(status)
+        entry_where = f" WHERE {' AND '.join(entry_clauses)}" if entry_clauses else ""
+
         conn = _duckdb.connect(str(resolved), read_only=True)
         try:
             # Verify the entries table exists.
@@ -1008,7 +1085,8 @@ def _cmd_export(config_path: str | None, fmt: str, output_path: str) -> int:
             entry_rows = conn.execute(
                 "SELECT id, content, entry_type, source, status, tags, metadata, "
                 "version, project, author, created_at, updated_at, created_by, "
-                "last_modified_by, expires_at, session_id FROM entries"
+                "last_modified_by, expires_at, session_id FROM entries" + entry_where,
+                entry_params,
             ).fetchall()
             entry_cols = [
                 "id",
@@ -1050,8 +1128,15 @@ def _cmd_export(config_path: str | None, fmt: str, output_path: str) -> int:
                         entry[col] = val
                 entries.append(entry)
 
-            # Query feed_sources.
-            feed_rows = conn.execute("SELECT * FROM feed_sources").fetchall()
+            # Query feed_sources, limiting to selected URLs when --source given.
+            if sources:
+                feed_placeholders = ", ".join("?" for _ in sources)
+                feed_rows = conn.execute(
+                    f"SELECT * FROM feed_sources WHERE url IN ({feed_placeholders})",
+                    list(sources),
+                ).fetchall()
+            else:
+                feed_rows = conn.execute("SELECT * FROM feed_sources").fetchall()
             feed_cols = [desc[0] for desc in conn.description]
             feed_sources: list[dict[str, Any]] = []
             for row in feed_rows:
@@ -2137,6 +2222,10 @@ def main(argv: list[str] | None = None) -> None:
             config_path=config_path,
             fmt=fmt,
             output_path=args.output,
+            entry_types=args.entry_types,
+            tags=args.tags,
+            sources=args.sources,
+            status=args.status,
         )
     elif command == "import":
         exit_code = _cmd_import(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -838,6 +838,202 @@ class TestExportCommand:
         assert rc == 1
 
 
+def _seed_export_db(db_path: str) -> None:
+    """Populate a DB with mixed entries + feed sources for filter tests."""
+    import asyncio
+
+    from distillery.models import EntrySource, EntryType
+    from distillery.store.duckdb import DuckDBStore
+    from tests.conftest import make_entry
+
+    async def _setup() -> None:
+        from distillery.mcp._stub_embedding import StubEmbeddingProvider
+
+        store = DuckDBStore(db_path=db_path, embedding_provider=StubEmbeddingProvider())
+        await store.initialize()
+        # Target row: session + both tags + claude-code origin.
+        await store.store(
+            make_entry(
+                content="session match",
+                entry_type=EntryType.SESSION,
+                source=EntrySource.CLAUDE_CODE,
+                tags=["domain/competitive", "team/eng"],
+            )
+        )
+        # Session but missing one of the AND tags.
+        await store.store(
+            make_entry(
+                content="session partial tags",
+                entry_type=EntryType.SESSION,
+                source=EntrySource.CLAUDE_CODE,
+                tags=["domain/competitive"],
+            )
+        )
+        # Right tags but wrong type.
+        await store.store(
+            make_entry(
+                content="inbox wrong type",
+                entry_type=EntryType.INBOX,
+                source=EntrySource.MANUAL,
+                tags=["domain/competitive", "team/eng"],
+            )
+        )
+        # Feed entry attributed to a feed URL via metadata.source_url.
+        await store.store(
+            make_entry(
+                content="feed item",
+                entry_type=EntryType.FEED,
+                source=EntrySource.MANUAL,
+                tags=[],
+                metadata={"source_type": "rss", "source_url": "https://eng.example.com/feed"},
+            )
+        )
+        await store.add_feed_source(
+            url="https://eng.example.com/feed", source_type="rss", label="eng"
+        )
+        await store.add_feed_source(
+            url="https://mkt.example.com/feed", source_type="rss", label="mkt"
+        )
+        await store.close()
+
+    asyncio.run(_setup())
+
+
+class TestExportFilters:
+    def test_type_and_tag_filter_keeps_only_matches(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """--type session --tag a --tag b exports only the row matching all."""
+        db_path = str(tmp_path / "test.db")
+        _seed_export_db(db_path)
+        cfg_path = write_config(tmp_path, db_path)
+        out_path = str(tmp_path / "eng.json")
+        rc = _cmd_export(
+            str(cfg_path),
+            "text",
+            out_path,
+            entry_types=["session"],
+            tags=["domain/competitive", "team/eng"],
+        )
+        assert rc == 0
+        data = json.loads(Path(out_path).read_text(encoding="utf-8"))
+        contents = [e["content"] for e in data["entries"]]
+        assert contents == ["session match"]
+
+    def test_no_filters_exports_whole_store(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """No filters reproduces the current whole-store output byte-for-byte."""
+        db_path = str(tmp_path / "test.db")
+        _seed_export_db(db_path)
+        cfg_path = write_config(tmp_path, db_path)
+        unfiltered = str(tmp_path / "all.json")
+        defaulted = str(tmp_path / "all_defaults.json")
+        rc1 = _cmd_export(str(cfg_path), "text", unfiltered)
+        rc2 = _cmd_export(
+            str(cfg_path),
+            "text",
+            defaulted,
+            entry_types=None,
+            tags=None,
+            sources=None,
+            status="any",
+        )
+        assert rc1 == 0
+        assert rc2 == 0
+        a = json.loads(Path(unfiltered).read_text(encoding="utf-8"))
+        b = json.loads(Path(defaulted).read_text(encoding="utf-8"))
+        # All four seeded entries and both feed sources present.
+        assert len(a["entries"]) == 4
+        assert len(a["feed_sources"]) == 2
+        # Explicit defaults match the bare call's structure (ignoring timestamp).
+        a.pop("exported_at")
+        b.pop("exported_at")
+        assert a == b
+
+    def test_source_filters_entries_and_feed_sources(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """--source keeps matching entries and only the matching feed sources."""
+        db_path = str(tmp_path / "test.db")
+        _seed_export_db(db_path)
+        cfg_path = write_config(tmp_path, db_path)
+        out_path = str(tmp_path / "feed.json")
+        rc = _cmd_export(
+            str(cfg_path),
+            "text",
+            out_path,
+            sources=["https://eng.example.com/feed"],
+        )
+        assert rc == 0
+        data = json.loads(Path(out_path).read_text(encoding="utf-8"))
+        # Only the feed entry whose metadata.source_url matches.
+        assert [e["content"] for e in data["entries"]] == ["feed item"]
+        # Feed-source export is limited to the selected URL.
+        assert [f["url"] for f in data["feed_sources"]] == ["https://eng.example.com/feed"]
+
+    def test_source_matches_origin_column(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """--source also matches the entry ``source`` (origin) column."""
+        db_path = str(tmp_path / "test.db")
+        _seed_export_db(db_path)
+        cfg_path = write_config(tmp_path, db_path)
+        out_path = str(tmp_path / "cc.json")
+        rc = _cmd_export(str(cfg_path), "text", out_path, sources=["claude-code"])
+        assert rc == 0
+        data = json.loads(Path(out_path).read_text(encoding="utf-8"))
+        contents = sorted(e["content"] for e in data["entries"])
+        assert contents == ["session match", "session partial tags"]
+
+    def test_status_filter_restricts_by_status(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """--status archived returns no rows when all seeded entries are active."""
+        db_path = str(tmp_path / "test.db")
+        _seed_export_db(db_path)
+        cfg_path = write_config(tmp_path, db_path)
+        out_path = str(tmp_path / "archived.json")
+        rc = _cmd_export(str(cfg_path), "text", out_path, status="archived")
+        assert rc == 0
+        data = json.loads(Path(out_path).read_text(encoding="utf-8"))
+        assert data["entries"] == []
+
+    def test_main_passes_filter_flags(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The argparse layer wires --type/--tag/--source through to the export."""
+        db_path = str(tmp_path / "test.db")
+        _seed_export_db(db_path)
+        cfg_path = write_config(tmp_path, db_path)
+        out_path = str(tmp_path / "via_main.json")
+        with pytest.raises(SystemExit) as exc:
+            main(
+                [
+                    "export",
+                    "--config",
+                    str(cfg_path),
+                    "--output",
+                    out_path,
+                    "--type",
+                    "session",
+                    "--tag",
+                    "domain/competitive",
+                    "--tag",
+                    "team/eng",
+                ]
+            )
+        assert exc.value.code == 0
+        data = json.loads(Path(out_path).read_text(encoding="utf-8"))
+        assert [e["content"] for e in data["entries"]] == ["session match"]
+
+
 # ---------------------------------------------------------------------------
 # import subcommand
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Gap

`distillery export` accepted only `--output` and dumped the entire store (all entries + all feed sources). Partitioning an instance (e.g. splitting a 51,724-entry ambient instance into eng/marketing slices, dropping a ~39k GitHub event-stub firehose) required export-everything-then-script-the-JSON.

## Fix

Additive filter flags on the existing `export` subcommand (no new MCP tool — honors the v0.4.0 stability pledge). Flags are ANDed together; omitting all of them reproduces the prior whole-store behaviour.

```
--type   ENTRY_TYPE     repeatable; entry_type IN (...)            (OR within group)
--tag    TAG            repeatable; one list_contains(tags, ?) each (AND across tags, per #626)
--source ORIGIN|FEED_URL repeatable; (source = ? OR metadata.source_url = ?) and limits feed_sources to matching url (OR within group)
--status active|archived|any   default any (no status filter)
```

`_cmd_export` gains keyword params `entry_types/tags/sources/status` (all defaulted), so existing callers are unaffected. The WHERE clause is built from hardcoded column names with every value bound via `?` — fully parameterized, no injection. Feed sources are restricted to `url IN (...)` only when `--source` is given.

## Acceptance

- [x] `distillery export --type session --tag domain/competitive --output eng.json` writes only matching entries — `TestExportFilters::test_type_and_tag_filter_keeps_only_matches` (type+tag AND; excludes the partial-tag row) and `test_main_passes_filter_flags` (argv threads flags into `_cmd_export`).
- [x] No filters = current whole-store behaviour (back-compat) — `test_no_filters_exports_whole_store` (bare 3-arg call and explicit-defaults call produce byte-identical payloads: all 4 entries + 2 feed sources).
- [x] Feed-source export respects `--source` selection — `test_source_filters_entries_and_feed_sources` (limits both entries and feed_sources to selected URLs) and `test_source_matches_origin_column` (OR-match on the `source` column).
- [x] (Beyond required) `--status` directional filter — `test_status_filter_restricts_by_status`.

`--query` (semantic) and `--exclude-tag` were marked "optionally" in the issue and intentionally not implemented (no embedding provider on the read-only export path).

## Test plan

```
PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/test_cli.py -k "TestExportFilters or TestExportCommand" -q
  -> 14 passed
PYTHONPATH=$PWD/src .venv/bin/mypy --strict src/distillery
  -> Success: no issues found in 72 source files
.venv/bin/ruff check src tests
  -> All checks passed!
```

Closes #634


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `export` command now supports filtering exported data with new CLI options for greater control: filter by entry type (`--type`), tags (`--tag`), source or feed URLs (`--source`), and entry status (`--status`). Multiple filters can be combined for more precise and efficient data exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->