### PR TITLE
perf: reduce DuckDB writer contention on the write side (#655)

### DIFF
--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -46,6 +46,16 @@ _DEFAULT_RELEVANCE_THRESHOLD = 0.0
 # skipped entirely — the external_id guarantee is sufficient.
 _AUTHORITATIVE_EXTERNAL_ID_TYPES: frozenset[str] = frozenset({"github", "rss"})
 
+# Maximum number of feed sources fetched + scored + stored concurrently per
+# poll cycle.  A poll over ~79 sources previously fanned out with an unbounded
+# ``asyncio.gather``, saturating the thread pool and the single DuckDB writer
+# lock for tens of seconds and self-inflicting upstream 429/502s (issue #655).
+# Bounding the fan-out with a semaphore keeps every source processed while
+# capping peak CPU / thread-pool / writer-lock pressure.  Five is a small,
+# conservative default; raise it only if the writer is no longer the
+# bottleneck.
+_DEFAULT_MAX_CONCURRENT_SOURCES = 5
+
 
 @dataclass
 class PollResult:
@@ -594,9 +604,14 @@ class FeedPoller:
         *,
         relevance_threshold: float | None = None,
         reader: JinaReaderClient | None = None,
+        max_concurrent_sources: int = _DEFAULT_MAX_CONCURRENT_SOURCES,
     ) -> None:
         self._store = store
         self._config = config
