### PR TITLE
feat(relations): graph-health metrics + surface in /briefing and /radar (#653)

### DIFF
--- a/skills/briefing/SKILL.md
+++ b/skills/briefing/SKILL.md
@@ -141,6 +141,14 @@ distillery_list(status="pending_review", limit=5, output_mode="full")
 
 Returns entries awaiting classification. If this call fails or returns nothing, omit the Pending Review section.
 
+**4j. Graph health (non-fatal, both modes):**
+
+```python
+distillery_relations(action="metrics", metric="health", scope="global", project=<project>)
+```
+
+Returns a consolidated graph-health snapshot for the project's relations subgraph. Record `orphan_rate`, `edge_count`, `graph_node_count`, `total_entries`, `mean_degree`, `connected_component_count`, and `largest_component_fraction`. If the call returns an `INTERNAL` error whose message contains `"NetworkX not installed"`, or fails for any other reason, omit the Graph Health section and continue (non-fatal). A high `orphan_rate` (→ 1.0) means most entries are unlinked; the goal is to see it trend down over time.
+
 ### Step 5: Synthesize Briefing
 
 Produce the briefing in markdown. Omit any section entirely if it has no data.
@@ -293,6 +301,14 @@ Generated: 2026-04-08 09:15 UTC
 ## Unresolved
 
 - [SESSION] Spike: evaluate pgvector as an alternative to DuckDB… — 5 days ago
+
+---
+
+## Graph Health
+
+- Orphan rate: 41.2% (1,902 of 3,242 entries unlinked) — trending down is the goal
+- Edges: 4,317 across 1,340 linked nodes — mean degree 6.4
+- Components: 12 (largest holds 94% of linked nodes)
 ```
 
 Team mode appends these additional sections after the solo sections (`/briefing --team` or auto-detected when >1 author):
@@ -343,6 +359,7 @@ Generated: 2026-04-08 09:15 UTC
 - Corrections section uses `distillery_relations(action="get", relation_type="corrects")` — failure is non-fatal
 - Stale knowledge failure is non-fatal — omit the section and continue
 - Unresolved failure is non-fatal — omit the section and continue
+- Graph Health uses `distillery_relations(action="metrics", metric="health")` — failure (incl. `NetworkX not installed`) is non-fatal; omit the section and continue. Render `orphan_rate` as a percentage; the line should frame the trend goal (orphan rate ↓)
 - Team mode is activated by `--team` flag or auto-detected: `distillery_list(group_by="author", project=<project>)` returning >1 author group
 - Header shows `(solo)` or `(team)` based on detected mode
 - Team sections (6, 7, 8) are additive — solo sections are always rendered unchanged

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -229,6 +229,16 @@ inline in the rendered output via the heading.
 
 **Optional stale flag:** For each community, if `updated_at` is available on every member and EVERY member has `updated_at < now - 60 days`, mark the community with a `[stale]` tag in its line. Skip the stale check silently if `updated_at` is not available without an extra fetch.
 
+**6d. Graph health:**
+
+Call `distillery_relations(action="metrics", metric="health", scope="global", limit=1)`. If `--project` was specified, also pass `project=<name>`.
+
+If 6b already emitted the `pip install distillery-mcp[graph]` note (NetworkX missing), skip this subsection. On success, render a one-line summary at the **top** of the Knowledge Structure section (above Orphans) so the reader sees the overall shape before the detail:
+
+`Graph health: orphan rate <orphan_rate as %>, <edge_count> edges over <graph_node_count>/<total_entries> nodes, mean degree <mean_degree>, <connected_component_count> components (largest <largest_component_fraction as %>).`
+
+Frame the goal inline: a falling `orphan_rate` and a `largest_component_fraction` approaching 1.0 indicate a consolidating, traversable graph.
+
 ### Step 7: Check for Duplicates (if --store specified)
 
 If `--store` was specified, check for duplicate digests before storing.

--- a/src/distillery/graph/metrics.py
+++ b/src/distillery/graph/metrics.py
@@ -106,3 +106,50 @@ def link_prediction(
         ebunch = None
     ranked = sorted(nx.adamic_adar_index(undirected, ebunch), key=lambda t: t[2], reverse=True)
     return [(u, v, float(p)) for u, v, p in ranked[:k]]
+
+
+def mean_degree(g: Any) -> float:
+    """Mean node degree on the undirected projection (``2·|E| / |V|``).
+
+    A graph-health signal: how densely connected the average node is. Computed
+    on the undirected projection so reciprocal directed edges collapse to one,
+    matching the other structural metrics in this module. Guards an empty graph
+    -> ``0.0``.
+    """
+    _require_networkx()
+    n = int(g.number_of_nodes())
+    if n == 0:
+        return 0.0
+    undirected = g.to_undirected() if g.is_directed() else g
+    return 2.0 * int(undirected.number_of_edges()) / n
+
+
+def connected_component_count(g: Any) -> int:
+    """Number of connected components on the undirected projection.
+
+    A graph-health signal: a fragmented graph has many small components; a
+    healthy one consolidates toward few large components. Guards an empty graph
+    -> ``0``.
+    """
+    _require_networkx()
+    if int(g.number_of_nodes()) == 0:
+        return 0
+    undirected = g.to_undirected() if g.is_directed() else g
+    return int(nx.number_connected_components(undirected))
+
+
+def largest_component_fraction(g: Any) -> float:
+    """Fraction of nodes in the largest connected component (``[0, 1]``).
+
+    A graph-health signal paired with ``connected_component_count``: a value
+    near 1 means most linked entries form a single giant component (good for
+    traversal); a low value means the graph is shattered into islands. Computed
+    on the undirected projection. Guards an empty graph -> ``0.0``.
+    """
+    _require_networkx()
+    n = int(g.number_of_nodes())
+    if n == 0:
+        return 0.0
+    undirected = g.to_undirected() if g.is_directed() else g
+    largest = max((len(c) for c in nx.connected_components(undirected)), default=0)
+    return largest / n

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1391,7 +1391,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
           - relation_id (str, required for remove): UUID of the relation to delete.
           - hops (int, optional for traverse, default=2): BFS depth, capped at [1, 3].
           - metric (str, required for metrics): Graph metric to compute.
-            Valid: [bridges, communities, constraint, link_prediction, orphans].
+            Valid: [bridges, communities, constraint, link_prediction, orphans, health].
             Requires the [graph] optional extra.
           - scope (str, optional for metrics, default="global"): Subgraph scope.
             Valid: [global, ego]. ``"ego"`` requires ``entry_id``.
@@ -1401,7 +1401,10 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             (strongest structural-hole brokers); ``link_prediction`` = top predicted
             edges by Adamic-Adar (pass ``entry_id`` to score adjacencies for one entry);
             ``orphans`` = sample (<=50) of entry IDs absent from the relations graph
-            (unlinked entries — feeds a linking / gap-scan pass).
+            (unlinked entries — feeds a linking / gap-scan pass); ``health`` = a
+            consolidated graph-health snapshot (no per-node results) adding
+            ``mean_degree``, ``connected_component_count`` and
+            ``largest_component_fraction`` to the standard totals block.
           - project / tags / date_from / date_to (optional, metrics global scope):
             restrict the entries whose relations participate in the graph.
 
@@ -1415,7 +1418,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
             node_count: int, edge_count: int } (traverse) or
           { action: "metrics", metric: str, scope: str, node_count: int, edge_count: int,
             total_entries: int, graph_node_count: int, orphan_rate: float,
-            results: list, count: int, computed_at: str, cache_hit: bool } (metrics).
+            results: list, count: int, computed_at: str, cache_hit: bool } (metrics),
+            plus mean_degree: float, connected_component_count: int and
+            largest_component_fraction: float when metric="health".
             ``orphan_rate`` = 1 - graph_node_count/total_entries (graph-health signal;
             0.0 when total_entries is 0). Or
           { action: "promote_entities", entities_created: int, entities_reused: int,

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -44,7 +44,7 @@ _ORPHANS_SAMPLE_CAP = 50
 # are soft-deleted and excluded from total_entries / orphan_rate.
 _NON_ARCHIVED_STATUSES = ["active", "pending_review"]
 
-_VALID_METRICS = {"bridges", "communities", "constraint", "link_prediction", "orphans"}
+_VALID_METRICS = {"bridges", "communities", "constraint", "link_prediction", "orphans", "health"}
 _VALID_SCOPES = {"global", "ego"}
 
 # ---------------------------------------------------------------------------
@@ -904,8 +904,11 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
     from distillery.graph.metrics import (
         bridges,
         communities,
+        connected_component_count,
         constraint,
+        largest_component_fraction,
         link_prediction,
+        mean_degree,
         orphan_rate,
     )
 
@@ -985,6 +988,10 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
     edge_count = g.number_of_edges()
     rate = orphan_rate(graph_node_count=graph_node_count, total_entries=total_entries)
 
+    # Extra scalar fields surfaced only by metric="health"; empty for others so
+    # the response envelope for the existing metrics is unchanged.
+    health_extra: dict[str, Any] = {}
+
     # ----- compute metric -----
     try:
         if metric == "bridges":
@@ -1011,6 +1018,16 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
                 filters=total_filters,
             )
             results = [{"id": entry_id} for entry_id in orphan_ids]
+        elif metric == "health":
+            # Consolidated graph-health snapshot: the scalar totals (computed
+            # above) plus degree/component structure. No per-node results — the
+            # signal is in the top-level fields (orphan_rate trend, fragmentation).
+            results = []
+            health_extra = {
+                "mean_degree": round(mean_degree(g), 6),
+                "connected_component_count": connected_component_count(g),
+                "largest_component_fraction": round(largest_component_fraction(g), 6),
+            }
         else:  # metric == "communities"
             comms = communities(g)
             comms_sorted = sorted(comms, key=lambda c: len(c), reverse=True)[:limit]
@@ -1029,6 +1046,7 @@ async def _handle_metrics(  # noqa: PLR0911, PLR0912
             "total_entries": total_entries,
             "graph_node_count": graph_node_count,
             "orphan_rate": round(rate, 6),
+            **health_extra,
             "results": results,
             "count": len(results),
             "computed_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/tests/graph/test_metrics.py
+++ b/tests/graph/test_metrics.py
@@ -14,8 +14,11 @@ from distillery.graph.builders import build_relations_graph  # noqa: E402
 from distillery.graph.metrics import (  # noqa: E402
     bridges,
     communities,
+    connected_component_count,
     constraint,
+    largest_component_fraction,
     link_prediction,
+    mean_degree,
     orphan_rate,
 )
 
@@ -142,3 +145,67 @@ def test_orphan_rate_clamps_when_nodes_exceed_total() -> None:
     """graph_node_count > total_entries (archived-but-linked nodes) clamps to
     0.0 instead of going negative (issue #635 review)."""
     assert orphan_rate(graph_node_count=2, total_entries=1) == 0.0
+
+
+def _two_components() -> list[dict[str, str]]:
+    """Two disjoint edges: {A,B} and {X,Y} — two components, four nodes."""
+    return [
+        {"from_id": "A", "to_id": "B", "relation_type": "link"},
+        {"from_id": "X", "to_id": "Y", "relation_type": "link"},
+    ]
+
+
+def _triangle() -> list[dict[str, str]]:
+    """Triangle A-B-C: 3 undirected edges over 3 nodes."""
+    return [
+        {"from_id": "A", "to_id": "B", "relation_type": "link"},
+        {"from_id": "B", "to_id": "C", "relation_type": "link"},
+        {"from_id": "C", "to_id": "A", "relation_type": "link"},
+    ]
+
+
+def test_mean_degree_empty_graph() -> None:
+    assert mean_degree(build_relations_graph([], directed=True)) == 0.0
+
+
+def test_mean_degree_triangle() -> None:
+    """3 undirected edges over 3 nodes -> 2·3/3 = 2.0."""
+    assert mean_degree(build_relations_graph(_triangle(), directed=True)) == 2.0
+
+
+def test_mean_degree_collapses_reciprocal_edges() -> None:
+    """A->B and B->A collapse to one undirected edge: 2·1/2 = 1.0."""
+    rels = [
+        {"from_id": "A", "to_id": "B", "relation_type": "link"},
+        {"from_id": "B", "to_id": "A", "relation_type": "related"},
+    ]
+    assert mean_degree(build_relations_graph(rels, directed=True)) == 1.0
+
+
+def test_connected_component_count_empty_graph() -> None:
+    assert connected_component_count(build_relations_graph([], directed=True)) == 0
+
+
+def test_connected_component_count_single() -> None:
+    g = build_relations_graph(_shared_neighbors(), directed=True)
+    assert connected_component_count(g) == 1
+
+
+def test_connected_component_count_multiple() -> None:
+    g = build_relations_graph(_two_components(), directed=True)
+    assert connected_component_count(g) == 2
+
+
+def test_largest_component_fraction_empty_graph() -> None:
+    assert largest_component_fraction(build_relations_graph([], directed=True)) == 0.0
+
+
+def test_largest_component_fraction_single_component() -> None:
+    g = build_relations_graph(_shared_neighbors(), directed=True)
+    assert largest_component_fraction(g) == 1.0
+
+
+def test_largest_component_fraction_two_equal_components() -> None:
+    """Two disjoint edges -> largest component is 2 of 4 nodes -> 0.5."""
+    g = build_relations_graph(_two_components(), directed=True)
+    assert largest_component_fraction(g) == 0.5

--- a/tests/test_mcp_tools/test_relations_metrics.py
+++ b/tests/test_mcp_tools/test_relations_metrics.py
@@ -452,6 +452,85 @@ async def test_metrics_orphans_returns_unlinked_ids(store) -> None:  # type: ign
     assert data["orphan_rate"] == 0.6
 
 
+async def test_metrics_health_returns_consolidated_snapshot(store) -> None:  # type: ignore[no-untyped-def]
+    """metric='health' adds mean_degree, connected_component_count and
+    largest_component_fraction to the standard totals block (issue #653)."""
+    pytest.importorskip("networkx")
+
+    await _seed_star_relations(store)  # star A->{B,C,D}: 4 nodes, 3 edges, 1 component
+
+    data = _parse(
+        await _handle_relations(store, {"action": "metrics", "metric": "health", "scope": "global"})
+    )
+    assert data.get("error") is not True
+    assert data["metric"] == "health"
+    # Standard totals block.
+    assert data["total_entries"] == 4
+    assert data["graph_node_count"] == 4
+    assert data["edge_count"] == 3
+    assert data["orphan_rate"] == 0.0
+    # Health-only scalar fields.
+    assert data["mean_degree"] == 1.5  # 2 * 3 / 4
+    assert data["connected_component_count"] == 1
+    assert data["largest_component_fraction"] == 1.0
+    # Health carries no per-node results.
+    assert data["results"] == []
+    assert data["count"] == 0
+
+
+async def test_metrics_health_empty_graph(store) -> None:  # type: ignore[no-untyped-def]
+    """With entries but no relations, health reports an empty graph: zero degree,
+    zero components, and an orphan_rate of 1.0."""
+    pytest.importorskip("networkx")
+
+    for i in range(3):
+        await _store_entry(store, content=f"orphan {i}")
+
+    data = _parse(
+        await _handle_relations(store, {"action": "metrics", "metric": "health", "scope": "global"})
+    )
+    assert data.get("error") is not True
+    assert data["graph_node_count"] == 0
+    assert data["edge_count"] == 0
+    assert data["orphan_rate"] == 1.0
+    assert data["mean_degree"] == 0.0
+    assert data["connected_component_count"] == 0
+    assert data["largest_component_fraction"] == 0.0
+
+
+async def test_metrics_health_components_fragmented(store) -> None:  # type: ignore[no-untyped-def]
+    """Two disjoint edges -> two components, largest holding half the nodes."""
+    pytest.importorskip("networkx")
+
+    ids = {name: await _store_entry(store, content=f"entry {name}") for name in "ABXY"}
+    await store.add_relation(ids["A"], ids["B"], "link")
+    await store.add_relation(ids["X"], ids["Y"], "link")
+
+    data = _parse(
+        await _handle_relations(store, {"action": "metrics", "metric": "health", "scope": "global"})
+    )
+    assert data.get("error") is not True
+    assert data["connected_component_count"] == 2
+    assert data["largest_component_fraction"] == 0.5
+    assert data["mean_degree"] == 1.0  # 2 * 2 / 4
+
+
+async def test_metrics_health_omits_scalars_for_other_metrics(store) -> None:  # type: ignore[no-untyped-def]
+    """The health-only scalar fields must NOT appear on other metrics, keeping
+    their response envelope unchanged."""
+    pytest.importorskip("networkx")
+
+    await _seed_star_relations(store)
+    data = _parse(
+        await _handle_relations(
+            store, {"action": "metrics", "metric": "bridges", "scope": "global"}
+        )
+    )
+    assert "mean_degree" not in data
+    assert "connected_component_count" not in data
+    assert "largest_component_fraction" not in data
+
+
 async def test_metrics_orphans_sample_is_capped(store, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """metric='orphans' returns at most the sample cap of unlinked IDs."""
     pytest.importorskip("networkx")


### PR DESCRIPTION
## What

Phase 0 of finishing epic #653 — the **graph-health surfacing** item (graph-maintenance #5). Gives operators a way to measure the orphan-rate trend that the rest of the epic drives down. Independent, low-risk, and inert until called.

## Changes

- **`graph/metrics.py`**: three new pure metrics on the undirected projection — `mean_degree` (2·|E|/|V|), `connected_component_count`, `largest_component_fraction`. Each guards the empty graph.
- **`distillery_relations`**: new `metric="health"` returning a consolidated snapshot — the existing totals block (`total_entries`, `graph_node_count`, `edge_count`, `orphan_rate`) plus the three new scalars, with no per-node `results`. Reuses the existing metrics cache. The response envelope for every other metric is unchanged (health-only fields are omitted otherwise).
- **`skills/briefing`**: new non-fatal "Graph Health" panel (gather step 4j + display section + rule).
- **`skills/radar`**: graph-health summary line at the top of the `--structure` section.

## Why this first

It's the measurement surface for the remaining phases (tag canonicalization, entity-promotion rollout, link suggestion). On the live `distillery-minimal` instance the graph is currently 99.5% orphaned; this lets `/briefing` and `/radar --structure` show that number trending down.

## Testing

- Unit tests for the three metrics (empty / single-component / multi-component / reciprocal-edge collapse).
- Tool-layer tests for the `health` response shape, empty graph, fragmented graph, and that the scalar fields don't leak into other metrics.
- `mypy --strict src/` clean (73 files); `ruff check src/ tests/` clean; full affected-area sweep: 242 passed.

## Scope note

No production data is touched by this PR. Per the rollout plan, all live data mutations (entity promotion, link suggestion, tag backfill) are gated to Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Graph Health view in graph metrics output, with summary stats for mean degree, connected components, and largest component size.
  * Graph Health is now available in related documentation and output templates.

* **Bug Fixes**
  * Graph Health checks are non-fatal and will be skipped gracefully if the required graph tooling is unavailable.
  * Improved handling of orphan rate display, now shown as a percentage with clearer guidance for interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->