### PR TITLE
perf(skills): radar mines tags in one distillery_list call, not six

### DIFF
--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -80,10 +80,14 @@ proceed to 3b. Report: `Using <N> user-supplied topic(s): <comma-separated>.`
 
 *Path 2 — Namespace-diverse interest profile (default):*
 
-Build an interest profile that excludes feed-ingested content. Make separate
-`distillery_list(group_by="tags", entry_type=<type>)` calls for curated
-types: `session`, `reference`, `bookmark`, `idea`, `note`, and `minutes`.
-Merge the group counts across all responses to obtain a combined count map.
+Build an interest profile that excludes feed-ingested content. Make a single
+call that aggregates tag counts across all curated types at once:
+
+`distillery_list(group_by="tags", entry_type=["session", "reference", "bookmark", "idea", "minutes"])`
+
+The grouped counts come back already merged across the curated types in this
+one call (the `entry_type` list is OR-matched), so use the returned group
+counts directly as the combined count map — no client-side merging needed.
 
 Then select **5 namespace-diverse tags**, *not* the raw top-5 by count. A
 tag's namespace is its hierarchical path with the leaf segment removed,
@@ -149,7 +153,7 @@ This fallback applies only to Path 2 (auto-derived interest profile). If
 `--topic` was supplied, Step 3b always has at least one query and 3c is
 skipped.
 
-If none of the curated-type `group_by="tags"` calls return any tags, fall back to:
+If the curated-type `group_by="tags"` call returns no tags, fall back to:
 
 `distillery_list(entry_type="feed", limit=<limit>, output_mode="summary", published_after=<iso>, include_evergreen=<bool>, project=<name?>)`
 
@@ -159,7 +163,7 @@ other projects when the user explicitly scoped the request.
 
 Report: `Retrieved <total> entries via recent listing (fallback, window=<days>d).`
 
