### PR TITLE
store: drop FORCE CHECKPOINT escalation that could deadlock the writer

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -47,12 +47,16 @@ logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
-# Consecutive plain-``CHECKPOINT`` failures after which we escalate to
-# ``FORCE CHECKPOINT``.  Plain CHECKPOINT fails with "there are other write
-# transactions active" under concurrent writers; left uncorrected the WAL
-# grows without bound and fills the volume (issue #648).  FORCE CHECKPOINT is
-# DuckDB's own hint for flushing regardless of active transactions.
-_FORCE_CHECKPOINT_AFTER_FAILURES = 3
+# Consecutive plain-``CHECKPOINT`` failures after which we emit an operator
+# WARNING.  Plain CHECKPOINT fails with "there are other write transactions
+# active" under concurrent writers; left uncorrected the WAL grows without
+# bound and fills the volume (issue #648).  We deliberately do NOT escalate to
+# ``FORCE CHECKPOINT`` here: it blocks indefinitely when another connection or
+# process holds an active write transaction, and running it under
+# ``_conn_lock`` would hang the writer (CI deadlock on slow cells, regression
+# from #648).  Persistent failures are surfaced via this WARNING and the
+# disk-backpressure guard instead.
+_WARN_AFTER_CHECKPOINT_FAILURES = 3
 
 # Free space on the database filesystem (bytes) below which we emit a
 # backpressure WARNING before the WAL can fill the volume (issue #648).
