### PR TITLE
perf(search): batch find_similar reuses stored vectors (Phase 2b 20→1 round-trip)

### DIFF
--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -18,7 +18,7 @@ effort: high
 
 Investigate compiles comprehensive context on a topic by executing a 4-phase retrieval: seed search, relationship expansion (with hidden-connection gap fill), tag expansion, and gap filling. It combines semantic search with explicit relationship traversal to surface context that keyword search alone misses.
 
-<!-- Recent changes: Phases 1 and 2 are fused into a single distillery_search(expand_graph=true, expand_hops=2, output_mode="full") call — server-side BFS returns the seeds plus their 2-hop graph neighbours (each with provenance/depth/parent_id/relation_type and inline content) in one round-trip, replacing the prior 1 search + up-to-20 traverse + N get fan-out (#651). Phase 2b find_similar calls run in bounded parallel batches (~4) and reuse the seed's stored embedding (source_entry_id → no re-embed, no budget spend). Relationship traversal is skipped when the seed set has no relations (sparse-graph short-circuit). -->
+<!-- Recent changes: Phases 1 and 2 are fused into a single distillery_search(expand_graph=true, expand_hops=2, output_mode="full") call — server-side BFS returns the seeds plus their 2-hop graph neighbours (each with provenance/depth/parent_id/relation_type and inline content) in one round-trip, replacing the prior 1 search + up-to-20 traverse + N get fan-out (#651). Phase 2b now issues a single batched distillery_find_similar(source_entry_ids=[...]) call (top ≤20 seeds) that reuses each seed's stored embedding (no re-embed, no budget spend) and runs all seeds server-side in one round-trip, returning results_by_seed — replacing the prior per-seed fan-out in bounded parallel batches (~4); the 502-under-concurrency concern is moot now that it is one call. Relationship traversal is skipped when the seed set has no relations (sparse-graph short-circuit). -->
 
 
 ## When to Use
@@ -130,28 +130,26 @@ returns not found for the `--entry` uuid, report the error and stop.
 
 **Phase 2b — Hidden Connections (gap fill via similarity):**
 
-For each **seed** (a Phase 1 `provenance="search"` entry), surface entries that are semantically similar to the seed but are NOT already linked to it via any relation (i.e., absent from `entry_relations` in either direction):
+For the **seeds** (Phase 1 `provenance="search"` entries), surface entries that are semantically similar to each seed but are NOT already linked to it via any relation (i.e., absent from `entry_relations` in either direction). Issue **ONE batched call** for up to the top 20 seeds by Phase 1 relevance score:
 
 ```python
 distillery_find_similar(
-    source_entry_id="<seed_id>",
+    source_entry_ids=[<top ≤20 seed ids by Phase-1 relevance>],
     exclude_linked=True,
     threshold=0.7,
     limit=5,
 )
 ```
 
-Passing `source_entry_id` reuses the seed's **already-stored embedding** — no re-embedding round-trip and no embedding-budget spend.
+Batch mode reuses each seed's **already-stored embedding** — no re-embedding round-trip and no embedding-budget spend — and runs all seeds in a single server-side read, returning everything in **one round-trip**. Cap at the top 20 seeds; skip the rest. When the sparse-graph short-circuit fired (Phase 1-2 `expanded_count` = 0), Phase 2b is the primary expansion lever — still run it.
 
-**Issue these calls in bounded parallel batches of ~4** (start the next batch only after the current returns). The seeds are independent, so batching is far faster than one-call-per-turn; keep batches small — the hosted endpoint has returned `Streamable HTTP error` (502) under heavier concurrency. Cap Phase 2b at the top 20 seeds by Phase 1 relevance score; skip the rest. When the sparse-graph short-circuit fired (Phase 1-2 `expanded_count` = 0), Phase 2b is the primary expansion lever — still run it.
-
-The response envelope includes `excluded_linked_count` (number of linked entries filtered out before scoring). The remaining hits are unlinked-but-semantically-related candidates.
+The response is `results_by_seed`, a map keyed by each seed id: `{ "<seed_id>": { results: [...], count, excluded_count } }`, plus `seed_count` and `threshold`. Each seed always self-excludes; with `exclude_linked=True`, linked entries are filtered out per seed. A seed with no stored embedding maps to an empty `results` list (not an error). Iterate `results_by_seed`: the hits are unlinked-but-semantically-related candidates.
 
 Add each returned entry id (not already in the result set) tagged as discovered in Phase 2b ("potentially related"). Do NOT add these to the Relationship Map — they have no recorded edge. Cite them in the Context Summary and the Sources table with a `potentially related` marker so the user knows the connection is inferred from embeddings, not stored as a relation.
 
-Report: `Phase 2b (Hidden Connections): <N> potentially related entries across <S> seeds (excluded_linked total: <X>).`
+Report: `Phase 2b (Hidden Connections): <N> potentially related entries across <S> seeds.`
 
-If `distillery_find_similar` returns zero entries for every seed, note this in the Phase 2b report and continue.
+If `results_by_seed` yields zero entries for every seed, note this in the Phase 2b report and continue.
 
 ---
 
@@ -323,7 +321,7 @@ Investigated "<topic>": <N> entries across <phases> phases, <K> relationship edg
 - Deduplicate the result set by entry ID across all phases — each entry counted once
 - Record which phase first discovered each entry
 - Phases 1-2 use one `distillery_search(expand_graph=true, expand_hops=2, output_mode="full")` call (server-side BFS); the `--entry` variant uses `distillery_get` + one `distillery_relations(action="traverse", hops=2, direction="both")`. Do not recurse into graph-expanded entries.
-- Phase 2b runs `distillery_find_similar(source_entry_id=<seed>, exclude_linked=true, threshold=0.7, limit=5)` per seed in bounded parallel batches of ~4, capped to the top 20 seeds; `source_entry_id` reuses the stored embedding (no re-embed)
+- Phase 2b runs ONE batched `distillery_find_similar(source_entry_ids=[<top ≤20 seeds>], exclude_linked=true, threshold=0.7, limit=5)` call (capped to the top 20 seeds); batch mode reuses each seed's stored embedding (no re-embed, no budget) and returns all seeds in one round-trip as `results_by_seed`
 - Phase 2b candidates are tagged `potentially related` — never include them in the Relationship Map (they have no stored edge); cite them with `[Entry <short-id>, potentially related]` in the Context Summary
 - Loop limits: up to 3 `distillery_search` calls in Phase 3, up to 3 targeted searches in Phase 4
 - Track relation edges separately from the result set entry count
@@ -331,7 +329,7 @@ Investigated "<topic>": <N> entries across <phases> phases, <K> relationship edg
 - If `--entry <uuid>` is provided and `distillery_get` returns not found, report the error and stop
 - Apply `--project` filter to all `distillery_search` calls in Phase 1 and Phase 4 when provided
 - `distillery_relations` returning empty `nodes`/`edges` for an entry is not an error — record 0 edges and continue
-- `distillery_find_similar` returning zero entries (after `exclude_linked` filtering) is not an error — record 0 candidates for that seed and continue
+- `distillery_find_similar` batch mode returning an empty `results` list for a seed (after `exclude_linked` filtering, or because the seed has no stored embedding) is not an error — record 0 candidates for that seed and continue
 - On MCP errors, see CONVENTIONS.md error handling — display and stop
 - No retry loops — report errors and stop
 - Display-only — this skill never stores output

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1059,6 +1059,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         conflict_check: bool = False,
         llm_responses: list[dict[str, Any]] | None = None,
         source_entry_id: str | None = None,
+        source_entry_ids: list[str] | None = None,
         exclude_linked: bool = False,
         accept_action: str | None = None,
     ) -> list[types.TextContent]:
@@ -1083,17 +1084,28 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             LLM conflict verdicts. Each item: { entry_id: str, is_conflict: bool, reasoning: str }.
           - source_entry_id (str, optional): Anchor entry whose content is used
             as the similarity probe when content is omitted, and whose id is
-            self-excluded from results. Required when exclude_linked=true.
+            self-excluded from results. Required when exclude_linked=true. When
+            set without content/dedup/conflict/accept_action, reuses the entry's
+            STORED embedding (no re-embed, no embedding-budget spend).
+          - source_entry_ids (list[str], optional): BATCH mode. Up to 50 seed
+            ids. Reuses each seed's STORED embedding (no re-embed, no
+            embedding-budget spend) and runs all similarity queries in ONE
+            round-trip. Standalone — cannot be combined with content,
+            source_entry_id, dedup_action, conflict_check, accept_action, or
+            llm_responses (INVALID_PARAMS). Honours threshold, limit, and
+            exclude_linked per seed; each seed always self-excludes.
           - exclude_linked (bool, optional, default=false): When true, filters out
