### PR TITLE
fix(store): embed search/find_similar queries off the event loop

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2330,7 +2330,11 @@ class DuckDBStore:
         """
         from distillery.store.protocol import SearchResult
 
-        embedding = self._embedding_provider.embed(query)
+        # Embed off-thread so the Jina HTTP round-trip (+ time.sleep retries on
+        # 429/5xx) does not block the event loop — mirrors ``store`` (issue
+        # #558). On the event loop a blocking embed starves the Fly health
+        # check during concurrent feed polls, which de-routes the machine.
+        embedding = await asyncio.to_thread(self._embedding_provider.embed, query)
         use_hybrid = self._hybrid_search and self._fts_available
 
         def _sync() -> list[SearchResult]:
@@ -2492,7 +2496,10 @@ class DuckDBStore:
         """
         from distillery.store.protocol import SearchResult
 
-        embedding = self._embedding_provider.embed(content)
+        # Embed off-thread so the blocking Jina round-trip does not run on the
+        # event loop — mirrors ``store`` and ``search`` (issue #558). Keeps the
+        # loop free to service the Fly health check under concurrent load.
+        embedding = await asyncio.to_thread(self._embedding_provider.embed, content)
 
         def _sync() -> list[SearchResult]:
             conn = self.connection


### PR DESCRIPTION
Closes #663.

## Root cause

`search()` (`store/duckdb.py:2333`) and `find_similar()` (`:2499`) embed the query **synchronously on the asyncio event loop**, unlike `store()` (`:1702`), `store_batch()`, and `update()` (`:2011`), which wrap the blocking call in `asyncio.to_thread` (#558).

The Jina provider uses a synchronous `httpx.Client` + `time.sleep` backoff on 429/5xx (`embedding/jina.py:199,227`). On the event loop, each read-path embed blocks the loop for the full round-trip + retries. Under a concurrent 79-source feed poll the loop cannot service the Fly health check (`GET /.well-known/oauth-authorization-server`, 5s/30s) → de-route mid-request. Every `search`/`find_similar` in `/investigate` (~27 per run) and `/radar` pays this — the dominant tail in the 30m+ skill latency.

Mechanism is distinct from #655 (WAL checkpoint starvation / suspend wake).

## Fix

```python
embedding = await asyncio.to_thread(self._embedding_provider.embed, query)
```

at both read-path call sites. No result-behavior change; the loop stays free to service the health check and to overlap concurrent embeds.

## Test

- `ruff check` + `ruff format --check`: clean
- `mypy --strict src/distillery/store/duckdb.py`: clean
- `pytest tests/test_find_similar_extended.py tests/test_duckdb_store.py`: 165 passed

## Acceptance (#663)

- [x] Both read-path embeds run off the event loop
- [x] No change to query results
- [ ] Under a concurrent poll, no health-check 0/1 de-route while a skill runs (verify on deploy via the observability work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness for search and similar-content lookups by processing query embedding work in the background instead of blocking the main execution path.
  * Reduced the chance of slowdowns during embedding-heavy operations, especially under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->