@@ -462,13 +466,20 @@ class DuckDBStore:
         Try using FORCE CHECKPOINT".  Left uncorrected the WAL grows
         without bound and fills the volume (``No space left on device``),
         which then truncates the WAL into an unbootable database (issue
-        #648).  So once the consecutive-failure streak crosses
-        :data:`_FORCE_CHECKPOINT_AFTER_FAILURES` we escalate to
-        ``FORCE CHECKPOINT`` — DuckDB's own hint — to flush the WAL
-        regardless of the active transactions.  A free-space guard
-        (:meth:`_check_disk_backpressure`) also warns before the volume
-        fills, since ``rate_limit.max_db_size_mb`` only measures the main
-        DB file and never the WAL.
+        #648).  Persistent failures are surfaced via a WARNING (once the
+        consecutive-failure streak crosses
+        :data:`_WARN_AFTER_CHECKPOINT_FAILURES`) plus the free-space guard
+        (:meth:`_check_disk_backpressure`), which warns before the volume
+        fills since ``rate_limit.max_db_size_mb`` only measures the main DB
+        file and never the WAL.
+
+        We deliberately do **not** escalate to ``FORCE CHECKPOINT``:
+        DuckDB cannot abort a write transaction held by another connection
+        or process, so ``FORCE CHECKPOINT`` blocks indefinitely under exactly
+        the sustained contention that triggers this path.  Because this runs
+        inside ``_run_sync`` while holding ``_conn_lock``, a blocked force
+        would hold that lock forever and starve every other write and status
+        probe — i.e. hang the process (CI deadlock regression from #648).
         """
         self._check_disk_backpressure()
         try:
@@ -480,62 +491,18 @@ class DuckDBStore:
             # already observed a successful write.  A persistent failure
             # streak means the WAL is accumulating writes (including HNSW
             # index entries under experimental persistence, whose replay
-            # has crashed on startup in production) — escalate so it is
-            # visible before the WAL becomes unreplayable.
+            # has crashed on startup in production) — warn so it is visible
+            # before the WAL becomes unreplayable.
             self._checkpoint_failures += 1
-            if self._checkpoint_failures >= _FORCE_CHECKPOINT_AFTER_FAILURES:
-                # FORCE CHECKPOINT aborts active write transactions, so it is
-                # only appropriate for the writer-contention case it is meant
-                # to clear (issue #648).  For unrelated failures (disk-full,
-                # permissions) forcing aborts concurrent writers for no
-                # benefit and does not fix the failure — log and wait instead.
-                message = str(exc)
-                is_contention = (
-                    "other write transactions active" in message
-                    or "Try using FORCE CHECKPOINT" in message
+            if self._checkpoint_failures >= _WARN_AFTER_CHECKPOINT_FAILURES:
+                logger.warning(
+                    "CHECKPOINT after write failed %d times in a row — "
+                    "WAL is accumulating un-flushed writes (non-fatal): %s",
+                    self._checkpoint_failures,
+                    exc,
                 )
-                if is_contention:
-                    logger.warning(
-                        "CHECKPOINT after write failed %d times in a row — "
-                        "WAL is accumulating un-flushed writes; forcing checkpoint "
-                        "(non-fatal): %s",
-                        self._checkpoint_failures,
-                        exc,
-                    )
-                    self._force_checkpoint(conn)
-                else:
-                    logger.warning(
-                        "CHECKPOINT after write failed %d times in a row — "
-                        "WAL is accumulating un-flushed writes; not forcing "
-                        "(non-contention failure, non-fatal): %s",
-                        self._checkpoint_failures,
-                        exc,
-                    )
             else:
                 logger.debug("CHECKPOINT after write failed (non-fatal): %s", exc)
-
-    def _force_checkpoint(self, conn: duckdb.DuckDBPyConnection) -> None:
-        """Issue ``FORCE CHECKPOINT`` to flush the WAL despite active writers.
-
-        ``FORCE CHECKPOINT`` is DuckDB's documented escape hatch when a
-        plain ``CHECKPOINT`` is blocked by concurrent write transactions.
-        It aborts those transactions so the WAL can be flushed to the main
-        database file, bounding WAL growth (issue #648).  On success the
-        consecutive-failure streak resets to 0; its own failure is logged
-        and swallowed, keeping the streak so the next write retries.
-        """
-        try:
-            conn.execute("FORCE CHECKPOINT")
-            logger.info(
-                "FORCE CHECKPOINT flushed the WAL after %d failed plain checkpoints",
-                self._checkpoint_failures,
-            )
-            self._checkpoint_failures = 0
-        except duckdb.Error as exc:
-            logger.warning(
-                "FORCE CHECKPOINT also failed (WAL still accumulating, non-fatal): %s",
-                exc,
-            )
 
     def _check_disk_backpressure(self) -> None:
         """Warn when the database filesystem is running low on free space.

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -16,7 +16,7 @@ import duckdb
 import pytest
 
 from distillery.models import Entry, EntrySource, EntryStatus, EntryType
-from distillery.store.duckdb import _FORCE_CHECKPOINT_AFTER_FAILURES, DuckDBStore
+from distillery.store.duckdb import _WARN_AFTER_CHECKPOINT_FAILURES, DuckDBStore
 from distillery.store.protocol import SearchResult
 from tests.conftest import make_entry
 
@@ -2085,15 +2085,19 @@ class TestHybridGracefulFallback:
 
 
 class TestCheckpointBackpressure:
-    """CHECKPOINT starvation guards: FORCE CHECKPOINT + disk backpressure (issue #648).
+    """CHECKPOINT starvation guards: WARNING + disk backpressure (issue #648).
 
     Plain ``CHECKPOINT`` after each write fails under concurrent write
     transactions ("there are other write transactions active"); left
-    uncorrected the WAL grows without bound and fills the volume.  These
-    tests drive the *mechanism* (a mock connection whose ``CHECKPOINT``
-    raises that error; a monkeypatched ``os.statvfs``) rather than real
-    concurrency / a real full disk.  A file-backed DB under ``tmp_path``
-    is used wherever a real local path is required.
+    uncorrected the WAL grows without bound and fills the volume.  We
+    surface that via a WARNING (and the disk-backpressure guard) but
+    deliberately do **not** escalate to ``FORCE CHECKPOINT``: it blocks
+    indefinitely when another connection/process holds a write transaction,
+    which would hold ``_conn_lock`` forever and hang the process (regression
+    from #648).  These tests drive the *mechanism* (a mock connection whose
+    ``CHECKPOINT`` raises that error; a monkeypatched ``os.statvfs``) rather
+    than real concurrency / a real full disk.  A file-backed DB under
+    ``tmp_path`` is used wherever a real local path is required.
     """
 
     @staticmethod
@@ -2103,90 +2107,41 @@ class TestCheckpointBackpressure:
             embedding_provider=mock_embedding_provider,
         )
 
-    async def test_force_checkpoint_issued_after_failure_streak(
-        self, tmp_path, mock_embedding_provider
+    async def test_failure_streak_warns_but_never_forces_checkpoint(
+        self, tmp_path, mock_embedding_provider, caplog
     ) -> None:
-        """Once the streak crosses the threshold, FORCE CHECKPOINT is issued."""
-        from unittest.mock import MagicMock, call
+        """Crossing the threshold logs a WARNING but never issues FORCE CHECKPOINT.
 
-        s = self._file_store(tmp_path, mock_embedding_provider)
-
-        active = duckdb.Error(
-            "Cannot CHECKPOINT: there are other write transactions active. "
-            "Try using FORCE CHECKPOINT"
-        )
-
-        def _execute(sql: str) -> None:
-            if sql == "CHECKPOINT":
-                raise active
-            # FORCE CHECKPOINT succeeds.
-
-        mock_conn = MagicMock()
-        mock_conn.execute.side_effect = _execute
-
-        # Below the threshold: only plain CHECKPOINT is attempted, no force.
-        for _ in range(_FORCE_CHECKPOINT_AFTER_FAILURES - 1):
-            s._checkpoint_after_write(mock_conn)  # noqa: SLF001
-        assert call("FORCE CHECKPOINT") not in mock_conn.execute.call_args_list
-        assert s._checkpoint_failures == _FORCE_CHECKPOINT_AFTER_FAILURES - 1  # noqa: SLF001
-
-        # Crossing the threshold issues FORCE CHECKPOINT, which succeeds and
-        # resets the streak to 0.
-        s._checkpoint_after_write(mock_conn)  # noqa: SLF001
-        assert call("FORCE CHECKPOINT") in mock_conn.execute.call_args_list
-        assert s._checkpoint_failures == 0  # noqa: SLF001
-
-    async def test_force_checkpoint_own_failure_keeps_streak(
-        self, tmp_path, mock_embedding_provider
-    ) -> None:
-        """If FORCE CHECKPOINT also fails, the streak is preserved (not reset)."""
-        from unittest.mock import MagicMock
-
-        s = self._file_store(tmp_path, mock_embedding_provider)
-        mock_conn = MagicMock()
-        # Both plain and forced checkpoints fail.  The plain CHECKPOINT must
-        # raise the writer-contention error so FORCE CHECKPOINT is attempted.
-        mock_conn.execute.side_effect = duckdb.Error(
-            "Cannot CHECKPOINT: there are other write transactions active. "
-            "Try using FORCE CHECKPOINT"
-        )
-
-        for _ in range(_FORCE_CHECKPOINT_AFTER_FAILURES):
-            s._checkpoint_after_write(mock_conn)  # noqa: SLF001
-
-        # FORCE CHECKPOINT was attempted on the threshold-crossing call ...
-        assert any(
-            c.args == ("FORCE CHECKPOINT",) for c in mock_conn.execute.call_args_list
-        )
-        # ... but since it also failed the streak is NOT reset.
-        assert s._checkpoint_failures == _FORCE_CHECKPOINT_AFTER_FAILURES  # noqa: SLF001
-
-    async def test_non_contention_failure_does_not_force_checkpoint(
-        self, tmp_path, mock_embedding_provider
-    ) -> None:
-        """A generic (non-contention) failure past the threshold never forces.
-
-        FORCE CHECKPOINT aborts active write transactions, so it is reserved
-        for the writer-contention case (issue #648).  An unrelated failure
-        (disk-full, permissions) must not escalate to FORCE CHECKPOINT even
-        once the streak crosses the threshold.
+        ``FORCE CHECKPOINT`` can block indefinitely when another
+        connection/process holds a write transaction, which under
+        ``_conn_lock`` would hang the process (regression from #648), so it
+        must never be issued — even under sustained writer contention.
         """
         from unittest.mock import MagicMock, call
 
         s = self._file_store(tmp_path, mock_embedding_provider)
         mock_conn = MagicMock()
-        # A non-contention failure (e.g. disk-full / permissions) on every
-        # plain CHECKPOINT.
-        mock_conn.execute.side_effect = duckdb.Error("IO Error: No space left on device")
+        # The writer-contention error on every plain CHECKPOINT — the exact
+        # condition that previously triggered the (now-removed) force path.
+        mock_conn.execute.side_effect = duckdb.Error(
+            "Cannot CHECKPOINT: there are other write transactions active. "
+            "Try using FORCE CHECKPOINT"
+        )
 
-        for _ in range(_FORCE_CHECKPOINT_AFTER_FAILURES + 1):
-            s._checkpoint_after_write(mock_conn)  # noqa: SLF001
+        with caplog.at_level("WARNING", logger="distillery.store.duckdb"):
+            for _ in range(_WARN_AFTER_CHECKPOINT_FAILURES + 1):
+                s._checkpoint_after_write(mock_conn)  # noqa: SLF001
 
-        # FORCE CHECKPOINT must never be issued for a non-contention failure,
-        # even though the streak has crossed the threshold.
+        # FORCE CHECKPOINT must never be issued, even under sustained contention.
         assert call("FORCE CHECKPOINT") not in mock_conn.execute.call_args_list
+        # The streak keeps climbing (no reset) and a WARNING is surfaced.
         assert (
-            s._checkpoint_failures == _FORCE_CHECKPOINT_AFTER_FAILURES + 1  # noqa: SLF001
+            s._checkpoint_failures == _WARN_AFTER_CHECKPOINT_FAILURES + 1  # noqa: SLF001
+        )
+        assert any(
+            "WAL is accumulating un-flushed writes" in r.message
+            for r in caplog.records
+            if r.levelname == "WARNING"
         )
 
     async def test_disk_backpressure_warns_when_free_space_low(

--- a/tests/test_store_wal_durability.py
+++ b/tests/test_store_wal_durability.py
@@ -577,17 +577,19 @@ class TestBackgroundWritesFlushWal:
 
 
 class TestCheckpointFailureEscalation:
-    """Swallowed checkpoint failures escalate to WARNING + FORCE CHECKPOINT.
+    """Swallowed checkpoint failures are surfaced via WARNING (we do not force).
 
     ``_checkpoint_after_write`` deliberately never raises — but logging
     every failure at DEBUG hid the 2026-06-12 incident's WAL growth until
     replay was already poisoned.  Three consecutive failures now log at
-    WARNING and escalate to ``FORCE CHECKPOINT`` to flush the WAL despite
-    active writers (issue #648); any success resets the streak.
+    WARNING so persistent WAL growth is visible (issue #648); any success
+    resets the streak.
 
-    FORCE CHECKPOINT aborts active write transactions, so escalation only
-    happens for the writer-contention failure it is meant to clear — hence
-    ``_FailingConn`` raises that specific error.
+    We deliberately do **not** escalate to ``FORCE CHECKPOINT``: it blocks
+    indefinitely when another connection/process holds a write transaction,
+    which under ``_conn_lock`` would hang the process (regression from
+    #648).  ``_FailingConn`` raises the writer-contention error to exercise
+    exactly that previously-forcing path and confirm it now only warns.
     """
 
     class _FailingConn:
@@ -615,10 +617,9 @@ class TestCheckpointFailureEscalation:
             store._checkpoint_after_write(self._FailingConn())  # type: ignore[arg-type]
         warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
         messages = [r.message for r in warnings]
-        # The streak warning fires, and the threshold-crossing call escalates to
-        # FORCE CHECKPOINT — which here also fails on _FailingConn (issue #648).
+        # The streak warning fires once the threshold is crossed; we no longer
+        # escalate to FORCE CHECKPOINT (it could deadlock the writer, #648).
         assert any("3 times in a row" in m for m in messages)
-        assert any("FORCE CHECKPOINT also failed" in m for m in messages)
 
     def test_success_resets_failure_streak(self, mock_embedding_provider) -> None:
         store = DuckDBStore(db_path=":memory:", embedding_provider=mock_embedding_provider)


### PR DESCRIPTION
## Root cause
`FORCE CHECKPOINT` blocks **indefinitely** when another connection/process holds an active write transaction — DuckDB cannot abort a transaction it doesn't own. PR #649 (issue #648) called it from `_checkpoint_after_write` after a 3-CHECKPOINT-failure streak. That runs inside `_run_sync` while holding `_conn_lock`, so a blocked force holds the lock forever and starves every other write + status probe → the process hangs.

Proven by a CI thread-stack dump (Linux 3.13 cell): the sole busy worker was stuck at
```
_sync_store → _checkpoint_after_write → _force_checkpoint → conn.execute("FORCE CHECKPOINT")
```
with all other workers idle. It only fires under sustained write contention (3 consecutive plain-CHECKPOINT failures), so it deadlocked the slow 2-core 3.12/3.13 cells under `TestStatusStaysResponsiveUnderWriteContention` (#558) but not faster cells or local runs.

## Fix
- Delete `_force_checkpoint`; `_checkpoint_after_write` now only emits a WARNING after the failure streak crosses the threshold (renamed `_FORCE_CHECKPOINT_AFTER_FAILURES` → `_WARN_AFTER_CHECKPOINT_FAILURES`).
- Keep the streak WARNING and the `_check_disk_backpressure` guard — persistent failures stay visible; the disk guard still warns before the volume fills (issue #648's second acceptance clause).
- `FORCE CHECKPOINT` is deliberately not used; a non-hanging WAL bound under cross-process contention needs process-level write serialization (separate follow-up).

## Acceptance
- [x] No executable `FORCE CHECKPOINT` remains (grep clean).
- [x] `TestStatusStaysResponsiveUnderWriteContention` passes repeatedly (no hang).
- [x] Streak still warns after 3 failures; resets on success; disk-backpressure tests retained; added `test_failure_streak_warns_but_never_forces_checkpoint`.

## Test plan
```
pytest tests/test_duckdb_store.py tests/test_store_wal_durability.py -q   # 151 passed
pytest tests/test_duckdb_store.py::TestStatusStaysResponsiveUnderWriteContention -q  # x3, no hang
mypy --strict src/distillery  # clean
ruff check src tests          # clean
```
Regression from #648; complements the #656 pytest-timeout safety net.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined checkpoint failure handling to emit warnings on repeated failures instead of escalating recovery attempts, improving visibility into operational issues and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->