### PR TITLE
feeds: configurable feed-size cap (default 10 MiB)

### DIFF
--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -364,6 +364,11 @@ class FeedsConfig:
             override in :func:`~distillery.feeds.rss._normalise_feed_url`
             still wins for ``reddit.com`` hosts.
         digest: ``/radar`` candidate-set settings (look-back window, etc.).
+        max_feed_bytes: Maximum accepted feed response body size in bytes.
+            Defaults to ``10 * 1024 * 1024`` (10 MiB).  Full-content feeds can
+            exceed the library default of 5 MiB
+            (:data:`~distillery.feeds.url_guard.MAX_RESPONSE_BYTES`); raise this
+            to accept larger feeds.  Must be a positive integer.
     """
 
     sources: list[FeedSourceConfig] = field(default_factory=list)
@@ -371,6 +376,7 @@ class FeedsConfig:
     reader: ReaderConfig = field(default_factory=ReaderConfig)
     user_agent: str = ""
     digest: DigestConfig = field(default_factory=DigestConfig)
+    max_feed_bytes: int = 10 * 1024 * 1024
 
 
 @dataclass
@@ -996,6 +1002,7 @@ def _parse_feeds(raw: dict[str, Any]) -> FeedsConfig:
         raw: Mapping (typically from YAML) containing any of the following keys:
             - ``sources`` (list of feed source mappings, default ``[]``)
             - ``thresholds`` (mapping with ``alert`` and ``digest`` keys)
+            - ``max_feed_bytes`` (int, default ``10 * 1024 * 1024``)
 
     Returns:
         A populated :class:`FeedsConfig` instance.
@@ -1033,6 +1040,10 @@ def _parse_feeds(raw: dict[str, Any]) -> FeedsConfig:
         raise ValueError(f"feeds.user_agent must be a string, got: {type(user_agent_raw).__name__}")
     user_agent = user_agent_raw.strip()
 
+    max_feed_bytes = _parse_strict_int(
+        raw.get("max_feed_bytes", 10 * 1024 * 1024), "feeds.max_feed_bytes"
+    )
+
     digest_raw = raw.get("digest", {}) or {}
     if not isinstance(digest_raw, dict):
         raise ValueError(f"feeds.digest must be a YAML mapping, got: {type(digest_raw).__name__}")
@@ -1044,6 +1055,7 @@ def _parse_feeds(raw: dict[str, Any]) -> FeedsConfig:
         reader=reader,
         user_agent=user_agent,
         digest=digest_cfg,
+        max_feed_bytes=max_feed_bytes,
     )
 
 
@@ -1349,6 +1361,7 @@ def _validate(config: DistilleryConfig) -> None:
             - feeds.thresholds.alert is not between 0.0 and 1.0.
             - feeds.thresholds.digest is not between 0.0 and 1.0.
             - feeds.thresholds.digest exceeds feeds.thresholds.alert.
+            - feeds.max_feed_bytes is not a positive integer.
     """
     valid_backends = {"duckdb", "motherduck"}
     if config.storage.backend not in valid_backends:
@@ -1462,6 +1475,11 @@ def _validate(config: DistilleryConfig) -> None:
     if digest > alert:
         raise ValueError(
             f"feeds.thresholds.digest ({digest}) must not exceed feeds.thresholds.alert ({alert})"
+        )
+    if config.feeds.max_feed_bytes <= 0:
+        raise ValueError(
+            "feeds.max_feed_bytes must be a positive integer, "
+            f"got: {config.feeds.max_feed_bytes}"
         )
 
     # Validate rate_limit settings.

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 from distillery.feeds.scorer import RelevanceScorer
 from distillery.feeds.tags import normalize_tag
 from distillery.feeds.truncation import truncate_content
+from distillery.feeds.url_guard import MAX_RESPONSE_BYTES
 
 if TYPE_CHECKING:
     from distillery.config import DistilleryConfig, FeedSourceConfig, TagsConfig
@@ -162,7 +163,12 @@ def _enriched_item_text(item: FeedItem, enriched_content: str | None) -> str:
     return truncate_content("\n".join(parts))
 
 
