### PR TITLE
feat(store): tag controlled-vocabulary alias map + canonicalization backfill (#653)

### DIFF
--- a/distillery.yaml.example
+++ b/distillery.yaml.example
@@ -270,3 +270,14 @@ tags:
   # classifier.  Setting this key explicitly (including to []) overrides the
   # default.  Example: ["kind", "system"] reserves both namespaces.
   reserved_prefixes: ["kind"]
+
+  # Controlled-vocabulary alias map: collapse fragmented tag spellings onto a
+  # single canonical tag (issue #653, ontology #3). Both keys and values must be
+  # valid tags. Chains (a -> b -> c) are flattened at load time; cycles are
+  # rejected. Aliases are applied by the canonicalize_tags backfill
+  # (distillery_relations action="canonicalize_tags") and by entity promotion,
+  # so an aliased variant promotes to the same entity node as its canonical
+  # form. Default (key omitted): {} — no aliasing.
+  # aliases:
+  #   "domain/sandbox": "domain/build/sandboxing"
+  #   "entity/cloudflare-sandboxes": "entity/cloudflare"

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -250,11 +250,19 @@ class TagsConfig:
             must appear before it qualifies for entity promotion. Entity/*
             and tech/* tags appearing on at least this many entries are
             candidates for promotion to entity nodes. Defaults to ``3``.
+        aliases: Controlled-vocabulary ``alias -> canonical`` map used to
+            de-fragment tags (issue #653, ontology #3). Variant spellings of a
+            concept (e.g. ``domain/sandbox`` and ``domain/build/sandboxing``)
+            map to a single canonical tag. Both keys and values must be valid
+            tags. Chains (``a -> b -> c``) are flattened at parse time so the
+            stored map is single-hop; cycles are rejected. Defaults to ``{}``
+            (no aliasing — inert on upgrade).
     """
 
     enforce_namespaces: bool = False
     reserved_prefixes: list[str] = field(default_factory=lambda: ["kind"])
     entity_promotion_threshold: int = 3
+    aliases: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -893,6 +901,51 @@ def _parse_link_suggestion(raw: dict[str, Any]) -> LinkSuggestionConfig:
     )
 
 
+# Full hierarchical tag grammar: segments ``[a-z0-9][a-z0-9-]*`` joined by ``/``.
+# Mirrors ``distillery.models.validate_tag`` so alias keys/values are validated at
+# config-load time without importing the model layer.
+_FULL_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*(?:/[a-z0-9][a-z0-9-]*)*$")
+
+
+def _flatten_alias_map(aliases: dict[str, str]) -> dict[str, str]:
+    """Resolve alias chains to a single hop and reject cycles.
+
+    ``{"a": "b", "b": "c"}`` flattens to ``{"a": "c", "b": "c"}`` so the runtime
+    lookup is O(1) and idempotent. A key mapping to itself is a permitted no-op.
+    A true cycle (``a -> b -> a``) raises ``ValueError``.
+    """
+    flat: dict[str, str] = {}
+    for key in aliases:
+        seen = [key]
+        cur = key
+        while cur in aliases:
+            nxt = aliases[cur]
+            if nxt == cur:  # self-map: terminal, no-op
+                break
+            if nxt in seen:
+                raise ValueError(
+                    "tags.aliases contains a cycle: " + " -> ".join([*seen, nxt])
+                )
+            seen.append(nxt)
+            cur = nxt
+        flat[key] = cur
+    return flat
+
+
+def _parse_alias_map(raw: Any) -> dict[str, str]:
+    """Parse, validate, and flatten the ``tags.aliases`` mapping."""
+    if not isinstance(raw, dict):
+        raise ValueError(f"tags.aliases must be a mapping, got: {type(raw).__name__}")
+    aliases: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not _FULL_TAG_RE.fullmatch(key):
+            raise ValueError(f"tags.aliases key is not a valid tag: {key!r}")
+        if not isinstance(value, str) or not _FULL_TAG_RE.fullmatch(value):
+            raise ValueError(f"tags.aliases value is not a valid tag: {value!r}")
+        aliases[key] = value
+    return _flatten_alias_map(aliases)
+
+
 def _parse_tags(raw: dict[str, Any]) -> TagsConfig:
     """Parse the ``tags`` section from a raw YAML mapping.
 
@@ -905,14 +958,18 @@ def _parse_tags(raw: dict[str, Any]) -> TagsConfig:
             - ``entity_promotion_threshold`` (int, default ``3``) — minimum
               number of entries on which a tag must appear before qualifying
               for entity promotion.
+            - ``aliases`` (mapping[str, str], default ``{}``) — controlled-
+              vocabulary ``alias -> canonical`` map; chains are flattened and
+              cycles rejected at parse time.
 
     Returns:
         A populated :class:`TagsConfig` instance.
 
     Raises:
         ValueError: If ``enforce_namespaces`` is not a boolean,
-            ``reserved_prefixes`` is not a list, or
-            ``entity_promotion_threshold`` is not a positive integer.
+            ``reserved_prefixes`` is not a list,
+            ``entity_promotion_threshold`` is not a positive integer, or
+            ``aliases`` is not a valid (flattenable, acyclic) tag map.
     """
     if not isinstance(raw, dict):
         raise ValueError(f"tags must be a YAML mapping, got: {type(raw).__name__}")
@@ -928,6 +985,8 @@ def _parse_tags(raw: dict[str, Any]) -> TagsConfig:
             f"tags.entity_promotion_threshold must be a positive integer, got: {threshold}"
         )
 
+    aliases = _parse_alias_map(raw["aliases"]) if "aliases" in raw else {}
+
     if "reserved_prefixes" in raw:
         prefixes_raw = raw["reserved_prefixes"]
         if not isinstance(prefixes_raw, list):
@@ -939,10 +998,15 @@ def _parse_tags(raw: dict[str, Any]) -> TagsConfig:
             enforce_namespaces=enforce_raw,
             reserved_prefixes=reserved_prefixes,
             entity_promotion_threshold=threshold,
+            aliases=aliases,
         )
 
     # Absent ``reserved_prefixes`` → use dataclass default (``["kind"]``).
-    return TagsConfig(enforce_namespaces=enforce_raw, entity_promotion_threshold=threshold)
+    return TagsConfig(
+        enforce_namespaces=enforce_raw,
+        entity_promotion_threshold=threshold,
+        aliases=aliases,
+    )
 
 
 def _parse_feed_source(raw: dict[str, Any], index: int) -> FeedSourceConfig:

--- a/src/distillery/feeds/tags.py
+++ b/src/distillery/feeds/tags.py
@@ -8,6 +8,7 @@ conforming tags.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable, Mapping, Sequence
 
 _TAG_RE = re.compile(r"[a-z0-9][a-z0-9\-]*")
 
@@ -66,3 +67,75 @@ def normalize_tag(tag: str, reserved_prefixes: list[str]) -> str:
     if not leaf:
         return tag
     return f"{top}/{leaf}"
+
+
+def canonicalize_tag(
+    tag: str,
+    *,
+    aliases: Mapping[str, str] | None = None,
+    reserved_prefixes: Sequence[str] = (),
+    normalize_namespaces: bool = False,
+) -> str:
+    """Resolve a tag to its canonical form (issue #653, ontology #3).
+
+    Two ordered steps, both optional:
+
+    1. **Alias substitution** — when *tag* is a key in the (already chain-
+       flattened) *aliases* map, replace it with its canonical target. A
+       whole-tag dict lookup only; no substring or prefix matching, so an alias
+       key ``domain/sand`` never affects ``domain/sandbox``.
+    2. **Namespace normalization** — when *normalize_namespaces* is true, apply
+       :func:`normalize_tag` so variant separator spellings of a reserved-prefix
+       tag collapse (``entity/cloudflare/workers`` -> ``entity/cloudflare-workers``).
+
+    Alias substitution runs first so an operator-declared merge wins over the
+    mechanical separator-collapse. Idempotent given a flattened (chain-free,
+    cycle-free) alias map: ``canonicalize_tag(canonicalize_tag(t)) ==
+    canonicalize_tag(t)``. Grammar validation stays the caller's responsibility
+    (the :class:`~distillery.models.Entry` constructor still validates tags).
+
+    Args:
+        tag: The full tag path (already lowercased / sanitised).
+        aliases: Flattened ``alias -> canonical`` map (see
+            :class:`~distillery.config.TagsConfig.aliases`). ``None`` / empty
+            means no alias step.
+        reserved_prefixes: Passed through to :func:`normalize_tag`.
+        normalize_namespaces: When true, run the namespace-normalization step.
+
+    Returns:
+        The canonical tag string (unchanged when no rule applies).
+    """
+    result = tag
+    if aliases:
+        result = aliases.get(result, result)
+    if normalize_namespaces:
+        result = normalize_tag(result, list(reserved_prefixes))
+    return result
+
+
+def canonicalize_tags(
+    tags: Iterable[str],
+    *,
+    aliases: Mapping[str, str] | None = None,
+    reserved_prefixes: Sequence[str] = (),
+    normalize_namespaces: bool = False,
+) -> list[str]:
+    """Canonicalize every tag and dedupe, preserving first-seen order.
+
+    Thin batch wrapper over :func:`canonicalize_tag`. Because aliasing can map
+    two distinct tags onto one canonical form, the dedupe is what collapses an
+    entry that carries both an alias and its target down to a single tag.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in tags:
+        canonical = canonicalize_tag(
+            t,
+            aliases=aliases,
+            reserved_prefixes=reserved_prefixes,
+            normalize_namespaces=normalize_namespaces,
+        )
+        if canonical not in seen:
+            seen.add(canonical)
+            out.append(canonical)
+    return out

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1373,7 +1373,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         graph metrics (bridges, communities) on the relations subgraph.
 
         PARAMS:
-          - action (str, required): Operation. Valid: [add, get, remove, traverse, metrics, promote_entities].
+          - action (str, required): Operation. Valid: [add, get, remove, traverse, metrics,
+            reconcile, list_candidates, resolve_candidate, suggest_links, promote_entities,
+            canonicalize_tags].
           - from_id (str, required for add): Source entry UUID.
           - to_id (str, required for add): Target entry UUID.
           - relation_type (str, required for add, optional for get/traverse): Relation type.

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -108,12 +108,13 @@ async def _handle_relations(
         "resolve_candidate",
         "suggest_links",
         "promote_entities",
+        "canonicalize_tags",
     ):
         return error_response(
             "INVALID_PARAMS",
             "action must be one of 'add', 'get', 'remove', 'traverse', 'metrics', "
             "'reconcile', 'list_candidates', 'resolve_candidate', 'suggest_links', "
-            f"'promote_entities'; got: {action!r}",
+            f"'promote_entities', 'canonicalize_tags'; got: {action!r}",
         )
 
     # ------------------------------------------------------------------
@@ -583,13 +584,15 @@ async def _handle_relations(
     if action == "promote_entities":
         threshold = 3  # default
         reserved_prefixes: list[str] | None = None
+        aliases: dict[str, str] | None = None
         if cfg is not None:
             tags_cfg = getattr(cfg, "tags", None)
             if tags_cfg is not None:
                 threshold = getattr(tags_cfg, "entity_promotion_threshold", threshold)
                 reserved_prefixes = getattr(tags_cfg, "reserved_prefixes", None)
+                aliases = getattr(tags_cfg, "aliases", None)
         try:
-            counts = await store.promote_entities(threshold, reserved_prefixes)
+            counts = await store.promote_entities(threshold, reserved_prefixes, aliases)
         except Exception:  # noqa: BLE001
             logger.exception("distillery_relations promote_entities: unexpected error")
             return error_response("INTERNAL", "Failed to promote entities")
@@ -601,6 +604,38 @@ async def _handle_relations(
                 "entities_reused": counts.get("entities_reused", 0),
                 "mentions_created": counts.get("mentions_created", 0),
                 "threshold": threshold,
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # action == "canonicalize_tags"
+    # ------------------------------------------------------------------
+    if action == "canonicalize_tags":
+        aliases_map: dict[str, str] = {}
+        reserved: list[str] | None = None
+        normalize_namespaces = False
+        if cfg is not None:
+            tags_cfg = getattr(cfg, "tags", None)
+            if tags_cfg is not None:
+                aliases_map = getattr(tags_cfg, "aliases", None) or {}
+                reserved = getattr(tags_cfg, "reserved_prefixes", None)
+                normalize_namespaces = bool(getattr(tags_cfg, "enforce_namespaces", False))
+        try:
+            counts = await store.canonicalize_existing_tags(
+                aliases_map,
+                reserved,
+                normalize_namespaces,
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("distillery_relations canonicalize_tags: unexpected error")
+            return error_response("INTERNAL", "Failed to canonicalize tags")
+
+        return success_response(
+            {
+                "action": "canonicalize_tags",
+                "entries_scanned": counts.get("entries_scanned", 0),
+                "entries_rewritten": counts.get("entries_rewritten", 0),
+                "tags_collapsed": counts.get("tags_collapsed", 0),
             }
         )
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -31,7 +31,7 @@ from urllib.parse import unquote, urlparse
 
 import duckdb
 
-from distillery.feeds.tags import normalize_tag
+from distillery.feeds.tags import canonicalize_tag, canonicalize_tags
 from distillery.models import Entry, EntrySource, EntryStatus, EntryType, validate_metadata
 from distillery.store.migrations import (
     _CREATE_META_TABLE,
@@ -4681,6 +4681,7 @@ class DuckDBStore:
         self,
         threshold: int,
         reserved_prefixes: list[str],
+        aliases: dict[str, str],
     ) -> tuple[dict[str, list[str]], dict[str, str]]:
         """Read-only first pass: compute the promotion plan.
 
@@ -4688,6 +4689,10 @@ class DuckDBStore:
         ``canonical_members`` maps each qualifying canonical tag to the sorted
         list of entry IDs carrying it, and ``existing_nodes`` maps a canonical
         ``source_tag`` to the id of an already-stored entity node.
+
+        Tags are resolved through the controlled-vocabulary *aliases* map before
+        the separator-collapse, so an aliased variant promotes to the same node
+        as its canonical form (issue #653, ontology #3).
         """
         assert self._conn is not None
         rows = self._conn.execute(
@@ -4700,7 +4705,12 @@ class DuckDBStore:
             for tag in tags_col:
                 if not isinstance(tag, str):
                     continue
-                canonical = normalize_tag(tag, reserved_prefixes)
+                canonical = canonicalize_tag(
+                    tag,
+                    aliases=aliases,
+                    reserved_prefixes=reserved_prefixes,
+                    normalize_namespaces=True,
+                )
                 if not (canonical.startswith("entity/") or canonical.startswith("tech/")):
                     continue
                 members.setdefault(canonical, set()).add(entry_id)
@@ -4833,6 +4843,7 @@ class DuckDBStore:
         self,
         threshold: int,
         reserved_prefixes: list[str] | None = None,
+        aliases: dict[str, str] | None = None,
     ) -> dict[str, int]:
         """Promote recurring ``entity/*`` and ``tech/*`` tags to entity nodes.
 
@@ -4843,7 +4854,7 @@ class DuckDBStore:
         # the configured reserved prefixes.
         prefixes = sorted({*(reserved_prefixes or []), "entity", "tech"})
         canonical_members, existing_nodes = await self._run_sync(
-            self._sync_promote_entities_plan, threshold, prefixes
+            self._sync_promote_entities_plan, threshold, prefixes, aliases or {}
         )
         # Embed the canonical names for nodes that don't yet exist, off the SQL
         # lock (issue #558 pattern).
@@ -4855,6 +4866,80 @@ class DuckDBStore:
             embeddings[canonical] = await asyncio.to_thread(self._embedding_provider.embed, name)
         return await self._run_sync(
             self._sync_promote_entities_write, canonical_members, embeddings
+        )
+
+    def _sync_canonicalize_existing_tags(
+        self,
+        aliases: dict[str, str],
+        reserved_prefixes: list[str],
+        normalize_namespaces: bool,
+    ) -> dict[str, int]:
+        """Rewrite every active entry's tags through the controlled vocabulary.
+
+        Idempotent: only entries whose canonicalized tag list differs from the
+        stored one are updated, so a second run rewrites zero rows. ``updated_at``
+        is left untouched so this mechanical migration does not distort recency
+        signals, and embeddings are not recomputed (tags do not feed embeddings).
+        """
+        assert self._conn is not None
+        conn = self._conn
+        rows = conn.execute(
+            "SELECT id, tags FROM entries WHERE status != 'archived'"
+        ).fetchall()
+        updates: list[tuple[list[str], str]] = []
+        entries_scanned = 0
+        tags_collapsed = 0
+        for entry_id, tags_col in rows:
+            entries_scanned += 1
+            old_tags = [t for t in (tags_col or []) if isinstance(t, str)]
+            if not old_tags:
+                continue
+            new_tags = canonicalize_tags(
+                old_tags,
+                aliases=aliases,
+                reserved_prefixes=reserved_prefixes,
+                normalize_namespaces=normalize_namespaces,
+            )
+            if new_tags != old_tags:
+                updates.append((new_tags, entry_id))
+                tags_collapsed += len(old_tags) - len(new_tags)
+
+        if updates:
+            try:
+                conn.execute("BEGIN TRANSACTION")
+                for new_tags, entry_id in updates:
+                    conn.execute(
+                        "UPDATE entries SET tags = ? WHERE id = ?",
+                        [new_tags, entry_id],
+                    )
+                conn.execute("COMMIT")
+            except Exception:
+                with contextlib.suppress(Exception):
+                    conn.execute("ROLLBACK")
+                raise
+            self._checkpoint_after_write(conn)
+
+        return {
+            "entries_scanned": entries_scanned,
+            "entries_rewritten": len(updates),
+            "tags_collapsed": tags_collapsed,
+        }
+
+    async def canonicalize_existing_tags(
+        self,
+        aliases: dict[str, str],
+        reserved_prefixes: list[str] | None = None,
+        normalize_namespaces: bool = False,
+    ) -> dict[str, int]:
+        """Rewrite stored tags through the controlled vocabulary (issue #653).
+
+        See :meth:`distillery.store.protocol.DistilleryStore.canonicalize_existing_tags`.
+        """
+        return await self._run_sync(
+            self._sync_canonicalize_existing_tags,
+            aliases,
+            reserved_prefixes or [],
+            normalize_namespaces,
         )
 
     def _sync_get_all_related_entry_ids(self) -> set[str]:

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -687,14 +687,17 @@ class DistilleryStore(Protocol):
         self,
         threshold: int,
         reserved_prefixes: list[str] | None = None,
+        aliases: dict[str, str] | None = None,
     ) -> dict[str, int]:
         """Promote recurring ``entity/*`` and ``tech/*`` tags to entity nodes.
 
-        Scans the tag vocabulary, normalises each ``entity/*`` and ``tech/*``
-        tag through the existing ``normalize_tag`` path so variant spellings
-        (``entity/cloudflare/workers`` vs ``entity/cloudflare-workers``)
-        collapse to one canonical key, and for every canonical tag appearing on
-        at least *threshold* entries:
+        Scans the tag vocabulary, resolves each tag through the controlled-
+        vocabulary *aliases* map and then the ``normalize_tag`` separator-
+        collapse so variant spellings (``entity/cloudflare/workers`` vs
+        ``entity/cloudflare-workers``) and declared aliases
+        (``entity/cloudflare-sandboxes`` -> ``entity/cloudflare``) converge to
+        one canonical key, and for every canonical ``entity/*`` / ``tech/*`` tag
+        appearing on at least *threshold* entries:
 
           * finds-or-creates exactly one ``entity`` entry keyed idempotently on
             the canonical tag (stored as ``metadata.source_tag``); no duplicate
@@ -714,11 +717,49 @@ class DistilleryStore(Protocol):
                 ``config.tags.reserved_prefixes``).  ``entity`` and ``tech`` are
                 always treated as reserved for promotion regardless of this
                 argument.  ``None`` is treated as an empty list.
+            aliases: Controlled-vocabulary ``alias -> canonical`` map (typically
+                ``config.tags.aliases``) applied before the separator-collapse so
+                aliased variants promote to the same node.  ``None`` is treated
+                as an empty map.
 
         Returns:
             Dict with ``entities_created`` (new entity nodes inserted),
             ``entities_reused`` (qualifying tags whose node already existed),
             and ``mentions_created`` (``mentions`` edges inserted).
+        """
+        ...
+
+    async def canonicalize_existing_tags(
+        self,
+        aliases: dict[str, str],
+        reserved_prefixes: list[str] | None = None,
+        normalize_namespaces: bool = False,
+    ) -> dict[str, int]:
+        """Rewrite stored tags through the controlled vocabulary (issue #653).
+
+        Backfill for ontology #3: scans every non-archived entry and rewrites
+        its tag list via :func:`distillery.feeds.tags.canonicalize_tags`
+        (alias substitution, then optional namespace normalization, then an
+        order-preserving dedupe). Only entries whose tag list actually changes
+        are written, so the operation is idempotent — a second run rewrites zero
+        rows. Embeddings are not recomputed (tags do not feed embeddings) and
+        ``updated_at`` is left untouched so recency signals are preserved.
+
+        Run this before a full :meth:`promote_entities` re-run so entity nodes
+        key off the canonical tag form.
+
+        Args:
+            aliases: Flattened ``alias -> canonical`` map
+                (``config.tags.aliases``).
+            reserved_prefixes: Prefixes eligible for namespace normalization
+                (only used when *normalize_namespaces* is true). ``None`` is an
+                empty list.
+            normalize_namespaces: When true, also apply the ``normalize_tag``
+                separator-collapse (typically ``config.tags.enforce_namespaces``).
+
+        Returns:
+            Dict with ``entries_scanned``, ``entries_rewritten`` and
+            ``tags_collapsed`` (total tags removed by within-entry dedupe).
         """
         ...
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -683,6 +683,71 @@ class TestTagsConfig:
         assert cfg.tags.enforce_namespaces is False
         assert "system" in cfg.tags.reserved_prefixes
 
+    def test_tags_aliases_default_empty(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            tags:
+              enforce_namespaces: false
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.tags.aliases == {}
+
+    def test_tags_aliases_parsed(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            tags:
+              aliases:
+                "domain/sandbox": "domain/build/sandboxing"
+                "entity/cloudflare-sandboxes": "entity/cloudflare"
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.tags.aliases["domain/sandbox"] == "domain/build/sandboxing"
+        assert cfg.tags.aliases["entity/cloudflare-sandboxes"] == "entity/cloudflare"
+
+    def test_tags_aliases_chain_is_flattened(self, tmp_path: Path) -> None:
+        """``a -> b -> c`` flattens so both a and b resolve to c."""
+        yaml_content = """\
+            tags:
+              aliases:
+                "domain/a": "domain/b"
+                "domain/b": "domain/c"
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.tags.aliases["domain/a"] == "domain/c"
+        assert cfg.tags.aliases["domain/b"] == "domain/c"
+
+    def test_tags_aliases_cycle_raises(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            tags:
+              aliases:
+                "domain/a": "domain/b"
+                "domain/b": "domain/a"
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="cycle"):
+            load_config(str(p))
+
+    def test_tags_aliases_invalid_key_raises(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            tags:
+              aliases:
+                "Domain/Sandbox": "domain/build/sandboxing"
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="aliases key"):
+            load_config(str(p))
+
+    def test_tags_aliases_invalid_value_raises(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            tags:
+              aliases:
+                "domain/sandbox": "domain//bad"
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="aliases value"):
+            load_config(str(p))
+
 
 # ---------------------------------------------------------------------------
 # FeedsConfig: dataclass defaults and loading

--- a/tests/test_entity_promotion.py
+++ b/tests/test_entity_promotion.py
@@ -107,6 +107,75 @@ async def test_promote_entities_is_idempotent(store) -> None:  # type: ignore[no
     assert len(nodes) == 1
 
 
+async def test_promote_entities_collapses_aliases(store) -> None:  # type: ignore[no-untyped-def]
+    """An aliased variant promotes to the same node as its canonical form (#653)."""
+    a = await _store_entry(store, content="alias", tags=["entity/cloudflare-sandboxes"])
+    b = await _store_entry(store, content="canonical", tags=["entity/cloudflare"])
+    c = await _store_entry(store, content="canonical too", tags=["entity/cloudflare"])
+
+    aliases = {"entity/cloudflare-sandboxes": "entity/cloudflare"}
+    counts = await store.promote_entities(threshold=3, aliases=aliases)
+
+    assert counts["entities_created"] == 1
+    assert counts["mentions_created"] == 3
+
+    nodes = await store.list_entries({"entry_type": EntryType.ENTITY.value}, limit=10, offset=0)
+    assert len(nodes) == 1
+    assert nodes[0].metadata["source_tag"] == "entity/cloudflare"
+    for entry_id in (a, b, c):
+        related = await store.get_related(entry_id, relation_type="mentions")
+        assert len(related) == 1
+        assert related[0]["to_id"] == nodes[0].id
+
+
+async def test_canonicalize_existing_tags_rewrites_and_dedupes(store) -> None:  # type: ignore[no-untyped-def]
+    """Backfill rewrites aliased tags and dedupes within an entry (#653)."""
+    a = await _store_entry(store, content="frag", tags=["domain/sandbox", "tech/duckdb"])
+    # Carries BOTH an alias and its canonical target -> collapses to one tag.
+    b = await _store_entry(
+        store, content="both", tags=["domain/sandbox", "domain/build/sandboxing"]
+    )
+    aliases = {"domain/sandbox": "domain/build/sandboxing"}
+
+    counts = await store.canonicalize_existing_tags(aliases)
+
+    assert counts["entries_scanned"] == 2
+    assert counts["entries_rewritten"] == 2
+    assert counts["tags_collapsed"] == 1  # entry b: 2 tags -> 1
+
+    ea = await store.get(a)
+    assert set(ea.tags) == {"domain/build/sandboxing", "tech/duckdb"}
+    eb = await store.get(b)
+    assert eb.tags == ["domain/build/sandboxing"]
+
+
+async def test_canonicalize_existing_tags_is_idempotent(store) -> None:  # type: ignore[no-untyped-def]
+    """A second backfill run rewrites zero rows."""
+    await _store_entry(store, content="frag", tags=["domain/sandbox"])
+    aliases = {"domain/sandbox": "domain/build/sandboxing"}
+
+    first = await store.canonicalize_existing_tags(aliases)
+    assert first["entries_rewritten"] == 1
+
+    second = await store.canonicalize_existing_tags(aliases)
+    assert second["entries_rewritten"] == 0
+
+
+async def test_canonicalize_then_promote_uses_canonical_node(store) -> None:  # type: ignore[no-untyped-def]
+    """Backfill before promote: aliased entries land on the canonical entity node."""
+    for i in range(3):
+        await _store_entry(store, content=f"e{i}", tags=["entity/cloudflare-sandboxes"])
+    aliases = {"entity/cloudflare-sandboxes": "entity/cloudflare"}
+
+    await store.canonicalize_existing_tags(aliases)
+    counts = await store.promote_entities(threshold=3, aliases=aliases)
+
+    assert counts["entities_created"] == 1
+    nodes = await store.list_entries({"entry_type": EntryType.ENTITY.value}, limit=10, offset=0)
+    assert len(nodes) == 1
+    assert nodes[0].metadata["source_tag"] == "entity/cloudflare"
+
+
 async def test_promote_entities_missing_embedding_does_not_raise(store) -> None:  # type: ignore[no-untyped-def]
     """Regression: missing embedding (concurrent deletion) is skipped, not KeyError.
 
@@ -120,7 +189,7 @@ async def test_promote_entities_missing_embedding_does_not_raise(store) -> None:
     # Obtain the canonical set by calling the plan step, then strip the
     # embedding so the write step sees the concurrent-deletion scenario.
     canonical_members, _ = await store._run_sync(
-        store._sync_promote_entities_plan, 3, ["entity", "tech"]
+        store._sync_promote_entities_plan, 3, ["entity", "tech"], {}
     )
     # Deliberately omit the embedding for "entity/acme" to reproduce the race.
     empty_embeddings: dict[str, list[float]] = {}

--- a/tests/test_mcp_tools/test_relations_canonicalize_tags.py
+++ b/tests/test_mcp_tools/test_relations_canonicalize_tags.py
@@ -1,0 +1,90 @@
+"""Unit tests for the ``canonicalize_tags`` action of ``distillery_relations``.
+
+Covers (issue #653, ontology #3):
+  - happy path: rewrites stored tags through cfg.tags.aliases and returns counts
+  - cfg=None: empty alias map -> no rewrites (no-op, safe default)
+  - INTERNAL error when the store raises
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from distillery.mcp.tools.relations import _handle_relations
+from tests.conftest import make_entry
+
+pytestmark = pytest.mark.unit
+
+
+async def _store_entry(store, **kwargs):  # type: ignore[no-untyped-def]
+    entry = make_entry(**kwargs)
+    await store.store(entry)
+    return entry.id
+
+
+def _parse(result: list) -> dict:  # type: ignore[type-arg]
+    assert len(result) == 1
+    return json.loads(result[0].text)  # type: ignore[no-any-return]
+
+
+class _FakeTagsCfg:
+    enforce_namespaces = False
+    reserved_prefixes = ["kind"]
+    aliases = {"domain/sandbox": "domain/build/sandboxing"}
+
+
+class _FakeCfg:
+    tags = _FakeTagsCfg()
+
+
+async def test_canonicalize_tags_happy_path(store) -> None:  # type: ignore[no-untyped-def]
+    """The backfill rewrites aliased tags and reports counts."""
+    a = await _store_entry(store, content="frag", tags=["domain/sandbox", "tech/duckdb"])
+
+    result = await _handle_relations(
+        store,
+        {"action": "canonicalize_tags"},
+        cfg=_FakeCfg(),
+    )
+    data = _parse(result)
+
+    assert data.get("error") is not True
+    assert data["action"] == "canonicalize_tags"
+    assert data["entries_scanned"] == 1
+    assert data["entries_rewritten"] == 1
+    assert data["tags_collapsed"] == 0
+
+    entry = await store.get(a)
+    assert set(entry.tags) == {"domain/build/sandboxing", "tech/duckdb"}
+
+
+async def test_canonicalize_tags_no_aliases_is_noop(store) -> None:  # type: ignore[no-untyped-def]
+    """With cfg=None (empty alias map), no entry is rewritten."""
+    await _store_entry(store, content="x", tags=["domain/sandbox"])
+
+    result = await _handle_relations(
+        store,
+        {"action": "canonicalize_tags"},
+        cfg=None,
+    )
+    data = _parse(result)
+
+    assert data.get("error") is not True
+    assert data["entries_rewritten"] == 0
+
+
+async def test_canonicalize_tags_internal_error(store) -> None:  # type: ignore[no-untyped-def]
+    store.canonicalize_existing_tags = AsyncMock(side_effect=RuntimeError("boom"))
+
+    result = await _handle_relations(
+        store,
+        {"action": "canonicalize_tags"},
+        cfg=_FakeCfg(),
+    )
+    data = _parse(result)
+
+    assert data["error"] is True
+    assert data["code"] == "INTERNAL"

--- a/tests/test_tag_canonicalization.py
+++ b/tests/test_tag_canonicalization.py
@@ -1,0 +1,81 @@
+"""Unit tests for tag canonicalization (issue #653, ontology #3).
+
+Covers the pure ``canonicalize_tag`` / ``canonicalize_tags`` helpers in
+``distillery.feeds.tags``: alias substitution, precedence over namespace
+normalization, idempotency, substring safety, and order-preserving dedupe.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.feeds.tags import canonicalize_tag, canonicalize_tags
+
+pytestmark = pytest.mark.unit
+
+
+def test_alias_collapse() -> None:
+    aliases = {"domain/sandbox": "domain/build/sandboxing"}
+    assert canonicalize_tag("domain/sandbox", aliases=aliases) == "domain/build/sandboxing"
+
+
+def test_alias_wins_over_namespace_normalize() -> None:
+    """Alias substitution runs before the separator-collapse, so an operator
+    merge wins over the mechanical normalization."""
+    aliases = {"entity/cloudflare/sandboxes": "entity/cloudflare"}
+    result = canonicalize_tag(
+        "entity/cloudflare/sandboxes",
+        aliases=aliases,
+        reserved_prefixes=["entity"],
+        normalize_namespaces=True,
+    )
+    # Alias fires first -> entity/cloudflare, NOT entity/cloudflare-sandboxes.
+    assert result == "entity/cloudflare"
+
+
+def test_namespace_normalize_without_matching_alias() -> None:
+    """With no matching alias, the namespace-collapse still applies."""
+    result = canonicalize_tag(
+        "entity/cloudflare/workers",
+        reserved_prefixes=["entity"],
+        normalize_namespaces=True,
+    )
+    assert result == "entity/cloudflare-workers"
+
+
+def test_no_op_for_unknown_tag() -> None:
+    assert canonicalize_tag("project/billing", aliases={"x": "y"}) == "project/billing"
+
+
+def test_namespace_normalize_off_by_default() -> None:
+    """Without normalize_namespaces, the separator-collapse does not run."""
+    assert canonicalize_tag("entity/cloudflare/workers") == "entity/cloudflare/workers"
+
+
+def test_substring_alias_does_not_fire() -> None:
+    """Whole-tag match only: an alias key must not match a longer tag."""
+    aliases = {"domain/sand": "domain/build/sandboxing"}
+    assert canonicalize_tag("domain/sandbox", aliases=aliases) == "domain/sandbox"
+
+
+def test_idempotent_with_flattened_map() -> None:
+    """Given a flattened (single-hop) map, canonicalization is idempotent."""
+    aliases = {"domain/sandbox": "domain/build/sandboxing"}
+    once = canonicalize_tag("domain/sandbox", aliases=aliases)
+    twice = canonicalize_tag(once, aliases=aliases)
+    assert once == twice == "domain/build/sandboxing"
+
+
+def test_canonicalize_tags_dedupes_preserving_order() -> None:
+    """Aliasing two tags onto one canonical form collapses to a single tag,
+    keeping first-seen order."""
+    aliases = {"domain/sandbox": "domain/build/sandboxing"}
+    result = canonicalize_tags(
+        ["tech/duckdb", "domain/sandbox", "domain/build/sandboxing"],
+        aliases=aliases,
+    )
+    assert result == ["tech/duckdb", "domain/build/sandboxing"]
+
+
+def test_canonicalize_tags_empty() -> None:
+    assert canonicalize_tags([]) == []


### PR DESCRIPTION
## What

Phase 1 of finishing epic #653 — the **controlled-vocabulary / alias map** (ontology #3). De-fragments tags (e.g. `domain/sandbox` vs `domain/build/sandboxing`) so co-occurrence edges and entity promotion key off a single canonical form. Inert on upgrade (empty default alias map).

## Changes

- **`feeds/tags.py`** — pure `canonicalize_tag` / `canonicalize_tags`: alias substitution → optional namespace normalization → order-preserving dedupe. **Wraps, does not modify, `normalize_tag`** so existing entity-node keys stay stable. Whole-tag match only (no substring matching); idempotent given a flattened map.
- **`config.py`** — `TagsConfig.aliases` (`alias -> canonical`). The parser validates tag grammar on keys/values, **flattens chains** (`a→b→c ⇒ a→c`), and **rejects cycles** at load time.
- **`store`** — `canonicalize_existing_tags()` backfill: rewrites stored tags through the alias map, **idempotently** (only changed rows written), with **no re-embedding** (tags don't feed embeddings) and **`updated_at` untouched** (preserves recency signals). Exposed as `distillery_relations action="canonicalize_tags"`.
- **`promote_entities()`** is now **alias-aware** — resolves aliases before the separator-collapse, so an aliased variant (`entity/cloudflare-sandboxes`) promotes to the same node as its canonical form (`entity/cloudflare`).
- **`distillery.yaml.example`** — documented `aliases` sample.

## Operational order (for Phase 4)

Run `canonicalize_tags` **before** `promote_entities` so entity nodes key off canonical tags. (No production data is touched by this PR — the rollout is gated to Phase 4.)

## Deferred to a follow-up PR (tracked)

- Write-path choke-point (canonicalize **new** writes via the store) and merge-site canonicalization (poller/classify/gh-sync).
- `known_namespaces` + `namespace_enforcement` (off/warn/strict) gating of unknown namespaces.

Neither is required for the rollout — the backfill cleans existing data, and the feed poller already applies `normalize_tag` when `enforce_namespaces` is on. Splitting keeps this PR focused (matches the design's recommended PR-1/PR-2 split).

## Testing

- Pure canonicalization (alias collapse, alias-before-normalize precedence, idempotency, substring safety, dedupe).
- Config parser (chain flatten, cycle → `ValueError`, invalid key/value).
- Idempotent backfill + within-entry dedupe; alias-aware promotion; backfill-then-promote lands on the canonical node; MCP action happy/no-op/error paths.
- Full suite: **3229 passed**, 79 skipped; `mypy --strict src/` clean (73 files); `ruff check src/ tests/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional tag aliasing support so related tags can be treated as a single canonical tag.
  * Added a new tag-canonicalization action to update existing records in bulk.
  * Entity promotion now uses canonical tags more consistently, reducing duplicate entity variants.

* **Bug Fixes**
  * Improved tag handling to flatten alias chains, reject invalid alias loops, and deduplicate repeated tags while preserving order.
  * Existing data can now be backfilled to align stored tags with the canonical vocabulary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->