### PR TITLE
feat(search): distillery_search entry_type accepts str | list[str]

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -937,7 +937,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
     async def distillery_search(  # noqa: PLR0913
         ctx: Context,
         query: str,
-        entry_type: str | None = None,
+        entry_type: str | list[str] | None = None,
         author: str | None = None,
         project: str | None = None,
         tags: list[str] | None = None,
@@ -979,7 +979,8 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
 
         PARAMS:
           - query (str, required): Natural-language search query.
-          - entry_type (str, optional): Filter by type.
+          - entry_type (str | list[str], optional): Filter by type, or a list of
+            types matched with OR (e.g. ["session", "reference"]).
           - author (str, optional): Filter by author.
           - project (str, optional): Filter by project scope.
           - tags (list[str], optional): Filter by tags (AND match).

--- a/src/distillery/mcp/tools/search.py
+++ b/src/distillery/mcp/tools/search.py
@@ -123,7 +123,8 @@ async def _handle_search(
     Parameters:
         store: Initialised :class:`~distillery.store.duckdb.DuckDBStore`.
         arguments: Dictionary containing at minimum the key `query` (str). May include
-            optional filter keys (e.g., `entry_type`, `author`, `project`, `tags`,
+            optional filter keys (e.g., `entry_type` — a single type str or a
+            list of types matched with OR, `author`, `project`, `tags`,
             `status`, `date_from`, `date_to`), `limit` (int), the additive
             graph-expansion params `expand_graph` (bool) and `expand_hops` (int, 1 or 2),
             and `output_mode` (str: "summary" | "full" | "ids", default "summary").
@@ -186,6 +187,14 @@ async def _handle_search(
             return error_response("BUDGET_EXCEEDED", "Embedding budget exceeded")
 
     filters = _build_filters_from_arguments(arguments)
+
+    # ``entry_type`` accepts a single type or a list of types (OR-matched via
+    # the store's IN-clause).  Reject an explicitly empty list here so it
+    # surfaces as INVALID_PARAMS rather than an opaque INTERNAL from the
+    # store-level guard (mirrors ``_handle_list``).
+    if filters is not None and filters.get("entry_type") == []:
+        return error_response("INVALID_PARAMS", "entry_type filter list must not be empty")
+
     filter_result = _apply_default_status_filter(filters, arguments)
     if isinstance(filter_result, list):
         # Error response from status-filter validation.

--- a/tests/test_mcp_tools/test_search_entry_type_list.py
+++ b/tests/test_mcp_tools/test_search_entry_type_list.py
@@ -1,0 +1,109 @@
+"""Tests for ``distillery_search`` ``entry_type`` list support.
+
+``_handle_search`` now accepts ``entry_type`` as either a single type string or
+a list of types matched with OR (the store's IN-clause).  This mirrors the
+``distillery_list`` precedent (PR #674) and unblocks /pour Pass 1a, which passes
+a curated list of types to ``distillery_search``.
+
+These tests exercise ``_handle_search`` directly against the shared in-memory
+``store`` fixture (hash-based embeddings — every stored entry is an
+unthresholded candidate, so the assertions are about which *types* survive the
+filter, not ranking).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from distillery.mcp.tools.search import _handle_search
+from distillery.models import EntryType
+from tests.conftest import make_entry, parse_mcp_response
+
+
+@pytest.fixture
+async def store_with_mixed_types(store: Any) -> Any:  # type: ignore[return]
+    """Store with one entry per curated type plus an excluded ``inbox`` entry.
+
+    Curated (mined by /pour Pass 1a): session, reference, bookmark, idea,
+    minutes.  The non-curated ``inbox`` entry must never appear when filtering
+    by the curated list (proves the IN-clause excludes other types).
+    """
+    entries = [
+        make_entry(content="s", entry_type=EntryType.SESSION),
+        make_entry(content="r", entry_type=EntryType.REFERENCE),
+        make_entry(content="b", entry_type=EntryType.BOOKMARK),
+        make_entry(content="i", entry_type=EntryType.IDEA),
+        make_entry(content="m", entry_type=EntryType.MINUTES),
+        make_entry(content="x", entry_type=EntryType.INBOX),
+    ]
+    for e in entries:
+        await store.store(e)
+    return store
+
+
+@pytest.mark.integration
+class TestSearchEntryTypeList:
+    async def test_entry_type_list_or_match(self, store_with_mixed_types: Any) -> None:
+        """A list of entry_types matches entries of EITHER type (OR / IN-clause)."""
+        result = await _handle_search(
+            store=store_with_mixed_types,
+            arguments={
+                "query": "anything",
+                "entry_type": ["session", "reference"],
+                "limit": 50,
+                "output_mode": "full",
+            },
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error")
+        returned_types = {hit["entry"]["entry_type"] for hit in data["results"]}
+        assert returned_types == {"session", "reference"}
+
+    async def test_curated_list_excludes_other_types(self, store_with_mixed_types: Any) -> None:
+        """The full curated /pour list returns only those types, never inbox."""
+        result = await _handle_search(
+            store=store_with_mixed_types,
+            arguments={
+                "query": "anything",
+                "entry_type": ["session", "bookmark", "minutes", "reference", "idea"],
+                "limit": 50,
+                "output_mode": "full",
+            },
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error")
+        returned_types = {hit["entry"]["entry_type"] for hit in data["results"]}
+        assert returned_types == {"session", "bookmark", "minutes", "reference", "idea"}
+        assert "inbox" not in returned_types
+
+    async def test_single_string_entry_type_still_works(self, store_with_mixed_types: Any) -> None:
+        """Backward compat: a plain string entry_type filters to that one type."""
+        result = await _handle_search(
+            store=store_with_mixed_types,
+            arguments={
+                "query": "anything",
+                "entry_type": "session",
+                "limit": 50,
+                "output_mode": "full",
+            },
+        )
+        data = parse_mcp_response(result)
+        assert not data.get("error")
+        returned_types = {hit["entry"]["entry_type"] for hit in data["results"]}
+        assert returned_types == {"session"}
+
+
+# Kept out of the integration-marked TestSearchEntryTypeList (uses the bare
+# ``store`` fixture, no mixed-type data) so it carries a single ``unit`` marker
+# rather than being double-selected by both ``-m unit`` and ``-m integration``.
+@pytest.mark.unit
+async def test_empty_entry_type_list_returns_error(store: Any) -> None:
+    result = await _handle_search(
+        store=store,
+        arguments={"query": "anything", "entry_type": [], "limit": 50},
+    )
+    data = parse_mcp_response(result)
+    assert data["error"] is True
+    assert data["code"] == "INVALID_PARAMS"


### PR DESCRIPTION
## Root cause

`/pour` Pass 1a calls `distillery_search(entry_type=["session","bookmark","minutes","reference","idea","digest"])`, but `distillery_search`'s `entry_type` param was typed `str | None`. The list was mangled by the str-only contract, so curated multi-type search silently degraded to a single type (or failed to match cleanly).

## Fix

- **server.py** — widen `distillery_search(entry_type=...)` from `str | None` → `str | list[str] | None`; update the docstring to note the list-of-types OR semantics (mirrors `distillery_list`).
- **`_handle_search`** — `_build_filters_from_arguments` already passes `entry_type` through as-is (a list stays a list), so the list flows straight to the store filter. Added the same empty-list → `INVALID_PARAMS` guard `distillery_list`'s handler uses, so an explicit `entry_type=[]` surfaces cleanly instead of as an opaque `INTERNAL` from the store-level `ValueError`.
- **store** — no change needed. `store.search` builds its WHERE via `_build_filter_clauses`, which already handles `entry_type` as `str | list[str]` (IN-clause) with an empty-list guard from [#674](https://github.com/norrietaylor/distillery/pull/674). Verified the hybrid BM25 path uses the same `where_sql`.

## Acceptance

All gate steps clean:

- `ruff check src/ tests/` → All checks passed
- `ruff format --check` (new test file) → already formatted (pre-existing drift in server.py/search.py left untouched per surgical-diff policy; verified those diffs exist on `origin/main`)
- `pytest -q` → 3181 passed, 98 skipped
- `mypy --strict src/distillery/` (CI parity: `[dev]` only) → Success: no issues found in 73 source files

New tests in `tests/test_mcp_tools/test_search_entry_type_list.py`: list-of-types OR match, the full curated `/pour` list excludes other types, single-string backward compat, empty list → `INVALID_PARAMS`.

`skills/pour/SKILL.md` already specifies the list (line 54) and needs no change — it works as-is now that the param is widened.

## References

- Mirrors [#674](https://github.com/norrietaylor/distillery/pull/674) (same widening for `distillery_list`).
- Fixes the `/pour` curated multi-type search follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search filtering now accepts multiple entry types at once, matching results for any selected type.
  * Single-type filtering continues to work as before.

* **Bug Fixes**
  * Empty entry-type filter lists are now rejected with a clear invalid-parameters error.
  * Search results now more consistently respect the selected type filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->