-If the curated-type `group_by="tags"` calls themselves error, treat that as an MCP error per the Rules section below — report and stop.
+If the curated-type `group_by="tags"` call itself errors, treat that as an MCP error per the Rules section below — report and stop.
 
 **3d. Empty results:**
 

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -800,7 +800,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     @server.tool
     async def distillery_list(  # noqa: PLR0913
         ctx: Context,
-        entry_type: str | None = None,
+        entry_type: str | list[str] | None = None,
         author: str | None = None,
         project: str | None = None,
         tags: list[str] | None = None,
@@ -836,7 +836,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         or ``include_archived=true`` to add archived entries to the default view.
 
         PARAMS:
-          - entry_type (str, optional): Filter by type. Valid: [session, bookmark, minutes,
+          - entry_type (str | list[str], optional): Filter by type, or a list of types
+            matched with OR (e.g. ["session", "reference"]) — pair with group_by to
+            aggregate across several types in one call. Valid: [session, bookmark, minutes,
             meeting, reference, idea, inbox, github, person, project, digest, feed].
           - author (str, optional): Filter by author.
           - project (str, optional): Filter by project scope.

--- a/src/distillery/mcp/tools/crud.py
+++ b/src/distillery/mcp/tools/crud.py
@@ -1703,6 +1703,13 @@ async def _handle_list(
 
     filters = _build_filters_from_arguments(arguments)
 
+    # ``entry_type`` accepts a single type or a list of types (OR-matched via
+    # the store's IN-clause).  Reject an explicitly empty list at the handler
+    # so it surfaces as INVALID_PARAMS rather than an opaque INTERNAL from the
+    # store-level guard (mirrors the empty-``status``-list behaviour).
+    if filters is not None and filters.get("entry_type") == []:
+        return error_response("INVALID_PARAMS", "entry_type filter list must not be empty")
+
     # review mode implicitly filters to pending_review status (takes precedence
     # over any default/visible-status logic).
     if output_mode == "review":

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2345,6 +2345,8 @@ class DuckDBStore:
         if "entry_type" in filters:
             val = filters["entry_type"]
             if isinstance(val, list):
+                if not val:
+                    raise ValueError("entry_type filter list must not be empty")
                 placeholders = ", ".join("?" for _ in val)
                 clauses.append(f"entry_type IN ({placeholders})")
                 params.extend(str(v) for v in val)

--- a/tests/test_mcp_tools/test_list_extensions.py
+++ b/tests/test_mcp_tools/test_list_extensions.py
@@ -734,13 +734,17 @@ class TestEntryTypeList:
         returned_types = {e["entry_type"] for e in data["entries"]}
         assert returned_types == {"session"}
 
-    @pytest.mark.unit
-    async def test_empty_entry_type_list_returns_error(self, store: Any) -> None:
-        result = await _handle_list(
-            store=store,
-            arguments={"entry_type": [], "limit": 50},
-        )
-        data = parse_mcp_response(result)
-        assert data["error"] is True
-        assert data["code"] == "INVALID_PARAMS"
-        assert "entry_type" in data["message"]
+
+# Kept out of the integration-marked TestEntryTypeList (uses the bare ``store``
+# fixture, no mixed-type data) so it carries a single ``unit`` marker rather than
+# being double-selected by both ``-m unit`` and ``-m integration``.
+@pytest.mark.unit
+async def test_empty_entry_type_list_returns_error(store: Any) -> None:
+    result = await _handle_list(
+        store=store,
+        arguments={"entry_type": [], "limit": 50},
+    )
+    data = parse_mcp_response(result)
+    assert data["error"] is True
+    assert data["code"] == "INVALID_PARAMS"
+    assert "entry_type" in data["message"]

--- a/tests/test_mcp_tools/test_list_extensions.py
+++ b/tests/test_mcp_tools/test_list_extensions.py
@@ -661,3 +661,86 @@ class TestMutualExclusivity:
         )
         data = parse_mcp_response(result)
         assert not data.get("error")
+
+
+# ---------------------------------------------------------------------------
+# entry_type as a list (OR / IN-clause) — radar single-aggregate path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def store_with_mixed_types(store: Any) -> Any:  # type: ignore[return]
+    """Store with one entry per curated type plus an excluded ``inbox`` entry.
+
+    Curated (mined by /radar): session, reference, bookmark, idea, minutes.
+    The non-curated ``inbox`` entry must never appear when filtering by the
+    curated list (proves the IN-clause excludes other types).
+    """
+    entries = [
+        make_entry(content="s", entry_type=EntryType.SESSION, tags=["alpha"]),
+        make_entry(content="r", entry_type=EntryType.REFERENCE, tags=["alpha", "beta"]),
+        make_entry(content="b", entry_type=EntryType.BOOKMARK, tags=["beta"]),
+        make_entry(content="i", entry_type=EntryType.IDEA, tags=["gamma"]),
+        make_entry(content="m", entry_type=EntryType.MINUTES, tags=["alpha"]),
+        make_entry(content="x", entry_type=EntryType.INBOX, tags=["alpha", "beta", "gamma"]),
+    ]
+    for e in entries:
+        await store.store(e)
+    return store
+
+
+@pytest.mark.integration
+class TestEntryTypeList:
+    async def test_entry_type_list_or_match(self, store_with_mixed_types: Any) -> None:
+        """A list of entry_types matches entries of EITHER type (OR / IN-clause)."""
+        result = await _handle_list(
+            store=store_with_mixed_types,
+            arguments={"entry_type": ["session", "reference"], "limit": 50},
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error")
+        returned_types = {e["entry_type"] for e in data["entries"]}
+        assert returned_types == {"session", "reference"}
+
+    async def test_group_by_tags_aggregates_across_type_list(
+        self, store_with_mixed_types: Any
+    ) -> None:
+        """group_by=tags with an entry_type list merges counts across types in one call."""
+        result = await _handle_list(
+            store=store_with_mixed_types,
+            arguments={
+                "group_by": "tags",
+                "entry_type": ["session", "reference", "bookmark", "idea", "minutes"],
+                "limit": 50,
+            },
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error")
+        by_tag = {g["value"]: g["count"] for g in data["groups"]}
+        # alpha: session + reference + minutes = 3; beta: reference + bookmark = 2;
+        # gamma: idea = 1.  The inbox entry (alpha/beta/gamma) is excluded.
+        assert by_tag.get("alpha") == 3
+        assert by_tag.get("beta") == 2
+        assert by_tag.get("gamma") == 1
+
+    async def test_single_string_entry_type_still_works(self, store_with_mixed_types: Any) -> None:
+        """Backward compat: a plain string entry_type filters to that one type."""
+        result = await _handle_list(
+            store=store_with_mixed_types,
+            arguments={"entry_type": "session", "limit": 50},
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error")
+        returned_types = {e["entry_type"] for e in data["entries"]}
+        assert returned_types == {"session"}
+
+    @pytest.mark.unit
+    async def test_empty_entry_type_list_returns_error(self, store: Any) -> None:
+        result = await _handle_list(
+            store=store,
+            arguments={"entry_type": [], "limit": 50},
+        )
+        data = parse_mcp_response(result)
+        assert data["error"] is True
+        assert data["code"] == "INVALID_PARAMS"
+        assert "entry_type" in data["message"]


### PR DESCRIPTION
## Root cause

`/radar` Path 2 (auto-derived interest profile) built its tag-count map by making **six** separate `distillery_list(group_by="tags", entry_type=<type>)` calls — one per curated type (`session`, `reference`, `bookmark`, `idea`, `note`, `minutes`) — and merging the group counts client-side. That's 6 list round-trips (~6 model turns) for a single aggregation.

## Fix

- **server.py** — widen `distillery_list`'s `entry_type` param from `str | None` to `str | list[str] | None`. A list is OR-matched (IN-clause); docstring updated to note pairing with `group_by` to aggregate across types in one call.
- **store/duckdb.py** — the `entry_type IN (...)` branch already existed; added an empty-list guard (`raise ValueError(...)`) mirroring the existing `status` guard.
- **handler (crud.py)** — `_handle_list` already forwards `entry_type` to store filters as-is (no str coercion). Added a handler-level empty-list check so an empty `entry_type` list surfaces as `INVALID_PARAMS` rather than an opaque `INTERNAL`.
- **skills/radar/SKILL.md** — Step 3a Path 2 now issues a single call:
  `distillery_list(group_by="tags", entry_type=["session", "reference", "bookmark", "idea", "minutes"])`
  Grouped counts come back already merged across the curated types. Downstream Step 3c/Rules wording updated from plural "calls" to singular "call". Namespace-diverse selection logic unchanged. (Note: the old list included `note`, which is not a valid `entry_type`; the new list uses the 5 valid curated types as specified.)
- **tests** — new `TestEntryTypeList` in `tests/test_mcp_tools/test_list_extensions.py`: list OR-match, `group_by="tags"` aggregation across a type list in one response, single-string backward compat, and empty-list → `INVALID_PARAMS`.

## Acceptance

- `ruff check src/ tests/` — All checks passed
- `ruff format --check` (changed files) — test file + duckdb.py clean (pre-existing drift in server.py/crud.py left untouched per surgical-diff policy)
- `pytest` — 3176 passed, 98 skipped
- `mypy --strict src/distillery/` (dev-only sync, CI parity) — Success, no issues in 73 files
- radar tag-mine: **6 calls → 1**

## References

Supersedes [#667](https://github.com/norrietaylor/distillery/pull/667).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filtering now supports providing multiple entry types in a single request, with results aggregated by tags across those types.
  * Radar interest-profile logic now uses a single aggregated tag-count lookup for improved consistency.

* **Bug Fixes**
  * Empty entry-type lists are now rejected with a clear validation error.
  * Tag-based fallback behavior is more precise when no tags are returned or when the curated tag query errors.

* **Tests**
  * Added coverage for multi-type filtering, tag aggregation, and invalid empty-list parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->