### PR TITLE
mcp: add output_mode (summary|full|ids) to distillery_search (#631)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -945,6 +945,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         include_evergreen: bool = False,
         expand_graph: bool = False,
         expand_hops: int = 1,
+        output_mode: str = "summary",
     ) -> list[types.TextContent]:
         """Search knowledge entries using semantic similarity (cosine distance, ranked descending).
 
@@ -997,8 +998,16 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             results.
           - expand_hops (int, optional, default=1): Depth of graph expansion when
             ``expand_graph=true``.  Must be 1 or 2.
+          - output_mode (str, optional, default="summary"): Response shape.
+            Valid: [summary, full, ids]. "summary" returns score plus a compact entry
+            (id/title/~200-char content_preview, no full body — default, keeps responses
+            small to conserve context). "full" returns score plus the entire entry
+            (pre-output_mode behaviour). "ids" returns score + id only.
 
-        RETURNS (success): { results: [{ score: float, entry: {...} }], count: int }.
+        RETURNS (success): { results: [{ score: float, ... }], count: int }.
+          Result shape follows ``output_mode``: "summary" (default) nests a compact
+          ``entry`` (no full content); "full" nests the complete ``entry``; "ids"
+          returns ``score`` + ``id`` only.
           When ``expand_graph=true`` each result also has ``provenance`` ("search" or
           "graph"); graph results additionally carry ``depth`` and ``parent_id``, and
           the envelope includes ``graph_expansion: { seed_count, expanded_count }``.
@@ -1015,6 +1024,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             include_evergreen=include_evergreen,
             expand_graph=expand_graph,
             expand_hops=expand_hops,
+            output_mode=output_mode,
             **_omit_none(
                 entry_type=entry_type,
                 author=author,

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -27,9 +27,16 @@ from distillery.mcp.tools._errors import upstream_error_response, validate_limit
 from distillery.mcp.tools.crud import (
     _apply_default_status_filter,
     _build_filters_from_arguments,
+    _entry_to_summary_dict,
 )
 
 logger = logging.getLogger(__name__)
+
+# Valid ``output_mode`` values for ``distillery_search`` (issue #631). Mirrors
+# the ``distillery_list`` precedent (#78) minus ``"review"`` (review is a
+# list-only concept). ``"summary"`` is the default to cut token cost on
+# agentic retrieval; ``"full"`` is the back-compat escape hatch.
+_VALID_SEARCH_OUTPUT_MODES = frozenset({"summary", "full", "ids"})
 
 # Maps ``distillery_find_similar(accept_action=...)`` values to the
 # ``entry_relations.relation_type`` written when the caller accepts a match
@@ -40,6 +47,42 @@ _ACCEPT_ACTION_TO_RELATION_TYPE: dict[str, str] = {
     "merge": "merge_source",
     "duplicate": "duplicate",
 }
+
+# ---------------------------------------------------------------------------
+# Output-mode shaping (issue #631)
+# ---------------------------------------------------------------------------
+
+
+def _shape_search_result(
+    entry: Any,
+    score: float,
+    output_mode: str,
+    *,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Shape a single search hit per ``output_mode`` (issue #631).
+
+    * ``full``: ``{"score", "entry": <full to_dict()>}`` — the pre-#631
+      behaviour, preserved exactly as the back-compat escape hatch.
+    * ``summary``: ``{"score", "entry": <_entry_to_summary_dict()>}`` — id /
+      title / ~200-char ``content_preview`` (no full content body). Reuses the
+      ``distillery_list`` summary helper so the shapes stay consistent.
+    * ``ids``: ``{"score", "id"}`` — id + score only.
+
+    ``extra`` carries graph-expansion annotations (``provenance``, ``depth``,
+    ``parent_id``) that are merged onto the result dict for every mode.
+    """
+    result: dict[str, Any]
+    if output_mode == "ids":
+        result = {"score": round(score, 6), "id": entry.id}
+    elif output_mode == "summary":
+        result = {"score": round(score, 6), "entry": _entry_to_summary_dict(entry)}
+    else:  # "full"
+        result = {"score": round(score, 6), "entry": entry.to_dict()}
+    if extra:
+        result.update(extra)
+    return result
+
 
 # ---------------------------------------------------------------------------
 # _handle_search
