### PR TITLE
perf(search): reuse stored embedding in find_similar(source_entry_id)

### DIFF
--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -164,8 +164,7 @@ async def _handle_search(
     if output_mode not in _VALID_SEARCH_OUTPUT_MODES:
         return error_response(
             "INVALID_PARAMS",
-            f"Field 'output_mode' must be one of: "
-            f"{', '.join(sorted(_VALID_SEARCH_OUTPUT_MODES))}",
+            f"Field 'output_mode' must be one of: {', '.join(sorted(_VALID_SEARCH_OUTPUT_MODES))}",
         )
 
     # --- embedding budget check (1 embed call per search) -------------------
@@ -566,12 +565,22 @@ async def _handle_find_similar(
                 source_entry_id, threshold=threshold, limit=limit
             )
         if search_results is None:
+            # Embed path: find_similar embeds `content` (one embedding).
             if cfg is not None:
                 await store.record_embedding_usage(
                     count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
                 )
             search_results = await store.find_similar(
                 content=content, threshold=threshold, limit=limit
+            )
+        elif (dedup_action or conflict_check) and cfg is not None:
+            # Stored-vector path spent no embedding for the similarity probe,
+            # but dedup_action / conflict_check below still embed `content`
+            # (run_dedup_check / run_conflict_* -> store.find_similar(content)),
+            # so reserve that embedding here — otherwise the stored path bypasses
+            # the BUDGET_EXCEEDED guard the pre-#666 single reservation provided.
+            await store.record_embedding_usage(
+                count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
             )
     except EmbeddingBudgetError:
         return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -554,17 +554,27 @@ async def _handle_find_similar(
             "Field 'llm_responses' requires conflict_check=true",
         )
 
-    # --- embedding budget check (1 embed call) ----------------------------
-    if cfg is not None:
-        try:
-            await store.record_embedding_usage(
-                count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
-            )
-        except EmbeddingBudgetError:
-            return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
-
+    # When the similarity probe is an existing entry's own content
+    # (source_entry_id with no explicit content), reuse its stored embedding
+    # instead of re-embedding it — no Jina round-trip and no budget spend. This
+    # is the /investigate Phase 2b hot path: one find_similar per seed (#663
+    # follow-up). Only the embed path below costs an embedding against budget.
     try:
-        search_results = await store.find_similar(content=content, threshold=threshold, limit=limit)
+        search_results = None
+        if source_entry_id is not None and not content_provided:
+            search_results = await store.find_similar_by_id(
+                source_entry_id, threshold=threshold, limit=limit
+            )
+        if search_results is None:
+            if cfg is not None:
+                await store.record_embedding_usage(
+                    count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
+                )
+            search_results = await store.find_similar(
+                content=content, threshold=threshold, limit=limit
+            )
+    except EmbeddingBudgetError:
+        return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
     except EmbeddingProviderError as exc:
         logger.warning(
             "Upstream embedding provider failed during find_similar "

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2537,6 +2537,81 @@ class DuckDBStore:
 
         return await self._run_sync(_sync)
 
+    def _similar_from_embedding(
+        self,
+        conn: Any,
+        embedding: list[float],
+        threshold: float,
+        limit: int,
+    ) -> list[SearchResult]:
+        """Run the cosine-similarity query for a precomputed *embedding*.
+
+        Shared similarity core for :meth:`find_similar_by_id`. Excludes
+        archived entries, mirroring ``find_similar``/``_sync_get`` defaults.
+        Runs under ``_conn_lock`` (the caller wraps it in ``_run_sync``).
+        """
+        from distillery.store.protocol import SearchResult
+
+        sql = (
+            f"SELECT {self._ENTRY_COLUMNS}, "
+            f"array_cosine_similarity(embedding, ?::FLOAT[{self._embedding_provider.dimensions}]) AS score "
+            f"FROM entries "
+            f"WHERE status != ? "
+            f"AND array_cosine_similarity(embedding, ?::FLOAT[{self._embedding_provider.dimensions}]) >= ? "
+            f"ORDER BY score DESC "
+            f"LIMIT ?"
+        )
+        raw_threshold = threshold * 2.0 - 1.0
+        params: list[Any] = [
+            embedding,
+            EntryStatus.ARCHIVED.value,
+            embedding,
+            raw_threshold,
+            limit,
+        ]
+        result = conn.execute(sql, params)
+        col_names = [desc[0] for desc in result.description]
+        rows = result.fetchall()
+        results: list[SearchResult] = []
+        for row in rows:
+            row_dict = dict(zip(col_names, row, strict=True))
+            raw_score = float(row_dict.pop("score"))
+            score = (raw_score + 1.0) / 2.0
+            entry = self._row_to_entry(tuple(row_dict.values()), list(row_dict.keys()))
+            results.append(SearchResult(entry=entry, score=score))
+        return results
+
+    async def find_similar_by_id(
+        self,
+        source_entry_id: str,
+        threshold: float,
+        limit: int,
+    ) -> list[SearchResult] | None:
+        """Find entries similar to *source_entry_id* using its STORED embedding.
+
+        Reuses the vector already persisted for the entry instead of
+        re-embedding its content — no embedding-provider round-trip and no
+        budget spend. This is the ``/investigate`` Phase 2b hot path (one
+        similarity probe per seed, ``source_entry_id`` set, no fresh content).
+
+        Returns ``None`` when the entry has no stored embedding so the caller
+        can fall back to embedding text. The source entry is not self-excluded
+        here; callers filter it (and linked entries) as before.
+        """
+
+        def _sync() -> list[SearchResult] | None:
+            conn = self.connection
+            row = conn.execute(
+                "SELECT embedding FROM entries WHERE id = ?",
+                [source_entry_id],
+            ).fetchone()
+            if row is None or row[0] is None:
+                return None
+            embedding: list[float] = list(row[0])
+            return self._similar_from_embedding(conn, embedding, threshold, limit)
+
+        return await self._run_sync(_sync)
+
     @overload
     async def list_entries(
         self,

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -206,6 +206,30 @@ class DistilleryStore(Protocol):
         """
         ...
 
+    async def find_similar_by_id(
+        self,
+        source_entry_id: str,
+        threshold: float,
+        limit: int,
+    ) -> list[SearchResult] | None:
+        """Find entries similar to *source_entry_id* using its STORED embedding.
+
+        Reuses the vector already persisted for the entry instead of
+        re-embedding its content (no embedding-provider round-trip, no budget
+        spend). Returns ``None`` when the entry has no stored embedding so the
+        caller can fall back to embedding fresh text.
+
+        Args:
+            source_entry_id: UUID of the entry whose stored vector is the probe.
+            threshold: Minimum cosine similarity (inclusive) for a result.
+            limit: Maximum number of results to return.
+
+        Returns:
+            ``SearchResult`` objects with ``score >= threshold`` (the source is
+            not self-excluded here), or ``None`` if no stored embedding exists.
+        """
+        ...
+
     @overload
     async def list_entries(
         self,

--- a/tests/test_find_similar_extended.py
+++ b/tests/test_find_similar_extended.py
@@ -651,3 +651,25 @@ class TestFindSimilarStoredEmbedding:
         # Handler self-excludes the source; the twin remains.
         assert "seed" not in contents
         assert "near" in contents
+
+    async def test_stored_path_reserves_budget_for_dedup(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+        cfg: DistilleryConfig,
+    ) -> None:
+        """source_entry_id + dedup_action still reserves budget on the stored
+        path (the dedup pass embeds content), so BUDGET_EXCEEDED is enforced and
+        not bypassed by the stored-vector fast path (#666 review)."""
+        embedding_provider.register("seed", _UNIT_A)
+        src_id = await store.store(make_entry(content="seed"))
+        cfg.rate_limit.embedding_budget_daily = 1
+        await store.record_embedding_usage(count=1, daily_limit=1)  # exhaust the budget
+
+        response = await _handle_find_similar(
+            store,
+            {"source_entry_id": src_id, "dedup_action": True},
+            cfg=cfg,
+        )
+        data = parse_mcp_response(response)
+        assert data.get("code") == "BUDGET_EXCEEDED"

--- a/tests/test_find_similar_extended.py
+++ b/tests/test_find_similar_extended.py
@@ -585,3 +585,69 @@ class TestFindSimilarCombinedModes:
         assert "dedup" in data
         assert "conflict_evaluation" in data
         assert data["conflict_evaluation"]["has_conflicts"] is True
+
+
+# ===========================================================================
+# Stored-embedding reuse: source_entry_id without content (#663 follow-up)
+# ===========================================================================
+
+
+class TestFindSimilarStoredEmbedding:
+    """A source_entry_id probe with no fresh content reuses the stored vector
+    instead of re-embedding — verified by asserting embed() is never called."""
+
+    async def test_find_similar_by_id_uses_stored_vector(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+    ) -> None:
+        embedding_provider.register("source", _UNIT_A)
+        embedding_provider.register("twin", _UNIT_A)
+        embedding_provider.register("orthogonal", _UNIT_B)
+        src_id = await store.store(make_entry(content="source"))
+        await store.store(make_entry(content="twin"))
+        await store.store(make_entry(content="orthogonal"))
+
+        with patch.object(
+            embedding_provider, "embed", side_effect=AssertionError("must not embed")
+        ):
+            results = await store.find_similar_by_id(src_id, threshold=0.9, limit=10)
+
+        assert results is not None
+        contents = {r.entry.content for r in results}
+        # Both A-vectors clear the threshold; the store layer does not
+        # self-exclude, so the source itself is present. The B-vector does not.
+        assert "source" in contents
+        assert "twin" in contents
+        assert "orthogonal" not in contents
+
+    async def test_find_similar_by_id_missing_entry_returns_none(self, store: DuckDBStore) -> None:
+        missing = "00000000-0000-0000-0000-000000000000"
+        assert await store.find_similar_by_id(missing, threshold=0.5, limit=10) is None
+
+    async def test_handler_source_entry_id_skips_embedding(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+        cfg: DistilleryConfig,
+    ) -> None:
+        embedding_provider.register("seed", _UNIT_A)
+        embedding_provider.register("near", _UNIT_A)
+        src_id = await store.store(make_entry(content="seed"))
+        await store.store(make_entry(content="near"))
+
+        with patch.object(
+            embedding_provider, "embed", side_effect=AssertionError("must not embed")
+        ):
+            response = await _handle_find_similar(
+                store,
+                {"source_entry_id": src_id, "threshold": 0.9, "limit": 10},
+                cfg=cfg,
+            )
+
+        data = parse_mcp_response(response)
+        assert "error" not in data
+        contents = {r["entry"]["content"] for r in data["results"]}
+        # Handler self-excludes the source; the twin remains.
+        assert "seed" not in contents
+        assert "near" in contents


### PR DESCRIPTION
Round-trip/embed reduction for `/investigate` (part of the skill-latency work). Independent of #664.

## Problem

`find_similar` with `source_entry_id` and **no explicit content** — the `/investigate` Phase 2b path (one probe per seed, capped at 20) — uses the source entry's own content as the probe. That content's vector is **already stored**, but the handler re-embedded it via Jina anyway (`search.py:503` fetches the entry; the old code then called `find_similar(content=...)` which re-embeds at `duckdb.py:2495`).

## Fix

- `DuckDBStore.find_similar_by_id(source_entry_id, threshold, limit)` — loads the stored vector (`SELECT embedding ...`) and runs the cosine query directly. **No embedding round-trip, no budget spend.** Returns `None` if the entry has no stored vector so the caller can fall back.
- Shared similarity core extracted as `_similar_from_embedding` (no change to the existing `find_similar` body, so no conflict with #664).
- `_handle_find_similar` routes `source_entry_id`-without-content to the stored path; embeds only for fresh content (or a missing vector).

Removes up to **~20 Jina round-trips per `/investigate` run**.

## Test

- New `TestFindSimilarStoredEmbedding` (3): stored-vector reuse (asserts `embed()` is **never called** via a raising mock), missing-entry → `None`, handler skips embedding + self-excludes the source.
- `ruff`/`mypy --strict` clean; `test_find_similar_extended`, `test_duckdb_store`, `test_dedup`, `test_mcp_server`, `test_e2e_mcp`, `test_quality_helpers`, `test_conflict` all pass.

## Note

Budget semantics change for the stored path: it no longer counts an embedding against `embedding_budget_daily` (correct — no API call is made).

Refs #663, #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added similarity search support that can reuse an item’s stored embedding, speeding up repeat lookups when source content is already available.
* **Bug Fixes**
  * Reduced unnecessary embedding usage during similarity checks, including cases with deduplication or conflict checking.
  * Ensured archived items are excluded and similarity results are filtered consistently when using stored embeddings.
  * Improved validation messaging for `output_mode` errors.
* **Tests**
  * Added coverage for stored-embedding similarity reuse and budget enforcement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->