### PR TITLE
test: cap per-test wall-clock with pytest-timeout to prevent CI hangs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "mypy>=1.0",
     "ruff>=0.1.0",
     "pytest-cov>=4.0",
+    "pytest-timeout>=2.1.0",
     "types-PyYAML>=6.0",
     "types-defusedxml>=0.7.0",
     "pytest-httpx>=0.30.0",
@@ -87,6 +88,13 @@ packages = ["src/distillery"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = ["-v", "--strict-markers", "--tb=short"]
+# Per-test wall-clock cap so a single deadlocked test can never hang CI for the
+# 6-hour job default. 120s is far above the slowest real test (~seconds) yet
+# well below a hang. ``thread`` method reliably fires even when the hang is
+# inside a C extension (DuckDB) that ignores SIGALRM, and dumps every thread's
+# stack on expiry so the culprit is identifiable.
+timeout = 120
+timeout_method = "thread"
 markers = [
     "unit: unit tests",
     "integration: integration tests",


### PR DESCRIPTION
## Root cause
A test deadlocked the `pytest` step on the Linux **3.12/3.13** CI cells for ~50 min (the job default is 6h) on the WAL batch merge (`39aff3e`). The `3.11`/`3.14` cells ran the identical suite green, and the full suite passes locally on macOS under both 3.12 and 3.13 (12× subset + 3× full, clean). So the hang is environment/timing-specific and not locally reproducible — there is no per-test timeout to surface it.

## Fix
```toml
# pyproject.toml [tool.pytest.ini_options]
timeout = 120
timeout_method = "thread"
```
- `pytest-timeout` added to `[dev]`.
- `120s` is far above the slowest real test (~seconds, bench excluded) and far below a hang.
- `thread` method fires even when the hang is inside a C extension (DuckDB) that ignores `SIGALRM`, and dumps every thread's stack on expiry.

## Effect
- CI can no longer hang for 6h on a single deadlocked test — it fails fast.
- If the deadlock recurs, the timeout traceback names the exact test + thread stacks, enabling a targeted root-cause fix.

## Test plan
- `pytest` header now shows `timeout: 120.0s`; config recognized (no `Unknown config option` warning).
- Full suite green locally: 3044 passed, 87.9% cov (3.13) and 153-test store subset green on 3.12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `pytest-timeout` to development dependencies.
  * Configured per-test timeouts (120-second limit) to improve CI reliability and prevent test execution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->