+        # Bound the per-cycle fan-out: at most ``max_concurrent_sources`` sources
+        # are fetched + scored + stored at once (issue #655).  Values < 1 are
+        # clamped to 1 so a misconfiguration can never deadlock the poll.
+        self._max_concurrent_sources = max(1, max_concurrent_sources)
         self._threshold = (
             relevance_threshold
             if relevance_threshold is not None
@@ -739,21 +754,29 @@ class FeedPoller:
         except Exception:  # noqa: BLE001
             logger.debug("FeedPoller: keyword map build failed — topic tagging disabled")
 
-        # Poll all sources concurrently — each ``_poll_source`` persists its
-        # own liveness (``last_polled_at``) before returning so a partial
+        # Poll sources concurrently but bounded — each ``_poll_source`` persists
+        # its own liveness (``last_polled_at``) before returning so a partial
         # cycle (e.g. the webhook background task is cancelled mid-gather)
         # still advances the per-source timestamps for sources that did
         # complete (issue #404).
-        results = await asyncio.gather(
-            *(
-                self._poll_source(
+        #
+        # A semaphore caps how many sources are in flight at once: an
+        # unbounded fan-out over ~79 sources saturated the thread pool and the
+        # single DuckDB writer lock for tens of seconds (issue #655).  Every
+        # source is still polled — only the peak concurrency is limited.
+        semaphore = asyncio.Semaphore(self._max_concurrent_sources)
+
+        async def _poll_source_bounded(source: FeedSourceConfig) -> PollResult:
+            async with semaphore:
+                return await self._poll_source(
                     source,
                     scorer,
                     keyword_map=keyword_map,
                     is_backfill=source.url in first_poll_urls,
                 )
-                for source in sources
-            ),
+
+        results = await asyncio.gather(
+            *(_poll_source_bounded(source) for source in sources),
             return_exceptions=True,
         )
 

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -237,6 +237,13 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 auto_link_max_links=config.auto_link.max_links,
             )
             await store.initialize()
+            # Flush the WAL during quiet windows so it never grows unbounded
+            # under continuous concurrent writers (poller + gh-sync) — the root
+            # cause of read-latency degradation in issue #655.  Plain CHECKPOINT
+            # only; skipped whenever the writer is busy, so it never blocks.
+            start_idle = getattr(store, "start_idle_checkpoint", None)
+            if callable(start_idle):
+                start_idle()
             if await store.get_metadata("feeds_seeded") != "true":
                 for src in config.feeds.sources:
                     with contextlib.suppress(ValueError):

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1294,8 +1294,18 @@ class DuckDBStore:
         while True:
             try:
                 await asyncio.sleep(self._idle_checkpoint_interval)
-                await self._idle_checkpoint_once()
             except asyncio.CancelledError:
+                raise
+            # Shield the sweep so a cancel (from stop_idle_checkpoint/close)
+            # waits for any in-flight CHECKPOINT worker to finish instead of
+            # releasing _conn_lock mid-checkpoint and leaving an orphan thread
+            # racing close()'s connection teardown (issue #416).
+            sweep = asyncio.ensure_future(self._idle_checkpoint_once())
+            try:
+                await asyncio.shield(sweep)
+            except asyncio.CancelledError:
+                with contextlib.suppress(Exception):
+                    await sweep
                 raise
             except Exception:  # noqa: BLE001 — a stray error must not kill the loop
                 logger.debug("Idle checkpoint sweep failed (non-fatal)", exc_info=True)

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -66,6 +66,25 @@ _WARN_AFTER_CHECKPOINT_FAILURES = 3
 # so a bloating WAL under checkpoint starvation is invisible to it.
 _DISK_BACKPRESSURE_FREE_BYTES = 256 * 1024 * 1024
 
+# Default DuckDB resource caps applied at connection init (issue #655).  None
+# were set before, so DuckDB sized its buffer manager off total host RAM and
+# spawned a worker thread per core — both unbounded under a concurrent feed
+# poll, which has a history of OOM kills (the memory limit was bumped
+# 512MB → 1024 → 2048 in prior incidents).  An explicit ~1GB ceiling and a
+# small thread count keep the writer cheap and predictable on a small Fly VM.
+# Both are overridable via the constructor for larger deployments.
+_DEFAULT_MEMORY_LIMIT_MB = 1024
+_DEFAULT_THREADS = 2
+
+# Interval (seconds) between idle-checkpoint sweeps (issue #655).  Under
+# continuous concurrent writes (poller + gh-sync) the per-write CHECKPOINT can
+# never acquire the writer lock, so the WAL grows unbounded and every read
+# replays an ever-larger WAL → latency degrades monotonically.  A background
+# task issues a *plain* CHECKPOINT during quiet windows (only when the writer
+# lock is free) so the WAL is flushed without ever blocking — or deadlocking —
+# a writer.  It deliberately NEVER escalates to FORCE CHECKPOINT (issue #648).
+_DEFAULT_IDLE_CHECKPOINT_INTERVAL_S = 60.0
+
 # Valid relation types — must match the set in mcp/tools/relations.py.
 _VALID_RELATION_TYPES = {
     "link",
@@ -209,11 +228,20 @@ class DuckDBStore:
         auto_link_enabled: bool = False,
         auto_link_threshold: float = 0.85,
         auto_link_max_links: int = 5,
+        memory_limit_mb: int | None = _DEFAULT_MEMORY_LIMIT_MB,
+        threads: int | None = _DEFAULT_THREADS,
     ) -> None:
         self._db_path = db_path
         self._embedding_provider = embedding_provider
         self._s3_region = s3_region
         self._s3_endpoint = s3_endpoint
+        # Explicit DuckDB resource caps applied at connection init (issue #655).
+        # ``None`` for either leaves DuckDB's default in place (host-RAM-sized
+        # buffer manager / one thread per core).  Non-positive values are
+        # treated as "unset" so a misconfiguration cannot pass an invalid
+        # PRAGMA to DuckDB.
+        self._memory_limit_mb = memory_limit_mb if memory_limit_mb and memory_limit_mb > 0 else None
+        self._threads = threads if threads and threads > 0 else None
         self._conn: duckdb.DuckDBPyConnection | None = None
         # Independent read-only handle on the same database, used by health
         # probes (``probe_readiness``/``count_entries``/``list_feed_sources``)
@@ -271,6 +299,12 @@ class DuckDBStore:
         # MCP/webhook layer reads it to fail fast with ``503 Retry-After``
         # and to report ``degraded`` status without waiting on a probe.
         self._terminal_failure: BaseException | None = None
+        # Background idle-checkpoint loop (issue #655).  ``None`` until
+        # ``start_idle_checkpoint`` is called from inside a running event loop
+        # (e.g. the server lifespan).  Flushes the WAL during quiet windows so
+        # it never grows unbounded under continuous concurrent writers.
+        self._idle_checkpoint_task: asyncio.Task[None] | None = None
+        self._idle_checkpoint_interval = _DEFAULT_IDLE_CHECKPOINT_INTERVAL_S
 
     # ------------------------------------------------------------------
     # Cloud path helpers
@@ -302,10 +336,36 @@ class DuckDBStore:
         parent = Path(self._db_path).parent
         parent.mkdir(parents=True, exist_ok=True)
 
+    def _apply_resource_pragmas(self, conn: duckdb.DuckDBPyConnection) -> None:
+        """Apply explicit ``memory_limit`` / ``threads`` PRAGMAs (issue #655).
+
+        DuckDB otherwise sizes its buffer manager off total host RAM and spawns
+        one worker thread per core — both unbounded, which under a concurrent
+        feed poll has OOM-killed the process (the limit was bumped
+        512MB → 1024 → 2048 in prior incidents) and oversubscribed the CPU.
+        Setting an explicit ~1GB ceiling and a small thread count keeps the
+        writer's resource use bounded and predictable.
+
+        Best-effort: a PRAGMA failure (e.g. an exotic DuckDB build) is logged
+        and swallowed so the store still opens with DuckDB's defaults rather
+        than failing init.
+        """
+        if self._memory_limit_mb is not None:
+            try:
+                conn.execute(f"PRAGMA memory_limit='{self._memory_limit_mb}MB'")
+            except duckdb.Error as exc:  # pragma: no cover — exotic builds only
+                logger.warning("Could not set DuckDB memory_limit PRAGMA: %s", exc)
+        if self._threads is not None:
+            try:
+                conn.execute(f"PRAGMA threads={self._threads}")
+            except duckdb.Error as exc:  # pragma: no cover — exotic builds only
+                logger.warning("Could not set DuckDB threads PRAGMA: %s", exc)
+
     def _open_connection(self) -> duckdb.DuckDBPyConnection:
         """Open (or create) the DuckDB database and return a connection."""
         self._ensure_parent_dir()
         conn = duckdb.connect(self._db_path)
+        self._apply_resource_pragmas(conn)
 
         # Lock down permissions only for local files that exist on disk.
         is_local = (
@@ -1160,6 +1220,9 @@ class DuckDBStore:
         Holds ``_conn_lock`` so the close cannot race an in-flight
         ``_run_sync`` worker still mutating the connection (issue #416).
         """
+        # Stop the idle-checkpoint loop *before* taking the conn lock so it can
+        # never run a CHECKPOINT against a connection we are about to close.
+        await self.stop_idle_checkpoint()
         if self._conn is None:
             return
         async with self._get_conn_lock():
@@ -1184,6 +1247,91 @@ class DuckDBStore:
             self._conn = None
             self._initialized = False
             logger.info("DuckDBStore connection closed")
+
+    # ------------------------------------------------------------------
+    # Idle-checkpoint loop (issue #655)
+    # ------------------------------------------------------------------
+
+    def start_idle_checkpoint(
+        self, *, interval_s: float = _DEFAULT_IDLE_CHECKPOINT_INTERVAL_S
+    ) -> None:
+        """Start a background task that checkpoints the WAL when the writer is idle.
+
+        Under continuous concurrent writes (the feed poller + gh-sync), the
+        per-write ``CHECKPOINT`` can never acquire the single DuckDB writer lock,
+        so the WAL grows unbounded and every read replays an ever-larger WAL —
+        read latency then degrades monotonically (issue #655).  This loop issues
+        a *plain* ``CHECKPOINT`` only during quiet windows: it skips entirely
+        whenever ``_conn_lock`` is held (a writer is active), so it never blocks
+        or queues behind a writer, and it never escalates to ``FORCE CHECKPOINT``
+        (which can deadlock under contention — issue #648).
+
+        Must be called from inside a running event loop (e.g. the server
+        lifespan).  Idempotent: a second call while the loop is already running
+        is a no-op.  No-op for in-memory databases, which have no WAL to flush.
+        """
+        if self._db_path == ":memory:":
+            return
+        if self._idle_checkpoint_task is not None and not self._idle_checkpoint_task.done():
+            return
+        self._idle_checkpoint_interval = interval_s
+        self._idle_checkpoint_task = asyncio.create_task(
+            self._idle_checkpoint_loop(), name="duckdb-idle-checkpoint"
+        )
+
+    async def stop_idle_checkpoint(self) -> None:
+        """Cancel the background idle-checkpoint loop if it is running."""
+        task = self._idle_checkpoint_task
+        if task is None:
+            return
+        self._idle_checkpoint_task = None
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def _idle_checkpoint_loop(self) -> None:
+        """Periodically flush the WAL during quiet windows (issue #655)."""
+        while True:
+            try:
+                await asyncio.sleep(self._idle_checkpoint_interval)
+                await self._idle_checkpoint_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 — a stray error must not kill the loop
+                logger.debug("Idle checkpoint sweep failed (non-fatal)", exc_info=True)
+
+    async def _idle_checkpoint_once(self) -> None:
+        """Run one plain CHECKPOINT iff the writer lock is currently free.
+
+        The ``locked()`` pre-check guarantees we never queue behind an active
+        writer: if a write is in flight we simply skip this sweep and try again
+        next interval.  Holding ``_conn_lock`` for the (non-blocking) plain
+        ``CHECKPOINT`` keeps the single-connection-one-thread invariant
+        (issue #416).  Failures are swallowed — the WAL just stays larger until
+        the next quiet window.
+        """
+        conn = self._conn
+        if conn is None or self._terminal_failure is not None:
+            return
+        lock = self._get_conn_lock()
+        # Skip rather than wait: a held lock means a writer is active, which is
+        # exactly when a plain CHECKPOINT would fail anyway.  Never block here.
+        if lock.locked():
+            logger.debug("Idle checkpoint skipped — writer active")
+            return
+        async with lock:
+            conn = self._conn
+            if conn is None:
+                return
+            try:
+                await asyncio.to_thread(conn.execute, "CHECKPOINT")
+                self._checkpoint_failures = 0
+                logger.debug("Idle checkpoint flushed WAL")
+            except duckdb.Error as exc:
+                # Another *connection*/process (e.g. gh-sync) may still hold a
+                # write transaction; plain CHECKPOINT fails fast and we retry
+                # next interval.  Never escalate to FORCE (issue #648).
+                logger.debug("Idle checkpoint skipped (non-fatal): %s", exc)
 
     @property
     def connection(self) -> duckdb.DuckDBPyConnection:

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -2382,7 +2382,7 @@ class TestIdleCheckpoint:
     """
 
     async def test_idle_checkpoint_once_flushes_wal(
-        self, tmp_path, deterministic_embedding_provider
+        self, tmp_path, deterministic_embedding_provider, caplog
     ) -> None:
         db_path = str(tmp_path / "idle_ckpt.db")
         store = DuckDBStore(
@@ -2391,18 +2391,21 @@ class TestIdleCheckpoint:
         )
         await store.initialize()
         try:
-            # Suppress per-write checkpoints so the WAL actually accumulates,
-            # isolating the idle sweep as the thing that flushes it.
+            # Suppress per-write checkpoints so the idle sweep is the thing that
+            # flushes the WAL.
             with patch.object(store, "_checkpoint_after_write", lambda *_a, **_k: None):
                 for i in range(5):
                     await store.store(make_entry(content=f"idle-{i}"))
-            wal_path = Path(db_path + ".wal")
-            wal_before = wal_path.stat().st_size if wal_path.exists() else 0
 
-            await store._idle_checkpoint_once()  # noqa: SLF001
+            # Assert the sweep actually executed the CHECKPOINT success path
+            # (and did not silently skip) via its debug log — WAL file size is
+            # environment-flaky and let the old assertion pass vacuously when the
+            # WAL was already 0 (#671 review).
+            import logging
 
-            wal_after = wal_path.stat().st_size if wal_path.exists() else 0
-            assert wal_after < wal_before or wal_after == 0
+            with caplog.at_level(logging.DEBUG, logger="distillery.store.duckdb"):
+                await store._idle_checkpoint_once()  # noqa: SLF001
+            assert "Idle checkpoint flushed WAL" in caplog.text
         finally:
             await store.close()
 

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -11,6 +11,7 @@ import contextlib
 import math
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import duckdb
 import pytest
@@ -401,9 +402,7 @@ class TestSearch:
         for r in results:
             assert "important" in r.entry.tags
 
-    async def test_search_filter_by_multiple_tags_is_intersection(
-        self, store: DuckDBStore
-    ) -> None:
+    async def test_search_filter_by_multiple_tags_is_intersection(self, store: DuckDBStore) -> None:
         """Multi-tag search ANDs the tags: only entries with *both* match (#626)."""
         await store.store(make_entry(content="entry only a", tags=["tag-a"]))
         await store.store(make_entry(content="entry only b", tags=["tag-b"]))
@@ -575,9 +574,7 @@ class TestListEntries:
         await store.store(make_entry(content="only a too", tags=["tag-a"]))
         await store.store(make_entry(content="only b", tags=["tag-b"]))
         await store.store(make_entry(content="both", tags=["tag-a", "tag-b"]))
-        result = await store.list_entries(
-            filters={"tags": ["tag-a", "tag-b"]}, limit=10, offset=0
-        )
+        result = await store.list_entries(filters={"tags": ["tag-a", "tag-b"]}, limit=10, offset=0)
         # Per-tag counts: tag-a == 3, tag-b == 2; AND must return <= min == 2 and
         # in fact only the single entry carrying both tags (proves intersection,
         # not the union of 4 that the old list_has_any produced).
@@ -1390,9 +1387,7 @@ class TestCorruptWalQuarantine:
 
         monkeypatch.setattr(Path, "rename", _rename)
 
-        replay_error = duckdb.Error(
-            "Failure while replaying WAL file: serialization error"
-        )
+        replay_error = duckdb.Error("Failure while replaying WAL file: serialization error")
         with caplog.at_level("ERROR"):  # noqa: SIM117
             with pytest.raises(duckdb.Error, match="replaying WAL"):
                 store._recover_from_wal_replay_failure(replay_error)  # noqa: SLF001
@@ -2311,6 +2306,162 @@ class TestEmbeddingBudgetCounterDoesNotStarveCheckpoint:
                     f"WAL grew to {wal_size} bytes — CHECKPOINT appears starved "
                     "(budget counter racing writes, issue #655 RC1)"
                 )
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Resource PRAGMAs (issue #655) — memory_limit / threads at connection init
+# ---------------------------------------------------------------------------
+
+
+class TestResourcePragmas:
+    """An explicit ``memory_limit`` / ``threads`` PRAGMA is set on connect.
+
+    None were set before, so DuckDB sized its buffer manager off total host RAM
+    and spawned one worker per core — both unbounded under a concurrent feed
+    poll (prior OOM history: 512MB → 1024 → 2048 bumps).  Issue #655.
+    """
+
+    async def test_default_pragmas_applied(self, mock_embedding_provider) -> None:
+        s = DuckDBStore(db_path=":memory:", embedding_provider=mock_embedding_provider)
+        await s.initialize()
+        try:
+            mem = s.connection.execute("SELECT current_setting('memory_limit')").fetchone()
+            threads = s.connection.execute("SELECT current_setting('threads')").fetchone()
+            assert mem is not None and threads is not None
+            # DuckDB normalises "1024MB" to a human string like "1.0 GiB"; assert
+            # it is a finite, non-default cap rather than the host-RAM default.
+            assert "GiB" in mem[0] or "MiB" in mem[0]
+            assert int(threads[0]) == 2
+        finally:
+            await s.close()
+
+    async def test_pragmas_overridable(self, mock_embedding_provider) -> None:
+        s = DuckDBStore(
+            db_path=":memory:",
+            embedding_provider=mock_embedding_provider,
+            memory_limit_mb=512,
+            threads=1,
+        )
+        await s.initialize()
+        try:
+            threads = s.connection.execute("SELECT current_setting('threads')").fetchone()
+            assert threads is not None
+            assert int(threads[0]) == 1
+        finally:
+            await s.close()
+
+    async def test_pragmas_disabled_when_none(self, mock_embedding_provider) -> None:
+        """Passing ``None`` / non-positive leaves DuckDB's defaults in place."""
+        s = DuckDBStore(
+            db_path=":memory:",
+            embedding_provider=mock_embedding_provider,
+            memory_limit_mb=None,
+            threads=0,  # non-positive -> treated as unset
+        )
+        # Both knobs resolve to "unset"; init must still succeed.
+        assert s._memory_limit_mb is None  # noqa: SLF001
+        assert s._threads is None  # noqa: SLF001
+        await s.initialize()
+        await s.close()
+
+
+# ---------------------------------------------------------------------------
+# Idle-checkpoint loop (issue #655) — flush WAL during quiet windows
+# ---------------------------------------------------------------------------
+
+
+class TestIdleCheckpoint:
+    """A background task flushes the WAL when the writer is idle (issue #655).
+
+    Under continuous concurrent writers the per-write CHECKPOINT can never
+    acquire the writer lock; the WAL grows unbounded and every read replays an
+    ever-larger WAL.  The idle loop issues a *plain* CHECKPOINT during quiet
+    windows only — it never blocks a writer and never escalates to FORCE.
+    """
+
+    async def test_idle_checkpoint_once_flushes_wal(
+        self, tmp_path, deterministic_embedding_provider
+    ) -> None:
+        db_path = str(tmp_path / "idle_ckpt.db")
+        store = DuckDBStore(
+            db_path=db_path,
+            embedding_provider=deterministic_embedding_provider,
+        )
+        await store.initialize()
+        try:
+            # Suppress per-write checkpoints so the WAL actually accumulates,
+            # isolating the idle sweep as the thing that flushes it.
+            with patch.object(store, "_checkpoint_after_write", lambda *_a, **_k: None):
+                for i in range(5):
+                    await store.store(make_entry(content=f"idle-{i}"))
+            wal_path = Path(db_path + ".wal")
+            wal_before = wal_path.stat().st_size if wal_path.exists() else 0
+
+            await store._idle_checkpoint_once()  # noqa: SLF001
+
+            wal_after = wal_path.stat().st_size if wal_path.exists() else 0
+            assert wal_after < wal_before or wal_after == 0
+        finally:
+            await store.close()
+
+    async def test_idle_checkpoint_skips_when_writer_active(
+        self, tmp_path, deterministic_embedding_provider
+    ) -> None:
+        """When ``_conn_lock`` is held the sweep skips — it never blocks a writer."""
+        import distillery.store.duckdb as duckdb_mod
+
+        store = DuckDBStore(
+            db_path=str(tmp_path / "idle_skip.db"),
+            embedding_provider=deterministic_embedding_provider,
+        )
+        await store.initialize()
+        try:
+            called = False
+
+            async def _spy_to_thread(fn, *args, **kwargs):
+                nonlocal called
+                called = True
+                return fn(*args, **kwargs)
+
+            lock = store._get_conn_lock()  # noqa: SLF001
+            async with lock:  # simulate an in-flight writer holding the lock
+                with patch.object(duckdb_mod.asyncio, "to_thread", _spy_to_thread):
+                    # Must return promptly (never block on the held lock) …
+                    await store._idle_checkpoint_once()  # noqa: SLF001
+            # … and must not have issued a CHECKPOINT while the writer held the lock.
+            assert called is False
+        finally:
+            await store.close()
+
+    async def test_start_stop_idle_checkpoint_lifecycle(
+        self, tmp_path, deterministic_embedding_provider
+    ) -> None:
+        store = DuckDBStore(
+            db_path=str(tmp_path / "idle_life.db"),
+            embedding_provider=deterministic_embedding_provider,
+        )
+        await store.initialize()
+        try:
+            store.start_idle_checkpoint(interval_s=0.01)
+            assert store._idle_checkpoint_task is not None  # noqa: SLF001
+            # Idempotent: a second start does not spawn a second task.
+            task = store._idle_checkpoint_task  # noqa: SLF001
+            store.start_idle_checkpoint(interval_s=0.01)
+            assert store._idle_checkpoint_task is task  # noqa: SLF001
+            await store.stop_idle_checkpoint()
+            assert store._idle_checkpoint_task is None  # noqa: SLF001
+        finally:
+            await store.close()
+
+    async def test_idle_checkpoint_noop_for_memory_db(self, mock_embedding_provider) -> None:
+        store = DuckDBStore(db_path=":memory:", embedding_provider=mock_embedding_provider)
+        await store.initialize()
+        try:
+            store.start_idle_checkpoint()
+            # In-memory DBs have no WAL — the loop is never started.
+            assert store._idle_checkpoint_task is None  # noqa: SLF001
         finally:
             await store.close()
 

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1582,3 +1582,77 @@ class TestGitHubReleasesPollEndToEnd:
 
         called_url = client.get.call_args.args[0]
         assert called_url.endswith("/repos/owner/repo/releases")
+
+
+# ---------------------------------------------------------------------------
+# FeedPoller.poll — bounded source concurrency (issue #655)
+# ---------------------------------------------------------------------------
+
+
+class TestFeedPollerConcurrencyBound:
+    """The per-cycle fan-out is bounded by a semaphore (issue #655).
+
+    An unbounded ``asyncio.gather`` over ~79 sources saturated the thread pool
+    and the single DuckDB writer lock; the poller now caps how many sources are
+    fetched + scored + stored concurrently.  These tests assert the bound holds
+    while still polling every source.
+    """
+
+    def _rss_source(self, idx: int) -> FeedSourceConfig:
+        return FeedSourceConfig(
+            url=f"https://example.com/rss/{idx}",
+            source_type="rss",
+            trust_weight=1.0,
+        )
+
+    async def test_concurrency_never_exceeds_limit(self) -> None:
+        import threading
+
+        n_sources = 20
+        max_concurrent = 5
+        sources = [self._rss_source(i) for i in range(n_sources)]
+        store = _make_store(feed_sources=[_source_to_dict(s) for s in sources])
+        cfg = _make_config(sources=sources, digest_threshold=1.1)  # store nothing
+
+        # Track in-flight fetches.  ``adapter.fetch`` runs in a worker thread via
+        # ``asyncio.to_thread`` so several can truly overlap — guard the counters
+        # with a lock and sleep briefly so overlap is observable if it occurs.
+        lock = threading.Lock()
+        in_flight = 0
+        peak = 0
+
+        def _fetch() -> list[FeedItem]:
+            nonlocal in_flight, peak
+            with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            import time
+
+            time.sleep(0.02)
+            with lock:
+                in_flight -= 1
+            return [_make_feed_item(item_id="x")]
+
+        def _build(*_args: object, **_kwargs: object) -> MagicMock:
+            adapter = MagicMock()
+            adapter.fetch.side_effect = _fetch
+            return adapter
+
+        with patch("distillery.feeds.poller._build_adapter", side_effect=_build):
+            poller = FeedPoller(store=store, config=cfg, max_concurrent_sources=max_concurrent)
+            summary = await poller.poll()
+
+        # Every source was still polled …
+        assert summary.sources_polled == n_sources
+        # … but never more than the configured number at once.
+        assert peak <= max_concurrent
+        # The bound was actually exercised (sanity: more than one ran at a time).
+        assert peak > 1
+
+    async def test_limit_clamped_to_at_least_one(self) -> None:
+        sources = [self._rss_source(0)]
+        store = _make_store(feed_sources=[_source_to_dict(s) for s in sources])
+        cfg = _make_config(sources=sources)
+        # A non-positive limit must be clamped to 1, never deadlock the poll.
+        poller = FeedPoller(store=store, config=cfg, max_concurrent_sources=0)
+        assert poller._max_concurrent_sources == 1


### PR DESCRIPTION
## Root cause (issue #655)

Under a concurrent feed poll (~79 sources) plus gh-sync, the single DuckDB writer is saturated: a Logfire trace showed reads (get/search/find_similar) blocking ~48s on the writer lock. Two compounding write-side problems:

1. **Unbounded poll fan-out.** `FeedPoller.poll` fanned out over all sources with an unbounded `asyncio.gather`, saturating the thread pool and the writer lock for tens of seconds per cycle and self-inflicting upstream 429/502s.
2. **No DuckDB resource caps.** No `memory_limit` / `threads` PRAGMA was ever set, so DuckDB sized its buffer manager off total host RAM and spawned one worker per core — both unbounded, with prior OOM history (the limit was bumped 512MB → 1024 → 2048 in earlier incidents).
3. **WAL checkpoint starvation.** With overlapping write transactions, the per-write plain `CHECKPOINT` can never acquire the lock, the WAL grows unbounded, and every read replays an ever-larger WAL → latency degrades monotonically ("slower over time" symptom).

A separate PR ([#670](https://github.com/norrietaylor/distillery/pull/670)) moved the *reads* off the writer lock. This PR is the **write side**: make the writer cheaper / shorter-held and bound the poll's resource use so the writer isn't saturated for ~48s in the first place.

## Changes

### A. Bound feed-poller concurrency (`perf(feeds)`)
- Added an `asyncio.Semaphore` (default **5**, constructor-overridable via `max_concurrent_sources`, clamped to ≥ 1) around `_poll_source`, so at most N sources are fetched + scored + stored concurrently.
- Behaviour preserved: every source is still polled; only peak concurrency is bounded. This cuts CPU / thread-pool saturation, self-inflicted upstream 429/502s, and writer contention.

### B. DuckDB resource PRAGMAs at connection init (`perf(store)`)
- Set explicit `memory_limit` (**~1GB**) and `threads` (**=2**) PRAGMAs in `_open_connection`, with safe defaults that are overridable via new constructor kwargs (`memory_limit_mb`, `threads`). `None` / non-positive leaves DuckDB's default in place. Best-effort: a PRAGMA failure is logged, not fatal.

### C. Idle-window checkpoint cadence (`perf(store)`) — implemented, safely
This is the riskiest part, so it was implemented conservatively. I read the existing checkpoint logic and history first: recent commits **deliberately dropped** a "FORCE CHECKPOINT escalation that could deadlock the writer" (issue #648). This change **does not** reintroduce that.

- Added an **opt-in background idle-checkpoint loop**, started by the server lifespan after `store.initialize()` and stopped in `close()`.
- It issues a **plain `CHECKPOINT` only during quiet windows**: it pre-checks `_conn_lock.locked()` and **skips** the sweep whenever a writer is active, so it never blocks or queues behind a writer.
- It holds `_conn_lock` only for the (non-blocking) plain `CHECKPOINT`, preserving the single-connection-one-thread invariant (issue #416). It **never** escalates to `FORCE CHECKPOINT`. No-op for in-memory DBs.
- Net effect: the WAL gets flushed during quiet windows so it can't grow unbounded, without any deadlock or writer-blocking risk.

## Tests
- `tests/test_poller.py::TestFeedPollerConcurrencyBound` — tracks in-flight fetch count via a patched adapter and asserts peak concurrency never exceeds the limit (while all sources are still polled); plus the clamp-to-1 guard.
- `tests/test_duckdb_store.py::TestResourcePragmas` — asserts `current_setting('memory_limit')` / `current_setting('threads')` reflect the applied PRAGMAs (default, overridden, and disabled paths).
- `tests/test_duckdb_store.py::TestIdleCheckpoint` — asserts the idle sweep flushes the WAL, **skips when the writer lock is held** (never blocks), start/stop lifecycle + idempotency, and the in-memory no-op.

## Results
- `ruff check src/ tests/` — clean
- `ruff format` — applied to changed files
- `mypy --strict src/distillery/` — clean (73 source files)
- `pytest -q` — **3143 passed, 98 skipped** (full suite)
- Diff stat: 5 files changed, ~419 insertions, ~16 deletions. `uv.lock` untouched.

Refs #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit on how many feed sources are processed concurrently per polling cycle.
  * Introduced optional idle-time database WAL checkpointing to maintain performance during quiet periods.

* **Bug Fixes**
  * Reduced database WAL growth under concurrent writers and improved overall stability during heavy polling.
  * Improved initialization and shutdown behavior so database maintenance starts/stops reliably.

* **Tests**
  * Added coverage for concurrency bounding and idle checkpoint behavior, including edge cases (e.g., in-memory databases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->