### PR TITLE
chore(relations): address link-suggestion review advisories (#653 follow-up)

### DIFF
--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -1446,6 +1446,11 @@ def _validate(config: DistilleryConfig) -> None:
             - classification.conflict_threshold is not between 0.0 and 1.0.
             - auto_link.threshold is not between 0.0 and 1.0.
             - auto_link.max_links is not greater than 0.
+            - link_suggestion.auto_create_threshold is not between 0.0 and 1.0.
+            - link_suggestion.review_floor is not between 0.0 and 1.0.
+            - link_suggestion.review_floor exceeds
+              link_suggestion.auto_create_threshold.
+            - link_suggestion.max_candidates_per_run is not greater than 0.
             - Any entry in tags.reserved_prefixes is not a valid tag segment.
             - feeds.thresholds.alert is not between 0.0 and 1.0.
             - feeds.thresholds.digest is not between 0.0 and 1.0.

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -72,6 +72,7 @@ _COOLDOWN_SECONDS: dict[str, int] = {
     "rescore": 3600,  # 1 hour
     "maintenance": 21600,  # 6 hours
     "classify-batch": 300,  # 5 minutes
+    "link-suggestion": 3600,  # 1 hour
 }
 
 # Per-endpoint locks to serialize dispatch and prevent TOCTOU races on
@@ -987,6 +988,13 @@ async def _run_maintenance(state: dict[str, Any]) -> JSONResponse:
         if classify_body.get("ok")
         else {"ok": False, "error": classify_body.get("error", "classify-batch failed")}
     )
+
+    # Re-check before link-suggestion — a fatal raised during classify-batch
+    # must halt the job rather than open a fresh DuckDB connection for the
+    # sweep against a dead store.
+    terminal = _terminal_failure_response(store)
+    if terminal is not None:
+        return terminal
 
     # 4. Link suggestion — sweep low-degree / orphan nodes and score candidate
     # edges.  Gated by config.link_suggestion.enabled; non-fatal so a failure

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -3646,8 +3646,17 @@ class DuckDBStore:
         valid_at: str | datetime | None = None,
         invalid_at: str | datetime | None = None,
         metadata: dict[str, Any] | None = None,
+        *,
+        checkpoint: bool = True,
     ) -> str:
-        """Synchronous implementation of add_relation(); called via asyncio.to_thread."""
+        """Synchronous implementation of add_relation(); called via asyncio.to_thread.
+
+        ``checkpoint`` defaults to ``True`` (the durable per-write behaviour).
+        Bounded-loop callers (e.g. :meth:`_sync_suggest_links`) pass ``False``
+        to suppress the per-row checkpoint and flush once at the end of the
+        batch, avoiding a CHECKPOINT storm under ``_conn_lock`` (issue #653
+        NOTE-1).
+        """
         assert self._conn is not None
         # Validate that both entries exist (including archived — preserves historical links).
         # Routes through :meth:`_sync_entry_exists` so this lookup uses the same SQL shape
@@ -3705,7 +3714,7 @@ class DuckDBStore:
                     f"UPDATE entry_relations SET {', '.join(set_parts)} WHERE id = ?",
                     [*set_params, relation_id],
                 )
-            if set_parts:
+            if set_parts and checkpoint:
                 self._checkpoint_after_write(self._conn)
             logger.debug(
                 "Relation already exists id=%s from=%s to=%s type=%s (attrs upserted=%d)",
@@ -3732,7 +3741,8 @@ class DuckDBStore:
                 metadata_json,
             ],
         )
-        self._checkpoint_after_write(self._conn)
+        if checkpoint:
+            self._checkpoint_after_write(self._conn)
         logger.debug(
             "Added relation id=%s from=%s to=%s type=%s",
             relation_id,
@@ -4050,8 +4060,14 @@ class DuckDBStore:
         to_id: str,
         relation_type: str,
         suggestion_score: float,
+        *,
+        checkpoint: bool = True,
     ) -> str:
-        """Synchronous implementation of add_relation_candidate(); via asyncio.to_thread."""
+        """Synchronous implementation of add_relation_candidate(); via asyncio.to_thread.
+
+        ``checkpoint`` defaults to ``True``; bounded-loop callers pass ``False``
+        to batch the WAL flush (issue #653 NOTE-1).
+        """
         assert self._conn is not None
         # Validate both entries exist (same permissive check as add_relation).
         if not self._sync_entry_exists(from_id):
@@ -4078,7 +4094,8 @@ class DuckDBStore:
             "VALUES (?, ?, ?, ?, ?)",
             [relation_id, from_id, to_id, relation_type, metadata_json],
         )
-        self._checkpoint_after_write(self._conn)
+        if checkpoint:
+            self._checkpoint_after_write(self._conn)
         logger.debug(
             "Added relation candidate id=%s from=%s to=%s type=%s score=%.3f",
             relation_id,
@@ -4321,15 +4338,24 @@ class DuckDBStore:
             return []
         embedding = list(seed_row[0])
         dims = self._embedding_provider.dimensions
+        # Exclude neighbours already linked to the seed (live edge or pending
+        # candidate, either direction) so the bounded LIMIT slots are spent on
+        # novel pairs rather than candidates the router would only discard via
+        # _sync_pair_has_edge — raising each sweep's yield (issue #653 NOTE-2).
         rows = self._conn.execute(
             f"SELECT id, array_cosine_similarity(embedding, ?::FLOAT[{dims}]) AS score "
             f"FROM entries "
             f"WHERE id != ? "
             f"AND status != ? "
             f"AND embedding IS NOT NULL "
+            f"AND NOT EXISTS ("
+            f"    SELECT 1 FROM entry_relations r "
+            f"    WHERE (r.from_id = ? AND r.to_id = entries.id) "
+            f"       OR (r.from_id = entries.id AND r.to_id = ?)"
+            f") "
             f"ORDER BY score DESC "
             f"LIMIT ?",
-            [embedding, seed_id, EntryStatus.ARCHIVED.value, limit],
+            [embedding, seed_id, EntryStatus.ARCHIVED.value, seed_id, seed_id, limit],
         ).fetchall()
         # Re-normalise the raw [-1, 1] score back to [0, 1] for threshold routing.
         return [(row[0], (float(row[1]) + 1.0) / 2.0) for row in rows]
@@ -4405,6 +4431,7 @@ class DuckDBStore:
         edges_created = 0
         candidates_queued = 0
         discarded = 0
+        wrote = False
         # Track unordered pairs already handled this run so the same pair is
         # never routed twice (e.g. surfaced by both seeds, or by both the
         # graph and embedding sources).
@@ -4440,18 +4467,31 @@ class DuckDBStore:
                     continue
                 seen_pairs.add(pair)
 
+                # Skip pairs that already have a live edge or a pending
+                # candidate (either direction): they are neither newly created,
+                # queued, nor genuinely "discarded".  Guarding here — rather
+                # than only in the create/queue branches — keeps the discarded
+                # count to truly novel sub-floor pairs (issue #653 NOTE-3).
+                if self._sync_pair_has_edge(seed, target):
+                    continue
+
                 if score >= auto_create_threshold:
-                    if self._sync_pair_has_edge(seed, target):
-                        continue
-                    self._sync_add_relation(seed, target, "related")
+                    self._sync_add_relation(seed, target, "related", checkpoint=False)
                     edges_created += 1
+                    wrote = True
                 elif score >= review_floor:
-                    if self._sync_pair_has_edge(seed, target):
-                        continue
-                    self._sync_add_relation_candidate(seed, target, "related", score)
+                    self._sync_add_relation_candidate(
+                        seed, target, "related", score, checkpoint=False
+                    )
                     candidates_queued += 1
+                    wrote = True
                 else:
                     discarded += 1
+
+        # Flush the batch's write set once rather than per row, keeping the
+        # _conn_lock critical section short (issue #653 NOTE-1).
+        if wrote:
+            self._checkpoint_after_write(self._conn)
 
         return {
             "edges_created": edges_created,

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -1483,6 +1483,33 @@ async def test_suggest_links_respects_candidate_bound() -> None:
 
 
 @pytest.mark.unit
+async def test_suggest_links_already_linked_sub_floor_not_discarded() -> None:
+    """An already-linked sub-floor neighbour is skipped entirely, not counted.
+
+    Regression for issue #653 NOTE-2/NOTE-3: a pair that already has a live
+    edge must not occupy a cosine slot nor inflate ``discarded``.  Before the
+    fix the sub-floor neighbour was returned by the candidate query and counted
+    as discarded even though it was already linked.
+    """
+    store, provider = await _controlled_store()
+    try:
+        seed = await _store_with_vector(store, provider, "seed", _unit_vec_with_cosine(1.0))
+        # raw cosine 0.05 -> normalised 0.525 (< review_floor 0.60).
+        low = await _store_with_vector(store, provider, "low", _unit_vec_with_cosine(0.05))
+
+        # Pre-link the pair; it should now be excluded from the sweep entirely.
+        await store.add_relation(seed, low, "related")
+
+        counts = await store.suggest_links()
+
+        assert counts["edges_created"] == 0
+        assert counts["candidates_queued"] == 0
+        assert counts["discarded"] == 0
+    finally:
+        await store.close()
+
+
+@pytest.mark.unit
 async def test_suggest_links_skips_existing_pending_candidate() -> None:
     """A pair with an existing pending row is not re-queued."""
     store, provider = await _controlled_store()


### PR DESCRIPTION
Follow-up to [#661](https://github.com/norrietaylor/distillery/pull/661). Clears the 6 non-blocking advisories from that PR's review (`docs/specs/18-spec-edge-by-default-and-link-suggestion/18-review-*.md`).

**Stacked on [#661](https://github.com/norrietaylor/distillery/pull/661)** — base is `feat/653-edge-by-default-link-suggestion` because the modified code only exists there. GitHub will retarget this to `main` once #661 merges.

## Changes

**Store (`suggest_links` sweep)**
- NOTE-1 — suppress per-write `CHECKPOINT` in the routing loop; flush once at sweep end. Keeps the `_conn_lock` critical section short on large runs (was hundreds–thousands of synchronous checkpoints).
- NOTE-2 — exclude already-linked neighbours (live or pending, either direction) from the cosine candidate query, so the bounded `LIMIT` slots go to novel pairs. Raises yield per sweep.
- NOTE-3 — guard already-linked pairs once at the top of routing; they are skipped rather than counted in `discarded`. New regression test: `test_suggest_links_already_linked_sub_floor_not_discarded`.

**MCP (`/api/maintenance` link phase)**
- NOTE-4 — add `link-suggestion` to `_COOLDOWN_SECONDS` (1h) so the reserved cooldown uses a deliberate value, not the 300s default.
- NOTE-5 — re-check `_terminal_failure_response` before the link phase, matching the poll→rescore and rescore→classify guards.

**Config**
- NOTE-6 — document the four `link_suggestion` validation checks in the `_validate` docstring (was omitted). The auto-link default-flip release note is already captured by its conventional commit in #661, so no manual CHANGELOG edit.

## Verification
- 3102 passed, 76 skipped; `ruff` + `mypy --strict` clean.
- `checkpoint` is an internal keyword-only param defaulting to `True` — public `add_relation` / `add_relation_candidate` behaviour is unchanged; only the sweep passes `checkpoint=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link suggestion processing so entries that are already connected are skipped cleanly, reducing unnecessary work and avoiding incorrect discard counts.
  * Added a safeguard so maintenance stops early if the store is already in a terminal failure state, returning a retry response sooner.
* **Documentation**
  * Clarified the documented validation rules for link suggestions when threshold settings conflict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->