-def _build_adapter(source: FeedSourceConfig, *, user_agent: str | None = None) -> Any:
+def _build_adapter(
+    source: FeedSourceConfig,
+    *,
+    user_agent: str | None = None,
+    max_feed_bytes: int = MAX_RESPONSE_BYTES,
+) -> Any:
     """Instantiate the correct adapter for *source*.
 
     For GitHub sources the ``GITHUB_TOKEN`` environment variable is read and
@@ -174,6 +180,9 @@ def _build_adapter(source: FeedSourceConfig, *, user_agent: str | None = None) -
         user_agent: Optional User-Agent override forwarded to RSS adapters.
             ``None`` / empty string lets the adapter pick its default
             (project name + version + contact URL).
+        max_feed_bytes: Maximum accepted feed response body size in bytes,
+            forwarded to RSS adapters. Defaults to the library cap
+            (:data:`~distillery.feeds.url_guard.MAX_RESPONSE_BYTES`).
 
     Returns:
         An adapter instance with a ``.fetch()`` method.
@@ -199,7 +208,7 @@ def _build_adapter(source: FeedSourceConfig, *, user_agent: str | None = None) -
     elif source.source_type == "rss":
         from distillery.feeds.rss import RSSAdapter
 
-        return RSSAdapter(url=source.url, user_agent=user_agent)
+        return RSSAdapter(url=source.url, user_agent=user_agent, max_bytes=max_feed_bytes)
     else:
         raise ValueError(
             f"Unsupported source_type {source.source_type!r} for url {source.url!r}. "
@@ -909,7 +918,11 @@ class FeedPoller:
         """
         # Build adapter
         try:
-            adapter = _build_adapter(source, user_agent=self._config.feeds.user_agent or None)
+            adapter = _build_adapter(
+                source,
+                user_agent=self._config.feeds.user_agent or None,
+                max_feed_bytes=self._config.feeds.max_feed_bytes,
+            )
         except ValueError as exc:
             result.errors.append(f"Failed to build adapter: {exc}")
             logger.warning("FeedPoller: %s", exc)

--- a/src/distillery/feeds/rss.py
+++ b/src/distillery/feeds/rss.py
@@ -24,7 +24,7 @@ import httpx
 
 from distillery import __version__
 from distillery.feeds.models import FeedItem
-from distillery.feeds.url_guard import fetch_feed_bytes
+from distillery.feeds.url_guard import MAX_RESPONSE_BYTES, fetch_feed_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -373,6 +373,11 @@ class RSSAdapter:
     ----------
     url:
         Full URL of the RSS or Atom feed.
+    max_bytes:
+        Maximum accepted response body size in bytes. Defaults to
+        :data:`~distillery.feeds.url_guard.MAX_RESPONSE_BYTES` (5 MiB);
+        the poller threads ``config.feeds.max_feed_bytes`` (10 MiB default)
+        so full-content feeds are not rejected.
 
     Raises
     ------
@@ -380,7 +385,13 @@ class RSSAdapter:
         If *url* is empty.
     """
 
-    def __init__(self, url: str, *, user_agent: str | None = None) -> None:
+    def __init__(
+        self,
+        url: str,
+        *,
+        user_agent: str | None = None,
+        max_bytes: int = MAX_RESPONSE_BYTES,
+    ) -> None:
         if not url.strip():
             raise ValueError("RSSAdapter requires a non-empty feed URL.")
         raw = url.strip()
@@ -392,6 +403,7 @@ class RSSAdapter:
         # "use the default" so misconfigured deployments still send a sane UA.
         ua = (user_agent or "").strip()
         self._user_agent = ua or DEFAULT_USER_AGENT
+        self._max_bytes = max_bytes
         self.last_polled_at: datetime | None = None
 
     # ------------------------------------------------------------------
@@ -434,7 +446,7 @@ class RSSAdapter:
         # ``fetch_feed_bytes`` follows redirects manually, re-validating the
         # host at every hop, and streams the body under a fixed size cap.
         with httpx.Client(timeout=_REQUEST_TIMEOUT, verify=True) as client:
-            content = fetch_feed_bytes(client, self._fetch_url, headers)
+            content = fetch_feed_bytes(client, self._fetch_url, headers, max_bytes=self._max_bytes)
 
         self.last_polled_at = datetime.now(tz=UTC)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -257,6 +257,25 @@ class TestYAMLLoading:
         assert cfg.feeds.digest.window_days == 14
         assert cfg.feeds.digest.candidate_limit == 50
 
+    def test_feeds_max_feed_bytes_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``feeds.max_feed_bytes`` defaults to 10 MiB."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+        cfg = load_config()
+        assert cfg.feeds.max_feed_bytes == 10 * 1024 * 1024
+
+    def test_feeds_max_feed_bytes_override(self, tmp_path: Path) -> None:
+        """``feeds.max_feed_bytes`` is overridable via YAML."""
+        yaml_content = """\
+            feeds:
+              max_feed_bytes: 6291456
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.feeds.max_feed_bytes == 6291456
+
 
 # ---------------------------------------------------------------------------
 # Validation errors
