### PR TITLE
perf(skills): radar mines tags in one list call, not six

### DIFF
--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -80,10 +80,10 @@ proceed to 3b. Report: `Using <N> user-supplied topic(s): <comma-separated>.`
 
 *Path 2 — Namespace-diverse interest profile (default):*
 
-Build an interest profile that excludes feed-ingested content. Make separate
-`distillery_list(group_by="tags", entry_type=<type>)` calls for curated
-types: `session`, `reference`, `bookmark`, `idea`, `note`, and `minutes`.
-Merge the group counts across all responses to obtain a combined count map.
+Build an interest profile that excludes feed-ingested content. Make a single
+`distillery_list(group_by="tags", entry_type=["session", "reference", "bookmark", "idea", "note", "minutes"])`
+call across the curated types — the grouped counts are already merged across all
+six types into one combined count map (one round-trip instead of six).
 
 Then select **5 namespace-diverse tags**, *not* the raw top-5 by count. A
 tag's namespace is its hierarchical path with the leaf segment removed,

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -81,9 +81,9 @@ proceed to 3b. Report: `Using <N> user-supplied topic(s): <comma-separated>.`
 *Path 2 — Namespace-diverse interest profile (default):*
 
 Build an interest profile that excludes feed-ingested content. Make a single
-`distillery_list(group_by="tags", entry_type=["session", "reference", "bookmark", "idea", "note", "minutes"])`
-call across the curated types — the grouped counts are already merged across all
-six types into one combined count map (one round-trip instead of six).
+`distillery_list(group_by="tags", entry_type=["session", "reference", "bookmark", "idea", "minutes"])`
+call across the curated types — the grouped counts are already merged across the
+curated types into one combined count map (one call instead of one per type).
 
 Then select **5 namespace-diverse tags**, *not* the raw top-5 by count. A
 tag's namespace is its hierarchical path with the leaf segment removed,
@@ -149,7 +149,7 @@ This fallback applies only to Path 2 (auto-derived interest profile). If
 `--topic` was supplied, Step 3b always has at least one query and 3c is
 skipped.
 
-If none of the curated-type `group_by="tags"` calls return any tags, fall back to:
+If the curated-type `group_by="tags"` call returns no tags, fall back to:
 
 `distillery_list(entry_type="feed", limit=<limit>, output_mode="summary", published_after=<iso>, include_evergreen=<bool>, project=<name?>)`
 
@@ -159,7 +159,7 @@ other projects when the user explicitly scoped the request.
 
 Report: `Retrieved <total> entries via recent listing (fallback, window=<days>d).`
 
