### PR TITLE
store: quarantine any un-replayable WAL instead of re-raising (#647)

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -697,16 +697,29 @@ class DuckDBStore:
             )
 
     def _recover_from_wal_replay_failure(self, exc: duckdb.Error) -> duckdb.DuckDBPyConnection:
-        """Recover from a WAL replay failure caused by FTS schema DDL.
+        """Recover from an un-replayable WAL by quarantining it.
 
-        Replay is known to fail for FTS-related DDL when the process was
-        killed between an FTS index rebuild and the subsequent checkpoint
-        (see issue #349).  Recovery moves the WAL file aside to a
-        timestamped backup so any uncommitted data is preserved for manual
-        inspection, then retries the connection.
+        Two failure classes are handled:
 
-        Only local file paths are eligible for recovery; in-memory,
-        S3, and MotherDuck URIs re-raise the original error.
+        * The FTS-schema-DDL replay failure (``Cannot drop entry
+          "fts_main_entries"``) seen when a process was killed between an
+          FTS index rebuild and the subsequent checkpoint (issue #349).
+        * Any other un-replayable WAL — serialization, truncation, or
+          corruption (e.g. ``SerializationException: not enough data in
+          file to deserialize result`` when a volume fills and DuckDB
+          truncates the WAL mid-write, issue #647).
+
+        In both cases recovery renames the ``.wal`` file aside to a
+        timestamped ``<db>.wal.corrupt.<timestamp>`` backup so any
+        uncommitted bytes are preserved for offline forensics, then
+        reopens the main database file (now without the WAL).  An instance
+        must never be permanently bricked by a bad WAL — re-raising on a
+        truncated WAL produced an unbootable crash loop in production.
+
+        Only local file paths with a ``.wal`` sidecar are eligible; if
+        quarantining the WAL does not let the database reopen, the original
+        error is re-raised (the WAL was not the cause) so unrelated
+        failures still surface instead of being silently swallowed.
 
         Returns
         -------
@@ -716,19 +729,18 @@ class DuckDBStore:
         Raises
         ------
         duckdb.Error
-            Re-raised when the error is not WAL/FTS-related, when the path
-            is not a recoverable local file, or when no ``.wal`` sidecar
-            exists on disk.
+            Re-raised when the path is not a recoverable local file, when
+            no ``.wal`` sidecar exists on disk, or when reopening after
+            quarantine still fails.
         """
         exc_msg = str(exc)
-        # Match only the specific replay-failure signature.  A broader
-        # substring match on "WAL" would also trigger on unrelated WAL
-        # open errors, silently moving user data aside.
+        # The FTS-DDL replay failure (#349) gets a tailored warning so the
+        # log explains the index will be rebuilt; every other un-replayable
+        # WAL (serialization/truncation/corruption, #647) is quarantined
+        # under the generic path below rather than re-raised.
         is_fts_replay_failure = "Failure while replaying WAL file" in exc_msg and (
             "fts_main_entries" in exc_msg or "Cannot drop entry" in exc_msg
         )
-        if not is_fts_replay_failure:
-            raise exc
 
         # Resolve _db_path to a real filesystem path.  urlparse treats
         # Windows drive letters (``C:\...``) as URI schemes, and file://
@@ -740,6 +752,8 @@ class DuckDBStore:
 
         wal_path = Path(str(db_file) + ".wal")
         if not wal_path.exists():
+            # No WAL sidecar means the WAL cannot be the culprit (e.g. a
+            # genuinely unrelated open error); surface the original error.
             raise exc
 
         # Move the WAL aside with a timestamped suffix so operators can
@@ -763,15 +777,37 @@ class DuckDBStore:
             )
             raise exc from rename_exc
 
-        logger.warning(
-            "Database WAL appears corrupt (FTS-related): %s. "
-            "Moved WAL aside to %s and retrying — uncommitted data has "
-            "been preserved for manual recovery but will NOT be replayed. "
-            "The FTS index will be rebuilt from scratch during init.",
-            exc,
-            backup_path,
-        )
-        return self._open_connection()
+        try:
+            conn = self._open_connection()
+        except duckdb.Error:
+            # Reopening still failed: the WAL was not the problem.  Restore
+            # it so we do not leave a misleading ``.corrupt`` sidecar, then
+            # re-raise the original error so the real failure surfaces.
+            with contextlib.suppress(OSError):
+                backup_path.rename(wal_path)
+            raise exc from None
+
+        if is_fts_replay_failure:
+            logger.warning(
+                "Database WAL appears corrupt (FTS-related): %s. "
+                "Moved WAL aside to %s and retrying — uncommitted data has "
+                "been preserved for manual recovery but will NOT be replayed. "
+                "The FTS index will be rebuilt from scratch during init.",
+                exc,
+                backup_path,
+            )
+        else:
+            logger.warning(
+                "Database WAL is un-replayable (corrupt/truncated): %s. "
+                "Quarantined the WAL to %s and reopened the last-checkpointed "
+                "main database WITHOUT it — any un-checkpointed writes still in "
+                "that WAL are LOST. The bytes are preserved at the quarantine "
+                "path for manual forensics. Booting to avoid a crash loop "
+                "(#647).",
+                exc,
+                backup_path,
+            )
+        return conn
 
     def _resolve_local_db_path(self) -> Path | None:
         """Return the filesystem path for ``self._db_path`` if it's local.

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -783,8 +783,30 @@ class DuckDBStore:
             # Reopening still failed: the WAL was not the problem.  Restore
             # it so we do not leave a misleading ``.corrupt`` sidecar, then
             # re-raise the original error so the real failure surfaces.
-            with contextlib.suppress(OSError):
+            try:
                 backup_path.rename(wal_path)
+            except OSError as restore_exc:
+                # Restoring the WAL failed too: the quarantine sidecar now
+                # holds the only copy of the unreplayed bytes.  Silently
+                # suppressing this would leave the WAL missing, so a later
+                # startup could proceed WITHOUT those bytes — the exact
+                # silent-data-loss path the rollback-on-reopen-failure
+                # guarantee exists to prevent.  Fail loud and tell the
+                # operator where the bytes are.
+                logger.error(
+                    "WAL restore FAILED after reopen also failed: could not "
+                    "move quarantined WAL %s back to %s for database %s. The "
+                    "unreplayed bytes remain ONLY in the quarantine sidecar "
+                    "%s — restore it manually before reopening to avoid "
+                    "silent data loss. Original replay failure: %s",
+                    backup_path,
+                    wal_path,
+                    self._db_path,
+                    backup_path,
+                    exc,
+                    exc_info=True,
+                )
+                raise exc from restore_exc
             raise exc from None
 
         if is_fts_replay_failure:

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -1342,6 +1342,75 @@ class TestCorruptWalQuarantine:
         finally:
             recovered.close()
 
+    async def test_reopen_failure_surfaces_when_wal_restore_also_fails(
+        self,
+        deterministic_embedding_provider: object,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ) -> None:
+        """If reopen fails AND the WAL restore fails, surface — never swallow.
+
+        Normal reopen-failure behaviour restores the quarantined WAL and
+        re-raises the original replay error so the real failure surfaces.
+        But if that restore ``rename`` ALSO fails, suppressing the OSError
+        would leave the WAL missing — a later startup could then proceed
+        WITHOUT the unreplayed bytes (silent data loss).  This drives both
+        failures and asserts the original error surfaces (chaining the
+        restore error) and the quarantine sidecar is left in place for
+        manual recovery.
+        """
+        db_path = str(tmp_path / "restore_fail.db")
+        conn = duckdb.connect(db_path)
+        conn.close()
+
+        wal_path = Path(db_path + ".wal")
+        wal_path.write_bytes(b"unreplayed-bytes")
+
+        store = DuckDBStore(
+            db_path=db_path,
+            embedding_provider=deterministic_embedding_provider,
+            hybrid_search=False,
+        )
+
+        # Force reopen-after-quarantine to fail so we enter the restore branch.
+        def _fail_reopen() -> object:
+            raise duckdb.Error("reopen still fails")
+
+        monkeypatch.setattr(store, "_open_connection", _fail_reopen)
+
+        # Let the quarantine rename (wal -> *.corrupt.*) succeed via the real
+        # implementation, but make the restore rename (*.corrupt.* -> wal) fail.
+        real_rename = Path.rename
+
+        def _rename(self: Path, target):  # type: ignore[no-untyped-def]
+            if self.name.endswith(".wal"):
+                return real_rename(self, target)
+            raise OSError("restore rename refused")
+
+        monkeypatch.setattr(Path, "rename", _rename)
+
+        replay_error = duckdb.Error(
+            "Failure while replaying WAL file: serialization error"
+        )
+        with caplog.at_level("ERROR"):  # noqa: SIM117
+            with pytest.raises(duckdb.Error, match="replaying WAL"):
+                store._recover_from_wal_replay_failure(replay_error)  # noqa: SLF001
+
+        # The quarantine sidecar must remain — it now holds the only copy of
+        # the unreplayed bytes — and the original WAL must NOT be back.
+        backups = list(tmp_path.glob("*.wal.corrupt.*"))
+        assert len(backups) == 1, f"quarantine sidecar must remain, got {backups}"
+        assert backups[0].read_bytes() == b"unreplayed-bytes"
+        assert not wal_path.exists(), "WAL must not be silently restored"
+
+        # A loud ERROR points the operator at the surviving sidecar.
+        errors = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+        assert any("WAL restore FAILED" in m for m in errors), (
+            "a restore failure must log a loud ERROR, not be swallowed"
+        )
+        assert any(str(backups[0]) in m for m in errors)
+
 
 # ---------------------------------------------------------------------------
 # Hybrid search (BM25 + vector RRF fusion with recency decay)

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import math
 from datetime import UTC, datetime
+from pathlib import Path
 
 import duckdb
 import pytest
@@ -1163,6 +1164,183 @@ class TestWalFtsReplayHardening:
             # Either outcome is acceptable; what matters is that the DB is
             # openable at all — before the fix, it was not.
             assert b"COUNT=" in r_proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Corrupt / truncated WAL quarantine (issue #647)
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptWalQuarantine:
+    """An un-replayable WAL must never permanently brick startup (#647).
+
+    Before the fix, ``_recover_from_wal_replay_failure`` only quarantined
+    the WAL for the FTS-schema-DDL replay failure (#349); every other
+    replay failure re-raised, so a truncated/corrupt WAL (e.g. a full
+    volume truncating the WAL mid-write) crash-looped the process forever.
+    The fix quarantines ANY un-replayable WAL — rename it aside, reopen the
+    last-checkpointed main DB without it, and log a loud warning.
+    """
+
+    @staticmethod
+    def _plant_corrupt_wal(db_path: str) -> Path:
+        """Leave a real, un-replayable WAL on disk next to ``db_path``.
+
+        Writes uncheckpointed rows so the WAL has genuine content, abandons
+        the connection (with checkpoint-on-shutdown disabled) so the WAL
+        survives, then overwrites a span in the middle with garbage to
+        corrupt a record's checksum.  Reopening DuckDB then fails replay
+        with a ``Failure while replaying WAL file`` error that is NOT the
+        FTS-DDL signature — exactly the production #647 case.
+        """
+        import gc
+        import uuid
+
+        conn = duckdb.connect(db_path)
+        conn.execute("PRAGMA disable_checkpoint_on_shutdown")
+        # Insert directly into the existing ``entries`` table so the WAL
+        # carries real, replayable records.
+        for _ in range(500):
+            conn.execute(
+                "INSERT INTO entries (id, content, embedding, entry_type, "
+                "source, author, project, tags, status, metadata, "
+                "created_at, updated_at, version) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                [
+                    str(uuid.uuid4()),
+                    "x" * 1000,
+                    [0.1, 0.2, 0.3, 0.4],
+                    "reference",
+                    "claude_code",
+                    "wal-bloat",
+                    None,
+                    [],
+                    "active",
+                    "{}",
+                    datetime.now(tz=UTC),
+                    datetime.now(tz=UTC),
+                    1,
+                ],
+            )
+        # Abandon the connection without an explicit checkpoint so the WAL
+        # is left on disk (close()/GC would otherwise flush it).
+        del conn
+        gc.collect()
+
+        wal_path = Path(db_path + ".wal")
+        size = wal_path.stat().st_size
+        assert size > 0, "expected a non-empty WAL to corrupt"
+        with open(wal_path, "r+b") as fh:
+            fh.seek(size // 3)
+            fh.write(b"\xff\xff\xff\xff" * 256)
+        return wal_path
+
+    async def test_corrupt_wal_quarantined_and_boots(
+        self,
+        deterministic_embedding_provider: object,
+        tmp_path,
+        caplog,
+    ) -> None:
+        """A corrupt WAL must boot on the last checkpoint, not crash-loop.
+
+        Acceptance for #647: create a store + checkpointed entry (so a main
+        DB exists), corrupt the ``.wal`` on disk, then reopen.  The store
+        must boot on the last-checkpointed main DB, the WAL must be moved
+        aside to a ``*.wal.corrupt.*`` sidecar (and the original ``.wal``
+        gone), a WARNING must be logged, and NO exception may be raised.
+        """
+        import uuid as _uuid
+
+        db_path = str(tmp_path / "distillery.db")
+
+        # 1. Create a store and write a checkpointed entry — main DB exists.
+        s1 = DuckDBStore(
+            db_path=db_path,
+            embedding_provider=deterministic_embedding_provider,
+        )
+        await s1.initialize()
+        keep_id = str(_uuid.uuid4())
+        await s1.store(make_entry(id=keep_id, content="this entry is checkpointed"))
+        await s1.close()
+
+        # 2. Corrupt/truncate the WAL on disk.
+        wal_path = self._plant_corrupt_wal(db_path)
+        assert wal_path.exists()
+
+        # 3. Reopen — must boot without raising and quarantine the WAL.
+        s2 = DuckDBStore(
+            db_path=db_path,
+            embedding_provider=deterministic_embedding_provider,
+        )
+        with caplog.at_level("WARNING"):
+            await s2.initialize()
+        try:
+            # Booted on the last-checkpointed main DB: the one checkpointed
+            # entry is present; the 500 un-checkpointed WAL rows are gone.
+            count = s2.connection.execute("SELECT COUNT(*) FROM entries").fetchone()
+            assert count is not None and count[0] == 1
+            kept = await s2.get(keep_id)
+            assert kept is not None
+        finally:
+            await s2.close()
+
+        # The original WAL was moved aside, not left in place.
+        assert not wal_path.exists(), "corrupt WAL should have been quarantined"
+        backups = list(tmp_path.glob("*.wal.corrupt.*"))
+        assert len(backups) == 1, f"expected one quarantine sidecar, got {backups}"
+
+        # A loud WARNING names the dropped path and the data-loss risk.
+        warnings = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "un-replayable" in r.getMessage()
+        ]
+        assert warnings, "expected a WARNING about the un-replayable WAL"
+        assert str(backups[0]) in warnings[0]
+        assert "LOST" in warnings[0]
+
+    async def test_fts_ddl_recovery_path_untouched(
+        self,
+        deterministic_embedding_provider: object,
+        tmp_path,
+        caplog,
+    ) -> None:
+        """The FTS-DDL recovery branch (#349) must not regress.
+
+        Drives the recovery helper directly with the exact FTS replay
+        signature and asserts it still quarantines the WAL and emits its
+        tailored "(FTS-related)" warning rather than the generic message.
+        """
+        db_path = str(tmp_path / "fts.db")
+        # Create a live DB file so reopening after quarantine succeeds.
+        conn = duckdb.connect(db_path)
+        conn.close()
+
+        wal_path = Path(db_path + ".wal")
+        wal_path.write_bytes(b"pretend-fts-wal")
+
+        store = DuckDBStore(
+            db_path=db_path,
+            embedding_provider=deterministic_embedding_provider,
+            hybrid_search=False,
+        )
+        fts_error = duckdb.Error(
+            "Dependency Error: Failure while replaying WAL file: Cannot drop "
+            'entry "fts_main_entries" because there are entries that depend on it.'
+        )
+        with caplog.at_level("WARNING"):
+            recovered = store._recover_from_wal_replay_failure(fts_error)  # noqa: SLF001
+        try:
+            assert not wal_path.exists()
+            backups = list(tmp_path.glob("*.wal.corrupt.*"))
+            assert len(backups) == 1
+            assert backups[0].read_bytes() == b"pretend-fts-wal"
+            messages = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+            assert any("FTS-related" in m for m in messages), (
+                "FTS-DDL recovery must keep its tailored warning (#349)"
+            )
+        finally:
+            recovered.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`_recover_from_wal_replay_failure` (`src/distillery/store/duckdb.py`) only quarantined the WAL for the FTS-schema-DDL replay failure it was written for (#349). For ANY other replay failure it hit `if not is_fts_replay_failure: raise exc`, so a truncated/corrupt WAL re-raised on every boot. In production (gominimal eng-memory, 2026-06-23) a full volume truncated the WAL mid-write, DuckDB raised `SerializationException: not enough data in file to deserialize result` during replay, and the instance crash-looped forever — unbootable until an operator deleted the WAL by hand.

## Fix

Remove the `if not is_fts_replay_failure: raise exc` gate so ANY un-replayable WAL (serialization / truncation / corruption, not just FTS DDL) is quarantined:

- Rename the `.wal` sidecar aside to a timestamped `<db>.wal.corrupt.<timestamp>` backup (bytes preserved for offline forensics).
- Reopen the last-checkpointed main DB without the WAL.
- Log a loud WARNING naming the dropped path and that un-checkpointed writes were LOST.

The #349 FTS-DDL path is preserved: it keeps its tailored "(FTS-related)" warning explaining the index will be rebuilt. A reopen-failure guard restores the WAL and re-raises the original error if reopening still fails (the WAL was not the cause), so genuinely unrelated open errors are not silently swallowed. Only local file paths with a `.wal` sidecar are eligible; in-memory / S3 / MotherDuck URIs and the no-sidecar case re-raise as before.

## Acceptance

- [x] A truncated/corrupt `distillery.db.wal` boots on the last-checkpointed main DB, WAL moved aside, warning logged, no crash loop → `tests/test_duckdb_store.py::TestCorruptWalQuarantine::test_corrupt_wal_quarantined_and_boots`
- [x] FTS-DDL recovery path (#349) does not regress → `tests/test_duckdb_store.py::TestCorruptWalQuarantine::test_fts_ddl_recovery_path_untouched`
- [x] Unrelated (non-WAL) open errors still re-raise → `tests/test_duckdb_store.py::test_recovery_ignores_unrelated_errors`

The acceptance test uses a real file-backed DB under `tmp_path` and plants a genuinely corrupt WAL on disk (uncheckpointed rows + mid-file garbage to break a record checksum), reproducing the production `Failure while replaying WAL file` class — not a mock. It fails against `origin/main` and passes against this fix.

## Test plan

```
PYTHONPATH="$PWD/src" .venv/bin/python -m pytest tests/test_duckdb_store.py -q   # 132 passed
PYTHONPATH="$PWD/src" .venv/bin/mypy --strict src/distillery                     # Success: 72 files
.venv/bin/ruff check src tests                                                   # All checks passed
```

Closes #647

## Related

Shares `src/distillery/store/duckdb.py` with the sibling WAL PR in this batch (different methods: `_recover_from_wal_replay_failure` vs `_checkpoint_after_write`). Merge one, then rebase the other; resolve semantically so both fixes coexist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database startup recovery when the write-ahead log contains corrupted or truncated/un-replayable content.
  * Unreplayable WAL files are now quarantined to a timestamped `*.wal.corrupt.*` backup, and recovery proceeds from the last checkpoint when possible.
  * Diagnostic messages now more clearly distinguish full-text search rebuild behavior from general data-loss cases, including where the quarantined log is stored.

* **Tests**
  * Added integration coverage for WAL quarantine on corrupt data, correct FTS-specific handling, and error behavior when quarantine/restore operations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->