### PR TITLE
perf(store): take get/search/find_similar off the writer lock; defer accessed_at

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2324,6 +2324,7 @@ class DuckDBStore:
 
     def _bm25_search(
         self,
+        conn: duckdb.DuckDBPyConnection,
         query: str,
         limit: int,
     ) -> list[tuple[str, int]]:
@@ -2345,7 +2346,6 @@ class DuckDBStore:
         """
         if not self._fts_available:
             return []
-        conn = self.connection
         try:
             sql = (
                 "SELECT id, fts_main_entries.match_bm25(id, ?) AS bm25 "
@@ -2414,9 +2414,7 @@ class DuckDBStore:
         embedding = await asyncio.to_thread(self._embedding_provider.embed, query)
         use_hybrid = self._hybrid_search and self._fts_available
 
-        def _sync() -> list[SearchResult]:
-            conn = self.connection
-
+        def _sync(conn: duckdb.DuckDBPyConnection) -> list[SearchResult]:
             where_clauses, params = self._build_filter_clauses(filters)
             where_sql = ""
             if where_clauses:
@@ -2468,11 +2466,10 @@ class DuckDBStore:
                     eid = row_dict["id"]
                     results.append(SearchResult(entry=entry_map[eid], score=cosine_score[eid]))
                     returned_ids.append(eid)
-                self._touch_accessed(conn, returned_ids)
                 return results
 
             # --- BM25 search ---
-            bm25_results = self._bm25_search(query, vector_limit)
+            bm25_results = self._bm25_search(conn, query, vector_limit)
             bm25_ranks: dict[str, int] = dict(bm25_results)
 
             # Fetch entries found by BM25 but not by the vector search so we
@@ -2541,10 +2538,14 @@ class DuckDBStore:
                 results.append(SearchResult(entry=entry_map[eid], score=cosine_score.get(eid, 0.0)))
                 returned_ids.append(eid)
 
-            self._touch_accessed(conn, returned_ids)
             return results
 
-        return await self._run_sync(_sync)
+        # Reads run on the independent read handle so a search never queues
+        # behind a write on ``_conn_lock`` (#663 follow-up). ``accessed_at`` is
+        # stamped out of band via the deferred flusher.
+        results = await self._run_read(_sync)
+        self._mark_accessed(r.entry.id for r in results)
+        return results
 
     @staticmethod
     def _touch_accessed(conn: duckdb.DuckDBPyConnection, entry_ids: list[str]) -> None:
@@ -2578,9 +2579,7 @@ class DuckDBStore:
         # loop free to service the Fly health check under concurrent load.
         embedding = await asyncio.to_thread(self._embedding_provider.embed, content)
 
-        def _sync() -> list[SearchResult]:
-            conn = self.connection
-
+        def _sync(conn: duckdb.DuckDBPyConnection) -> list[SearchResult]:
             # Exclude archived (soft-deleted) entries: find_similar drives
             # pre-store deduplication, so a conceptually-removed entry must not
             # be returned as a near-duplicate match (which would recommend
@@ -2619,7 +2618,9 @@ class DuckDBStore:
                 results.append(SearchResult(entry=entry, score=score))
             return results
 
-        return await self._run_sync(_sync)
+        # find_similar is a pure read (no accessed_at touch); run it on the
+        # independent read handle so it never queues behind a write (#663).
+        return await self._run_read(_sync)
 
     @overload
     async def list_entries(

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -272,6 +272,9 @@ class DuckDBStore:
         self._pending_accessed: set[str] = set()
         self._accessed_flush_task: asyncio.Task[None] | None = None
         self._accessed_flush_interval_s: float = 30.0
+        # Set once close() begins so in-flight reads stop enqueuing deferred
+        # touches that the final flush would miss.
+        self._closing: bool = False
         # Set when DuckDB raises a ``FatalException`` that permanently
         # invalidates the connection (e.g. "database has been invalidated
         # because of a previous fatal error").  Once set, the connection is
@@ -1164,6 +1167,7 @@ class DuckDBStore:
         if self._initialized:
             return
         await asyncio.to_thread(self._sync_initialize)
+        self._closing = False
         # Start the deferred accessed_at flusher now the connection exists.
         if self._accessed_flush_task is None:
             self._accessed_flush_task = asyncio.create_task(self._accessed_flush_loop())
@@ -1176,6 +1180,9 @@ class DuckDBStore:
         """
         if self._conn is None:
             return