@@ -73,15 +116,19 @@ async def _handle_search(
         store: Initialised :class:`~distillery.store.duckdb.DuckDBStore`.
         arguments: Dictionary containing at minimum the key `query` (str). May include
             optional filter keys (e.g., `entry_type`, `author`, `project`, `tags`,
-            `status`, `date_from`, `date_to`), `limit` (int), and the additive
-            graph-expansion params `expand_graph` (bool) and `expand_hops` (int, 1 or 2).
+            `status`, `date_from`, `date_to`), `limit` (int), the additive
+            graph-expansion params `expand_graph` (bool) and `expand_hops` (int, 1 or 2),
+            and `output_mode` (str: "summary" | "full" | "ids", default "summary").
         cfg: Optional configuration used to enforce embedding budget.
 
     Returns:
-        MCP content list containing a single JSON object with `results` (list of objects
-        each with `score` and `entry`) and `count` (int) describing the number of results
-        returned.  When ``expand_graph=True`` results also include ``provenance`` and the
-        envelope includes a ``graph_expansion`` field.
+        MCP content list containing a single JSON object with `results` (list of objects)
+        and `count` (int).  Result shape follows ``output_mode`` (issue #631): "summary"
+        (default) returns `score` plus a compact `entry` (id/title/~200-char
+        content_preview, no full body); "full" returns `score` plus the full `entry`
+        (pre-#631 behaviour); "ids" returns `score` and `id` only.  When
+        ``expand_graph=True`` results also include ``provenance`` and the envelope
+        includes a ``graph_expansion`` field.
     """
     from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
 
@@ -108,6 +155,18 @@ async def _handle_search(
     expand_hops: int = expand_hops_raw
     if expand_hops not in (1, 2):
         return error_response("INVALID_PARAMS", "expand_hops must be 1 or 2")
+
+    # --- output_mode (issue #631) ------------------------------------------
+    output_mode: str = arguments.get("output_mode", "summary")
+    err_output_mode = validate_type(arguments, "output_mode", str, "string")
+    if err_output_mode:
+        return error_response("INVALID_PARAMS", err_output_mode)
+    if output_mode not in _VALID_SEARCH_OUTPUT_MODES:
+        return error_response(
+            "INVALID_PARAMS",
+            f"Field 'output_mode' must be one of: "
+            f"{', '.join(sorted(_VALID_SEARCH_OUTPUT_MODES))}",
+        )
 
     # --- embedding budget check (1 embed call per search) -------------------
     if cfg is not None:
@@ -145,9 +204,7 @@ async def _handle_search(
         )
 
     if not expand_graph:
-        results = [
-            {"score": round(sr.score, 6), "entry": sr.entry.to_dict()} for sr in search_results
-        ]
+        results = [_shape_search_result(sr.entry, sr.score, output_mode) for sr in search_results]
 
         # Log the search event to search_log for later implicit-feedback correlation.
         search_logging = cfg is None or cfg.rate_limit.search_logging_enabled
@@ -176,7 +233,7 @@ async def _handle_search(
     allowed_statuses: set[str] | None = _allowed_statuses_from_filters(filters)
     try:
         merged_results, seed_count, expanded_count = await _expand_search_with_graph(
-            store, search_results, expand_hops, limit, allowed_statuses
+            store, search_results, expand_hops, limit, allowed_statuses, output_mode
         )
     except Exception:  # noqa: BLE001
         logger.exception("Error during graph expansion in distillery_search")
@@ -234,6 +291,7 @@ async def _expand_search_with_graph(
     expand_hops: int,
     limit: int,
     allowed_statuses: set[str] | None = None,
+    output_mode: str = "full",
 ) -> tuple[list[dict[str, Any]], int, int]:
     """BFS-expand the seed search results via ``store.get_related``.
 
@@ -248,6 +306,10 @@ async def _expand_search_with_graph(
     merge — preventing archived (or otherwise-filtered) entries from
     leaking into the result via graph expansion.  When ``None`` no
     status-based filtering is applied to expanded entries.
+
+    ``output_mode`` (issue #631) controls per-hit shaping ("summary" | "full"
+    | "ids") via :func:`_shape_search_result`; graph annotations
+    (``provenance``/``depth``/``parent_id``) are preserved in every mode.
     """
     seed_ids: set[str] = {sr.entry.id for sr in search_results}
     seed_score_by_id: dict[str, float] = {sr.entry.id: float(sr.score) for sr in search_results}
@@ -306,21 +368,25 @@ async def _expand_search_with_graph(
             # filtered) entries never leak in via BFS.
             continue
         expanded_results.append(
-            {
-                "score": round(info["_score"], 6),
-                "entry": entry.to_dict(),
-                "provenance": "graph",
-                "depth": info["_depth"],
-                "parent_id": info["_parent_id"],
-            }
+            _shape_search_result(
+                entry,
+                info["_score"],
+                output_mode,
+                extra={
+                    "provenance": "graph",
+                    "depth": info["_depth"],
+                    "parent_id": info["_parent_id"],
+                },
+            )
         )
 
     seed_dicts: list[dict[str, Any]] = [
-        {
-            "score": round(sr.score, 6),
-            "entry": sr.entry.to_dict(),
-            "provenance": "search",
-        }
+        _shape_search_result(
+            sr.entry,
+            sr.score,
+            output_mode,
+            extra={"provenance": "search"},
+        )
         for sr in search_results
     ]
 

--- a/tests/test_list_archived_default.py
+++ b/tests/test_list_archived_default.py
@@ -159,9 +159,12 @@ class TestApplyDefaultStatusFilter:
 @pytest.mark.unit
 class TestSearchDefaultExcludesArchived:
     async def test_default_search_excludes_archived(self, status_mixed_store) -> None:
+        # output_mode="full" so the entry payload carries ``status`` (the
+        # summary default introduced by #631 omits it). The archived-exclusion
+        # contract under test is independent of output_mode.
         result = await _handle_search(
             store=status_mixed_store,
-            arguments={"query": "entry content", "limit": 50},
+            arguments={"query": "entry content", "limit": 50, "output_mode": "full"},
         )
         data = parse_mcp_response(result)
         statuses = {r["entry"]["status"] for r in data["results"]}
@@ -170,7 +173,12 @@ class TestSearchDefaultExcludesArchived:
     async def test_search_status_any_includes_archived(self, status_mixed_store) -> None:
         result = await _handle_search(
             store=status_mixed_store,
-            arguments={"query": "entry content", "limit": 50, "status": "any"},
+            arguments={
+                "query": "entry content",
+                "limit": 50,
+                "status": "any",
+                "output_mode": "full",
+            },
         )
         data = parse_mcp_response(result)
         statuses = {r["entry"]["status"] for r in data["results"]}
@@ -183,6 +191,7 @@ class TestSearchDefaultExcludesArchived:
                 "query": "entry content",
                 "limit": 50,
                 "include_archived": True,
+                "output_mode": "full",
             },
         )
         data = parse_mcp_response(result)
@@ -196,6 +205,7 @@ class TestSearchDefaultExcludesArchived:
                 "query": "entry content",
                 "limit": 50,
                 "status": "archived",
+                "output_mode": "full",
             },
         )
         data = parse_mcp_response(result)

--- a/tests/test_mcp_tools/test_search_output_mode.py
+++ b/tests/test_mcp_tools/test_search_output_mode.py
@@ -1,0 +1,152 @@
+"""Tests for ``distillery_search`` output_mode shaping (issue #631).
+
+``_handle_search`` gained an ``output_mode`` param mirroring the
+``distillery_list`` precedent (#78):
+
+  - "summary" (default): score + compact entry (id/title/~200-char
+    content_preview, NO full content body)
+  - "full": score + full entry (pre-#631 behaviour, back-compat escape hatch)
+  - "ids": score + id only
+
+These tests exercise ``_handle_search`` directly against the shared in-memory
+``store`` fixture (hash-based embeddings — every stored entry is an
+unthresholded candidate, which is sufficient since we assert on shaping, not
+ranking).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from distillery.mcp.tools.search import _handle_search
+from distillery.models import EntryType
+from tests.conftest import make_entry, parse_mcp_response
+
+pytestmark = pytest.mark.unit
+
+
+# A body comfortably longer than the 200-char summary preview so we can assert
+# the preview is truncated and the full body is omitted in summary mode.
+_LONG_BODY = "Distillery output mode body sentence. " * 30
+
+
+async def _store_long_entry(store, content: str = _LONG_BODY) -> str:
+    entry = make_entry(content=content, entry_type=EntryType.INBOX)
+    await store.store(entry)
+    return entry.id
+
+
+def _payload_size(response) -> int:  # type: ignore[no-untyped-def]
+    """Serialised byte size of the MCP text payload (proxy for token cost)."""
+    return len(response[0].text)
+
+
+# ---------------------------------------------------------------------------
+# Default (summary) shape
+# ---------------------------------------------------------------------------
+
+
+async def test_default_output_mode_is_summary(store) -> None:  # type: ignore[no-untyped-def]
+    """Default search returns id/title/preview/score and NOT full content."""
+    await _store_long_entry(store)
+
+    response = await _handle_search(store, {"query": "anything"})
+    data = parse_mcp_response(response)
+
+    assert data["count"] >= 1
+    hit = data["results"][0]
+
+    # score present on the hit
+    assert "score" in hit
+    # compact entry: id + title + content_preview, NO full content body
+    entry = hit["entry"]
+    assert "id" in entry
+    assert "title" in entry
+    assert "content_preview" in entry
+    assert "content" not in entry
+    # preview is truncated to ~200 chars (+ ellipsis) — strictly shorter than body
+    assert len(entry["content_preview"]) <= 201
+    assert len(entry["content_preview"]) < len(_LONG_BODY)
+
+
+# ---------------------------------------------------------------------------
+# full mode == pre-#631 behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_output_mode_full_returns_full_content(store) -> None:  # type: ignore[no-untyped-def]
+    """output_mode=full reproduces the current behaviour: full content per hit."""
+    await _store_long_entry(store)
+
+    response = await _handle_search(store, {"query": "anything", "output_mode": "full"})
+    data = parse_mcp_response(response)
+
+    hit = data["results"][0]
+    entry = hit["entry"]
+    # full mode carries the complete content body verbatim
+    assert entry["content"] == _LONG_BODY
+    # and is shaped exactly like the legacy {score, entry: to_dict()} pair
+    assert set(hit.keys()) == {"score", "entry"}
+
+
+# ---------------------------------------------------------------------------
+# ids mode
+# ---------------------------------------------------------------------------
+
+
+async def test_output_mode_ids_returns_id_and_score_only(store) -> None:  # type: ignore[no-untyped-def]
+    """output_mode=ids returns id + score only (no entry body)."""
+    entry_id = await _store_long_entry(store)
+
+    response = await _handle_search(store, {"query": "anything", "output_mode": "ids"})
+    data = parse_mcp_response(response)
+
+    hit = data["results"][0]
+    assert set(hit.keys()) == {"score", "id"}
+    assert hit["id"] == entry_id
+    assert "entry" not in hit
+
+
+# ---------------------------------------------------------------------------
+# token reduction: summary payload is materially smaller than full
+# ---------------------------------------------------------------------------
+
+
+async def test_summary_payload_smaller_than_full(store) -> None:  # type: ignore[no-untyped-def]
+    """A multi-hit summary search is materially smaller than the full payload."""
+    for _ in range(5):
+        await _store_long_entry(store)
+
+    summary_resp = await _handle_search(store, {"query": "anything", "output_mode": "summary"})
+    full_resp = await _handle_search(store, {"query": "anything", "output_mode": "full"})
+
+    summary_data = parse_mcp_response(summary_resp)
+    full_data = parse_mcp_response(full_resp)
+
+    # Same number of hits in both modes (ranking unchanged).
+    assert summary_data["count"] == full_data["count"] >= 5
+    # Summary mode returns materially fewer characters than full mode.
+    assert _payload_size(summary_resp) < _payload_size(full_resp)
+
+
+# ---------------------------------------------------------------------------
+# validation
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_output_mode_rejected(store) -> None:  # type: ignore[no-untyped-def]
+    """An unknown output_mode value yields INVALID_PARAMS."""
+    response = await _handle_search(store, {"query": "anything", "output_mode": "bogus"})
+    payload = json.loads(response[0].text)
+    assert payload["error"] is True
+    assert payload["code"] == "INVALID_PARAMS"
+
+
+async def test_output_mode_review_rejected(store) -> None:  # type: ignore[no-untyped-def]
+    """``review`` is a list-only mode and is rejected for search."""
+    response = await _handle_search(store, {"query": "anything", "output_mode": "review"})
+    payload = json.loads(response[0].text)
+    assert payload["error"] is True
+    assert payload["code"] == "INVALID_PARAMS"


### PR DESCRIPTION
## Gap

`distillery_search` returned full entry `content` for every hit. For agentic memory retrieval (many searches/session, multiple hits each) that is token-expensive. `distillery_list` already had `output_mode=summary` (#78) and `find_similar` has progressive disclosure; `search` did not.

## Fix

Additive `output_mode` param on `distillery_search` (`summary` | `full` | `ids`), defaulting to `summary`. No new MCP tool (v0.4.0 pledge).

```python
# src/distillery/mcp/tools/search.py
_VALID_SEARCH_OUTPUT_MODES = frozenset({"summary", "full", "ids"})

def _shape_search_result(entry, score, output_mode, *, extra=None):
    if output_mode == "ids":
        result = {"score": round(score, 6), "id": entry.id}
    elif output_mode == "summary":
        result = {"score": round(score, 6), "entry": _entry_to_summary_dict(entry)}
    else:  # "full"
        result = {"score": round(score, 6), "entry": entry.to_dict()}
    if extra:
        result.update(extra)
    return result
```

- `summary` (default): `score` + compact `entry` (id/title/~200-char `content_preview`, no full body), reusing `_entry_to_summary_dict` so the shape matches `distillery_list` (#78).
- `full`: `score` + full `entry.to_dict()` — pre-#631 behaviour, back-compat escape hatch.
- `ids`: `score` + `id` only.
- Shaping applied in BOTH the plain and graph-expansion paths via the shared `_shape_search_result`; graph annotations (`provenance`/`depth`/`parent_id`) preserved in every mode. Ranking unchanged.
- Invalid values (including list-only `review`) rejected with `INVALID_PARAMS`.
- The four archived-exclusion search tests now pass `output_mode=full` because they assert on `entry["status"]`, which the summary default omits; the filtering contract under test is unchanged.

## Acceptance

- [x] `distillery_search` default returns id/title/preview/score, not full content — `test_default_output_mode_is_summary` (asserts `content_preview` present, `content` absent, preview <= 201 chars).
- [x] `output_mode=full` reproduces current behaviour — `test_output_mode_full_returns_full_content` (asserts `entry["content"] == _LONG_BODY` and `{score, entry}` shape).
- [x] Measurable token reduction on a multi-hit search — `test_summary_payload_smaller_than_full` (5-hit search; summary payload byte size strictly less than full).

Bonus coverage: `test_output_mode_ids_returns_id_and_score_only`, `test_invalid_output_mode_rejected`, `test_output_mode_review_rejected`.

## Test plan

```
PYTHONPATH=src .venv/bin/python -m pytest tests/test_mcp_tools/test_search_output_mode.py \
  tests/test_list_archived_default.py tests/test_mcp_tools -q
  -> 120 passed

PYTHONPATH=src .venv/bin/mypy --strict src/distillery
  -> Success: no issues found in 72 source files

.venv/bin/ruff check src tests
  -> All checks passed!
```

Closes #631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now support selectable output modes: "summary" (compact preview, default), "full" (complete details), or "ids" (minimal with ID and score only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->