-            entries already linked to source_entry_id via entry_relations
-            (any direction, any relation_type). Surfaces hidden connections.
+            entries already linked to source_entry_id (or, in batch mode, to each
+            seed) via entry_relations (any direction, any relation_type).
+            Surfaces hidden connections.
           - accept_action (str, optional): When set, persists an
             entry_relations row from source_entry_id to each result above
             threshold. Valid: ['link' → related, 'merge' → merge_source,
             'duplicate' → duplicate]. Requires source_entry_id. Idempotent via
             the unique (from_id, to_id, relation_type) index.
 
-        RETURNS (success): { results: [{ score: float, entry: {...} }], count: int, threshold: float,
+        RETURNS (success, single/content): { results: [{ score: float, entry: {...} }], count: int,
+          threshold: float,
           dedup?: { action: str, similar_entries: list },
           conflict_candidates?: list, conflict_evaluation?: dict,
           excluded_linked_count?: int }
@@ -1102,6 +1114,12 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           (when exclude_linked=true) and the self-exclusion of source_entry_id
           itself (when source_entry_id == candidate); a non-zero value is
           therefore possible even with exclude_linked=false.
+        RETURNS (success, batch / source_entry_ids):
+          { results_by_seed: { "<seed_id>": { results: [{ score: float, entry: {...} }],
+              count: int, excluded_count: int } },
+            seed_count: int, threshold: float }
+          A seed with no stored embedding maps to an empty results list (not an
+          error). excluded_count is best-effort (reported as 0 in batch mode).
         RETURNS (error): { error: true, code: "INVALID_PARAMS" | "NOT_FOUND" | "BUDGET_EXCEEDED" | "INTERNAL", message: "..." }
 
         RELATED: distillery_store (stores with automatic dedup/conflict checks),
@@ -1119,6 +1137,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 content=content,
                 llm_responses=llm_responses,
                 source_entry_id=source_entry_id,
+                source_entry_ids=source_entry_ids,
                 accept_action=accept_action,
             ),
         )

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -48,6 +48,12 @@ _ACCEPT_ACTION_TO_RELATION_TYPE: dict[str, str] = {
     "duplicate": "duplicate",
 }
 
+# Maximum number of seed ids accepted by the ``distillery_find_similar`` batch
+# mode (``source_entry_ids``). Bounds one round-trip's work to the /investigate
+# Phase 2b cap (top 20 seeds) plus headroom; larger lists are rejected with
+# INVALID_PARAMS.
+_FIND_SIMILAR_BATCH_MAX_SEEDS = 50
+
 # ---------------------------------------------------------------------------
 # Output-mode shaping (issue #631)
 # ---------------------------------------------------------------------------