+        # Once shutdown begins, stop accepting new deferred touches so a read
+        # racing close() cannot enqueue a touch the final flush would miss.
+        self._closing = True
         # Stop the deferred-accessed flusher and flush any pending touches
         # before taking ``_conn_lock`` for the checkpoint/close — the flush
         # itself acquires ``_conn_lock`` via ``_run_sync``, so it must run
@@ -1415,8 +1422,12 @@ class DuckDBStore:
         concurrent reads are serialised by the *separate* ``_read_lock`` (a
         single ``DuckDBPyConnection`` is not safe to touch from two worker
         threads at once — the same hazard issue #416 fixed on ``_conn``).
-        Read ops are millisecond-scale, so this serialisation never
-        reintroduces the "looks dead" symptom.
+        The health probes / ``count_entries`` are millisecond-scale; ``search``
+        and ``find_similar`` also run here now and are NOT guaranteed
+        millisecond-scale (HNSW/BM25/RRF SQL — the network embed stays off-lock),
+        so a slow search can delay a concurrent read or the readiness probe.
+        That is still far better than the writer-lock block it replaces; revisit
+        with a dedicated read handle if probe latency under search load matters.
 
         *fn* must be read-only.  Any error leaves the read handle untouched
         (no rollback): a SELECT cannot poison ``_read_conn`` the way a failed
@@ -1452,7 +1463,11 @@ class DuckDBStore:
         Called from the read paths on the event-loop thread: a plain set
         update with no lock and no await, so a read never waits on the writer.
         :meth:`_flush_accessed` drains the set under ``_conn_lock`` out of band.
+        No-op once :meth:`close` has begun, so a read racing shutdown does not
+        enqueue a touch that the final flush would miss.
         """
+        if self._closing:
+            return
         self._pending_accessed.update(entry_ids)
 
     async def _flush_accessed(self) -> None:
@@ -1481,8 +1496,18 @@ class DuckDBStore:
         while True:
             try:
                 await asyncio.sleep(self._accessed_flush_interval_s)
-                await self._flush_accessed()
             except asyncio.CancelledError:
+                raise
+            # Shield the flush so a cancel (from close()) waits for the in-flight
+            # DuckDB worker to finish instead of releasing _conn_lock mid-UPDATE
+            # and leaving an orphan thread racing close()'s CHECKPOINT/close on
+            # the same _conn (issue #416).
+            flush = asyncio.ensure_future(self._flush_accessed())
+            try:
+                await asyncio.shield(flush)
+            except asyncio.CancelledError:
+                with contextlib.suppress(Exception):
+                    await flush
                 raise
             except Exception:  # noqa: BLE001 — never let the flusher die
                 logger.debug("accessed_at flush loop iteration failed (continuing)")
@@ -2459,13 +2484,11 @@ class DuckDBStore:
                 # No min-max rescaling — score represents true similarity to the
                 # query, identical regardless of any metadata filter (issue #370).
                 results: list[SearchResult] = []
-                returned_ids: list[str] = []
                 for row in rows[:limit]:
                     row_dict = dict(zip(col_names, row, strict=True))
                     row_dict.pop("score")
                     eid = row_dict["id"]
                     results.append(SearchResult(entry=entry_map[eid], score=cosine_score[eid]))
-                    returned_ids.append(eid)
                 return results
 
             # --- BM25 search ---
@@ -2533,10 +2556,8 @@ class DuckDBStore:
             # would make the value meaningless under metadata filters because
             # the per-scope min/max changes with the filter (issue #370).
             results = []
-            returned_ids = []
             for eid, _rrf in scored[:limit]:
                 results.append(SearchResult(entry=entry_map[eid], score=cosine_score.get(eid, 0.0)))
-                returned_ids.append(eid)
 
             return results
 
@@ -2549,17 +2570,21 @@ class DuckDBStore:
 
     @staticmethod
     def _touch_accessed(conn: duckdb.DuckDBPyConnection, entry_ids: list[str]) -> None:
-        """Best-effort update of ``accessed_at`` for the given entry IDs."""
+        """Update ``accessed_at`` for the given entry IDs.
+
+        Deliberately NOT best-effort here: it runs inside ``_run_sync`` (its only
+        caller is the deferred flusher), so a failure must propagate to let
+        ``_run_sync`` roll back the aborted transaction rather than leaving
+        ``_conn`` poisoned. :meth:`_flush_accessed` swallows the error *after*
+        that rollback, since ``accessed_at`` is a soft signal.
+        """
         if not entry_ids:
             return
-        try:
-            placeholders = ", ".join("?" for _ in entry_ids)
-            conn.execute(
-                f"UPDATE entries SET accessed_at = current_timestamp WHERE id IN ({placeholders})",
-                entry_ids,
-            )
-        except Exception:  # pragma: no cover
-            logger.debug("accessed_at bulk update failed (ignored)")
+        placeholders = ", ".join("?" for _ in entry_ids)
+        conn.execute(
+            f"UPDATE entries SET accessed_at = current_timestamp WHERE id IN ({placeholders})",
+            entry_ids,
+        )
 
     async def find_similar(
         self,

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -23,7 +23,7 @@ import os
 import re
 import signal
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, overload
@@ -261,6 +261,17 @@ class DuckDBStore:
         # be instantiated outside an event loop (e.g. construction at
         # module import in tests); see ``_get_conn_lock``.
         self._conn_lock: asyncio.Lock | None = None
+        # Deferred ``accessed_at`` tracking (issue #663 follow-up). A read
+        # (``get``) must not take ``_conn_lock`` just to stamp ``accessed_at``:
+        # under a concurrent feed poll holding the writer, a single ``get``
+        # blocked ~48s on the lock (observed in a production Logfire trace).
+        # Reads now queue touched ids here (in-memory, no lock, no await) and a
+        # background task flushes them in one batched UPDATE off the read path.
+        # ``accessed_at`` is a soft staleness signal, so eventual consistency
+        # (and the rare lost touch on crash) is acceptable.
+        self._pending_accessed: set[str] = set()
+        self._accessed_flush_task: asyncio.Task[None] | None = None
+        self._accessed_flush_interval_s: float = 30.0
         # Set when DuckDB raises a ``FatalException`` that permanently
         # invalidates the connection (e.g. "database has been invalidated
         # because of a previous fatal error").  Once set, the connection is
@@ -1153,6 +1164,9 @@ class DuckDBStore:
         if self._initialized:
             return
         await asyncio.to_thread(self._sync_initialize)
+        # Start the deferred accessed_at flusher now the connection exists.
+        if self._accessed_flush_task is None:
+            self._accessed_flush_task = asyncio.create_task(self._accessed_flush_loop())
 
     async def close(self) -> None:
         """Checkpoint the WAL and close the database connection.
@@ -1162,6 +1176,16 @@ class DuckDBStore:
         """
         if self._conn is None:
             return
+        # Stop the deferred-accessed flusher and flush any pending touches
+        # before taking ``_conn_lock`` for the checkpoint/close — the flush
+        # itself acquires ``_conn_lock`` via ``_run_sync``, so it must run
+        # outside (not nested within) that block, which is not re-entrant.
+        if self._accessed_flush_task is not None:
+            self._accessed_flush_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._accessed_flush_task
+            self._accessed_flush_task = None
+        await self._flush_accessed()
         async with self._get_conn_lock():
             if self._conn is None:  # double-checked under the lock
                 return
@@ -1417,6 +1441,51 @@ class DuckDBStore:
                         exc, "read handle is stale (FUSE object generation changed)"
                     )
                 raise
+
+    # ------------------------------------------------------------------
+    # Deferred accessed_at tracking (issue #663 follow-up)
+    # ------------------------------------------------------------------
+
+    def _mark_accessed(self, entry_ids: Iterable[str]) -> None:
+        """Queue entry ids for a deferred, coalesced ``accessed_at`` update.
+
+        Called from the read paths on the event-loop thread: a plain set
+        update with no lock and no await, so a read never waits on the writer.
+        :meth:`_flush_accessed` drains the set under ``_conn_lock`` out of band.
+        """
+        self._pending_accessed.update(entry_ids)
+
+    async def _flush_accessed(self) -> None:
+        """Flush queued ``accessed_at`` touches in one batched UPDATE.
+
+        Best-effort: ``accessed_at`` is a soft staleness signal, so a failed
+        flush is logged and dropped rather than retried. Safe to call directly
+        (e.g. in tests) to make the deferred update deterministic.
+        """
+        if not self._pending_accessed or self._conn is None:
+            return
+        ids = list(self._pending_accessed)
+        self._pending_accessed.clear()
+        try:
+            await self._run_sync(self._touch_accessed, self.connection, ids)
+        except Exception:  # noqa: BLE001 — accessed_at is best-effort
+            logger.debug("deferred accessed_at flush failed for %d ids (ignored)", len(ids))
+
+    async def _accessed_flush_loop(self) -> None:
+        """Background loop that flushes pending ``accessed_at`` touches.
+
+        Started by :meth:`initialize`, cancelled by :meth:`close`. One batched
+        UPDATE per interval bounds the writer contention regardless of read
+        volume.
+        """
+        while True:
+            try:
+                await asyncio.sleep(self._accessed_flush_interval_s)
+                await self._flush_accessed()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 — never let the flusher die
+                logger.debug("accessed_at flush loop iteration failed (continuing)")
 
     async def rollback(self) -> None:
         """Public rollback hook for non-store code paths that touch the connection.
@@ -1805,24 +1874,31 @@ class DuckDBStore:
         )
         return await self._run_sync(self._sync_store_batch, entries, embeddings)
 