@@ -423,6 +442,33 @@ class TestValidationErrors:
         """
         p = write_yaml(tmp_path, yaml_content)
         with pytest.raises(ValueError, match="candidate_limit"):
+            load_config(str(p))
+
+    def test_feeds_max_feed_bytes_zero_raises_value_error(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            feeds:
+              max_feed_bytes: 0
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="max_feed_bytes"):
+            load_config(str(p))
+
+    def test_feeds_max_feed_bytes_negative_raises_value_error(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            feeds:
+              max_feed_bytes: -1
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="max_feed_bytes"):
+            load_config(str(p))
+
+    def test_feeds_max_feed_bytes_non_integer_raises_value_error(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            feeds:
+              max_feed_bytes: 6.5
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="max_feed_bytes"):
             load_config(str(p))
 
     def test_explicit_missing_path_raises_file_not_found(self, tmp_path: Path) -> None:

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -829,6 +829,50 @@ class TestRSSAdapter:
         with _mock_rss_http(handler), pytest.raises(ResponseTooLargeError):
             RSSAdapter("https://example.com/rss").fetch()
 
+    def test_default_max_bytes_is_library_cap(self) -> None:
+        from distillery.feeds.url_guard import MAX_RESPONSE_BYTES
+
+        adapter = RSSAdapter("https://example.com/rss")
+        assert adapter._max_bytes == MAX_RESPONSE_BYTES
+
+    def test_fetch_passes_max_bytes_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The adapter must forward its configured cap to ``fetch_feed_bytes``.
+        captured: dict[str, int] = {}
+
+        def _fake_fetch(
+            client: httpx.Client, url: str, headers: dict[str, str], *, max_bytes: int, **_: object
+        ) -> bytes:
+            captured["max_bytes"] = max_bytes
+            return _RSS_XML
+
+        monkeypatch.setattr("distillery.feeds.rss.fetch_feed_bytes", _fake_fetch)
+        RSSAdapter("https://example.com/rss", max_bytes=10 * 1024 * 1024).fetch()
+        assert captured["max_bytes"] == 10 * 1024 * 1024
+
+    def test_fetch_accepts_six_mib_body_under_ten_mib_cap(self) -> None:
+        # A ~6 MiB full-content feed (e.g. northflank.com/blog/rss ~6.90 MB,
+        # smallcultfollowing.com/babysteps/atom.xml ~6.66 MB) is rejected under
+        # the 5 MiB library default but accepted once the adapter cap is raised
+        # to 10 MiB — proving the size cap is honoured and configurable.
+        from distillery.feeds.url_guard import ResponseTooLargeError
+
+        # A valid RSS document padded to ~6 MiB so parsing succeeds once the
+        # body is accepted.
+        padding = "y" * (6 * 1024 * 1024)
+        big_feed = _RSS_XML.replace(b"Content of first post", padding.encode())
+        assert len(big_feed) > 5 * 1024 * 1024
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=big_feed)
+
+        with _mock_rss_http(handler), pytest.raises(ResponseTooLargeError):
+            RSSAdapter("https://example.com/rss").fetch()
+
+        with _mock_rss_http(handler):
+            adapter = RSSAdapter("https://example.com/rss", max_bytes=10 * 1024 * 1024)
+            items = adapter.fetch()
+        assert len(items) == 2
+
     def test_pin_dns_overrides_getaddrinfo_within_scope(self) -> None:
         """``_pin_dns`` must force ``socket.getaddrinfo`` to return the pinned
         IP for the target host and only for the duration of the context.

