### PR TITLE
store: force-checkpoint + disk backpressure to bound WAL under concurrent writers (#648)

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -484,14 +484,33 @@ class DuckDBStore:
             # visible before the WAL becomes unreplayable.
             self._checkpoint_failures += 1
             if self._checkpoint_failures >= _FORCE_CHECKPOINT_AFTER_FAILURES:
-                logger.warning(
-                    "CHECKPOINT after write failed %d times in a row — "
-                    "WAL is accumulating un-flushed writes; forcing checkpoint "
-                    "(non-fatal): %s",
-                    self._checkpoint_failures,
-                    exc,
+                # FORCE CHECKPOINT aborts active write transactions, so it is
+                # only appropriate for the writer-contention case it is meant
+                # to clear (issue #648).  For unrelated failures (disk-full,
+                # permissions) forcing aborts concurrent writers for no
+                # benefit and does not fix the failure — log and wait instead.
+                message = str(exc)
+                is_contention = (
+                    "other write transactions active" in message
+                    or "Try using FORCE CHECKPOINT" in message
                 )
-                self._force_checkpoint(conn)
+                if is_contention:
+                    logger.warning(
+                        "CHECKPOINT after write failed %d times in a row — "
+                        "WAL is accumulating un-flushed writes; forcing checkpoint "
+                        "(non-fatal): %s",
+                        self._checkpoint_failures,
+                        exc,
+                    )
+                    self._force_checkpoint(conn)
+                else:
+                    logger.warning(
+                        "CHECKPOINT after write failed %d times in a row — "
+                        "WAL is accumulating un-flushed writes; not forcing "
+                        "(non-contention failure, non-fatal): %s",
+                        self._checkpoint_failures,
+                        exc,
+                    )
             else:
                 logger.debug("CHECKPOINT after write failed (non-fatal): %s", exc)
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -47,6 +47,19 @@ logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
+# Consecutive plain-``CHECKPOINT`` failures after which we escalate to
+# ``FORCE CHECKPOINT``.  Plain CHECKPOINT fails with "there are other write
+# transactions active" under concurrent writers; left uncorrected the WAL
+# grows without bound and fills the volume (issue #648).  FORCE CHECKPOINT is
+# DuckDB's own hint for flushing regardless of active transactions.
+_FORCE_CHECKPOINT_AFTER_FAILURES = 3
+
+# Free space on the database filesystem (bytes) below which we emit a
+# backpressure WARNING before the WAL can fill the volume (issue #648).
+# ``rate_limit.max_db_size_mb`` only measures the main DB file, not the WAL,
+# so a bloating WAL under checkpoint starvation is invisible to it.
+_DISK_BACKPRESSURE_FREE_BYTES = 256 * 1024 * 1024
+
 
 class EntriesIntegrityError(RuntimeError):
     """Raised when a post-bulk-rewrite read-back of ``entries`` fails.
@@ -442,7 +455,22 @@ class DuckDBStore:
         has already been committed to the WAL, so returning success to
         the caller is still correct.  A failed checkpoint just means the
         WAL stays slightly larger than usual.
+
+        Under *concurrent* write transactions (e.g. a feed poller and a
+        doc-sync writing at once) a plain ``CHECKPOINT`` fails with
+        "Cannot CHECKPOINT: there are other write transactions active.
+        Try using FORCE CHECKPOINT".  Left uncorrected the WAL grows
+        without bound and fills the volume (``No space left on device``),
+        which then truncates the WAL into an unbootable database (issue
+        #648).  So once the consecutive-failure streak crosses
+        :data:`_FORCE_CHECKPOINT_AFTER_FAILURES` we escalate to
+        ``FORCE CHECKPOINT`` — DuckDB's own hint — to flush the WAL
+        regardless of the active transactions.  A free-space guard
+        (:meth:`_check_disk_backpressure`) also warns before the volume
+        fills, since ``rate_limit.max_db_size_mb`` only measures the main
+        DB file and never the WAL.
         """
+        self._check_disk_backpressure()
         try:
             conn.execute("CHECKPOINT")
             self._checkpoint_failures = 0
@@ -455,15 +483,75 @@ class DuckDBStore:
             # has crashed on startup in production) — escalate so it is
             # visible before the WAL becomes unreplayable.
             self._checkpoint_failures += 1
-            if self._checkpoint_failures >= 3:
+            if self._checkpoint_failures >= _FORCE_CHECKPOINT_AFTER_FAILURES:
                 logger.warning(
                     "CHECKPOINT after write failed %d times in a row — "
-                    "WAL is accumulating un-flushed writes (non-fatal): %s",
+                    "WAL is accumulating un-flushed writes; forcing checkpoint "
+                    "(non-fatal): %s",
                     self._checkpoint_failures,
                     exc,
                 )
+                self._force_checkpoint(conn)
             else:
                 logger.debug("CHECKPOINT after write failed (non-fatal): %s", exc)
+
+    def _force_checkpoint(self, conn: duckdb.DuckDBPyConnection) -> None:
+        """Issue ``FORCE CHECKPOINT`` to flush the WAL despite active writers.
+
+        ``FORCE CHECKPOINT`` is DuckDB's documented escape hatch when a
+        plain ``CHECKPOINT`` is blocked by concurrent write transactions.
+        It aborts those transactions so the WAL can be flushed to the main
+        database file, bounding WAL growth (issue #648).  On success the
+        consecutive-failure streak resets to 0; its own failure is logged
+        and swallowed, keeping the streak so the next write retries.
+        """
+        try:
+            conn.execute("FORCE CHECKPOINT")
+            logger.info(
+                "FORCE CHECKPOINT flushed the WAL after %d failed plain checkpoints",
+                self._checkpoint_failures,
+            )
+            self._checkpoint_failures = 0
+        except duckdb.Error as exc:
+            logger.warning(
+                "FORCE CHECKPOINT also failed (WAL still accumulating, non-fatal): %s",
+                exc,
+            )
+
+    def _check_disk_backpressure(self) -> None:
+        """Warn when the database filesystem is running low on free space.
+
+        ``rate_limit.max_db_size_mb`` (config) caps the *main* DB file but
+        never the WAL, so a WAL bloating under checkpoint starvation is
+        invisible to it until the volume fills and DuckDB crashes mid-write
+        (issue #648).  This lightweight ``os.statvfs`` probe on the DB
+        directory surfaces a WARNING before that happens.
+
+        It is best-effort and never raises: in-memory / non-local databases
+        have no filesystem path (skip), and platforms without ``statvfs``
+        or that error on the call are skipped quietly.
+        """
+        db_file = self._resolve_local_db_path()
+        if db_file is None:
+            # In-memory or remote (S3/MotherDuck) DB — no local WAL to fill.
+            return
+        statvfs = getattr(os, "statvfs", None)
+        if statvfs is None:
+            # Platform without statvfs (e.g. Windows) — skip quietly.
+            return
+        try:
+            stat = statvfs(str(db_file.parent))
+        except OSError as exc:
+            logger.debug("Disk backpressure check skipped (statvfs failed): %s", exc)
+            return
+        free_bytes = stat.f_bavail * stat.f_frsize
+        if free_bytes < _DISK_BACKPRESSURE_FREE_BYTES:
+            logger.warning(
+                "Low free space on database filesystem: %.0f MB free at %s — "
+                "WAL growth may fill the volume (issue #648)",
+                free_bytes / (1024 * 1024),
+                db_file.parent,
+            )
 
     def _sync_verify_entries_readable(self, entry_ids: Sequence[str]) -> None:
         """Read-back verification after a bulk rewrite of ``entries`` (issue #584).

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -15,7 +15,7 @@ import duckdb
 import pytest
 
 from distillery.models import Entry, EntrySource, EntryStatus, EntryType
-from distillery.store.duckdb import DuckDBStore
+from distillery.store.duckdb import _FORCE_CHECKPOINT_AFTER_FAILURES, DuckDBStore
 from distillery.store.protocol import SearchResult
 from tests.conftest import make_entry
 
@@ -1835,6 +1835,168 @@ class TestHybridGracefulFallback:
     ) -> None:
         """_fts_available should be False when hybrid_search is disabled."""
         assert vector_only_store._fts_available is False  # noqa: SLF001
+
+
+class TestCheckpointBackpressure:
+    """CHECKPOINT starvation guards: FORCE CHECKPOINT + disk backpressure (issue #648).
+
+    Plain ``CHECKPOINT`` after each write fails under concurrent write
+    transactions ("there are other write transactions active"); left
+    uncorrected the WAL grows without bound and fills the volume.  These
+    tests drive the *mechanism* (a mock connection whose ``CHECKPOINT``
+    raises that error; a monkeypatched ``os.statvfs``) rather than real
+    concurrency / a real full disk.  A file-backed DB under ``tmp_path``
+    is used wherever a real local path is required.
+    """
+
+    @staticmethod
+    def _file_store(tmp_path, mock_embedding_provider) -> DuckDBStore:
+        return DuckDBStore(
+            db_path=str(tmp_path / "distillery.db"),
+            embedding_provider=mock_embedding_provider,
+        )
+
+    async def test_force_checkpoint_issued_after_failure_streak(
+        self, tmp_path, mock_embedding_provider
+    ) -> None:
+        """Once the streak crosses the threshold, FORCE CHECKPOINT is issued."""
+        from unittest.mock import MagicMock, call
+
+        s = self._file_store(tmp_path, mock_embedding_provider)
+
+        active = duckdb.Error(
+            "Cannot CHECKPOINT: there are other write transactions active. "
+            "Try using FORCE CHECKPOINT"
+        )
+
+        def _execute(sql: str) -> None:
+            if sql == "CHECKPOINT":
+                raise active
+            # FORCE CHECKPOINT succeeds.
+
+        mock_conn = MagicMock()
+        mock_conn.execute.side_effect = _execute
+
+        # Below the threshold: only plain CHECKPOINT is attempted, no force.
+        for _ in range(_FORCE_CHECKPOINT_AFTER_FAILURES - 1):
+            s._checkpoint_after_write(mock_conn)  # noqa: SLF001
+        assert call("FORCE CHECKPOINT") not in mock_conn.execute.call_args_list
+        assert s._checkpoint_failures == _FORCE_CHECKPOINT_AFTER_FAILURES - 1  # noqa: SLF001
+
+        # Crossing the threshold issues FORCE CHECKPOINT, which succeeds and
+        # resets the streak to 0.
+        s._checkpoint_after_write(mock_conn)  # noqa: SLF001
+        assert call("FORCE CHECKPOINT") in mock_conn.execute.call_args_list
+        assert s._checkpoint_failures == 0  # noqa: SLF001
+
+    async def test_force_checkpoint_own_failure_keeps_streak(
+        self, tmp_path, mock_embedding_provider
+    ) -> None:
+        """If FORCE CHECKPOINT also fails, the streak is preserved (not reset)."""
+        from unittest.mock import MagicMock
+
+        s = self._file_store(tmp_path, mock_embedding_provider)
+        mock_conn = MagicMock()
+        # Both plain and forced checkpoints fail.
+        mock_conn.execute.side_effect = duckdb.Error("checkpoint blocked")
+
+        for _ in range(_FORCE_CHECKPOINT_AFTER_FAILURES):
+            s._checkpoint_after_write(mock_conn)  # noqa: SLF001
+
+        # FORCE CHECKPOINT was attempted on the threshold-crossing call ...
+        assert any(
+            c.args == ("FORCE CHECKPOINT",) for c in mock_conn.execute.call_args_list
+        )
+        # ... but since it also failed the streak is NOT reset.
+        assert s._checkpoint_failures == _FORCE_CHECKPOINT_AFTER_FAILURES  # noqa: SLF001
+
+    async def test_disk_backpressure_warns_when_free_space_low(
+        self, tmp_path, mock_embedding_provider, monkeypatch, caplog
+    ) -> None:
+        """A low-free-space statvfs report emits a WARNING for a file-backed DB."""
+        import os as _os
+
+        s = self._file_store(tmp_path, mock_embedding_provider)
+
+        class _Stat:
+            f_bavail = 1
+            f_frsize = 4096  # ~4 KB free — well below the threshold.
+
+        monkeypatch.setattr(_os, "statvfs", lambda _path: _Stat())
+
+        with caplog.at_level("WARNING", logger="distillery.store.duckdb"):
+            s._check_disk_backpressure()  # noqa: SLF001
+
+        assert any("Low free space" in r.message for r in caplog.records)
+
+    async def test_disk_backpressure_silent_when_space_ample(
+        self, tmp_path, mock_embedding_provider, monkeypatch, caplog
+    ) -> None:
+        """Ample free space produces no WARNING."""
+        import os as _os
+
+        s = self._file_store(tmp_path, mock_embedding_provider)
+
+        class _Stat:
+            f_bavail = 10_000_000
+            f_frsize = 4096  # ~40 GB free.
+
+        monkeypatch.setattr(_os, "statvfs", lambda _path: _Stat())
+
+        with caplog.at_level("WARNING", logger="distillery.store.duckdb"):
+            s._check_disk_backpressure()  # noqa: SLF001
+
+        assert not any("Low free space" in r.message for r in caplog.records)
+
+    async def test_disk_backpressure_skipped_for_in_memory(
+        self, mock_embedding_provider, monkeypatch, caplog
+    ) -> None:
+        """In-memory DBs have no local path — the statvfs guard is skipped."""
+        import os as _os
+
+        s = DuckDBStore(db_path=":memory:", embedding_provider=mock_embedding_provider)
+
+        def _fail(_path):
+            raise AssertionError("statvfs must not be called for in-memory DB")
+
+        monkeypatch.setattr(_os, "statvfs", _fail)
+
+        with caplog.at_level("WARNING", logger="distillery.store.duckdb"):
+            s._check_disk_backpressure()  # noqa: SLF001  — must not raise
+
+        assert not any("Low free space" in r.message for r in caplog.records)
+
+    async def test_disk_backpressure_skipped_when_statvfs_unavailable(
+        self, tmp_path, mock_embedding_provider, monkeypatch, caplog
+    ) -> None:
+        """Platforms without ``os.statvfs`` (e.g. Windows) skip the guard cleanly."""
+        import os as _os
+
+        s = self._file_store(tmp_path, mock_embedding_provider)
+        monkeypatch.delattr(_os, "statvfs", raising=False)
+
+        with caplog.at_level("WARNING", logger="distillery.store.duckdb"):
+            s._check_disk_backpressure()  # noqa: SLF001  — must not raise
+
+        assert not any("Low free space" in r.message for r in caplog.records)
+
+    async def test_disk_backpressure_skipped_when_statvfs_errors(
+        self, tmp_path, mock_embedding_provider, monkeypatch, caplog
+    ) -> None:
+        """A statvfs OSError is swallowed (no WARNING, no raise)."""
+        import os as _os
+
+        s = self._file_store(tmp_path, mock_embedding_provider)
+
+        def _raise(_path):
+            raise OSError("unsupported")
+
+        monkeypatch.setattr(_os, "statvfs", _raise)
+
+        with caplog.at_level("WARNING", logger="distillery.store.duckdb"):
+            s._check_disk_backpressure()  # noqa: SLF001  — must not raise
+
+        assert not any("Low free space" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -1897,8 +1897,12 @@ class TestCheckpointBackpressure:
 
         s = self._file_store(tmp_path, mock_embedding_provider)
         mock_conn = MagicMock()
-        # Both plain and forced checkpoints fail.
-        mock_conn.execute.side_effect = duckdb.Error("checkpoint blocked")
+        # Both plain and forced checkpoints fail.  The plain CHECKPOINT must
+        # raise the writer-contention error so FORCE CHECKPOINT is attempted.
+        mock_conn.execute.side_effect = duckdb.Error(
+            "Cannot CHECKPOINT: there are other write transactions active. "
+            "Try using FORCE CHECKPOINT"
+        )
 
         for _ in range(_FORCE_CHECKPOINT_AFTER_FAILURES):
             s._checkpoint_after_write(mock_conn)  # noqa: SLF001
@@ -1909,6 +1913,34 @@ class TestCheckpointBackpressure:
         )
         # ... but since it also failed the streak is NOT reset.
         assert s._checkpoint_failures == _FORCE_CHECKPOINT_AFTER_FAILURES  # noqa: SLF001
+
+    async def test_non_contention_failure_does_not_force_checkpoint(
+        self, tmp_path, mock_embedding_provider
+    ) -> None:
+        """A generic (non-contention) failure past the threshold never forces.
+
+        FORCE CHECKPOINT aborts active write transactions, so it is reserved
+        for the writer-contention case (issue #648).  An unrelated failure
+        (disk-full, permissions) must not escalate to FORCE CHECKPOINT even
+        once the streak crosses the threshold.
+        """
+        from unittest.mock import MagicMock, call
+
+        s = self._file_store(tmp_path, mock_embedding_provider)
+        mock_conn = MagicMock()
+        # A non-contention failure (e.g. disk-full / permissions) on every
+        # plain CHECKPOINT.
+        mock_conn.execute.side_effect = duckdb.Error("IO Error: No space left on device")
+
+        for _ in range(_FORCE_CHECKPOINT_AFTER_FAILURES + 1):
+            s._checkpoint_after_write(mock_conn)  # noqa: SLF001
+
+        # FORCE CHECKPOINT must never be issued for a non-contention failure,
+        # even though the streak has crossed the threshold.
+        assert call("FORCE CHECKPOINT") not in mock_conn.execute.call_args_list
+        assert (
+            s._checkpoint_failures == _FORCE_CHECKPOINT_AFTER_FAILURES + 1  # noqa: SLF001
+        )
 
     async def test_disk_backpressure_warns_when_free_space_low(
         self, tmp_path, mock_embedding_provider, monkeypatch, caplog

--- a/tests/test_store_wal_durability.py
+++ b/tests/test_store_wal_durability.py
@@ -584,11 +584,18 @@ class TestCheckpointFailureEscalation:
     replay was already poisoned.  Three consecutive failures now log at
     WARNING and escalate to ``FORCE CHECKPOINT`` to flush the WAL despite
     active writers (issue #648); any success resets the streak.
+
+    FORCE CHECKPOINT aborts active write transactions, so escalation only
+    happens for the writer-contention failure it is meant to clear — hence
+    ``_FailingConn`` raises that specific error.
     """
 
     class _FailingConn:
         def execute(self, sql: str) -> None:
-            raise duckdb.Error("checkpoint refused")
+            raise duckdb.Error(
+                "Cannot CHECKPOINT: there are other write transactions active. "
+                "Try using FORCE CHECKPOINT"
+            )
 
     class _OkConn:
         def execute(self, sql: str) -> None:

--- a/tests/test_store_wal_durability.py
+++ b/tests/test_store_wal_durability.py
@@ -577,12 +577,13 @@ class TestBackgroundWritesFlushWal:
 
 
 class TestCheckpointFailureEscalation:
-    """Swallowed checkpoint failures escalate to WARNING after a streak.
+    """Swallowed checkpoint failures escalate to WARNING + FORCE CHECKPOINT.
 
     ``_checkpoint_after_write`` deliberately never raises — but logging
     every failure at DEBUG hid the 2026-06-12 incident's WAL growth until
     replay was already poisoned.  Three consecutive failures now log at
-    WARNING; any success resets the streak.
+    WARNING and escalate to ``FORCE CHECKPOINT`` to flush the WAL despite
+    active writers (issue #648); any success resets the streak.
     """
 
     class _FailingConn:
@@ -606,8 +607,11 @@ class TestCheckpointFailureEscalation:
             assert warnings == [], "warned before the streak threshold"
             store._checkpoint_after_write(self._FailingConn())  # type: ignore[arg-type]
         warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
-        assert len(warnings) == 1
-        assert "3 times in a row" in warnings[0].message
+        messages = [r.message for r in warnings]
+        # The streak warning fires, and the threshold-crossing call escalates to
+        # FORCE CHECKPOINT — which here also fails on _FailingConn (issue #648).
+        assert any("3 times in a row" in m for m in messages)
+        assert any("FORCE CHECKPOINT also failed" in m for m in messages)
 
     def test_success_resets_failure_streak(self, mock_embedding_provider) -> None:
         store = DuckDBStore(db_path=":memory:", embedding_provider=mock_embedding_provider)


### PR DESCRIPTION
## Root cause

`_checkpoint_after_write` flushes the WAL after each write to bound its size with a plain `CHECKPOINT`. Under concurrent write transactions (feed poller + doc-sync writing at once) that fails with `Cannot CHECKPOINT: there are other write transactions active. Try using FORCE CHECKPOINT`. The old code only incremented `_checkpoint_failures` and logged at `>=3` — it took no corrective action, so under sustained concurrency the WAL grew without bound until the volume filled (`No space left on device`), crashing mid-write and truncating the WAL into an unbootable DB (production gominimal, 2026-06-23: 55 consecutive failures). Separately, `rate_limit.max_db_size_mb` caps only the main DB file, never the WAL, so a bloating WAL was invisible to existing guards.

## Fix

Implements issue options 1 and 3 in `src/distillery/store/duckdb.py`:

- **FORCE CHECKPOINT escalation** (`_force_checkpoint`): once the consecutive plain-`CHECKPOINT` failure streak crosses the named constant `_FORCE_CHECKPOINT_AFTER_FAILURES = 3`, escalate to `FORCE CHECKPOINT` (DuckDB's documented escape hatch) to flush the WAL despite active writers. Success resets the streak to 0; a forced-checkpoint failure is logged and swallowed, keeping the streak so the next write retries.
- **Disk backpressure probe** (`_check_disk_backpressure`): a best-effort `os.statvfs` check on the DB directory runs before each checkpoint and WARNs below `_DISK_BACKPRESSURE_FREE_BYTES = 256 MB` free. Never raises: skips in-memory/remote DBs (no local path), platforms without `statvfs`, and `statvfs` errors. Both helpers reuse the existing `_resolve_local_db_path` resolution.

Option 2 (process-level write lock) was intentionally omitted: options 1 + 3 satisfy the acceptance criterion, and serializing on the shared `_conn` was judged higher-risk.

## Acceptance

- [x] Concurrent writes keep the WAL bounded (checkpoints succeed or are forced) → `test_force_checkpoint_issued_after_failure_streak`, `test_force_checkpoint_own_failure_keeps_streak`, `test_warns_after_three_consecutive_failures`, `test_success_resets_failure_streak`
- [x] A bloating WAL trips a guard/log before filling the disk → `test_disk_backpressure_warns_when_free_space_low`, `test_disk_backpressure_silent_when_space_ample`, `test_disk_backpressure_skipped_for_in_memory`, `test_disk_backpressure_skipped_when_statvfs_unavailable`, `test_disk_backpressure_skipped_when_statvfs_errors`

## Test plan

```
PYTHONPATH="$PWD/src" .venv/bin/python -m pytest tests/test_duckdb_store.py tests/test_store_wal_durability.py -q
# 149 passed

PYTHONPATH="$PWD/src" .venv/bin/mypy --strict src/distillery
# Success: no issues found in 72 source files

.venv/bin/ruff check src tests
# All checks passed!
```

Concurrent-writer behavior is verified via a mock connection raising the exact `there are other write transactions active` error plus a `conn.execute("FORCE CHECKPOINT")` call-args spy. Real cross-process checkpoint starvation is not deterministically reproducible in a unit test; this is the standard substitute.

Closes #648

## Related

Shares `src/distillery/store/duckdb.py` with the sibling WAL PR in this batch (different methods: `_recover_from_wal_replay_failure` vs `_checkpoint_after_write`). Merge one, then rebase the other; resolve semantically so both fixes coexist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable escalation for repeated `CHECKPOINT` contention, including automatic `FORCE CHECKPOINT` when a failure streak threshold is reached.
  * Added proactive WAL disk-space backpressure checks with warning logs when free space is low.

* **Bug Fixes**
  * Improved handling of non-fatal `CHECKPOINT` failures: only contention triggers forced escalation; other failure types no longer force.

* **Tests**
  * Expanded integration and log-based assertions for checkpoint backpressure, streak reset behavior, and disk-warning emission/skip cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->