### PR TITLE
perf(store): take list_entries and aggregate_entries off the writer lock

### DIFF
--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -3009,9 +3009,7 @@ class DuckDBStore:
             return await self._get_entry_stats(filters, stale_days=stale_days)
 
         # ----- default list mode -----
-        def _sync() -> list[Entry]:
-            conn = self.connection
-
+        def _sync(conn: Any) -> list[Entry]:
             where_clauses, params = self._build_filter_clauses(filters)
 
             if stale_days is not None:
@@ -3038,7 +3036,10 @@ class DuckDBStore:
             rows = result.fetchall()
             return [self._row_to_entry(row, col_names) for row in rows]
 
-        return await self._run_sync(_sync)
+        # Read-only SELECT routed via the independent read handle so a list
+        # never queues behind a slow write on ``_conn_lock`` (the #670
+        # contention class). ``accessed_at`` is only a stale-filter WHERE clause.
+        return await self._run_read(_sync)
 
     async def _get_entry_stats(
         self,
@@ -3054,9 +3055,7 @@ class DuckDBStore:
         if stale_days is not None and stale_days < 0:
             raise ValueError("stale_days must be non-negative")
 
-        def _sync() -> dict[str, Any]:
-            conn = self.connection
-
+        def _sync(conn: Any) -> dict[str, Any]:
             where_clauses, params = self._build_filter_clauses(filters)
 
             if stale_days is not None:
@@ -3113,7 +3112,10 @@ class DuckDBStore:
                 "storage_bytes": storage_bytes,
             }
 
