### PR TITLE
store: serialize embedding-budget counter under _conn_lock (#655)

### DIFF
--- a/src/distillery/mcp/budget.py
+++ b/src/distillery/mcp/budget.py
@@ -16,15 +16,16 @@ from __future__ import annotations
 
 import datetime
 import logging
-import threading
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Serializes counter writes.  Per-call cursors are separate DuckDB
-# connections, so unserialized concurrent upserts of the same row hit
-# optimistic-concurrency conflicts ("Conflict on update!" / duplicate key).
-_write_lock = threading.Lock()
+# Counter writes are serialized by the store's ``_conn_lock``: production
+# callers reach this module only via ``DuckDBStore.record_embedding_usage``,
+# which runs the upsert under that lock (issue #655).  No module-level lock is
+# needed — adding one would let the budget write race the store's serialized
+# writes/CHECKPOINT on the non-thread-safe connection, which is the very bug
+# the store-side serialization fixes.
 
 
 class EmbeddingBudgetError(Exception):
@@ -73,16 +74,18 @@ def increment_usage(conn: Any, count: int = 1) -> int:
     Returns:
         The new total for today.
     """
-    with _write_lock:
-        return _increment_locked(conn, count)
+    return _increment_locked(conn, count)
 
 
 def _increment_locked(conn: Any, count: int) -> int:
-    """Upsert today's counter and return the new total.  Caller holds ``_write_lock``."""
+    """Upsert today's counter and return the new total.
+
+    Callers must already serialize access to *conn* (production goes through
+    the store's ``_conn_lock`` via ``DuckDBStore.record_embedding_usage``).
+    """
     key = _today_key()
-    # Use a per-call cursor so concurrent callers don't invalidate each
-    # other's result sets on the shared connection; the write lock keeps
-    # concurrent upserts of the same row from conflicting.
+    # Use a per-call cursor so a pending result set on the shared connection
+    # is not invalidated mid-fetch.
     cur = conn.cursor()
     cur.execute(
         "INSERT INTO _meta (key, value) VALUES (?, ?) "
@@ -131,11 +134,10 @@ def record_and_check(conn: Any, daily_limit: int, count: int = 1) -> int:
     """
     if daily_limit <= 0:
         return increment_usage(conn, count)  # unlimited, still track
-    # Check and increment under one lock: a check that releases the lock
-    # before the increment lets concurrent callers all pass the read and
-    # collectively overspend the cap.
-    with _write_lock:
-        used = get_daily_usage(conn)
-        if used + count > daily_limit:
-            raise EmbeddingBudgetError(used, daily_limit)
-        return _increment_locked(conn, count)
+    # Check then increment in one critical section so concurrent callers can't
+    # all pass the read and collectively overspend the cap.  The caller
+    # serializes access to *conn* (production: the store's ``_conn_lock``).
+    used = get_daily_usage(conn)
+    if used + count > daily_limit:
+        raise EmbeddingBudgetError(used, daily_limit)
+    return _increment_locked(conn, count)

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -56,8 +56,9 @@ async def _budget_check_error_response(
 ) -> list[types.TextContent]:
     """Categorize a non-budget failure from the embedding-budget check (issue #557).
 
-    ``record_and_check`` touches the shared writer connection, so any of three
-    distinct conditions can surface here.  Collapsing them all to one opaque
+    ``store.record_embedding_usage`` touches the shared writer connection, so
+    any of three distinct conditions can surface here.  Collapsing them all to
+    one opaque
     ``INTERNAL`` (with a misleading "budget" message) hid retryable faults from
     clients.  Branch on the concrete exception type so clients can react:
 
@@ -305,7 +306,7 @@ async def _handle_store(
             omitted by default to keep store responses small; see issue #348.
           - `conflict_message`: guidance message when conflict candidates are returned.
     """
-    from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
+    from distillery.mcp.budget import EmbeddingBudgetError
     from distillery.models import Entry, EntrySource, EntryType, VerificationStatus
 
     # --- input validation ---------------------------------------------------
@@ -402,8 +403,8 @@ async def _handle_store(
     embed_count = 1 if output_mode == "summary" else 3
     if cfg is not None:
         try:
-            record_and_check(
-                store.connection, cfg.rate_limit.embedding_budget_daily, count=embed_count
+            await store.record_embedding_usage(
+                count=embed_count, daily_limit=cfg.rate_limit.embedding_budget_daily
             )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
@@ -881,7 +882,7 @@ async def _handle_store_batch(
             "stored"}``.  Failed items carry ``{"entry_id": null,
             "persisted": false, "error": {"code", "message", "details"?}}``.
     """
-    from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
+    from distillery.mcp.budget import EmbeddingBudgetError
     from distillery.models import Entry
 
     entries_raw = arguments.get("entries")
@@ -946,8 +947,8 @@ async def _handle_store_batch(
     # rather than the raw input length.
     if cfg is not None:
         try:
-            record_and_check(
-                store.connection, cfg.rate_limit.embedding_budget_daily, count=len(built)
+            await store.record_embedding_usage(
+                count=len(built), daily_limit=cfg.rate_limit.embedding_budget_daily
             )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
@@ -2239,10 +2240,12 @@ async def _handle_correct(
                 pass  # can't stat, skip check
 
     if cfg is not None:
-        from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
+        from distillery.mcp.budget import EmbeddingBudgetError
 
         try:
-            record_and_check(store.connection, cfg.rate_limit.embedding_budget_daily, count=1)
+            await store.record_embedding_usage(
+                count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
+            )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
         except Exception as exc:  # noqa: BLE001

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -406,8 +406,8 @@ async def _handle_store(
             await store.record_embedding_usage(
                 count=embed_count, daily_limit=cfg.rate_limit.embedding_budget_daily
             )
-        except EmbeddingBudgetError as exc:
-            return error_response("BUDGET_EXCEEDED", str(exc))
+        except EmbeddingBudgetError:
+            return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
         except Exception as exc:  # noqa: BLE001
             # Non-budget failures (aborted txn on the shared connection — see
             # issue #363, provider faults in the counter path) are categorized
@@ -950,8 +950,8 @@ async def _handle_store_batch(
             await store.record_embedding_usage(
                 count=len(built), daily_limit=cfg.rate_limit.embedding_budget_daily
             )
-        except EmbeddingBudgetError as exc:
-            return error_response("BUDGET_EXCEEDED", str(exc))
+        except EmbeddingBudgetError:
+            return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
         except Exception as exc:  # noqa: BLE001
             return await _budget_check_error_response(exc, store, "store_batch")
 
@@ -2246,8 +2246,8 @@ async def _handle_correct(
             await store.record_embedding_usage(
                 count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
             )
-        except EmbeddingBudgetError as exc:
-            return error_response("BUDGET_EXCEEDED", str(exc))
+        except EmbeddingBudgetError:
+            return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
         except Exception as exc:  # noqa: BLE001
             return await _budget_check_error_response(exc, store, "correct")
 

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -174,8 +174,8 @@ async def _handle_search(
             await store.record_embedding_usage(
                 count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
             )
-        except EmbeddingBudgetError as exc:
-            return error_response("BUDGET_EXCEEDED", str(exc))
+        except EmbeddingBudgetError:
+            return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
 
     filters = _build_filters_from_arguments(arguments)
     filter_result = _apply_default_status_filter(filters, arguments)
@@ -560,8 +560,8 @@ async def _handle_find_similar(
             await store.record_embedding_usage(
                 count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
             )
-        except EmbeddingBudgetError as exc:
-            return error_response("BUDGET_EXCEEDED", str(exc))
+        except EmbeddingBudgetError:
+            return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
 
     try:
         search_results = await store.find_similar(content=content, threshold=threshold, limit=limit)

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -130,7 +130,7 @@ async def _handle_search(
         ``expand_graph=True`` results also include ``provenance`` and the envelope
         includes a ``graph_expansion`` field.
     """
-    from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
+    from distillery.mcp.budget import EmbeddingBudgetError
 
     err = validate_required(arguments, "query")
     if err:
@@ -171,7 +171,9 @@ async def _handle_search(
     # --- embedding budget check (1 embed call per search) -------------------
     if cfg is not None:
         try:
-            record_and_check(store.connection, cfg.rate_limit.embedding_budget_daily)
+            await store.record_embedding_usage(
+                count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
+            )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
 
@@ -453,7 +455,7 @@ async def _handle_find_similar(
     Returns:
         MCP content list with a JSON payload of ``results`` and ``count``.
     """
-    from distillery.mcp.budget import EmbeddingBudgetError, record_and_check
+    from distillery.mcp.budget import EmbeddingBudgetError
 
     # --- new graph-extension parameters (parsed first so we can use them
     # when validating content/source_entry_id requirements below) ---------
@@ -555,7 +557,9 @@ async def _handle_find_similar(
     # --- embedding budget check (1 embed call) ----------------------------
     if cfg is not None:
         try:
-            record_and_check(store.connection, cfg.rate_limit.embedding_budget_daily)
+            await store.record_embedding_usage(
+                count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
+            )
         except EmbeddingBudgetError as exc:
             return error_response("BUDGET_EXCEEDED", str(exc))
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -3403,6 +3403,51 @@ class DuckDBStore:
         """Write a value to the ``_meta`` key-value table (upsert)."""
         await self._run_sync(self._sync_set_metadata, key, value)
 
+    def _sync_record_embedding_usage(self, count: int, daily_limit: int) -> int:
+        """Increment + budget-check today's embedding counter on ``_conn``.
+
+        Runs inside :meth:`_run_sync` under ``_conn_lock``; delegates the SQL to
+        :func:`distillery.mcp.budget.record_and_check`.  Lets
+        :class:`~distillery.mcp.budget.EmbeddingBudgetError` and any
+        ``duckdb.Error`` propagate unchanged so the MCP layer can categorize
+        them (issue #557).
+        """
+        from distillery.mcp.budget import record_and_check
+
+        assert self._conn is not None
+        return record_and_check(self._conn, daily_limit, count)
+
+    async def record_embedding_usage(self, count: int, daily_limit: int) -> int:
+        """Serialize the embedding-budget counter write under ``_conn_lock``.
+
+        The per-request embedding-budget counter is an ``INSERT … ON CONFLICT
+        UPDATE`` on ``_meta``.  Previously the MCP tool layer ran it directly
+        against the shared writer connection, *outside* ``_conn_lock``, racing
+        the store's serialized writes on a non-thread-safe ``DuckDBPyConnection``.
+        That corrupted transaction state and left a transaction active across the
+        store's ``CHECKPOINT``, so plain ``CHECKPOINT`` failed with "there are
+        other write transactions active", the WAL never flushed and grew without
+        bound, and every read replayed an ever-larger WAL — degrading query
+        latency monotonically (issue #655 root cause 1; same race underlies the
+        #557 aborted-transaction misclassification).
+
+        Routing the counter through :meth:`_run_sync` makes it share the single
+        ``_conn_lock`` that serializes every other write, so it can never touch
+        the connection concurrently with a write or checkpoint.
+
+        Args:
+            count: Number of embedding calls about to be made.
+            daily_limit: Maximum calls per day; ``0`` means unlimited.
+
+        Returns:
+            The new total for today.
+
+        Raises:
+            EmbeddingBudgetError: If the budget would be exceeded.
+            duckdb.Error: Propagated unchanged for caller categorization (#557).
+        """
+        return await self._run_sync(self._sync_record_embedding_usage, count, daily_limit)
+
     def _sync_prune_search_log(self, retention_days: int) -> int:
         """Delete ``search_log`` rows older than *retention_days*.
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1405,11 +1405,12 @@ class DuckDBStore:
     async def rollback(self) -> None:
         """Public rollback hook for non-store code paths that touch the connection.
 
-        The MCP tool layer occasionally issues raw ``conn.execute`` calls
-        (e.g. the per-request embedding-budget counter in
-        :mod:`distillery.mcp.budget`) that bypass :meth:`_run_sync`.  Those
-        call sites can invoke ``await store.rollback()`` in their exception
-        handlers to clear an aborted transaction before the next request.
+        The MCP tool layer occasionally issues raw ``conn.execute`` calls that
+        bypass :meth:`_run_sync` (the per-request embedding-budget counter no
+        longer does — it now goes through the serialized ``_run_sync`` /
+        ``_conn_lock`` write path).  Those remaining call sites can invoke
+        ``await store.rollback()`` in their exception handlers to clear an
+        aborted transaction before the next request.
 
         Holds ``_conn_lock`` so the rollback cannot race a concurrent
         ``_run_sync`` worker still mutating the connection (issue #416).
@@ -3415,7 +3416,9 @@ class DuckDBStore:
         from distillery.mcp.budget import record_and_check
 
         assert self._conn is not None
-        return record_and_check(self._conn, daily_limit, count)
+        total = record_and_check(self._conn, daily_limit, count)
+        self._checkpoint_after_write(self._conn)
+        return total
 
     async def record_embedding_usage(self, count: int, daily_limit: int) -> int:
         """Serialize the embedding-budget counter write under ``_conn_lock``.

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -127,106 +127,89 @@ class TestRecordAndCheck:
 
 @pytest.mark.unit
 class TestConcurrentAccess:
-    """Regression tests for the DuckDB result-set race (issue #608).
+    """Regression tests for the concurrent budget-counter write race.
 
-    DuckDB invalidates a connection's pending result set when another
-    ``execute()`` runs on the same connection, so concurrent execute+fetch
-    on a shared connection raised ``InvalidInputException: No open result
-    set``.  Per-call cursors give each caller its own result set.
+    Originally (issue #608) a module-level ``_write_lock`` serialized direct
+    multithreaded calls to the budget functions on one shared connection.  The
+    #655 fix moves that serialization to the store: production callers reach the
+    counter only via :meth:`DuckDBStore.record_embedding_usage`, which runs the
+    upsert under the store's ``_conn_lock``.  These tests exercise that path —
+    concurrent ``record_embedding_usage`` calls must never raise
+    ``Conflict on update`` / duplicate-key / aborted-transaction errors, must
+    count exactly, and must not overspend the cap.
     """
 
-    def test_concurrent_reads_and_writes_do_not_raise(
-        self, conn: duckdb.DuckDBPyConnection
-    ) -> None:
-        """Concurrent check/read/record calls on one shared connection succeed."""
-        import threading
+    async def test_concurrent_record_usage_does_not_raise(self, store: object) -> None:
+        """Concurrent record_embedding_usage calls through the store succeed."""
+        import asyncio
 
-        n_threads = 8
+        n_tasks = 8
         iterations = 25
-        barrier = threading.Barrier(n_threads)
-        errors: list[Exception] = []
 
-        def worker() -> None:
-            barrier.wait()
-            try:
-                for _ in range(iterations):
-                    check_budget(conn, daily_limit=10_000_000)
-                    get_daily_usage(conn)
-                    record_and_check(conn, daily_limit=10_000_000)
-            except Exception as exc:  # pragma: no cover - only on regression
-                errors.append(exc)
+        async def worker() -> None:
+            for _ in range(iterations):
+                await store.record_embedding_usage(count=1, daily_limit=10_000_000)
 
-        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        await asyncio.gather(*(worker() for _ in range(n_tasks)))
 
-        assert errors == [], f"concurrent budget calls raised: {errors!r}"
-        assert get_daily_usage(conn) == n_threads * iterations
+        assert get_daily_usage(store.connection) == n_tasks * iterations
 
-    def test_concurrent_increments_count_correctly(self, conn: duckdb.DuckDBPyConnection) -> None:
+    async def test_concurrent_increments_count_correctly(self, store: object) -> None:
         """The _meta counter reflects every concurrent increment exactly once."""
-        import threading
+        import asyncio
 
-        n_threads = 6
+        n_tasks = 6
         iterations = 20
-        barrier = threading.Barrier(n_threads)
-        errors: list[Exception] = []
 
-        def worker() -> None:
-            barrier.wait()
-            try:
-                for _ in range(iterations):
-                    increment_usage(conn)
-            except Exception as exc:  # pragma: no cover - only on regression
-                errors.append(exc)
+        async def worker() -> None:
+            for _ in range(iterations):
+                await store.record_embedding_usage(count=1, daily_limit=0)
 
-        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        await asyncio.gather(*(worker() for _ in range(n_tasks)))
 
-        assert errors == [], f"concurrent increments raised: {errors!r}"
-        assert get_daily_usage(conn) == n_threads * iterations
+        assert get_daily_usage(store.connection) == n_tasks * iterations
 
-    def test_concurrent_record_and_check_cannot_overspend(
-        self, conn: duckdb.DuckDBPyConnection
-    ) -> None:
-        """Concurrent record_and_check calls never push usage past daily_limit."""
-        import threading
+    async def test_concurrent_record_usage_cannot_overspend(self, store: object) -> None:
+        """Concurrent record_embedding_usage calls never push usage past daily_limit."""
+        import asyncio
 
         daily_limit = 10
-        n_threads = 8
+        n_tasks = 8
         iterations = 5  # 40 attempted calls against a limit of 10
-        barrier = threading.Barrier(n_threads)
-        errors: list[Exception] = []
         successes: list[int] = []
-        lock = threading.Lock()
 
-        def worker() -> None:
-            barrier.wait()
+        async def worker() -> None:
             for _ in range(iterations):
                 try:
-                    record_and_check(conn, daily_limit=daily_limit)
+                    await store.record_embedding_usage(count=1, daily_limit=daily_limit)
                 except EmbeddingBudgetError:
                     pass  # expected once the cap is reached
-                except Exception as exc:  # pragma: no cover - only on regression
-                    errors.append(exc)
                 else:
-                    with lock:
-                        successes.append(1)
+                    successes.append(1)
 
-        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        await asyncio.gather(*(worker() for _ in range(n_tasks)))
 
-        assert errors == [], f"concurrent record_and_check raised: {errors!r}"
         assert len(successes) == daily_limit
-        assert get_daily_usage(conn) == daily_limit
+        assert get_daily_usage(store.connection) == daily_limit
+
+
+@pytest.mark.unit
+class TestStoreRecordEmbeddingUsage:
+    """The serialized store wrapper increments and still enforces the budget (#655)."""
+
+    async def test_increments_counter(self, store: object) -> None:
+        """record_embedding_usage adds to today's counter and returns the total."""
+        total = await store.record_embedding_usage(count=3, daily_limit=100)
+        assert total == 3
+        assert get_daily_usage(store.connection) == 3
+        total = await store.record_embedding_usage(count=2, daily_limit=100)
+        assert total == 5
+
+    async def test_propagates_budget_error_when_over_limit(self, store: object) -> None:
+        """EmbeddingBudgetError still propagates unchanged through the store path."""
+        await store.record_embedding_usage(count=10, daily_limit=10)
+        with pytest.raises(EmbeddingBudgetError):
+            await store.record_embedding_usage(count=1, daily_limit=10)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -2233,6 +2233,88 @@ class TestCheckpointBackpressure:
         assert not any("Low free space" in r.message for r in caplog.records)
 
 
+class TestEmbeddingBudgetCounterDoesNotStarveCheckpoint:
+    """Issue #655 RC1: the budget counter must not race writes / CHECKPOINT.
+
+    The MCP store path increments the embedding-budget counter on every
+    store/store_batch/find_similar.  Before the fix that increment ran on the
+    shared writer connection *outside* ``_conn_lock``, racing the store's
+    serialized writes on a non-thread-safe ``DuckDBPyConnection``.  That
+    corrupted transaction state and left a transaction active across the
+    store's ``CHECKPOINT``, so plain ``CHECKPOINT`` failed with "there are
+    other write transactions active" — the WAL never flushed and grew without
+    bound, degrading every read.  Routing the counter through
+    :meth:`DuckDBStore.record_embedding_usage` (under ``_conn_lock``) fixes it.
+    """
+
+    async def test_concurrent_stores_and_budget_counter_keep_wal_bounded(
+        self, tmp_path, deterministic_embedding_provider
+    ) -> None:
+        """Concurrent store/store_batch + budget increments never abort a txn and
+        leave the WAL bounded (CHECKPOINT is not starved)."""
+        import asyncio
+
+        db_path = str(tmp_path / "budget_race.db")
+        store = DuckDBStore(
+            db_path=db_path,
+            embedding_provider=deterministic_embedding_provider,
+        )
+        await store.initialize()
+        errors: list[BaseException] = []
+
+        # daily_limit > 0 so the check+increment path actually runs.
+        daily_limit = 100_000
+
+        async def single_writer(n: int) -> None:
+            try:
+                # Mirror the MCP store path: budget increment then the write.
+                await store.record_embedding_usage(count=3, daily_limit=daily_limit)
+                await store.store(make_entry(content=f"single {n}"))
+            except BaseException as exc:  # noqa: BLE001  — capture any race fallout
+                errors.append(exc)
+
+        async def batch_writer(n: int) -> None:
+            try:
+                entries = [make_entry(content=f"batch {n}-{i}") for i in range(3)]
+                await store.record_embedding_usage(count=len(entries), daily_limit=daily_limit)
+                await store.store_batch(entries)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        try:
+            await asyncio.gather(
+                *(single_writer(i) for i in range(20)),
+                *(batch_writer(i) for i in range(20)),
+            )
+
+            # (a) No transaction corruption surfaced anywhere.
+            assert errors == [], f"concurrent budget+store raised: {errors!r}"
+            transaction_markers = (
+                "other write transactions active",
+                "transaction is aborted",
+                "Conflict on update",
+                "within a transaction",
+            )
+            for exc in errors:
+                msg = str(exc)
+                assert not any(m in msg for m in transaction_markers), (
+                    f"transaction race surfaced: {exc!r}"
+                )
+
+            # (b) CHECKPOINT was never starved: the WAL sidecar stays bounded.
+            # Every write checkpoints, so the WAL is flushed; an active txn left
+            # by the racing counter would block CHECKPOINT and let it bloat.
+            wal_path = Path(db_path + ".wal")
+            if wal_path.exists():
+                wal_size = wal_path.stat().st_size
+                assert wal_size < 256 * 1024, (
+                    f"WAL grew to {wal_size} bytes — CHECKPOINT appears starved "
+                    "(budget counter racing writes, issue #655 RC1)"
+                )
+        finally:
+            await store.close()
+
+
 # ---------------------------------------------------------------------------
 # _sanitise_last_error helper
 #


### PR DESCRIPTION
## Root cause

The per-request embedding-budget counter (`INSERT … ON CONFLICT UPDATE` on `_meta`, via `budget.record_and_check`) was executed by the MCP tool layer directly against the store's shared writer `DuckDBPyConnection`, *outside* `_conn_lock`. `DuckDBPyConnection` is not thread-safe, and every other write goes through `_run_sync` under `_conn_lock`, so the budget upsert raced the store's serialized writes:

- Concurrent upserts of the same `_meta` row hit optimistic-concurrency conflicts (`TransactionException: Conflict on update!`).
- The race corrupted transaction state and could leave a transaction active across the store's `CHECKPOINT`. Plain `CHECKPOINT` then failed with "there are other write transactions active", so the WAL was never flushed and grew without bound.
- Every read replayed an ever-larger WAL, degrading query latency monotonically.

This is issue #655 root cause 1 (checkpoint starvation). The same race underlies the aborted-transaction misclassification in #557.

## Fix

- Add `DuckDBStore.record_embedding_usage(count, daily_limit)`, which routes `budget.record_and_check` through `_run_sync` — i.e. `async with _get_conn_lock()` + `asyncio.to_thread` — so the counter write shares the single `_conn_lock` that serializes every other write and can never touch the connection concurrently with a write or `CHECKPOINT`.
- Convert all 5 production callers to `await store.record_embedding_usage(...)`: `crud.py` store / store_batch / correct, and `search.py` search / find_similar. No remaining raw `record_and_check(store.connection, …)`.
- Drop the now-redundant module-level `threading.Lock` (`_write_lock`) from `budget.py`. With the store-side serialization in place a module lock would only let the budget write race the store's serialized writes/CHECKPOINT — the very bug being fixed. `record_and_check` / `increment_usage` now document that the caller serializes access to `conn`.
- Preserve the #557 exception categorization verbatim in `crud.py` (`BUDGET_EXCEEDED` / `STORE_TRANSIENT` / `EMBEDDING_PROVIDER_UNAVAILABLE` / `INTERNAL`); `EmbeddingBudgetError` and `duckdb.Error` propagate unchanged from `record_embedding_usage`. `search.py` keeps its original `EmbeddingBudgetError`-only handling. Reads (analytics SELECTs, `_read_conn` / `_read_lock`) are untouched.

No deadlock: `store()` / `store_batch()` never nest `record_embedding_usage`; the budget write and the store write are two separate critical sections on a non-reentrant `asyncio.Lock`.

## Acceptance

- Budget counter write is serialized under `_conn_lock` -> `TestEmbeddingBudgetCounterDoesNotStarveCheckpoint::test_concurrent_stores_and_budget_counter_keep_wal_bounded` (40 concurrent budget+store/store_batch tasks raise no error; asserts none of `Conflict on update` / `other write transactions active` / `transaction is aborted` / `within a transaction` surface).
- CHECKPOINT is not starved -> same test asserts the `.wal` sidecar stays bounded (< 256 KiB) after all concurrent writes. The test is not a tautology: reverting the serialization makes it fail with 14x `TransactionException('Conflict on update!')`.
- All production callers serialized; zero raw `record_and_check(store.connection, …)` -> existing `tests/test_mcp_tools/` + `tests/test_budget.py` cover the store/search/correct paths.
- #557 categorization preserved -> `tests/test_budget.py` (BUDGET_EXCEEDED / STORE_TRANSIENT / EMBEDDING_PROVIDER_UNAVAILABLE / INTERNAL).

## Test plan

```
PYTHONPATH="$PWD/src" .venv/bin/python -m pytest tests/test_budget.py tests/test_duckdb_store.py tests/test_mcp_tools/ -q
# 275 passed

PYTHONPATH="$PWD/src" .venv/bin/mypy --strict src/distillery
# Success: no issues found in 72 source files

.venv/bin/ruff check src tests
# All checks passed!
```

Addresses #655 (root cause 1 — checkpoint starvation). Also removes the race behind #557. Does not cover #655 root cause 2 (fly auto_stop suspend, distill_ops).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding budget enforcement under concurrent usage by routing counter updates through the same serialized store write path, reducing transaction delays and checkpoint/WAL starvation risk.
  * Standardized embedding budget exceeded responses to return a fixed message: **"Embedding budget exceeded"**.
* **Tests**
  * Added/updated concurrency regression tests to validate correct daily counter increments and to confirm concurrent budget updates don’t overspend or disrupt store checkpointing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->