### PR TITLE
ci(supply-chain): auto-deploy gominimal/distillery-gominimal on publish

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -293,3 +293,15 @@ jobs:
             -f image_tag=sha-${{ steps.tags.outputs.short_sha }}
         env:
           GH_TOKEN: ${{ secrets.DISTILL_OPS_DEPLOY_TOKEN }}
+
+      - name: Trigger deploy in gominimal/distillery-gominimal
+        run: |
+          # The downstream fly-deploy.yml is a matrix over both Fly apps
+          # (distillery-mcp-gominimal + distillery-mcp-marketing), so a single
+          # container-published dispatch deploys both. Using repository_dispatch
+          # (not workflow_dispatch) also fires fly-image-smoke.yml in that repo,
+          # validating the new image's runtime contract alongside the deploy.
+          echo '{"event_type":"container-published","client_payload":{"image_tag":"sha-${{ steps.tags.outputs.short_sha }}"}}' \
+            | gh api repos/gominimal/distillery-gominimal/dispatches --input -
+        env:
+          GH_TOKEN: ${{ secrets.GOMINIMAL_DEPLOY_TOKEN }}


### PR DESCRIPTION
## What

After the image is published to GHCR, dispatch a `container-published` `repository_dispatch` to **gominimal/distillery-gominimal** (the new Fly deploy repo), mirroring the existing `distill_ops` trigger.

That repo's `fly-deploy.yml` is a **matrix over both Fly apps** (`distillery-mcp-gominimal` + `distillery-mcp-marketing`), so a single dispatch deploys both. Using `repository_dispatch` (not `workflow_dispatch`) also fires that repo's `fly-image-smoke.yml`, validating the new image's runtime contract (cleared ENTRYPOINT / `sh -c` CMD / busybox / nonroot / networkx) alongside the deploy.

## Required before this works

Add repo secret **`GOMINIMAL_DEPLOY_TOKEN`** to `norrietaylor/distillery`: a fine-grained PAT scoped to `gominimal/distillery-gominimal` with **Contents: Read and write** (the permission `POST /repos/{owner}/{repo}/dispatches` requires). `DISTILL_OPS_DEPLOY_TOKEN` can't be reused — it's scoped to a different owner.

## Notes

- The `distill_ops` dispatch is left intact; remove it when GCP/`distill_ops` is decommissioned.
- `image_tag` is passed as `sha-<short_sha>`, matching the downstream smoke-test's accepted format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to automatically trigger downstream deployment when container images are published, with image tag information forwarded for deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->