-        return await self._run_sync(_sync)
+        # Read-only aggregate routed via the independent read handle so the
+        # ``output="stats"`` path of ``list_entries`` never queues behind a
+        # write on ``_conn_lock`` (the #670 contention class).
+        return await self._run_read(_sync)
 
     async def count_entries(
         self,
@@ -3183,8 +3185,7 @@ class DuckDBStore:
             raise ValueError("stale_days must be non-negative")
         group_expr = _AGGREGATE_EXPR_MAP[group_by]
 
-        def _sync() -> dict[str, Any]:
-            conn = self.connection
+        def _sync(conn: Any) -> dict[str, Any]:
             where_clauses, params = self._build_filter_clauses(filters)
             if stale_days is not None:
                 where_clauses.append(
@@ -3266,7 +3267,10 @@ class DuckDBStore:
                 "total_entries": total_entries,
             }
 
-        return await self._run_sync(_sync)
+        # Read-only grouped aggregate routed via the independent read handle so
+        # it never queues behind a write on ``_conn_lock`` (the #670 contention
+        # class). ``accessed_at`` is only a stale-filter WHERE clause.
+        return await self._run_read(_sync)
 
     # ------------------------------------------------------------------
     # Audit logging

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -1897,7 +1897,10 @@ class TestConnectionLockSerialization:
         await s.initialize()
         # ``initialize`` does not go through ``_run_sync`` so lock is still None.
         assert s._conn_lock is None  # noqa: SLF001
-        await s.list_entries(filters=None, limit=1, offset=0)
+        # ``list_entries`` now runs on the read handle (``_run_read``), so it no
+        # longer arms ``_conn_lock``; use a write (``store``) to trigger the
+        # first ``_run_sync`` call.
+        await s.store(make_entry(content="lazy-lock trigger"))
         assert s._conn_lock is not None  # noqa: SLF001
         await s.close()
 
@@ -1984,6 +1987,57 @@ class TestStatusStaysResponsiveUnderWriteContention:
             await asyncio.wait_for(_status(), timeout=2.0)
             elapsed = asyncio.get_event_loop().time() - start
             assert elapsed < 1.0, f"status probes took {elapsed:.3f}s under write load"
+
+            await asyncio.gather(*writers)
+        finally:
+            await store.close()
+
+    async def test_list_and_aggregate_respond_while_writes_are_in_flight(self) -> None:
+        """list_entries / aggregate_entries answer in <1s under write load.
+
+        Regression for taking ``list_entries`` (default-list + ``output="stats"``
+        paths) and ``aggregate_entries`` off the single writer lock: they now run
+        on the independent read handle via ``_run_read`` instead of ``_run_sync``
+        (the #670 contention class).  Seed the store, fire concurrent
+        embedding-bound writes (500ms/embed) that hold the writer, then assert the
+        reads complete quickly *and* return correct results.
+        """
+        import asyncio
+
+        provider = _SlowEmbeddingProvider(delay=0.5)
+        store = DuckDBStore(db_path=":memory:", embedding_provider=provider)
+        await store.initialize()
+        try:
+            # Seed 5 entries before the contention so the reads have data.
+            for i in range(5):
+                await store.store(make_entry(content=f"seed {i}"))
+
+            # Fire 10 embedding-bound writes; each holds a worker for ~500ms.
+            writers = [
+                asyncio.create_task(store.store(make_entry(content=f"slow write {i}")))
+                for i in range(10)
+            ]
+            # Give the writers a moment to start embedding off-thread.
+            await asyncio.sleep(0.05)
+
+            async def _reads() -> None:
+                # Default list mode.
+                entries = await store.list_entries(filters=None, limit=100, offset=0)
+                assert len(entries) == 5
+                # Stats mode (delegates to _get_entry_stats).
+                stats = await store.list_entries(filters=None, limit=100, offset=0, output="stats")
+                assert isinstance(stats, dict)
+                assert stats["total_entries"] == 5
+                # group_by mode (delegates to aggregate_entries).
+                grouped = await store.aggregate_entries(
+                    group_by="entry_type", filters=None, limit=10
+                )
+                assert grouped["total_entries"] == 5
+
+            start = asyncio.get_event_loop().time()
+            await asyncio.wait_for(_reads(), timeout=2.0)
+            elapsed = asyncio.get_event_loop().time() - start
+            assert elapsed < 1.0, f"list/aggregate reads took {elapsed:.3f}s under write load"
 
             await asyncio.gather(*writers)
         finally:

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -2021,18 +2021,25 @@ class TestStatusStaysResponsiveUnderWriteContention:
             await asyncio.sleep(0.05)
 
             async def _reads() -> None:
+                # Counts are race-tolerant (>= 5, <= 15): now that these reads run
+                # on the independent read handle, they can legitimately observe any
+                # of the 10 in-flight writes that have already committed — the three
+                # reads sample at different instants, so an exact count is racy. The
+                # regression guard is the <1s latency assertion below (reads must not
+                # queue behind the writer lock); the counts just confirm the reads
+                # return the seeded rows and a coherent result.
                 # Default list mode.
                 entries = await store.list_entries(filters=None, limit=100, offset=0)
-                assert len(entries) == 5
+                assert 5 <= len(entries) <= 15
                 # Stats mode (delegates to _get_entry_stats).
                 stats = await store.list_entries(filters=None, limit=100, offset=0, output="stats")
                 assert isinstance(stats, dict)
-                assert stats["total_entries"] == 5
+                assert 5 <= stats["total_entries"] <= 15
                 # group_by mode (delegates to aggregate_entries).
                 grouped = await store.aggregate_entries(
                     group_by="entry_type", filters=None, limit=10
                 )
-                assert grouped["total_entries"] == 5
+                assert 5 <= grouped["total_entries"] <= 15
 
             start = asyncio.get_event_loop().time()
             await asyncio.wait_for(_reads(), timeout=2.0)


### PR DESCRIPTION
## Root cause

`list_entries` (the default-list path and the `output="stats"` path, which
delegates to `_get_entry_stats`) and `aggregate_entries` ran via `_run_sync`,
which holds `_conn_lock` — the single **writer** lock on the write connection.
Under the 79-source feed poll holding the writer, every list/aggregate read
queues behind it. This is the exact contention class [#670](https://github.com/norrietaylor/distillery/pull/670)
already removed for `get` / `search` / `find_similar`.

## Fix

Route these reads via `_run_read` on the **independent read handle**
(`_read_conn`, its own `_read_lock`), so the SELECTs never queue behind a write:

- Each inner `_sync` closure now takes the `conn` it is given (`def _sync(conn: Any)`)
  instead of `conn = self.connection`. Touching the write connection off
  `_conn_lock` from a worker thread is the [#416](https://github.com/norrietaylor/distillery/issues/416)
  heap-corruption hazard — avoided.
- Each `return await self._run_sync(_sync)` → `return await self._run_read(_sync)`.

The three converted closures are **read-only** (SELECT / COUNT / grouped
aggregate only — no `UPDATE`/`INSERT`/`_mark_accessed`/`record_*`/`_checkpoint_after_write`).
The `accessed_at` references are read-only `WHERE COALESCE(accessed_at, updated_at) < ...`
stale-filter clauses. No write was moved onto the read handle.

Converted (list_entries ×2 + aggregate_entries):
1. `list_entries` default-list `_sync` (the paginated `SELECT … ORDER BY created_at`).
2. `_get_entry_stats` `_sync` (the `output="stats"` path of `list_entries`).
3. `aggregate_entries` `_sync` (the `group_by` path; scalar + tags CTE).

The filter-builder helpers (`_build_filter_clauses`) are pure Python — no `conn` — so they are unchanged.

## Tests

- Existing list/aggregate tests pass unchanged.
- Updated `test_lock_lazy_initialized_on_first_use`: it used `list_entries` as a
  proxy for "first `_run_sync` call"; since `list_entries` is now a read path it
  no longer arms `_conn_lock`, so the test now triggers via a write (`store`).
- Added `test_list_and_aggregate_respond_while_writes_are_in_flight`, mirroring
  the #558/#670 harness (`_SlowEmbeddingProvider`, 500ms/embed): seed entries,
  fire 10 concurrent embedding-bound writes holding the writer, then assert
  `list_entries` (default + stats) and `aggregate_entries` all complete in <1s
  and return correct results.

## Acceptance / gate

- `ruff check src/ tests/` — All checks passed
- `ruff format --check` (changed files) — 2 files already formatted
- `pytest` — 3173 passed, 98 skipped
- `mypy --strict src/distillery/` (CI parity: `[dev]` only) — Success, no issues in 73 files

Benefits `/briefing` (a read dashboard doing ~11 list + relations + search calls),
`/radar`, `/digest`, and investigate Phase 3 — these now read off the independent
handle instead of queueing behind the feed-poll writer.

## References

- [#670](https://github.com/norrietaylor/distillery/pull/670) — same pattern (get/search/find_similar off the writer lock)
- [#416](https://github.com/norrietaylor/distillery/issues/416) — heap-corruption hazard avoided (worker uses passed `conn`)
- Foundation for the briefing optimization.

**Do NOT merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness for browsing entries while write operations are in progress.
  * List views, stats views, and grouped summaries now run on a separate read path and no longer wait behind ongoing writes.
  * Confirmed that entry counts and aggregated results remain correct during concurrent writes.
* **Tests**
  * Updated and added integration coverage to ensure reads complete quickly under write contention and return race-tolerant totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->