-If the curated-type `group_by="tags"` calls themselves error, treat that as an MCP error per the Rules section below — report and stop.
+If the curated-type `group_by="tags"` call itself errors, treat that as an MCP error per the Rules section below — report and stop.
 
 **3d. Empty results:**
 

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -793,7 +793,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     @server.tool
     async def distillery_list(  # noqa: PLR0913
         ctx: Context,
-        entry_type: str | None = None,
+        entry_type: str | list[str] | None = None,
         author: str | None = None,
         project: str | None = None,
         tags: list[str] | None = None,
@@ -829,7 +829,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         or ``include_archived=true`` to add archived entries to the default view.
 
         PARAMS:
-          - entry_type (str, optional): Filter by type. Valid: [session, bookmark, minutes,
+          - entry_type (str | list[str], optional): Filter by type, or a list of types
+            matched with OR (e.g. ["session", "reference"]) — pair with group_by to
+            aggregate across several types in one call. Valid: [session, bookmark, minutes,
             meeting, reference, idea, inbox, github, person, project, digest, feed].
           - author (str, optional): Filter by author.
           - project (str, optional): Filter by project scope.

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2085,6 +2085,8 @@ class DuckDBStore:
         if "entry_type" in filters:
             val = filters["entry_type"]
             if isinstance(val, list):
+                if not val:
+                    raise ValueError("entry_type filter list must not be empty")
                 placeholders = ", ".join("?" for _ in val)
                 clauses.append(f"entry_type IN ({placeholders})")
                 params.extend(str(v) for v in val)

--- a/tests/test_mcp_tools/test_list_extensions.py
+++ b/tests/test_mcp_tools/test_list_extensions.py
@@ -457,6 +457,23 @@ class TestGroupBy:
         by_tag = {g["value"]: g["count"] for g in data["groups"]}
         assert by_tag.get("api") == 3
 
+    async def test_group_by_tags_entry_type_list(self, store: Any) -> None:
+        """entry_type as a list aggregates group_by across several types in one
+        call — radar's 6-call tag-mine collapses to one round-trip (#654)."""
+        await store.store(make_entry(content="s", entry_type=EntryType.SESSION, tags=["topic"]))
+        await store.store(make_entry(content="r", entry_type=EntryType.REFERENCE, tags=["topic"]))
+        await store.store(make_entry(content="b", entry_type=EntryType.BOOKMARK, tags=["topic"]))
+
+        result = await _handle_list(
+            store=store,
+            arguments={"group_by": "tags", "entry_type": ["session", "reference"], "limit": 50},
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error")
+        by_tag = {g["value"]: g["count"] for g in data["groups"]}
+        # Only the session + reference entries count; the bookmark is excluded.
+        assert by_tag.get("topic") == 2
+
     async def test_group_by_tags_with_tag_prefix(self, store: Any) -> None:
         """group_by=tags with tag_prefix limits the grouping to matching tags.
 

--- a/tests/test_mcp_tools/test_list_extensions.py
+++ b/tests/test_mcp_tools/test_list_extensions.py
@@ -474,6 +474,15 @@ class TestGroupBy:
         # Only the session + reference entries count; the bookmark is excluded.
         assert by_tag.get("topic") == 2
 
+    async def test_group_by_tags_empty_entry_type_list_errors_cleanly(self, store: Any) -> None:
+        """An empty entry_type list is rejected with a clean error, not a raw
+        ParserException from `entry_type IN ()` (#667 review)."""
+        result = await _handle_list(
+            store=store, arguments={"group_by": "tags", "entry_type": []}
+        )
+        data = parse_mcp_response(result)
+        assert data.get("error")
+
     async def test_group_by_tags_with_tag_prefix(self, store: Any) -> None:
         """group_by=tags with tag_prefix limits the grouping to matching tags.
 


### PR DESCRIPTION
Round-trip cut for `/radar` (the round-trip half of #654).

## Problem

`/radar` Path 2 builds its interest profile with **six** sequential `distillery_list(group_by="tags", entry_type=X)` calls (session / reference / bookmark / idea / note / minutes) and merges the counts client-side (`skills/radar/SKILL.md`).

The store already supports a list `entry_type` (`store/duckdb.py:2087` builds `entry_type IN (...)`), and `_handle_list` passes it through — but the `distillery_list` tool signature was `entry_type: str | None`, so the FastMCP schema only accepted a single string.

## Fix

- Widen `distillery_list(entry_type: str | list[str] | None)` (`server.py:796`) so the MCP schema accepts an array; the value already flows through `_omit_none` → `_handle_list` → the store's `IN (...)` clause unchanged.
- Update the radar skill to make **one** `distillery_list(group_by="tags", entry_type=[…six types…])` call; `group_by` aggregates across all six server-side into the same combined count map.

**Five fewer round-trips** (and five fewer `_conn_lock` acquisitions) per `/radar` run.

## Test

- New `test_group_by_tags_entry_type_list`: `entry_type=["session","reference"]` with `group_by="tags"` counts only those types (bookmark excluded).
- `ruff` + `mypy --strict` clean; `test_list_extensions` + `test_mcp_server` (tool registration with the union type) pass — 96 tests.

## Note

The complementary half of #654 (short-TTL memoization of `group_by=tags` + graph metrics) is a larger, invalidation-correctness-sensitive change and is intentionally **not** in this PR.

Refs #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering list results by multiple entry types in a single request, with grouped tag counts reflecting the combined selection.
* **Bug Fixes**
  * Improved validation and error handling for empty multi-type filters to prevent query failures.
* **Documentation**
  * Updated the “Step 3a/3c” interest-profile spec to match the single aggregated grouping approach and revised wording for fallback and error behavior.
* **Tests**
  * Added coverage for multi-type grouped tag counting and for rejecting an empty entry-type list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->