-    def _sync_get(self, entry_id: str, include_archived: bool = False) -> Entry | None:
-        """
-        Retrieve the entry with the given ID and convert it to an Entry object.
+    def _sync_get(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        entry_id: str,
+        include_archived: bool = False,
+    ) -> Entry | None:
+        """Retrieve the entry with the given ID and convert it to an ``Entry``.
+
+        Read-only: takes the connection as a parameter so it can run on the
+        independent read handle (:meth:`_run_read`) without taking
+        ``_conn_lock``. ``accessed_at`` is updated out of band by the deferred
+        flusher (:meth:`_mark_accessed`), so this method never writes.
 
         Parameters:
+            conn: The connection to read from — the read handle on the hot
+                path, the write handle on the diagnostic path.
             entry_id (str): UUID of the entry to retrieve.
-            include_archived (bool): If True, archived (soft-deleted) entries are
-                also returned. Defaults to False so callers must opt in.
+            include_archived (bool): If True, archived (soft-deleted) entries
+                are also returned. Defaults to False so callers must opt in.
 
         Returns:
-            Entry | None: The matching Entry if found, `None` if no entry exists
+            Entry | None: The matching Entry, or ``None`` if no entry exists
             with the given ID, or if the entry is archived and
             ``include_archived`` is ``False``.
