### PR TITLE
mcp: surface orphan rate in distillery_relations metrics (#635)

### DIFF
--- a/src/distillery/graph/metrics.py
+++ b/src/distillery/graph/metrics.py
@@ -9,6 +9,21 @@ from distillery.graph import nx
 from distillery.graph.builders import _require_networkx
 
 
+def orphan_rate(*, graph_node_count: int, total_entries: int) -> float:
+    """Fraction of entries that never appear in the relations graph.
+
+    Computed as ``1 - graph_node_count / total_entries``. The relations graph
+    only contains entries that are an endpoint of at least one relation, so an
+    entry with no relations is invisible to every graph metric. A high value
+    signals a near-empty graph (graph-health signal for operators).
+
+    Guards ``total_entries == 0`` -> ``0.0``.
+    """
+    if total_entries <= 0:
+        return 0.0
+    return 1.0 - graph_node_count / total_entries
+
+
 def bridges(g: Any, *, k: int = 10) -> list[tuple[str, float]]:
     """Top-k entries by betweenness centrality (descending)."""
     _require_networkx()

--- a/src/distillery/graph/metrics.py
+++ b/src/distillery/graph/metrics.py
@@ -17,11 +17,15 @@ def orphan_rate(*, graph_node_count: int, total_entries: int) -> float:
     entry with no relations is invisible to every graph metric. A high value
     signals a near-empty graph (graph-health signal for operators).
 
-    Guards ``total_entries == 0`` -> ``0.0``.
+    Guards ``total_entries == 0`` -> ``0.0`` and clamps the result to ``[0, 1]``:
+    the graph is built from unfiltered relations and may contain archived-but-
+    still-linked nodes that are excluded from ``total_entries``, so
+    ``graph_node_count`` can exceed the denominator (a documented rate must
+    never be negative; issue #635).
     """
     if total_entries <= 0:
         return 0.0
-    return 1.0 - graph_node_count / total_entries
+    return max(0.0, min(1.0, 1.0 - graph_node_count / total_entries))
 
 
 def bridges(g: Any, *, k: int = 10) -> list[tuple[str, float]]:

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1353,15 +1353,17 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - relation_id (str, required for remove): UUID of the relation to delete.
           - hops (int, optional for traverse, default=2): BFS depth, capped at [1, 3].
           - metric (str, required for metrics): Graph metric to compute.
-            Valid: [bridges, communities, constraint, link_prediction]. Requires
-            the [graph] optional extra.
+            Valid: [bridges, communities, constraint, link_prediction, orphans].
+            Requires the [graph] optional extra.
           - scope (str, optional for metrics, default="global"): Subgraph scope.
             Valid: [global, ego]. ``"ego"`` requires ``entry_id``.
           - limit (int, optional for metrics, default=10): top-k results.
             ``bridges`` = entries by betweenness centrality; ``communities`` = K
             largest communities; ``constraint`` = entries by lowest Burt constraint
             (strongest structural-hole brokers); ``link_prediction`` = top predicted
-            edges by Adamic-Adar (pass ``entry_id`` to score adjacencies for one entry).
+            edges by Adamic-Adar (pass ``entry_id`` to score adjacencies for one entry);
+            ``orphans`` = sample (<=50) of entry IDs absent from the relations graph
+            (unlinked entries — feeds a linking / gap-scan pass).
           - project / tags / date_from / date_to (optional, metrics global scope):
             restrict the entries whose relations participate in the graph.
 
@@ -1374,7 +1376,10 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             nodes: [{id: str, depth: int}], edges: [{from_id, to_id, relation_type}],
             node_count: int, edge_count: int } (traverse) or
           { action: "metrics", metric: str, scope: str, node_count: int, edge_count: int,
+            total_entries: int, graph_node_count: int, orphan_rate: float,
             results: list, count: int, computed_at: str, cache_hit: bool } (metrics).
+            ``orphan_rate`` = 1 - graph_node_count/total_entries (graph-health signal;
+            0.0 when total_entries is 0).
         RETURNS (error): { error: true, code: "NOT_FOUND" | "INVALID_PARAMS" | "INTERNAL", message: "..." }
 
         RELATED: distillery_correct (creates 'corrects' relations automatically),

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -746,14 +746,20 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
     # rate (e.g. a zero-orphan project reads as 0.833). Ego scope passes no
     # entry-side filters, so the count stays over all non-archived entries.
     total_filters: dict[str, Any] = {"status": _NON_ARCHIVED_STATUSES}
-    if project is not None:
-        total_filters["project"] = project
-    if tags:
-        total_filters["tags"] = tags
-    if date_from is not None:
-        total_filters["date_from"] = date_from
-    if date_to is not None:
-        total_filters["date_to"] = date_to
+    # Only global scope applies the entry-side filters to the graph (see the
+    # _collect_global_relations call above); ego scope ignores them and builds
+    # the subgraph around the root. Gate the denominator the same way so the
+    # population behind total_entries / orphan_rate / metric="orphans" matches
+    # the population behind the graph.
+    if scope == "global":
+        if project is not None:
+            total_filters["project"] = project
+        if tags:
+            total_filters["tags"] = tags
+        if date_from is not None:
+            total_filters["date_from"] = date_from
+        if date_to is not None:
+            total_filters["date_to"] = date_to
     try:
         total_entries = await store.count_entries(filters=total_filters)
     except Exception:  # noqa: BLE001

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -580,14 +580,16 @@ async def _sample_orphan_ids(
     *,
     graph_node_ids: set[str],
     cap: int,
+    filters: dict[str, Any],
 ) -> list[str]:
-    """Return up to *cap* non-archived entry IDs absent from the relations graph.
+    """Return up to *cap* entry IDs matching *filters* but absent from the graph.
 
     A sample — not the full orphan set — so the payload stays bounded on large
-    instances. Pages ``list_entries`` (non-archived only) and keeps the first
+    instances. *filters* carries the non-archived status plus any entry-side
+    filters (project/tags/date_*) so the sample is scoped consistently with the
+    graph and ``total_entries``. Pages ``list_entries`` and keeps the first
     *cap* IDs that are not graph nodes.
     """
-    filters = {"status": _NON_ARCHIVED_STATUSES}
     orphans: list[str] = []
     offset = 0
     while len(orphans) < cap:
@@ -736,13 +738,24 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
         return error_response("INTERNAL", "Failed to build relations graph")
 
     # ----- graph-health totals -----
-    # total_entries is the count of all non-archived entries; graph_node_count
-    # is how many of them are reachable via at least one relation. orphan_rate
-    # surfaces the gap (issue #635).
+    # total_entries is the count of non-archived entries; graph_node_count is
+    # how many of them are reachable via at least one relation. orphan_rate
+    # surfaces the gap (issue #635). The denominator MUST carry the same
+    # entry-side filters (project/tags/date_*) that scope the graph in global
+    # scope, otherwise a filtered graph over an unfiltered total inflates the
+    # rate (e.g. a zero-orphan project reads as 0.833). Ego scope passes no
+    # entry-side filters, so the count stays over all non-archived entries.
+    total_filters: dict[str, Any] = {"status": _NON_ARCHIVED_STATUSES}
+    if project is not None:
+        total_filters["project"] = project
+    if tags:
+        total_filters["tags"] = tags
+    if date_from is not None:
+        total_filters["date_from"] = date_from
+    if date_to is not None:
+        total_filters["date_to"] = date_to
     try:
-        total_entries = await store.count_entries(
-            filters={"status": _NON_ARCHIVED_STATUSES}
-        )
+        total_entries = await store.count_entries(filters=total_filters)
     except Exception:  # noqa: BLE001
         logger.exception("distillery_relations metrics: failed to count entries")
         return error_response("INTERNAL", "Failed to count entries")
@@ -771,7 +784,10 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
             # relations graph (unlinked). Capped to bound the payload.
             graph_node_ids = set(g.nodes())
             orphan_ids = await _sample_orphan_ids(
-                store, graph_node_ids=graph_node_ids, cap=_ORPHANS_SAMPLE_CAP
+                store,
+                graph_node_ids=graph_node_ids,
+                cap=_ORPHANS_SAMPLE_CAP,
+                filters=total_filters,
             )
             results = [{"id": entry_id} for entry_id in orphan_ids]
         else:  # metric == "communities"

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -36,7 +36,15 @@ _METRICS_EGO_HOPS = 2
 _GRAPH_METRICS_PAGE_SIZE = 1000
 _GRAPH_METRICS_MAX_IDS = 100_000
 
-_VALID_METRICS = {"bridges", "communities", "constraint", "link_prediction"}
+# Max number of unlinked entry IDs returned by metric="orphans" (a sample, not
+# the full set — feeds a linking / gap-scan pass without unbounded payloads).
+_ORPHANS_SAMPLE_CAP = 50
+
+# Statuses counted as "live" entries for graph-health totals. Archived entries
+# are soft-deleted and excluded from total_entries / orphan_rate.
+_NON_ARCHIVED_STATUSES = ["active", "pending_review"]
+
+_VALID_METRICS = {"bridges", "communities", "constraint", "link_prediction", "orphans"}
 _VALID_SCOPES = {"global", "ego"}
 
 # ---------------------------------------------------------------------------
@@ -567,6 +575,40 @@ async def _collect_ego_relations(
     return edges
 
 
+async def _sample_orphan_ids(
+    store: Any,
+    *,
+    graph_node_ids: set[str],
+    cap: int,
+) -> list[str]:
+    """Return up to *cap* non-archived entry IDs absent from the relations graph.
+
+    A sample — not the full orphan set — so the payload stays bounded on large
+    instances. Pages ``list_entries`` (non-archived only) and keeps the first
+    *cap* IDs that are not graph nodes.
+    """
+    filters = {"status": _NON_ARCHIVED_STATUSES}
+    orphans: list[str] = []
+    offset = 0
+    while len(orphans) < cap:
+        page = await store.list_entries(
+            filters=filters,
+            limit=_GRAPH_METRICS_PAGE_SIZE,
+            offset=offset,
+        )
+        if not page:
+            break
+        for entry in page:
+            if entry.id not in graph_node_ids:
+                orphans.append(entry.id)
+                if len(orphans) >= cap:
+                    break
+        if len(page) < _GRAPH_METRICS_PAGE_SIZE:
+            break
+        offset += _GRAPH_METRICS_PAGE_SIZE
+    return orphans
+
+
 async def _handle_metrics(  # noqa: PLR0911, PLR0912
     store: Any,
     arguments: dict[str, Any],
@@ -642,7 +684,13 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
     # ----- cache lookup -----
     from distillery.graph.builders import build_relations_graph
     from distillery.graph.cache import default_cache
-    from distillery.graph.metrics import bridges, communities, constraint, link_prediction
+    from distillery.graph.metrics import (
+        bridges,
+        communities,
+        constraint,
+        link_prediction,
+        orphan_rate,
+    )
 
     cache = default_cache()
     cache_key = (
@@ -687,6 +735,22 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
         logger.exception("distillery_relations metrics: failed to build graph")
         return error_response("INTERNAL", "Failed to build relations graph")
 
+    # ----- graph-health totals -----
+    # total_entries is the count of all non-archived entries; graph_node_count
+    # is how many of them are reachable via at least one relation. orphan_rate
+    # surfaces the gap (issue #635).
+    try:
+        total_entries = await store.count_entries(
+            filters={"status": _NON_ARCHIVED_STATUSES}
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("distillery_relations metrics: failed to count entries")
+        return error_response("INTERNAL", "Failed to count entries")
+
+    graph_node_count = g.number_of_nodes()
+    edge_count = g.number_of_edges()
+    rate = orphan_rate(graph_node_count=graph_node_count, total_entries=total_entries)
+
     # ----- compute metric -----
     try:
         if metric == "bridges":
@@ -702,6 +766,14 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
             # entry_id (when given) is the source node — emerging adjacencies for it.
             preds = link_prediction(g, source=entry_id_value, k=limit)
             results = [{"source": u, "target": v, "score": round(p, 6)} for u, v, p in preds]
+        elif metric == "orphans":
+            # Sample of entries present in the store but absent from the
+            # relations graph (unlinked). Capped to bound the payload.
+            graph_node_ids = set(g.nodes())
+            orphan_ids = await _sample_orphan_ids(
+                store, graph_node_ids=graph_node_ids, cap=_ORPHANS_SAMPLE_CAP
+            )
+            results = [{"id": entry_id} for entry_id in orphan_ids]
         else:  # metric == "communities"
             comms = communities(g)
             comms_sorted = sorted(comms, key=lambda c: len(c), reverse=True)[:limit]
@@ -715,8 +787,11 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
             "action": "metrics",
             "metric": metric,
             "scope": scope,
-            "node_count": g.number_of_nodes(),
-            "edge_count": g.number_of_edges(),
+            "node_count": graph_node_count,
+            "edge_count": edge_count,
+            "total_entries": total_entries,
+            "graph_node_count": graph_node_count,
+            "orphan_rate": round(rate, 6),
             "results": results,
             "count": len(results),
             "computed_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/tests/graph/test_metrics.py
+++ b/tests/graph/test_metrics.py
@@ -16,6 +16,7 @@ from distillery.graph.metrics import (  # noqa: E402
     communities,
     constraint,
     link_prediction,
+    orphan_rate,
 )
 
 pytestmark = pytest.mark.unit
@@ -121,3 +122,17 @@ def test_link_prediction_global_surfaces_shared_pair() -> None:
 def test_link_prediction_unknown_source_returns_empty() -> None:
     g = build_relations_graph(_shared_neighbors(), directed=True)
     assert link_prediction(g, source="ZZZ", k=5) == []
+
+
+def test_orphan_rate_partial() -> None:
+    """8 entries with 2 in the graph -> orphan_rate 0.75 (issue #635)."""
+    assert orphan_rate(graph_node_count=2, total_entries=8) == 0.75
+
+
+def test_orphan_rate_all_linked() -> None:
+    assert orphan_rate(graph_node_count=4, total_entries=4) == 0.0
+
+
+def test_orphan_rate_zero_total_is_guarded() -> None:
+    """total_entries == 0 -> orphan_rate 0.0 (no division by zero)."""
+    assert orphan_rate(graph_node_count=0, total_entries=0) == 0.0

--- a/tests/graph/test_metrics.py
+++ b/tests/graph/test_metrics.py
@@ -136,3 +136,9 @@ def test_orphan_rate_all_linked() -> None:
 def test_orphan_rate_zero_total_is_guarded() -> None:
     """total_entries == 0 -> orphan_rate 0.0 (no division by zero)."""
     assert orphan_rate(graph_node_count=0, total_entries=0) == 0.0
+
+
+def test_orphan_rate_clamps_when_nodes_exceed_total() -> None:
+    """graph_node_count > total_entries (archived-but-linked nodes) clamps to
+    0.0 instead of going negative (issue #635 review)."""
+    assert orphan_rate(graph_node_count=2, total_entries=1) == 0.0

--- a/tests/test_mcp_tools/test_relations_metrics.py
+++ b/tests/test_mcp_tools/test_relations_metrics.py
@@ -292,6 +292,94 @@ async def test_metrics_cache_hit_flips_on_second_call(store) -> None:  # type: i
 
 
 # ---------------------------------------------------------------------------
+# Graph-health: total_entries / graph_node_count / orphan_rate (issue #635).
+# ---------------------------------------------------------------------------
+
+
+async def test_metrics_includes_graph_health_fields(store) -> None:  # type: ignore[no-untyped-def]
+    """Metrics response carries total_entries, graph_node_count, edge_count,
+    orphan_rate (issue #635)."""
+    pytest.importorskip("networkx")
+
+    await _seed_star_relations(store)  # 4 entries, all linked
+
+    data = _parse(
+        await _handle_relations(
+            store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+        )
+    )
+    assert data.get("error") is not True
+    assert data["total_entries"] == 4
+    assert data["graph_node_count"] == 4
+    assert data["edge_count"] == 3
+    # All 4 entries are linked -> no orphans.
+    assert data["orphan_rate"] == 0.0
+
+
+async def test_metrics_orphan_rate_high_when_few_linked(store) -> None:  # type: ignore[no-untyped-def]
+    """8 entries, only 2 linked -> orphan_rate 0.75 (issue #635 acceptance)."""
+    pytest.importorskip("networkx")
+
+    ids = [await _store_entry(store, content=f"entry {i}") for i in range(8)]
+    # Link only the first two; the remaining six are orphans.
+    await store.add_relation(ids[0], ids[1], "link")
+
+    data = _parse(
+        await _handle_relations(
+            store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+        )
+    )
+    assert data.get("error") is not True
+    assert data["total_entries"] == 8
+    assert data["graph_node_count"] == 2
+    assert data["orphan_rate"] == 0.75
+
+
+async def test_metrics_orphans_returns_unlinked_ids(store) -> None:  # type: ignore[no-untyped-def]
+    """metric='orphans' returns entry IDs present in the store but absent
+    from the relations graph (issue #635)."""
+    pytest.importorskip("networkx")
+
+    ids = [await _store_entry(store, content=f"entry {i}") for i in range(5)]
+    # Link the first two; ids[2], ids[3], ids[4] are orphans.
+    await store.add_relation(ids[0], ids[1], "link")
+
+    data = _parse(
+        await _handle_relations(
+            store, {"action": "metrics", "metric": "orphans", "scope": "global"}
+        )
+    )
+    assert data.get("error") is not True
+    assert data["metric"] == "orphans"
+    returned = {row["id"] for row in data["results"]}
+    assert returned == {ids[2], ids[3], ids[4]}
+    # Graph-health fields are present alongside the orphan sample.
+    assert data["total_entries"] == 5
+    assert data["graph_node_count"] == 2
+    assert data["orphan_rate"] == 0.6
+
+
+async def test_metrics_orphans_sample_is_capped(store, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """metric='orphans' returns at most the sample cap of unlinked IDs."""
+    pytest.importorskip("networkx")
+
+    monkeypatch.setattr(
+        "distillery.mcp.tools.relations._ORPHANS_SAMPLE_CAP",
+        3,
+    )
+    for i in range(10):
+        await _store_entry(store, content=f"orphan {i}")
+
+    data = _parse(
+        await _handle_relations(
+            store, {"action": "metrics", "metric": "orphans", "scope": "global"}
+        )
+    )
+    assert data.get("error") is not True
+    assert len(data["results"]) == 3
+
+
+# ---------------------------------------------------------------------------
 # NetworkX missing — runs even without the [graph] extra installed.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_mcp_tools/test_relations_metrics.py
+++ b/tests/test_mcp_tools/test_relations_metrics.py
@@ -390,6 +390,44 @@ async def test_metrics_orphan_rate_filtered_uses_scoped_denominator(store) -> No
     assert data["orphan_rate"] == 0.0
 
 
+async def test_metrics_ego_scope_ignores_entry_filters_for_denominator(store) -> None:  # type: ignore[no-untyped-def]
+    """Ego scope builds the subgraph around the root and ignores the entry-side
+    filters (project/tags/date_*); total_entries / orphan_rate must use the same
+    unfiltered, all-non-archived population so the rate stays consistent with the
+    graph (issue #635 review: filtered denominator over an unfiltered ego graph).
+    """
+    pytest.importorskip("networkx")
+
+    # Ego root + neighbour share a project; a third unrelated entry has none.
+    root = await _store_entry(store, content="root", project="proj-x")
+    neighbour = await _store_entry(store, content="neighbour", project="proj-x")
+    await store.add_relation(root, neighbour, "link")
+    await _store_entry(store, content="unrelated", project="proj-y")
+
+    data = _parse(
+        await _handle_relations(
+            store,
+            {
+                "action": "metrics",
+                "metric": "bridges",
+                "scope": "ego",
+                "entry_id": root,
+                # A filter that, if (incorrectly) applied to the denominator,
+                # would shrink total_entries to the 2 proj-x entries.
+                "project": "proj-x",
+            },
+        )
+    )
+    assert data.get("error") is not True
+    assert data["scope"] == "ego"
+    # Ego graph = root + its 1-hop neighbour (2 nodes), filters ignored.
+    assert data["graph_node_count"] == 2
+    # Denominator ignores the project filter too: all 3 non-archived entries.
+    assert data["total_entries"] == 3
+    # orphan_rate = (3 - 2) / 3, consistent with the unfiltered ego population.
+    assert data["orphan_rate"] == round(1 / 3, 6)
+
+
 async def test_metrics_orphans_returns_unlinked_ids(store) -> None:  # type: ignore[no-untyped-def]
     """metric='orphans' returns entry IDs present in the store but absent
     from the relations graph (issue #635)."""

--- a/tests/test_mcp_tools/test_relations_metrics.py
+++ b/tests/test_mcp_tools/test_relations_metrics.py
@@ -335,6 +335,61 @@ async def test_metrics_orphan_rate_high_when_few_linked(store) -> None:  # type:
     assert data["orphan_rate"] == 0.75
 
 
+async def test_metrics_orphan_rate_never_negative_with_archived_linked(store) -> None:  # type: ignore[no-untyped-def]
+    """An archived-but-still-linked entry is a graph node but not counted in
+    total_entries; orphan_rate must clamp to >= 0.0 rather than go negative
+    (issue #635 review: reproduced orphan_rate=-1.0)."""
+    pytest.importorskip("networkx")
+
+    a = await _store_entry(store, content="entry A")
+    b = await _store_entry(store, content="entry B")
+    await store.add_relation(a, b, "link")
+    # Archive one endpoint: it stays in the graph (the relation still exists)
+    # but drops out of total_entries -> graph_node_count (2) > total_entries (1).
+    await store.update(a, {"status": "archived"})
+
+    data = _parse(
+        await _handle_relations(
+            store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+        )
+    )
+    assert data.get("error") is not True
+    assert data["total_entries"] == 1
+    assert data["graph_node_count"] == 2
+    assert data["orphan_rate"] >= 0.0
+    assert data["orphan_rate"] == 0.0
+
+
+async def test_metrics_orphan_rate_filtered_uses_scoped_denominator(store) -> None:  # type: ignore[no-untyped-def]
+    """With a project filter, total_entries must be scoped to that project too,
+    so a fully-linked project reads orphan_rate 0.0 — not inflated by unrelated
+    entries (issue #635 review: reproduced 0.833 for a zero-orphan project)."""
+    pytest.importorskip("networkx")
+
+    p1 = await _store_entry(store, content="P1", project="proj-x")
+    p2 = await _store_entry(store, content="P2", project="proj-x")
+    await store.add_relation(p1, p2, "link")
+    # Ten unrelated entries with no project — must NOT inflate proj-x's rate.
+    for i in range(10):
+        await _store_entry(store, content=f"other {i}")
+
+    data = _parse(
+        await _handle_relations(
+            store,
+            {
+                "action": "metrics",
+                "metric": "bridges",
+                "scope": "global",
+                "project": "proj-x",
+            },
+        )
+    )
+    assert data.get("error") is not True
+    assert data["total_entries"] == 2
+    assert data["graph_node_count"] == 2
+    assert data["orphan_rate"] == 0.0
+
+
 async def test_metrics_orphans_returns_unlinked_ids(store) -> None:  # type: ignore[no-untyped-def]
     """metric='orphans' returns entry IDs present in the store but absent
     from the relations graph (issue #635)."""


### PR DESCRIPTION
## Gap

`distillery_relations action=metrics` reported only `node_count`/`edge_count` over the relations subgraph. On a 51,724-entry instance the subgraph is 120 nodes / 296 edges — 99.77% of entries are invisible to every metric, with no signal of it. Operators couldn't see graph health: a near-empty graph and a richly-linked one both "succeed".

## Fix

`action=metrics` now returns `total_entries`, `graph_node_count`, `edge_count`, and `orphan_rate` (`1 - graph_node_count/total_entries`), plus a new `metric=orphans` returning a capped sample of unlinked entry IDs. Additive only — `node_count`/`edge_count` retained, no new MCP tool.

Two correctness fixes applied after review:

- `orphan_rate` clamps to `[0, 1]`. The graph is built from unfiltered `list_relations()`, so an archived-but-still-linked entry is a graph node but is excluded from `total_entries` (non-archived only), making `graph_node_count > total_entries`. Without the clamp the rate went negative (reproduced -1.0).

```python
return max(0.0, min(1.0, 1.0 - graph_node_count / total_entries))
```

- `total_entries` is scoped with the same entry-side filters (`project`/`tags`/`date_from`/`date_to`) that scope the graph in global scope. Previously the denominator ignored them while the graph was filtered, inflating the rate (reproduced 0.833 for a zero-orphan project). The `metric=orphans` sample is scoped with the same filters for consistency.

```python
total_filters: dict[str, Any] = {"status": _NON_ARCHIVED_STATUSES}
if project is not None:
    total_filters["project"] = project
# ... tags / date_from / date_to
total_entries = await store.count_entries(filters=total_filters)
```

## Acceptance

- [x] **Metrics response includes node/edge/total counts + orphan_rate** — `test_metrics_includes_graph_health_fields` asserts `total_entries`, `graph_node_count`, `edge_count`, `orphan_rate` are present; `test_metrics_response_envelope_shape` checks the envelope.
- [x] **On a feed-heavy instance the high orphan rate is visible without external counting** — `test_metrics_orphan_rate_high_when_few_linked` (8 entries, 2 linked -> `orphan_rate` 0.75); `test_metrics_orphans_returns_unlinked_ids` returns the exact unlinked ID set.
- [x] **orphan_rate never negative (review mustFix)** — `test_metrics_orphan_rate_never_negative_with_archived_linked` (archived-but-linked endpoint, `total_entries=1`, `graph_node_count=2`, asserts `orphan_rate == 0.0`); `test_orphan_rate_clamps_when_nodes_exceed_total` unit test on the pure function.
- [x] **orphan_rate not inflated under entry-side filters (review mustFix)** — `test_metrics_orphan_rate_filtered_uses_scoped_denominator` (fully-linked `project=proj-x` + 10 unrelated entries, asserts `total_entries=2`, `orphan_rate == 0.0`).

## Test plan

```
PYTHONPATH=src python -m pytest tests/test_mcp_tools/test_relations_metrics.py tests/graph/test_metrics.py -q
  -> 32 passed
PYTHONPATH=src python -m pytest tests/test_mcp_tools/ tests/graph/ -q
  -> 122 passed
mypy --strict src/distillery
  -> Success: no issues found in 72 source files
ruff check src tests
  -> All checks passed!
```

Closes #635


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an orphan detection metric to identify entries missing from the relations graph.
  * Extended `distillery_relations` metrics output with `total_entries`, `graph_node_count`, and `orphan_rate` (`1 - graph_node_count/total_entries`), plus support for `metric="orphans"` to return sampled unlinked entry IDs.
  * Implemented a sampling cap for orphan ID retrieval.

* **Bug Fixes**
  * Improved `orphan_rate` handling to avoid negative or divide-by-zero results via clamping.

* **Tests**
  * Added regression and edge-case coverage for orphan metrics, scoping, clamping, and sampling limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->