--- a/tests/test_feeds_url_guard.py
+++ b/tests/test_feeds_url_guard.py
@@ -200,6 +200,31 @@ class TestFetchFeedBytes:
     def test_default_size_cap_is_five_mib(self) -> None:
         assert MAX_RESPONSE_BYTES == 5 * 1024 * 1024
 
+    def test_six_mib_body_rejected_under_five_mib_cap(self) -> None:
+        # A ~6 MiB feed (e.g. northflank.com/blog/rss, ~6.90 MB) exceeds the
+        # library default of 5 MiB and must be rejected when that cap applies.
+        body = b"x" * (6 * 1024 * 1024)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=body)
+
+        with _client(handler) as client, pytest.raises(ResponseTooLargeError):
+            fetch_feed_bytes(client, f"http://{_PUBLIC}/feed", {}, max_bytes=5 * 1024 * 1024)
+
+    def test_six_mib_body_accepted_under_ten_mib_cap(self) -> None:
+        # The same ~6 MiB feed is accepted once the configurable cap is raised
+        # to 10 MiB (the FeedsConfig default), proving the cap is honoured.
+        body = b"x" * (6 * 1024 * 1024)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=body)
+
+        with _client(handler) as client:
+            fetched = fetch_feed_bytes(
+                client, f"http://{_PUBLIC}/feed", {}, max_bytes=10 * 1024 * 1024
+            )
+        assert len(fetched) == len(body)
+
     def test_http_error_propagates(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(503)

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -916,6 +916,46 @@ class TestBuildAdapterGitHubToken:
             )
 
 
+class TestBuildAdapterMaxFeedBytes:
+    """_build_adapter() and the poller thread feeds.max_feed_bytes into RSS."""
+
+    def test_default_max_bytes_is_library_cap(self) -> None:
+        from distillery.feeds.poller import _build_adapter
+        from distillery.feeds.url_guard import MAX_RESPONSE_BYTES
+
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        adapter = _build_adapter(src)
+        assert adapter._max_bytes == MAX_RESPONSE_BYTES  # noqa: SLF001
+
+    def test_threads_configured_cap_into_rss_adapter(self) -> None:
+        from distillery.feeds.poller import _build_adapter
+
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        adapter = _build_adapter(src, max_feed_bytes=10 * 1024 * 1024)
+        assert adapter._max_bytes == 10 * 1024 * 1024  # noqa: SLF001
+
+    async def test_poller_threads_config_max_feed_bytes(self) -> None:
+        """The poller must pass cfg.feeds.max_feed_bytes to the RSS adapter."""
+        src = FeedSourceConfig(url="https://example.com/rss", source_type="rss")
+        store = _make_store(feed_sources=[_source_to_dict(src)])
+        cfg = _make_config(sources=[src], digest_threshold=0.0)
+        cfg.feeds.max_feed_bytes = 7 * 1024 * 1024
+
+        captured: dict[str, int] = {}
+
+        def _capture(source: FeedSourceConfig, *, max_feed_bytes: int, **_: object) -> MagicMock:
+            captured["max_feed_bytes"] = max_feed_bytes
+            adapter = MagicMock()
+            adapter.fetch.return_value = []
+            return adapter
+
+        with patch("distillery.feeds.poller._build_adapter", side_effect=_capture):
+            poller = FeedPoller(store=store, config=cfg)
+            await poller.poll()
+
+        assert captured["max_feed_bytes"] == 7 * 1024 * 1024
+
+
 # ---------------------------------------------------------------------------
 # FeedPoller._persist_poll_status — persists liveness metadata per poll
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