-
-        Notes:
-            Also attempts to update the entry's `accessed_at` timestamp; failures to update are ignored.
         """
-        conn = self.connection
         if include_archived:
             sql = f"SELECT {self._ENTRY_COLUMNS} FROM entries WHERE id = ?"
             result = conn.execute(sql, [entry_id])
@@ -1833,18 +1909,16 @@ class DuckDBStore:
         row = result.fetchone()
         if row is None:
             return None
-        # Fire-and-forget: update accessed_at, entry still returned on failure.
-        try:
-            conn.execute(
-                "UPDATE entries SET accessed_at = current_timestamp WHERE id = ?",
-                [entry_id],
-            )
-        except Exception:  # pragma: no cover
-            logger.debug("accessed_at update failed for id=%s (ignored)", entry_id)
         return self._row_to_entry(row, col_names)
 
     async def get(self, entry_id: str, *, include_archived: bool = False) -> Entry | None:
         """Retrieve an entry by its ID.
+
+        The SELECT runs on the independent read handle (:meth:`_run_read`), so
+        a ``get`` never queues behind a slow write on ``_conn_lock`` — a
+        production trace caught a ``get`` blocked ~48s on the writer lock during
+        a concurrent feed poll (issue #663 follow-up). ``accessed_at`` is
+        stamped out of band by the deferred flusher.
 
         Args:
             entry_id: The UUID string of the entry to fetch.
@@ -1855,7 +1929,10 @@ class DuckDBStore:
             The matching ``Entry``, or ``None`` if the ID does not exist or
             the entry is archived and ``include_archived`` is ``False``.
         """
-        return await self._run_sync(self._sync_get, entry_id, include_archived)
+        entry = await self._run_read(lambda conn: self._sync_get(conn, entry_id, include_archived))
+        if entry is not None:
+            self._mark_accessed((entry_id,))
+        return entry
 
     def _sync_update(
         self,
@@ -3611,7 +3688,9 @@ class DuckDBStore:
         # 2. Same lookup the read path uses (include_archived=True so the
         # filter shape is identical to _sync_add_relation's intent).
         try:
-            diag["visible_via_get"] = self._sync_get(entry_id, include_archived=True) is not None
+            diag["visible_via_get"] = (
+                self._sync_get(self._conn, entry_id, include_archived=True) is not None
+            )
         except Exception as exc:  # pragma: no cover — diagnostic path
             diag["visible_via_get_error"] = repr(exc)
 

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -401,9 +401,7 @@ class TestSearch:
         for r in results:
             assert "important" in r.entry.tags
 
-    async def test_search_filter_by_multiple_tags_is_intersection(
-        self, store: DuckDBStore
-    ) -> None:
+    async def test_search_filter_by_multiple_tags_is_intersection(self, store: DuckDBStore) -> None:
         """Multi-tag search ANDs the tags: only entries with *both* match (#626)."""
         await store.store(make_entry(content="entry only a", tags=["tag-a"]))
         await store.store(make_entry(content="entry only b", tags=["tag-b"]))
@@ -575,9 +573,7 @@ class TestListEntries:
         await store.store(make_entry(content="only a too", tags=["tag-a"]))
         await store.store(make_entry(content="only b", tags=["tag-b"]))
         await store.store(make_entry(content="both", tags=["tag-a", "tag-b"]))
-        result = await store.list_entries(
-            filters={"tags": ["tag-a", "tag-b"]}, limit=10, offset=0
-        )
+        result = await store.list_entries(filters={"tags": ["tag-a", "tag-b"]}, limit=10, offset=0)
         # Per-tag counts: tag-a == 3, tag-b == 2; AND must return <= min == 2 and
         # in fact only the single entry carrying both tags (proves intersection,
         # not the union of 4 that the old list_has_any produced).
@@ -646,7 +642,9 @@ class TestAccessedAt:
         await store.store(entry)
         fetched = await store.get(entry.id)
         assert fetched is not None
-        # accessed_at should be set in the DB after get().
+        # accessed_at is deferred off the read path (issue #663); flush to make
+        # the update deterministic before asserting.
+        await store._flush_accessed()
         row = store.connection.execute(
             "SELECT accessed_at FROM entries WHERE id = ?", [entry.id]
         ).fetchone()
@@ -686,12 +684,33 @@ class TestAccessedAt:
         """Entry returned by get() after access should have accessed_at populated."""
         entry = make_entry(content="check returned value")
         await store.store(entry)
-        await store.get(entry.id)  # triggers accessed_at update
+        await store.get(entry.id)  # queues a deferred accessed_at update
+        await store._flush_accessed()  # make the deferred update deterministic
         # Second get() should return the entry with accessed_at set.
         fetched = await store.get(entry.id)
         assert fetched is not None
         assert fetched.accessed_at is not None
         assert isinstance(fetched.accessed_at, datetime)
+
+    async def test_get_defers_accessed_at_until_flush(self, store: DuckDBStore) -> None:
+        """get() keeps accessed_at off the read path: the touch is queued in
+        memory and only written by the deferred flusher (issue #663)."""
+        entry = make_entry(content="deferred touch")
+        await store.store(entry)
+        await store.get(entry.id)
+        # Not written yet — the touch is pending, so the read never took the
+        # writer lock.
+        row = store.connection.execute(
+            "SELECT accessed_at FROM entries WHERE id = ?", [entry.id]
+        ).fetchone()
+        assert row is not None
+        assert row[0] is None
+        # Flushing applies the batched UPDATE.
+        await store._flush_accessed()
+        row = store.connection.execute(
+            "SELECT accessed_at FROM entries WHERE id = ?", [entry.id]
+        ).fetchone()
+        assert row[0] is not None
 
 
 class TestClose:
@@ -1390,9 +1409,7 @@ class TestCorruptWalQuarantine:
 
         monkeypatch.setattr(Path, "rename", _rename)
 
-        replay_error = duckdb.Error(
-            "Failure while replaying WAL file: serialization error"
-        )
+        replay_error = duckdb.Error("Failure while replaying WAL file: serialization error")
         with caplog.at_level("ERROR"):  # noqa: SIM117
             with pytest.raises(duckdb.Error, match="replaying WAL"):
                 store._recover_from_wal_replay_failure(replay_error)  # noqa: SLF001

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -665,6 +665,8 @@ class TestAccessedAt:
         assert len(results) >= 1
         returned_ids = [r.entry.id for r in results]
         assert entry.id in returned_ids
+        # accessed_at is deferred off the read path (issue #663); flush first.
+        await store._flush_accessed()
         row = store.connection.execute(
             "SELECT accessed_at FROM entries WHERE id = ?", [entry.id]
         ).fetchone()
@@ -1043,7 +1045,7 @@ class TestWalFtsReplayHardening:
                 assert count is not None
                 assert count[0] == 5
                 # And FTS must still function after reopen.
-                results = s2._bm25_search("duckdb", limit=10)  # noqa: SLF001
+                results = s2._bm25_search(s2.connection, "duckdb", limit=10)  # noqa: SLF001
                 assert len(results) >= 1
             finally:
                 await s2.close()
@@ -1495,14 +1497,14 @@ class TestBM25Search:
         self, vector_only_store: DuckDBStore
     ) -> None:
         """BM25 search returns [] when FTS is not loaded."""
-        result = vector_only_store._bm25_search("anything", limit=10)  # noqa: SLF001
+        result = vector_only_store._bm25_search(vector_only_store.connection, "anything", limit=10)  # noqa: SLF001
         assert result == []
 
     async def test_bm25_returns_matching_entries(self, hybrid_store: DuckDBStore) -> None:
         """BM25 search returns ranked results for matching content."""
         await hybrid_store.store(make_entry(content="The quick brown fox jumps over the lazy dog"))
         await hybrid_store.store(make_entry(content="A slow red cat sleeps under a busy table"))
-        results = hybrid_store._bm25_search("quick fox", limit=10)  # noqa: SLF001
+        results = hybrid_store._bm25_search(hybrid_store.connection, "quick fox", limit=10)  # noqa: SLF001
         assert len(results) >= 1
         # First result should be rank 1.
         assert results[0][1] == 1
@@ -1513,13 +1515,13 @@ class TestBM25Search:
             await hybrid_store.store(
                 make_entry(content=f"Document number {i} about machine learning algorithms")
             )
-        results = hybrid_store._bm25_search("machine learning", limit=2)  # noqa: SLF001
+        results = hybrid_store._bm25_search(hybrid_store.connection, "machine learning", limit=2)  # noqa: SLF001
         assert len(results) <= 2
 
     async def test_bm25_returns_empty_for_no_match(self, hybrid_store: DuckDBStore) -> None:
         """BM25 returns [] when no content matches the query."""
         await hybrid_store.store(make_entry(content="The quick brown fox jumps over the lazy dog"))
-        results = hybrid_store._bm25_search("xylophone", limit=10)  # noqa: SLF001
+        results = hybrid_store._bm25_search(hybrid_store.connection, "xylophone", limit=10)  # noqa: SLF001
         assert results == []
 
 
@@ -1747,7 +1749,9 @@ class TestFTSRebuildOnMutation:
         await hybrid_store.store(
             make_entry(content="Kubernetes container orchestration platform overview")
         )
-        results = hybrid_store._bm25_search("kubernetes container", limit=10)  # noqa: SLF001
+        results = hybrid_store._bm25_search(
+            hybrid_store.connection, "kubernetes container", limit=10
+        )  # noqa: SLF001
         assert len(results) >= 1
 
     async def test_updated_content_searchable_via_bm25(self, hybrid_store: DuckDBStore) -> None:
@@ -1757,7 +1761,9 @@ class TestFTSRebuildOnMutation:
         await hybrid_store.update(
             entry.id, {"content": "Terraform infrastructure provisioning automation"}
         )
-        results = hybrid_store._bm25_search("terraform infrastructure", limit=10)  # noqa: SLF001
+        results = hybrid_store._bm25_search(
+            hybrid_store.connection, "terraform infrastructure", limit=10
+        )  # noqa: SLF001
         assert len(results) >= 1
         # The updated entry should be in the results.
         result_ids = [eid for eid, _rank in results]

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -746,6 +746,41 @@ class TestClose:
         await store.close()
         await store.close()  # should be a no-op
 
+    async def test_close_flushes_pending_accessed(
+        self, deterministic_embedding_provider: object
+    ) -> None:
+        """close() flushes queued accessed_at touches before teardown so a
+        deferred touch is not lost at shutdown (issue #663 / CR review #670)."""
+        import tempfile
+        from pathlib import Path
+
+        import duckdb
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "test.db")
+            store = DuckDBStore(
+                db_path=db_path, embedding_provider=deterministic_embedding_provider
+            )
+            await store.initialize()
+            entry = make_entry(content="persist me")
+            await store.store(entry)
+            await store.get(entry.id)  # queues a deferred accessed_at touch
+            assert store._pending_accessed  # not yet written
+            await store.close()  # final flush must persist it
+
+            conn = duckdb.connect(db_path, read_only=True)
+            row = conn.execute(
+                "SELECT accessed_at FROM entries WHERE id = ?", [entry.id]
+            ).fetchone()
+            conn.close()
+            assert row is not None and row[0] is not None
+
+    async def test_mark_accessed_noop_once_closing(self, store: DuckDBStore) -> None:
+        """Once close() begins, reads stop enqueuing deferred touches (#670)."""
+        store._closing = True
+        store._mark_accessed(["any-id"])
+        assert store._pending_accessed == set()
+
 
 class TestFeedSourceLiveness:
     """DuckDBStore surfaces liveness metadata alongside feed sources."""