@@ -463,6 +469,13 @@ async def _handle_find_similar(
     """
     from distillery.mcp.budget import EmbeddingBudgetError
 
+    # --- batch mode (source_entry_ids) ------------------------------------
+    # Reuses each seed's STORED embedding — no re-embed, no budget spend — and
+    # runs all similarity queries in ONE store read acquisition. Standalone:
+    # mutually exclusive with the embed-based modes below.
+    if "source_entry_ids" in arguments and arguments.get("source_entry_ids") is not None:
+        return await _handle_find_similar_batch(store, arguments)
+
     # --- new graph-extension parameters (parsed first so we can use them
     # when validating content/source_entry_id requirements below) ---------
     err_source_id_type = validate_type(arguments, "source_entry_id", str, "string")
@@ -560,31 +573,59 @@ async def _handle_find_similar(
             "Field 'llm_responses' requires conflict_check=true",
         )
 
-    # --- embedding budget check (1 embed call) ----------------------------
-    if cfg is not None:
+    # --- stored-vector fast path (single source_entry_id) -------------------
+    # When the probe is a source entry's own content (no explicit ``content``)
+    # and no embed-dependent mode is active, reuse the seed's STORED embedding
+    # via ``find_similar_by_id`` — skipping both the Jina round-trip and the
+    # embedding-budget spend. Falls back to the embed path when the entry has no
+    # stored embedding (returns None).
+    search_results = None
+    can_reuse_stored_vector = (
+        source_entry_id is not None
+        and not content_provided
+        and not dedup_action
+        and not conflict_check
+        and accept_action is None
+    )
+    if can_reuse_stored_vector:
         try:
-            await store.record_embedding_usage(
-                count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
+            assert source_entry_id is not None
+            search_results = await store.find_similar_by_id(
+                source_entry_id=source_entry_id, threshold=threshold, limit=limit
             )
-        except EmbeddingBudgetError:
-            return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
+        except Exception:  # noqa: BLE001
+            logger.exception("Error in distillery_find_similar (stored-vector path)")
+            return error_response("INTERNAL", "find_similar failed")
 
-    try:
-        search_results = await store.find_similar(content=content, threshold=threshold, limit=limit)
-    except EmbeddingProviderError as exc:
-        logger.warning(
-            "Upstream embedding provider failed during find_similar "
-            "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
-            exc.provider,
-            exc.endpoint,
-            exc.status_code,
-            exc.retry_after,
-            exc,
-        )
-        return upstream_error_response(exc)
-    except Exception:  # noqa: BLE001
-        logger.exception("Error in distillery_find_similar")
-        return error_response("INTERNAL", "find_similar failed")
+    # --- embed path (content probe or no stored embedding) -----------------
+    if search_results is None:
+        # 1 embed call.
+        if cfg is not None:
+            try:
+                await store.record_embedding_usage(
+                    count=1, daily_limit=cfg.rate_limit.embedding_budget_daily
+                )
+            except EmbeddingBudgetError:
+                return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
+
+        try:
+            search_results = await store.find_similar(
+                content=content, threshold=threshold, limit=limit
+            )
+        except EmbeddingProviderError as exc:
+            logger.warning(
+                "Upstream embedding provider failed during find_similar "
+                "(provider=%s endpoint=%s status=%s retry_after=%s): %s",
+                exc.provider,
+                exc.endpoint,
+                exc.status_code,
+                exc.retry_after,
+                exc,
+            )
+            return upstream_error_response(exc)
+        except Exception:  # noqa: BLE001
+            logger.exception("Error in distillery_find_similar")
+            return error_response("INTERNAL", "find_similar failed")
 
     # --- graph-extension filtering (self + linked exclusion) ---------------
     excluded_linked_count = 0
@@ -818,6 +859,119 @@ async def _handle_find_similar(
                 )
 
     return success_response(payload)
+
+
+# ---------------------------------------------------------------------------
+# _handle_find_similar_batch (source_entry_ids)
+# ---------------------------------------------------------------------------
+
+# Embed-based modes that batch mode forbids — batch mode is standalone and
+# spends zero embedding budget, so combining it with any of these is a caller
+# error rather than a silent partial behaviour.
+_BATCH_FORBIDDEN_PARAMS = (
+    "content",
+    "source_entry_id",
+    "dedup_action",
+    "conflict_check",
+    "accept_action",
+    "llm_responses",
+)
+
+
+async def _handle_find_similar_batch(
+    store: Any,
+    arguments: dict[str, Any],
+) -> list[types.TextContent]:
+    """Batch path of ``distillery_find_similar`` (``source_entry_ids``).
+
+    Reuses each seed's STORED embedding (no re-embed, no embedding-budget spend)
+    and runs all similarity queries in ONE store read acquisition. Standalone:
+    combining ``source_entry_ids`` with any embed-based mode
+    (``content``/``source_entry_id``/``dedup_action``/``conflict_check``/
+    ``accept_action``/``llm_responses``) is rejected with INVALID_PARAMS.
+
+    Returns a payload keyed by seed id::
+
+        {"results_by_seed": {"<seed_id>": {"results": [{"score", "entry"}],
+            "count": N, "excluded_count": X}},
+         "seed_count": K, "threshold": 0.7}
+    """
+    # Batch mode is standalone: reject embed-based companions up-front.
+    conflicting = [p for p in _BATCH_FORBIDDEN_PARAMS if arguments.get(p) is not None]
+    if conflicting:
+        return error_response(
+            "INVALID_PARAMS",
+            "source_entry_ids (batch mode) is standalone and cannot be combined with "
+            f"{', '.join(sorted(conflicting))}",
+        )
+
+    raw_ids = arguments.get("source_entry_ids")
+    if not isinstance(raw_ids, list):
+        return error_response(
+            "INVALID_PARAMS", "Field 'source_entry_ids' must be a list of strings"
+        )
+    if len(raw_ids) == 0:
+        return error_response("INVALID_PARAMS", "Field 'source_entry_ids' must be a non-empty list")
+    if len(raw_ids) > _FIND_SIMILAR_BATCH_MAX_SEEDS:
+        return error_response(
+            "INVALID_PARAMS",
+            f"Field 'source_entry_ids' accepts at most {_FIND_SIMILAR_BATCH_MAX_SEEDS} ids "
+            f"(got {len(raw_ids)})",
+        )
+    for sid in raw_ids:
+        if not isinstance(sid, str) or sid.strip() == "":
+            return error_response(
+                "INVALID_PARAMS", "Field 'source_entry_ids' must be a list of non-empty strings"
+            )
+    # De-dupe while preserving order so one stored vector is fetched per id.
+    seed_ids: list[str] = list(dict.fromkeys(raw_ids))
+
+    threshold_raw = arguments.get("threshold", 0.8)
+    err_threshold = validate_type(arguments, "threshold", (int, float), "number")
+    if err_threshold:
+        return error_response("INVALID_PARAMS", err_threshold)
+    threshold = float(threshold_raw) if threshold_raw is not None else 0.8
+    if not (0.0 <= threshold <= 1.0):
+        return error_response("INVALID_PARAMS", "Field 'threshold' must be in [0.0, 1.0]")
+
+    limit_result = validate_limit(arguments.get("limit", 10), min_val=1, max_val=200, default=10)
+    if isinstance(limit_result, tuple):
+        return error_response(*limit_result)
+    limit = limit_result
+
+    exclude_linked: bool = bool(arguments.get("exclude_linked", False))
+
+    # ONE read acquisition for all seeds — zero embedding budget spent (the
+    # stored vectors are reused, so record_embedding_usage is never called).
+    try:
+        results_by_id = await store.find_similar_by_ids(seed_ids, threshold, limit, exclude_linked)
+    except Exception:  # noqa: BLE001
+        logger.exception("Error in distillery_find_similar (batch path)")
+        return error_response("INTERNAL", "find_similar batch failed")
+
+    results_by_seed: dict[str, Any] = {}
+    for sid in seed_ids:
+        seed_results = results_by_id.get(sid, [])
+        shaped = [{"score": round(sr.score, 6), "entry": sr.entry.to_dict()} for sr in seed_results]
+        # ``excluded_count`` (best-effort): the store performs the self/linked
+        # exclusion internally over an over-fetched candidate window and returns
+        # only the survivors, so the per-seed count of dropped candidates is not
+        # observable here. It is reported as 0 and documented as best-effort;
+        # callers needing exact exclusion accounting should use the single-seed
+        # path with ``exclude_linked`` (which surfaces ``excluded_linked_count``).
+        results_by_seed[sid] = {
+            "results": shaped,
+            "count": len(shaped),
+            "excluded_count": 0,
+        }
+
+    return success_response(
+        {
+            "results_by_seed": results_by_seed,
+            "seed_count": len(seed_ids),
+            "threshold": threshold,
+        }
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -877,6 +877,12 @@ _BATCH_FORBIDDEN_PARAMS = (
     "llm_responses",
 )
 
+# Subset of the forbidden params that the server wrapper always forwards with a
+# default (``False``) rather than omitting when unset. These are conflicts only
+# when truthy — otherwise a plain batch call (which carries the defaults) would
+# be wrongly rejected as combining modes.
+_BATCH_FORBIDDEN_DEFAULTED_BOOLS = frozenset({"dedup_action", "conflict_check"})
+
 
 async def _handle_find_similar_batch(
     store: Any,
@@ -896,8 +902,18 @@ async def _handle_find_similar_batch(
             "count": N, "excluded_count": X}},
          "seed_count": K, "threshold": 0.7}
     """
-    # Batch mode is standalone: reject embed-based companions up-front.
-    conflicting = [p for p in _BATCH_FORBIDDEN_PARAMS if arguments.get(p) is not None]
+    # Batch mode is standalone: reject embed-based companions up-front. The
+    # server wrapper always forwards the defaulted booleans (dedup_action,
+    # conflict_check) even when unset, so for those we flag only a truthy value;
+    # the rest are forwarded via _omit_none and so are absent unless supplied.
+    conflicting: list[str] = []
+    for p in _BATCH_FORBIDDEN_PARAMS:
+        value = arguments.get(p)
+        if p in _BATCH_FORBIDDEN_DEFAULTED_BOOLS:
+            if value:
+                conflicting.append(p)
+        elif value is not None:
+            conflicting.append(p)
     if conflicting:
         return error_response(
             "INVALID_PARAMS",

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2805,6 +2805,132 @@ class DuckDBStore:
         # independent read handle so it never queues behind a write (#663).
         return await self._run_read(_sync)
 
+    def _similar_from_embedding(
+        self,
+        conn: Any,
+        embedding: list[float],
+        threshold: float,
+        limit: int,
+    ) -> list[SearchResult]:
+        """Cosine-similarity query for a precomputed embedding.
+
+        Mirrors :meth:`find_similar`'s SQL exactly — excludes archived
+        (soft-deleted) entries and converts the API's normalized ``[0, 1]``
+        threshold to DuckDB's raw ``[-1, 1]`` cosine range — but takes a vector
+        directly instead of embedding ``content``. Runs on whatever handle the
+        caller passes; the public batch entry points wrap it in ``_run_read``.
+        """
+        from distillery.store.protocol import SearchResult
+
+        dims = self._embedding_provider.dimensions
+        sql = (
+            f"SELECT {self._ENTRY_COLUMNS}, "
+            f"array_cosine_similarity(embedding, ?::FLOAT[{dims}]) AS score "
+            f"FROM entries "
+            f"WHERE status != ? "
+            f"AND array_cosine_similarity(embedding, ?::FLOAT[{dims}]) >= ? "
+            f"ORDER BY score DESC "
+            f"LIMIT ?"
+        )
+        # Convert normalized [0, 1] threshold to raw [-1, 1] for SQL comparison.
+        raw_threshold = threshold * 2.0 - 1.0
+        params: list[Any] = [
+            embedding,
+            EntryStatus.ARCHIVED.value,
+            embedding,
+            raw_threshold,
+            limit,
+        ]
+        result = conn.execute(sql, params)
+        col_names = [desc[0] for desc in result.description]
+
+        results: list[SearchResult] = []
+        for row in result.fetchall():
+            row_dict = dict(zip(col_names, row, strict=True))
+            raw_score = float(row_dict.pop("score"))
+            score = (raw_score + 1.0) / 2.0
+            entry = self._row_to_entry(
+                tuple(row_dict.values()),
+                list(row_dict.keys()),
+            )
+            results.append(SearchResult(entry=entry, score=score))
+        return results
+
+    async def find_similar_by_id(
+        self,
+        source_entry_id: str,
+        threshold: float,
+        limit: int,
+    ) -> list[SearchResult] | None:
+        """Single-seed similarity using the entry's STORED embedding.
+
+        Reuses the entry's already-computed embedding vector — no re-embed and
+        no embedding-budget spend. Returns ``None`` when the entry is missing or
+        has no stored embedding (so the caller can fall back to the embed path);
+        otherwise returns the cosine-similarity matches (archived excluded,
+        self NOT excluded — the caller handles self/linked exclusion to preserve
+        the existing handler behaviour). One ``_run_read`` acquisition.
+        """
+
+        def _sync(conn: Any) -> list[SearchResult] | None:
+            row = conn.execute(
+                "SELECT embedding FROM entries WHERE id = ?", [source_entry_id]
+            ).fetchone()
+            if row is None or row[0] is None:
+                return None
+            vec = list(row[0])
+            return self._similar_from_embedding(conn, vec, threshold, limit)
+
+        return await self._run_read(_sync)
+
+    async def find_similar_by_ids(
+        self,
+        source_entry_ids: list[str],
+        threshold: float,
+        limit: int,
+        exclude_linked: bool,
+    ) -> dict[str, list[SearchResult]]:
+        """Batch similarity using each entry's STORED embedding.
+
+        For a LIST of source entry ids, reuses each entry's already-stored
+        embedding vector (no re-embed, no embedding-budget spend) and runs ALL
+        similarity queries in ONE ``_run_read`` acquisition. For each id: fetch
+        its stored embedding; if NULL/missing, map to ``[]``; otherwise run the
+        cosine query, always self-exclude the seed id, and — when
+        *exclude_linked* — also exclude ids linked to the seed via
+        ``entry_relations`` (``from_id`` or ``to_id`` matches the seed, either
+        direction). Over-fetches ``limit + 50`` candidates before exclusion so up
+        to *limit* survive, then truncates to *limit*.
+
+        Returns a dict keyed by every requested id (preserving duplicates is not
+        guaranteed — a later id overwrites an earlier identical one).
+        """
+
+        def _sync(conn: Any) -> dict[str, list[SearchResult]]:
+            out: dict[str, list[SearchResult]] = {}
+            for sid in source_entry_ids:
+                row = conn.execute("SELECT embedding FROM entries WHERE id = ?", [sid]).fetchone()
+                if row is None or row[0] is None:
+                    out[sid] = []
+                    continue
+                vec = list(row[0])
+                candidates = self._similar_from_embedding(conn, vec, threshold, limit + 50)
+                exclude = {sid}
+                if exclude_linked:
+                    rels = conn.execute(
+                        "SELECT from_id, to_id FROM entry_relations WHERE from_id = ? OR to_id = ?",
+                        [sid, sid],
+                    ).fetchall()
+                    for f, t in rels:
+                        if f != sid:
+                            exclude.add(f)
+                        if t != sid:
+                            exclude.add(t)
+                out[sid] = [r for r in candidates if r.entry.id not in exclude][:limit]
+            return out
+
+        return await self._run_read(_sync)
+
     @overload
     async def list_entries(
         self,

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -206,6 +206,62 @@ class DistilleryStore(Protocol):
         """
         ...
 
+    async def find_similar_by_id(
+        self,
+        source_entry_id: str,
+        threshold: float,
+        limit: int,
+    ) -> list[SearchResult] | None:
+        """Single-seed similarity using the entry's STORED embedding.
+
+        Reuses the entry's already-computed embedding vector — no re-embed and
+        no embedding-budget spend.
+
+        Args:
+            source_entry_id: UUID string of the entry whose stored embedding is
+                used as the similarity probe.
+            threshold: Minimum cosine similarity (inclusive) in ``[0.0, 1.0]``.
+            limit: Maximum number of results to return.
+
+        Returns:
+            List of ``SearchResult`` objects (archived excluded; the seed itself
+            is NOT excluded — the caller handles self/linked exclusion), sorted
+            by descending score; or ``None`` when the entry is missing or has no
+            stored embedding (so the caller can fall back to the embed path).
+        """
+        ...
+
+    async def find_similar_by_ids(
+        self,
+        source_entry_ids: list[str],
+        threshold: float,
+        limit: int,
+        exclude_linked: bool,
+    ) -> dict[str, list[SearchResult]]:
+        """Batch similarity using each entry's STORED embedding.
+
+        For a list of source entry ids, reuses each entry's already-stored
+        embedding vector (no re-embed, no embedding-budget spend) and runs all
+        similarity queries in one read acquisition.
+
+        Args:
+            source_entry_ids: UUID strings of the seed entries.
+            threshold: Minimum cosine similarity (inclusive) in ``[0.0, 1.0]``.
+            limit: Maximum number of results to return per seed.
+            exclude_linked: When ``True``, results for each seed also exclude
+                ids linked to that seed via ``entry_relations`` (either
+                direction, any relation_type). The seed itself is always
+                self-excluded.
+
+        Returns:
+            Dict keyed by every requested id; each value is the list of
+            ``SearchResult`` objects for that seed (archived, self, and — when
+            *exclude_linked* — linked ids removed), sorted by descending score
+            and capped at *limit*. A seed with no stored embedding maps to an
+            empty list rather than raising.
+        """
+        ...
+
     @overload
     async def list_entries(
         self,

--- a/tests/test_find_similar_batch.py
+++ b/tests/test_find_similar_batch.py
@@ -1,0 +1,433 @@
+"""Tests for the ``distillery_find_similar`` batch mode (``source_entry_ids``).
+
+Covers the server-side batch path that reuses each seed's STORED embedding (no
+re-embed, no embedding-budget spend) and runs all similarity queries in one read
+acquisition:
+
+  - store.find_similar_by_ids: keyed map, missing-embedding seed -> [],
+    self-exclusion, linked exclusion, threshold + limit honoured per seed.
+  - store.find_similar_by_id: single-seed stored-vector reuse (returns None when
+    no stored embedding).
+  - the MCP handler batch path: payload shape, zero embedding budget, and
+    INVALID_PARAMS validation (forbidden companions, empty / oversized list).
+  - the single source_entry_id handler path now reuses the stored vector (no
+    embed) and still self/linked-excludes.
+
+Uses the ControlledEmbeddingProvider for deterministic similarity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.config import DistilleryConfig, load_config
+from distillery.mcp.tools.search import _handle_find_similar
+from distillery.store.duckdb import DuckDBStore
+from tests.conftest import ControlledEmbeddingProvider, make_entry, parse_mcp_response
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Unit vectors for deterministic similarity (8D ControlledEmbeddingProvider)
+# ---------------------------------------------------------------------------
+
+_UNIT_A = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+_UNIT_B = [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def embedding_provider(
+    controlled_embedding_provider: ControlledEmbeddingProvider,
+) -> ControlledEmbeddingProvider:
+    return controlled_embedding_provider
+
+
+@pytest.fixture
+async def store(embedding_provider: ControlledEmbeddingProvider) -> DuckDBStore:  # type: ignore[return]
+    s = DuckDBStore(db_path=":memory:", embedding_provider=embedding_provider)
+    await s.initialize()
+    yield s
+    await s.close()
+
+
+@pytest.fixture
+def cfg() -> DistilleryConfig:
+    return load_config()
+
+
+# ===========================================================================
+# Store: find_similar_by_ids
+# ===========================================================================
+
+
+class TestFindSimilarByIds:
+    async def test_returns_map_keyed_by_every_requested_id(
+        self, store: DuckDBStore, embedding_provider: ControlledEmbeddingProvider
+    ) -> None:
+        embedding_provider.register("seed one", _UNIT_A)
+        embedding_provider.register("seed two", _UNIT_B)
+        s1 = await store.store(make_entry(content="seed one"))
+        s2 = await store.store(make_entry(content="seed two"))
+
+        out = await store.find_similar_by_ids(
+            [s1, s2], threshold=0.5, limit=5, exclude_linked=False
+        )
+
+        assert set(out.keys()) == {s1, s2}
+
+    async def test_missing_embedding_maps_to_empty_list(self, store: DuckDBStore) -> None:
+        missing = "00000000-0000-0000-0000-000000000000"
+        out = await store.find_similar_by_ids(
+            [missing], threshold=0.5, limit=5, exclude_linked=False
+        )
+        assert out == {missing: []}
+
+    async def test_self_exclusion(
+        self, store: DuckDBStore, embedding_provider: ControlledEmbeddingProvider
+    ) -> None:
+        embedding_provider.register("alpha", _UNIT_A)
+        embedding_provider.register("alpha twin", _UNIT_A)
+        s1 = await store.store(make_entry(content="alpha"))
+        twin = await store.store(make_entry(content="alpha twin"))
+
+        out = await store.find_similar_by_ids([s1], threshold=0.5, limit=5, exclude_linked=False)
+
+        result_ids = {sr.entry.id for sr in out[s1]}
+        assert s1 not in result_ids, "seed must never appear in its own results"
+        assert twin in result_ids
+
+    async def test_exclude_linked_removes_linked_entries(
+        self, store: DuckDBStore, embedding_provider: ControlledEmbeddingProvider
+    ) -> None:
+        embedding_provider.register("src", _UNIT_A)
+        embedding_provider.register("linked", _UNIT_A)
+        embedding_provider.register("unlinked", _UNIT_A)
+        src = await store.store(make_entry(content="src"))
+        linked = await store.store(make_entry(content="linked"))
+        unlinked = await store.store(make_entry(content="unlinked"))
+        await store.add_relation(src, linked, "link")
+
+        out = await store.find_similar_by_ids([src], threshold=0.5, limit=5, exclude_linked=True)
+        result_ids = {sr.entry.id for sr in out[src]}
+
+        assert linked not in result_ids, "linked entry must be excluded"
+        assert unlinked in result_ids
+        assert src not in result_ids
+
+    async def test_exclude_linked_incoming_direction(
+        self, store: DuckDBStore, embedding_provider: ControlledEmbeddingProvider
+    ) -> None:
+        # Relation points TO the seed (seed is to_id) — must still be excluded.
+        embedding_provider.register("seedX", _UNIT_A)
+        embedding_provider.register("inbound", _UNIT_A)
+        seed = await store.store(make_entry(content="seedX"))
+        inbound = await store.store(make_entry(content="inbound"))
+        await store.add_relation(inbound, seed, "link")
+
+        out = await store.find_similar_by_ids([seed], threshold=0.5, limit=5, exclude_linked=True)
+        result_ids = {sr.entry.id for sr in out[seed]}
+        assert inbound not in result_ids
+
+    async def test_threshold_honored(
+        self, store: DuckDBStore, embedding_provider: ControlledEmbeddingProvider
+    ) -> None:
+        embedding_provider.register("base", _UNIT_A)
+        embedding_provider.register("aligned", _UNIT_A)
+        embedding_provider.register("orthogonal", _UNIT_B)
+        seed = await store.store(make_entry(content="base"))
+        aligned = await store.store(make_entry(content="aligned"))
+        orthogonal = await store.store(make_entry(content="orthogonal"))
+
+        # _UNIT_A vs _UNIT_B cosine = 0 -> normalized score 0.5; threshold 0.9
+        # keeps only the aligned (score 1.0) match.
+        out = await store.find_similar_by_ids([seed], threshold=0.9, limit=5, exclude_linked=False)
+        result_ids = {sr.entry.id for sr in out[seed]}
+        assert aligned in result_ids
+        assert orthogonal not in result_ids
+
+    async def test_limit_honored(
+        self, store: DuckDBStore, embedding_provider: ControlledEmbeddingProvider
+    ) -> None:
+        embedding_provider.register("hub", _UNIT_A)
+        seed = await store.store(make_entry(content="hub"))
+        for i in range(6):
+            text = f"match {i}"
+            embedding_provider.register(text, _UNIT_A)
+            await store.store(make_entry(content=text))
+
+        out = await store.find_similar_by_ids([seed], threshold=0.5, limit=3, exclude_linked=False)
+        assert len(out[seed]) == 3
+
+
+# ===========================================================================
+# Store: find_similar_by_id (single-seed convenience)
+# ===========================================================================
+
+
+class TestFindSimilarById:
+    async def test_returns_matches_for_existing_embedding(
+        self, store: DuckDBStore, embedding_provider: ControlledEmbeddingProvider
+    ) -> None:
+        embedding_provider.register("anchor", _UNIT_A)
+        embedding_provider.register("near", _UNIT_A)
+        anchor = await store.store(make_entry(content="anchor"))
+        near = await store.store(make_entry(content="near"))
+
+        results = await store.find_similar_by_id(anchor, threshold=0.5, limit=5)
+        assert results is not None
+        result_ids = {sr.entry.id for sr in results}
+        # NOTE: find_similar_by_id does NOT self-exclude (the handler does).
+        assert near in result_ids
+
+    async def test_returns_none_when_entry_missing(self, store: DuckDBStore) -> None:
+        results = await store.find_similar_by_id(
+            "00000000-0000-0000-0000-000000000000", threshold=0.5, limit=5
+        )
+        assert results is None
+
+
+# ===========================================================================
+# MCP handler: batch path
+# ===========================================================================
+
+
+class TestHandlerBatch:
+    async def test_payload_shape(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+        cfg: DistilleryConfig,
+    ) -> None:
+        embedding_provider.register("seedA", _UNIT_A)
+        embedding_provider.register("matchA", _UNIT_A)
+        seed = await store.store(make_entry(content="seedA"))
+        match = await store.store(make_entry(content="matchA"))
+
+        response = await _handle_find_similar(
+            store,
+            {"source_entry_ids": [seed], "threshold": 0.5, "limit": 5},
+            cfg=cfg,
+        )
+        data = parse_mcp_response(response)
+
+        assert "error" not in data, data
+        assert data["seed_count"] == 1
+        assert data["threshold"] == 0.5
+        assert seed in data["results_by_seed"]
+        seed_block = data["results_by_seed"][seed]
+        assert set(seed_block.keys()) == {"results", "count", "excluded_count"}
+        result_ids = {r["entry"]["id"] for r in seed_block["results"]}
+        assert match in result_ids
+        assert seed not in result_ids
+        # Each result carries score + entry dict.
+        for r in seed_block["results"]:
+            assert "score" in r and "entry" in r
+
+    async def test_batch_spends_no_embedding_budget(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+        cfg: DistilleryConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        embedding_provider.register("seedB", _UNIT_A)
+        seed = await store.store(make_entry(content="seedB"))
+
+        embed_calls = 0
+        original_embed = embedding_provider.embed
+
+        def _counting_embed(text: str) -> list[float]:
+            nonlocal embed_calls
+            embed_calls += 1
+            return original_embed(text)
+
+        monkeypatch.setattr(embedding_provider, "embed", _counting_embed)
+
+        record_calls = 0
+        original_record = store.record_embedding_usage
+
+        async def _counting_record(*args: object, **kwargs: object) -> int:
+            nonlocal record_calls
+            record_calls += 1
+            return await original_record(*args, **kwargs)
+
+        monkeypatch.setattr(store, "record_embedding_usage", _counting_record)
+
+        response = await _handle_find_similar(
+            store, {"source_entry_ids": [seed], "threshold": 0.5}, cfg=cfg
+        )
+        data = parse_mcp_response(response)
+
+        assert "error" not in data, data
+        assert embed_calls == 0, "batch mode must not re-embed"
+        assert record_calls == 0, "batch mode must not record embedding usage"
+
+    async def test_missing_seed_maps_to_empty_results(
+        self, store: DuckDBStore, cfg: DistilleryConfig
+    ) -> None:
+        missing = "00000000-0000-0000-0000-000000000000"
+        response = await _handle_find_similar(store, {"source_entry_ids": [missing]}, cfg=cfg)
+        data = parse_mcp_response(response)
+        assert "error" not in data, data
+        assert data["results_by_seed"][missing]["results"] == []
+        assert data["results_by_seed"][missing]["count"] == 0
+
+    async def test_exclude_linked_per_seed(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+        cfg: DistilleryConfig,
+    ) -> None:
+        embedding_provider.register("S", _UNIT_A)
+        embedding_provider.register("L", _UNIT_A)
+        embedding_provider.register("U", _UNIT_A)
+        seed = await store.store(make_entry(content="S"))
+        linked = await store.store(make_entry(content="L"))
+        unlinked = await store.store(make_entry(content="U"))
+        await store.add_relation(seed, linked, "link")
+
+        response = await _handle_find_similar(
+            store,
+            {"source_entry_ids": [seed], "exclude_linked": True, "threshold": 0.5},
+            cfg=cfg,
+        )
+        data = parse_mcp_response(response)
+        result_ids = {r["entry"]["id"] for r in data["results_by_seed"][seed]["results"]}
+        assert linked not in result_ids
+        assert unlinked in result_ids
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {"content": "x"},
+            {"source_entry_id": "abc"},
+            {"dedup_action": True},
+            {"conflict_check": True},
+            {"accept_action": "link"},
+            {"llm_responses": [{"entry_id": "x", "is_conflict": True}]},
+        ],
+    )
+    async def test_invalid_params_when_combined_with_embed_modes(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+        cfg: DistilleryConfig,
+        extra: dict[str, object],
+    ) -> None:
+        embedding_provider.register("seedC", _UNIT_A)
+        seed = await store.store(make_entry(content="seedC"))
+
+        response = await _handle_find_similar(store, {"source_entry_ids": [seed], **extra}, cfg=cfg)
+        data = parse_mcp_response(response)
+        assert data.get("error") is True
+        assert data["code"] == "INVALID_PARAMS"
+
+    async def test_invalid_params_empty_list(
+        self, store: DuckDBStore, cfg: DistilleryConfig
+    ) -> None:
+        response = await _handle_find_similar(store, {"source_entry_ids": []}, cfg=cfg)
+        data = parse_mcp_response(response)
+        assert data.get("error") is True
+        assert data["code"] == "INVALID_PARAMS"
+
+    async def test_invalid_params_too_many(self, store: DuckDBStore, cfg: DistilleryConfig) -> None:
+        ids = [f"id-{i}" for i in range(51)]
+        response = await _handle_find_similar(store, {"source_entry_ids": ids}, cfg=cfg)
+        data = parse_mcp_response(response)
+        assert data.get("error") is True
+        assert data["code"] == "INVALID_PARAMS"
+
+    async def test_invalid_params_non_string_member(
+        self, store: DuckDBStore, cfg: DistilleryConfig
+    ) -> None:
+        response = await _handle_find_similar(store, {"source_entry_ids": ["ok", ""]}, cfg=cfg)
+        data = parse_mcp_response(response)
+        assert data.get("error") is True
+        assert data["code"] == "INVALID_PARAMS"
+
+
+# ===========================================================================
+# MCP handler: single source_entry_id path now reuses the stored vector
+# ===========================================================================
+
+
+class TestHandlerSingleStoredVector:
+    async def test_single_source_entry_id_reuses_stored_vector_no_embed(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+        cfg: DistilleryConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        embedding_provider.register("single seed", _UNIT_A)
+        embedding_provider.register("single other", _UNIT_A)
+        seed = await store.store(make_entry(content="single seed"))
+        other = await store.store(make_entry(content="single other"))
+
+        record_calls = 0
+        original_record = store.record_embedding_usage
+
+        async def _counting_record(*args: object, **kwargs: object) -> int:
+            nonlocal record_calls
+            record_calls += 1
+            return await original_record(*args, **kwargs)
+
+        monkeypatch.setattr(store, "record_embedding_usage", _counting_record)
+
+        embed_calls = 0
+        original_embed = embedding_provider.embed
+
+        def _counting_embed(text: str) -> list[float]:
+            nonlocal embed_calls
+            embed_calls += 1
+            return original_embed(text)
+
+        monkeypatch.setattr(embedding_provider, "embed", _counting_embed)
+
+        response = await _handle_find_similar(
+            store,
+            {"source_entry_id": seed, "threshold": 0.5},
+            cfg=cfg,
+        )
+        data = parse_mcp_response(response)
+
+        assert "error" not in data, data
+        assert record_calls == 0, "single source_entry_id path must not spend budget"
+        assert embed_calls == 0, "single source_entry_id path must not re-embed"
+        result_ids = {r["entry"]["id"] for r in data["results"]}
+        assert seed not in result_ids, "source entry must be self-excluded"
+        assert other in result_ids
+
+    async def test_single_source_entry_id_still_excludes_linked(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+        cfg: DistilleryConfig,
+    ) -> None:
+        embedding_provider.register("anchor seed", _UNIT_A)
+        embedding_provider.register("linked target", _UNIT_A)
+        embedding_provider.register("free target", _UNIT_A)
+        seed = await store.store(make_entry(content="anchor seed"))
+        linked = await store.store(make_entry(content="linked target"))
+        free = await store.store(make_entry(content="free target"))
+        await store.add_relation(seed, linked, "link")
+
+        response = await _handle_find_similar(
+            store,
+            {"source_entry_id": seed, "exclude_linked": True, "threshold": 0.5},
+            cfg=cfg,
+        )
+        data = parse_mcp_response(response)
+
+        assert "error" not in data, data
+        result_ids = {r["entry"]["id"] for r in data["results"]}
+        assert linked not in result_ids
+        assert free in result_ids
+        assert seed not in result_ids
+        assert data["excluded_linked_count"] >= 1

--- a/tests/test_find_similar_batch.py
+++ b/tests/test_find_similar_batch.py
@@ -351,6 +351,41 @@ class TestHandlerBatch:
         assert data.get("error") is True
         assert data["code"] == "INVALID_PARAMS"
 
+    async def test_defaulted_booleans_do_not_trigger_conflict(
+        self,
+        store: DuckDBStore,
+        embedding_provider: ControlledEmbeddingProvider,
+        cfg: DistilleryConfig,
+    ) -> None:
+        # The server wrapper (distillery_find_similar) ALWAYS forwards
+        # dedup_action/conflict_check/exclude_linked with their defaults, even
+        # for a bare batch call. Those defaulted falses must NOT be read as
+        # combining embed modes — regression: every public batch call returned
+        # INVALID_PARAMS ("cannot be combined with conflict_check, dedup_action")
+        # because the handler used `arguments.get(p) is not None`.
+        embedding_provider.register("seedD", _UNIT_A)
+        embedding_provider.register("matchD", _UNIT_A)
+        seed = await store.store(make_entry(content="seedD"))
+        match = await store.store(make_entry(content="matchD"))
+
+        # Args exactly as src/distillery/mcp/server.py builds them for a bare
+        # distillery_find_similar(source_entry_ids=[...]) call.
+        args = {
+            "threshold": 0.5,
+            "limit": 5,
+            "dedup_action": False,
+            "conflict_check": False,
+            "exclude_linked": False,
+            "source_entry_ids": [seed],
+        }
+        response = await _handle_find_similar(store, args, cfg=cfg)
+        data = parse_mcp_response(response)
+
+        assert "error" not in data, data
+        assert data["seed_count"] == 1
+        result_ids = {r["entry"]["id"] for r in data["results_by_seed"][seed]["results"]}
+        assert match in result_ids
+
 
 # ===========================================================================
 # MCP handler: single source_entry_id path now reuses the stored vector


### PR DESCRIPTION
## Root cause

A Logfire trace of a real `/investigate` on the eng instance: **Phase 2b made 20 `distillery_find_similar` calls totaling 12.6s (70% of the 18.0s run)**. The httpx scope showed **27 Jina embeds** in the window = 7 searches + 20 `find_similar`, each re-embedding the seed entry's content (~628ms each) even though that seed already has a stored embedding vector. So Phase 2b paid for 20 redundant embeds and 20 separate MCP round-trips.

## Fix

Add a **server-side batch mode** to `distillery_find_similar` plus a single-seed stored-vector fast path:

- **Store** (`store/duckdb.py`): `_similar_from_embedding` (cosine query for a precomputed vector — archived excluded, same `[0,1]→[-1,1]` threshold conversion as `find_similar`), `find_similar_by_ids` (batch — ONE `_run_read` acquisition for all seeds; per-seed self-exclusion + linked exclusion via `entry_relations.from_id/to_id` either direction; over-fetch `limit+50` then filter then `[:limit]`), and `find_similar_by_id` (single-seed convenience, returns `None` when no stored embedding). All use the `conn` arg from `_run_read` (never `self.connection`).
- **Protocol** (`store/protocol.py`): matching async signatures + docstrings for mypy --strict.
- **MCP tool** (`mcp/tools/search.py` + `mcp/server.py`): new `source_entry_ids: list[str] | None` param. Batch path spends **zero** embedding budget (never calls `record_embedding_usage`), is standalone (rejects `content`/`source_entry_id`/`dedup_action`/`conflict_check`/`accept_action`/`llm_responses` with `INVALID_PARAMS`), validates non-empty strings, caps at 50. The existing single `source_entry_id` path (no content/dedup/conflict/accept) now reuses the stored vector via `find_similar_by_id` (skips the embed + budget spend) and falls back to the embed path when the entry has no stored embedding — self/linked exclusion + `excluded_linked_count` unchanged. `content`/`source_entry_id` embed paths otherwise behave exactly as before.
- **Skill** (`skills/investigate/SKILL.md`): Phase 2b now issues ONE batched `distillery_find_similar(source_entry_ids=[...top ≤20...], exclude_linked=True, threshold=0.7, limit=5)` call and iterates `results_by_seed`; removed the "bounded parallel batches of ~4" guidance (one call now — the 502-under-concurrency concern is moot).

New batch return shape:

```json
{"results_by_seed": {"<seed_id>": {"results": [{"score": 0.83, "entry": {...}}], "count": N, "excluded_count": X}},
 "seed_count": K, "threshold": 0.7}
```

(`excluded_count` is best-effort, reported as 0 in batch mode — see Acceptance note.)

## Acceptance

Gate (all clean):

```
$ uv run --extra dev ruff check src/ tests/        → All checks passed!
$ .venv/bin/mypy --strict src/distillery/           → Success: no issues found in 73 source files
$ uv run --extra dev pytest -q                       → 3171 passed, 98 skipped
```

New test module `tests/test_find_similar_batch.py` (24 cases) covers: keyed `results_by_seed` map; missing-embedding seed → `[]`; self-exclusion; `exclude_linked` (both directions); threshold + limit per seed; handler batch path spends **no** embed / no `record_embedding_usage`; `INVALID_PARAMS` for forbidden companions, empty list, >50; and the single `source_entry_id` path reusing the stored vector with self/linked exclusion intact.

Expected `/investigate` impact: Phase 2b **20 calls → 1**, **20 embeds → 0**.

## References

Closes the `find_similar` re-embed issue (Phase 2b paid for 20 redundant Jina embeds + 19 extra round-trips). Subsumes [#666](https://github.com/norrietaylor/distillery/pull/666) (stored-embedding reuse for the single-seed path) by also batching the multi-seed hot path.

### Deviations / notes
- `excluded_count` is reported as `0` in batch mode (documented best-effort): the store performs self/linked exclusion internally over the over-fetched window and returns only survivors, so the per-seed dropped-candidate count is not observable in the handler without changing the spec'd `dict[str, list[SearchResult]]` return type. The single-seed path still surfaces the exact `excluded_linked_count`.
- `entry_relations` columns verified against the real schema (`from_id`, `to_id`, `relation_type`) — the spec's SQL was correct, no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch similarity lookup via `source_entry_ids`, returning results grouped per seed in one request.
  * Introduced a faster similarity path that reuses stored vectors when possible (reduces extra work/round-trips).

* **Bug Fixes**
  * Improved behavior for seeds without stored embeddings by returning empty results (no errors).
  * Ensured linked entries can be excluded from similarity results when requested.

* **Tests**
  * Added unit tests covering batch and single-seed similarity responses, exclusion behavior, and invalid input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->