Feed fetching used a hard-coded 5 MiB cap (`MAX_RESPONSE_BYTES` at `src/distillery/feeds/url_guard.py:41`), and `RSSAdapter.fetch()` never passed a `max_bytes` argument to `fetch_feed_bytes`, so the library default always applied. Full-content feeds that exceed 5 MiB were rejected with `ResponseTooLargeError` — observed on `northflank.com/blog/rss` (~6.90 MB) and `smallcultfollowing.com/babysteps/atom.xml` (~6.66 MB).

## Fix

Make the cap configurable and thread it end-to-end:

- `FeedsConfig.max_feed_bytes` — new field, default `10 * 1024 * 1024` (10 MiB), parsed via `_parse_strict_int` and validated `> 0` in `_validate`.
- `FeedPoller.poll()` reads `self._config.feeds.max_feed_bytes` and forwards it through `_build_adapter(..., max_feed_bytes=...)` to `RSSAdapter(max_bytes=...)`, which stores `self._max_bytes` and passes it to `fetch_feed_bytes(..., max_bytes=self._max_bytes)`.
- Both the `Content-Length` pre-check and the streaming `iter_bytes` check in `fetch_feed_bytes` honor the configured cap.

Back-compat preserved: `url_guard.MAX_RESPONSE_BYTES` stays 5 MiB, and direct `RSSAdapter` / `_build_adapter` callers default to the 5 MiB library cap (documented in docstrings). The `distillery_watch` reachability probe is left unchanged (HEAD/GET only, no body ingest).

## Acceptance

- 6 MiB body rejected under a 5 MiB cap at the url_guard level → `tests/test_feeds_url_guard.py::TestFetchFeedBytes::test_six_mib_body_rejected_under_five_mib_cap`
- 6 MiB body accepted under a 10 MiB cap at the url_guard level → `tests/test_feeds_url_guard.py::TestFetchFeedBytes::test_six_mib_body_accepted_under_ten_mib_cap`
- 6 MiB feed rejected at 5 MiB / accepted at 10 MiB through the RSS adapter → `tests/test_feeds.py::TestRSSAdapter::test_fetch_accepts_six_mib_body_under_ten_mib_cap`
- RSS adapter defaults to the library cap and forwards its cap to `fetch_feed_bytes` → `tests/test_feeds.py::TestRSSAdapter::test_default_max_bytes_is_library_cap`, `::test_fetch_passes_max_bytes_through`
- `_build_adapter` defaults to the library cap and threads a configured cap → `tests/test_poller.py::TestBuildAdapterMaxFeedBytes::test_default_max_bytes_is_library_cap`, `::test_threads_configured_cap_into_rss_adapter`
- Poller passes `cfg.feeds.max_feed_bytes` to the adapter → `tests/test_poller.py::TestBuildAdapterMaxFeedBytes::test_poller_threads_config_max_feed_bytes`
- Config default is 10 MiB and overridable; zero/negative/non-integer rejected → `tests/test_config.py::TestYAMLLoading::test_feeds_max_feed_bytes_default`, `::test_feeds_max_feed_bytes_override`, `tests/test_config.py::TestValidationErrors::test_feeds_max_feed_bytes_zero_raises_value_error`, `::test_feeds_max_feed_bytes_negative_raises_value_error`, `::test_feeds_max_feed_bytes_non_integer_raises_value_error`

## Test plan

```
PYTHONPATH="$PWD/src" .venv/bin/python -m pytest tests/test_config.py tests/test_feeds.py tests/test_feeds_url_guard.py tests/test_poller.py -q
# 359 passed

PYTHONPATH="$PWD/src" .venv/bin/mypy --strict src/distillery
# Success: no issues found in 72 source files

.venv/bin/ruff check src tests
# All checks passed!
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `feeds.max_feed_bytes` setting to cap the maximum RSS/feed response body size accepted by the system (defaults to 10 MB). You can now customize this limit in your configuration to control feed fetching behavior and resource usage.

* **Tests**
  * Added comprehensive test coverage for feed size limit validation, configuration loading, and various limit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->