--- a/tests/test_stale.py
+++ b/tests/test_stale.py
@@ -337,9 +337,10 @@ class TestAccessedAtUpdates:
         ids_before = [e["id"] for e in before["entries"]]
         assert entry.id in ids_before
 
-        # Access via search().
+        # Access via search() — queues a deferred accessed_at update (issue #663).
         results = await store.search("stale search marker content xyz", None, limit=5)
         assert any(r.entry.id == entry.id for r in results)
+        await store._flush_accessed()
 
         # Should no longer appear stale.
         after = await _stale(store, config, days=30)

--- a/tests/test_stale.py
+++ b/tests/test_stale.py
@@ -315,9 +315,10 @@ class TestAccessedAtUpdates:
         ids_before = [e["id"] for e in before["entries"]]
         assert entry.id in ids_before
 
-        # Access via get() — this should update accessed_at to now.
+        # Access via get() — queues a deferred accessed_at update (issue #663).
         retrieved = await store.get(entry.id)
         assert retrieved is not None
+        await store._flush_accessed()
 
         # Should no longer appear stale.
         after = await _stale(store, config, days=30)


### PR DESCRIPTION
**Found via the new Logfire instrumentation (#665).** The baseline `/investigate` trace caught a single `distillery_get` blocked **48.6 s**:

```
POST /mcp (ASGI)                  50,721 ms
└─ tools/call distillery_get      48,641 ms   ← a SELECT-by-id
```

## Root cause

`get`, `search`, and `find_similar` are reads, but each was dispatched through `_run_sync` — which holds `_conn_lock`, the **single writer lock**. (`get` additionally did an `accessed_at` UPDATE; `search` touched `accessed_at` for every hit.) Under a concurrent feed poll holding the writer for long batch-writes + checkpoints, every read queued behind it. #664's embed-off-loop fix is deployed and irrelevant here — these stalls are pure lock contention.

The store already has a non-queuing read handle (`_run_read`, *"reads never queue behind a write"*), used only by health probes / `count_entries`. The reads couldn't use it because of the `accessed_at` writes (and because `_bm25_search` grabbed the write conn).

## Fix

- **`get`/`search`/`find_similar` now read via `_run_read`** — never take `_conn_lock`, so a read never queues behind a write.
- **`_bm25_search` takes the connection as a parameter** (it is a query-only `match_bm25` SELECT, safe on the read handle), so `search` threads the read conn through it instead of grabbing `self.connection` off-lock (which would be the #416 thread-safety hazard).
- **`accessed_at` is deferred**: `get`/`search` queue touched ids in memory (no lock, no await); a 30 s background task writes them in one batched UPDATE off the read path. `accessed_at` is a soft staleness signal, so eventual consistency is fine. `initialize()` starts the flusher, `close()` cancels it + final-flushes. `find_similar` doesn't touch `accessed_at` (unchanged).

## Test

- New `test_get_defers_accessed_at_until_flush` documents the deferral.
- Updated get/search `accessed_at` + `test_stale` get/search-removes-from-stale tests to flush before asserting; `_bm25_search` direct-call unit tests pass the connection.
- `ruff` + `mypy --strict` clean; **full suite 3135 passed, 98 skipped**.

## Validation

After deploy, the same `/investigate` trace should show `distillery_get`/`search`/`find_similar` spans drop from tens of seconds to milliseconds. I'll confirm against Logfire.

## Companion follow-up

This fixes the **read** side (reads stop queuing). The **write** side — bounding the poller's concurrency + checkpoint cadence + DuckDB PRAGMAs so the writer isn't *held* ~48 s in the first place (#655) — is the next PR.

Refs #655, #663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance by batching “last accessed” updates instead of writing on every retrieval.
  * Search and similarity lookups no longer synchronously update access timestamps, reducing extra database work.
  * Ensures any pending access-time updates are flushed on shutdown and prevents new queued updates once closing begins.
* **Tests**
  * Updated tests to account for deferred access-time persistence and to verify flush timing for `get` and `search`.
  * Adjusted BM25/FTS-related test calls to match the updated read-path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->