### PR TITLE
feat(relations): typed (from_type, relation, to_type) relation schema (#653)

### DIFF
--- a/distillery.yaml.example
+++ b/distillery.yaml.example
@@ -270,3 +270,14 @@ tags:
   # classifier.  Setting this key explicitly (including to []) overrides the
   # default.  Example: ["kind", "system"] reserves both namespaces.
   reserved_prefixes: ["kind"]
+
+# ---------------------------------------------------------------------------
+# Relation-graph schema settings (issue #653, ontology #1)
+# ---------------------------------------------------------------------------
+relations:
+  # When true, creating an edge whose (from_type, relation, to_type) triple is
+  # not in the relation ontology is rejected. When false (default), violations
+  # are logged (warn-only) but the edge is still created — the safe default for
+  # a graph populated before any schema existed. Audit first with
+  # `distillery_relations action="audit_schema"`; flip to true once it is clean.
+  enforce_schema: false

--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -689,6 +689,7 @@ def _cmd_poll(config_path: str | None, fmt: str, source_url: str | None) -> int:
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            enforce_relation_schema=cfg.relations.enforce_schema,
         )
         await store.initialize()
 
@@ -845,6 +846,7 @@ def _cmd_retag(
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            enforce_relation_schema=cfg.relations.enforce_schema,
         )
         await store.initialize()
 
@@ -970,6 +972,7 @@ def _cmd_gh_backfill(
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            enforce_relation_schema=cfg.relations.enforce_schema,
         )
         await store.initialize()
         try:
@@ -1293,6 +1296,7 @@ def _cmd_import(
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            enforce_relation_schema=cfg.relations.enforce_schema,
         )
         await store.initialize()
 
@@ -1994,6 +1998,7 @@ def _cmd_maintenance_classify(
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            enforce_relation_schema=cfg.relations.enforce_schema,
         )
         try:
             await store.initialize()

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -231,6 +231,23 @@ class LinkSuggestionConfig:
 
 
 @dataclass
+class RelationsConfig:
+    """Relation-graph schema configuration (issue #653, ontology #1).
+
+    Attributes:
+        enforce_schema: When ``True``, creating an edge whose
+            ``(from_type, relation, to_type)`` triple is not in
+            :data:`distillery.relations.schema.RELATION_SCHEMA` is rejected.
+            When ``False`` (default), violations are logged (warn-only) but the
+            edge is still created — a safe default for an already-populated graph
+            built before any schema existed. Flip to ``True`` only after an audit
+            (``distillery_relations action="audit_schema"``) returns clean.
+    """
+
+    enforce_schema: bool = False
+
+
+@dataclass
 class TagsConfig:
     """Tag namespace configuration.
 
@@ -559,6 +576,7 @@ class DistilleryConfig:
     auto_link: AutoLinkConfig = field(default_factory=AutoLinkConfig)
     link_suggestion: LinkSuggestionConfig = field(default_factory=LinkSuggestionConfig)
     tags: TagsConfig = field(default_factory=TagsConfig)
+    relations: RelationsConfig = field(default_factory=RelationsConfig)
     feeds: FeedsConfig = field(default_factory=FeedsConfig)
     rate_limit: RateLimitConfig = field(default_factory=RateLimitConfig)
     server: ServerConfig = field(default_factory=ServerConfig)
@@ -891,6 +909,28 @@ def _parse_link_suggestion(raw: dict[str, Any]) -> LinkSuggestionConfig:
         review_floor=review_floor,
         max_candidates_per_run=max_candidates_per_run,
     )
+
+
+def _parse_relations(raw: dict[str, Any]) -> RelationsConfig:
+    """Parse the ``relations`` section from a raw YAML mapping (issue #653).
+
+    Args:
+        raw: Mapping (typically from YAML) containing any of:
+            - ``enforce_schema`` (bool, default ``False``)
+
+    Returns:
+        A populated :class:`RelationsConfig` instance.
+
+    Raises:
+        ValueError: If ``raw`` is not a mapping or ``enforce_schema`` is not a
+            boolean.
+    """
+    if not isinstance(raw, dict):
+        raise ValueError(f"relations must be a YAML mapping, got: {type(raw).__name__}")
+    enforce_raw = raw.get("enforce_schema", False)
+    if not isinstance(enforce_raw, bool):
+        raise ValueError(f"relations.enforce_schema must be a boolean, got: {enforce_raw!r}")
+    return RelationsConfig(enforce_schema=enforce_raw)
 
 
 def _parse_tags(raw: dict[str, Any]) -> TagsConfig:
@@ -1728,6 +1768,7 @@ def load_config(config_path: str | None = None) -> DistilleryConfig:
     auto_link_raw = raw.get("auto_link", {}) or {}
     link_suggestion_raw = raw.get("link_suggestion", {}) or {}
     tags_raw = raw.get("tags", {}) or {}
+    relations_raw = raw.get("relations", {}) or {}
     feeds_raw = raw.get("feeds", {}) or {}
     rate_limit_raw = raw.get("rate_limit", {}) or {}
     server_raw = raw.get("server", {})
@@ -1743,6 +1784,7 @@ def load_config(config_path: str | None = None) -> DistilleryConfig:
         auto_link=_parse_auto_link(auto_link_raw),
         link_suggestion=_parse_link_suggestion(link_suggestion_raw),
         tags=_parse_tags(tags_raw),
+        relations=_parse_relations(relations_raw),
         feeds=_parse_feeds(feeds_raw),
         rate_limit=_parse_rate_limit(rate_limit_raw),
         server=_parse_server(server_raw),

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -183,6 +183,7 @@ def _build_background_store_factory(
             auto_link_enabled=config.auto_link.enabled,
             auto_link_threshold=config.auto_link.threshold,
             auto_link_max_links=config.auto_link.max_links,
+            enforce_relation_schema=config.relations.enforce_schema,
         )
         await store.initialize()
         return store
@@ -235,6 +236,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 auto_link_enabled=config.auto_link.enabled,
                 auto_link_threshold=config.auto_link.threshold,
                 auto_link_max_links=config.auto_link.max_links,
+                enforce_relation_schema=config.relations.enforce_schema,
             )
             await store.initialize()
             # Flush the WAL during quiet windows so it never grows unbounded
@@ -1373,7 +1375,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         graph metrics (bridges, communities) on the relations subgraph.
 
         PARAMS:
-          - action (str, required): Operation. Valid: [add, get, remove, traverse, metrics, promote_entities].
+          - action (str, required): Operation. Valid: [add, get, remove, traverse, metrics,
+            reconcile, list_candidates, resolve_candidate, suggest_links, promote_entities,
+            audit_schema].
           - from_id (str, required for add): Source entry UUID.
           - to_id (str, required for add): Target entry UUID.
           - relation_type (str, required for add, optional for get/traverse): Relation type.

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -18,6 +18,7 @@ from distillery.mcp.tools._common import (
     error_response,
     success_response,
 )
+from distillery.relations.schema import VALID_RELATION_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -53,20 +54,9 @@ _VALID_SCOPES = {"global", "ego"}
 
 _VALID_DIRECTIONS = {"outgoing", "incoming", "both"}
 
-_VALID_RELATION_TYPES = {
-    "link",
-    "corrects",
-    "supersedes",
-    "related",
-    "blocks",
-    "depends_on",
-    "citation",
-    "duplicate",
-    "merge_source",
-    "sync_source",
-    "mentions",
-    "chunk",
-}
+# Single source of truth in relations.schema (issue #653 de-duplicated the copy
+# that used to be maintained here in parallel with store/duckdb.py).
+_VALID_RELATION_TYPES = VALID_RELATION_TYPES
 
 
 async def _handle_relations(
@@ -108,12 +98,13 @@ async def _handle_relations(
         "resolve_candidate",
         "suggest_links",
         "promote_entities",
+        "audit_schema",
     ):
         return error_response(
             "INVALID_PARAMS",
             "action must be one of 'add', 'get', 'remove', 'traverse', 'metrics', "
             "'reconcile', 'list_candidates', 'resolve_candidate', 'suggest_links', "
-            f"'promote_entities'; got: {action!r}",
+            f"'promote_entities', 'audit_schema'; got: {action!r}",
         )
 
     # ------------------------------------------------------------------
@@ -601,6 +592,25 @@ async def _handle_relations(
                 "entities_reused": counts.get("entities_reused", 0),
                 "mentions_created": counts.get("mentions_created", 0),
                 "threshold": threshold,
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # action == "audit_schema"
+    # ------------------------------------------------------------------
+    if action == "audit_schema":
+        try:
+            violations = await store.audit_relation_schema()
+        except Exception:  # noqa: BLE001
+            logger.exception("distillery_relations audit_schema: unexpected error")
+            return error_response("INTERNAL", "Failed to audit relation schema")
+
+        return success_response(
+            {
+                "action": "audit_schema",
+                "violations": violations,
+                "count": len(violations),
+                "clean": len(violations) == 0,
             }
         )
 

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -478,6 +478,7 @@ async def _ensure_store(
             auto_link_enabled=config.auto_link.enabled,
             auto_link_threshold=config.auto_link.threshold,
             auto_link_max_links=config.auto_link.max_links,
+            enforce_relation_schema=config.relations.enforce_schema,
         )
         await store.initialize()
 

--- a/src/distillery/relations/__init__.py
+++ b/src/distillery/relations/__init__.py
@@ -1,0 +1,1 @@
+"""Relation ontology for the knowledge graph (issue #653)."""

--- a/src/distillery/relations/schema.py
+++ b/src/distillery/relations/schema.py
@@ -1,0 +1,143 @@
+"""Typed relation schema for the knowledge graph (issue #653, ontology #1).
+
+Single source of truth for two things:
+
+1. ``VALID_RELATION_TYPES`` — the closed vocabulary of relation-type *names*.
+   This replaces the two duplicated copies that previously lived in
+   ``store/duckdb.py`` and ``mcp/tools/relations.py``.
+2. ``RELATION_SCHEMA`` — the legal ``(from_type, relation, to_type)`` triples,
+   i.e. which entry types may sit on either end of each relation. ``"*"`` is a
+   wildcard matching any (current or future) entry type; multi-target unions
+   (the epic's ``session -> citation -> reference|bookmark``) are expressed as
+   multiple rows rather than a special union object, so membership is a plain
+   set lookup.
+
+The validator is a pure function callable from both the async ``add_relation``
+path and the synchronous raw-SQL writers, so a single schema governs every edge
+creator.
+
+Design note — the initial table is deliberately wildcard-heavy for the
+corpus-wide *semantic* relations (``related``, ``link``, ``citation``,
+``duplicate``, ``merge_source``) and the curation relations. Those are created
+by auto-link / reconcile / suggest_links / find_similar over arbitrary type
+pairs, so narrowing them would retroactively outlaw existing edges and sabotage
+the very writers epic #653 is turning on. Only the relations the epic wants
+*structurally* constrained get narrow triples. The unions can be tightened in a
+later hardening step once the real type-pair distribution is known (use
+``audit_relation_schema`` on the store to surface it).
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Wildcard endpoint — matches any entry type, including types added later.
+WILDCARD = "*"
+
+#: Closed vocabulary of relation-type names (single source of truth).
+VALID_RELATION_TYPES: frozenset[str] = frozenset(
+    {
+        "link",
+        "corrects",
+        "supersedes",
+        "related",
+        "blocks",
+        "depends_on",
+        "citation",
+        "duplicate",
+        "merge_source",
+        "sync_source",
+        "mentions",
+        "chunk",
+    }
+)
+
+#: Legal ``(from_type, relation, to_type)`` triples. ``WILDCARD`` on either end
+#: matches any entry type. Derived so that nothing currently created by a real
+#: edge writer becomes illegal (see module docstring).
+RELATION_SCHEMA: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        # --- gh-sync structural & cross-reference edges ---
+        ("github", "depends_on", "github"),  # sub-issue -> epic
+        ("github", "citation", "github"),  # PR -> issue
+        ("github", "link", "github"),  # generic cross-ref
+        # --- epic-named narrow examples ---
+        ("session", "citation", "reference"),  # session -> citation -> reference|bookmark
+        ("session", "citation", "bookmark"),
+        ("feed", "related", "project"),
+        # --- mentions -> person|entity (epic example + promote_entities) ---
+        # promote_entities writes ANY from-type -> entity, so the from side is
+        # wildcard to grandfather every member entry.
+        (WILDCARD, "mentions", "person"),
+        (WILDCARD, "mentions", "entity"),
+        # --- chunk: structural doc-split linking, any -> any ---
+        (WILDCARD, "chunk", WILDCARD),
+        # --- corpus-wide semantic / dedup relations (see module docstring) ---
+        (WILDCARD, "related", WILDCARD),
+        (WILDCARD, "link", WILDCARD),
+        (WILDCARD, "citation", WILDCARD),
+        (WILDCARD, "duplicate", WILDCARD),
+        (WILDCARD, "merge_source", WILDCARD),
+        # --- curation / manual relations (no automated writer today) ---
+        (WILDCARD, "supersedes", WILDCARD),
+        (WILDCARD, "corrects", WILDCARD),
+        (WILDCARD, "blocks", WILDCARD),
+        (WILDCARD, "sync_source", WILDCARD),
+    }
+)
+
+
+class RelationSchemaError(ValueError):
+    """Raised when a ``(from_type, relation, to_type)`` triple is not allowed.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers in
+    the MCP relation tool surface it as a clean error response.
+    """
+
+
+def triple_allowed(from_type: str, relation_type: str, to_type: str) -> bool:
+    """Return whether the triple is permitted by ``RELATION_SCHEMA``.
+
+    Checks the four wildcard combinations (exact, from-wild, to-wild, both-wild)
+    so a single membership helper is fully symmetric.
+    """
+    return (
+        (from_type, relation_type, to_type) in RELATION_SCHEMA
+        or (WILDCARD, relation_type, to_type) in RELATION_SCHEMA
+        or (from_type, relation_type, WILDCARD) in RELATION_SCHEMA
+        or (WILDCARD, relation_type, WILDCARD) in RELATION_SCHEMA
+    )
+
+
+def validate_relation_triple(
+    from_type: str,
+    relation_type: str,
+    to_type: str,
+    *,
+    enforce: bool = True,
+) -> None:
+    """Validate an edge against the relation ontology.
+
+    The relation-type *name* check is unconditional — an unknown ``relation_type``
+    always raises :class:`RelationSchemaError` regardless of *enforce* (a typo'd
+    type is never legitimate). The *triple* (endpoint-pairing) check is gated by
+    *enforce*: when ``True`` an illegal triple raises; when ``False`` (warn-only
+    mode) it logs a WARNING and returns, giving operators a migration window
+    before strict enforcement is switched on.
+    """
+    if relation_type not in VALID_RELATION_TYPES:
+        raise RelationSchemaError(
+            f"Invalid relation_type {relation_type!r}. "
+            f"Must be one of: {', '.join(sorted(VALID_RELATION_TYPES))}."
+        )
+    if triple_allowed(from_type, relation_type, to_type):
+        return
+    msg = (
+        f"Relation schema violation: ({from_type!r}, {relation_type!r}, "
+        f"{to_type!r}) is not an allowed (from_type, relation, to_type) triple."
+    )
+    if enforce:
+        raise RelationSchemaError(msg)
+    logger.warning("%s (warn-only mode — edge allowed)", msg)

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -33,6 +33,11 @@ import duckdb
 
 from distillery.feeds.tags import normalize_tag
 from distillery.models import Entry, EntrySource, EntryStatus, EntryType, validate_metadata
+from distillery.relations.schema import (
+    VALID_RELATION_TYPES,
+    triple_allowed,
+    validate_relation_triple,
+)
 from distillery.store.migrations import (
     _CREATE_META_TABLE,
     backfill_relations_from_content_refs,
@@ -85,21 +90,10 @@ _DEFAULT_THREADS = 2
 # a writer.  It deliberately NEVER escalates to FORCE CHECKPOINT (issue #648).
 _DEFAULT_IDLE_CHECKPOINT_INTERVAL_S = 60.0
 
-# Valid relation types — must match the set in mcp/tools/relations.py.
-_VALID_RELATION_TYPES = {
-    "link",
-    "corrects",
-    "supersedes",
-    "related",
-    "blocks",
-    "depends_on",
-    "citation",
-    "duplicate",
-    "merge_source",
-    "sync_source",
-    "mentions",
-    "chunk",
-}
+# Valid relation types — single source of truth lives in relations.schema; this
+# alias preserves the existing internal name (issue #653 de-duplicated the copy
+# that used to be maintained here in parallel with mcp/tools/relations.py).
+_VALID_RELATION_TYPES = VALID_RELATION_TYPES
 
 
 class EntriesIntegrityError(RuntimeError):
@@ -228,6 +222,7 @@ class DuckDBStore:
         auto_link_enabled: bool = False,
         auto_link_threshold: float = 0.85,
         auto_link_max_links: int = 5,
+        enforce_relation_schema: bool = False,
         memory_limit_mb: int | None = _DEFAULT_MEMORY_LIMIT_MB,
         threads: int | None = _DEFAULT_THREADS,
     ) -> None:
@@ -274,6 +269,10 @@ class DuckDBStore:
         self._auto_link_enabled: bool = auto_link_enabled
         self._auto_link_threshold: float = auto_link_threshold
         self._auto_link_max_links: int = auto_link_max_links
+        # Typed relation-schema enforcement (issue #653, ontology #1). OFF by
+        # default (warn-only) so an already-populated graph built before any
+        # schema is never retroactively rejected; flip on after a clean audit.
+        self._enforce_relation_schema: bool = enforce_relation_schema
         # Serializes access to the shared ``DuckDBPyConnection``.  DuckDB
         # connections are **not** thread-safe for concurrent use, but every
         # store operation funnels through ``asyncio.to_thread`` which runs
@@ -3961,6 +3960,21 @@ class DuckDBStore:
         row = self._conn.execute("SELECT id FROM entries WHERE id = ?", [entry_id]).fetchone()
         return row is not None
 
+    def _sync_entry_type(self, entry_id: str) -> str | None:
+        """Return *entry_id*'s ``entry_type``, or ``None`` if it does not exist.
+
+        Doubles as an existence probe (``None`` ⇔ absent) so the relation write
+        path can fetch the endpoint type and check existence in one query — used
+        by :meth:`_sync_add_relation` to validate the typed relation schema
+        without an extra round-trip (issue #653, ontology #1). Archived entries
+        are considered present (same rule as :meth:`_sync_entry_exists`).
+        """
+        assert self._conn is not None
+        row = self._conn.execute(
+            "SELECT entry_type FROM entries WHERE id = ?", [entry_id]
+        ).fetchone()
+        return str(row[0]) if row is not None else None
+
     def _sync_diagnose_missing_entry(self, entry_id: str) -> dict[str, Any]:
         """Collect cross-table visibility info for *entry_id* on the error path.
 
@@ -4084,10 +4098,13 @@ class DuckDBStore:
                 f"Invalid relation_type {relation_type!r}. "
                 f"Must be one of: {', '.join(sorted(_VALID_RELATION_TYPES))}."
             )
-        # Validate that both entries exist (including archived — preserves historical links).
-        # Routes through :meth:`_sync_entry_exists` so this lookup uses the same SQL shape
-        # as every other existence check; see issue #515 for the asymmetry this prevents.
-        if not self._sync_entry_exists(from_id):
+        # Validate that both entries exist (including archived — preserves historical links)
+        # and capture their entry_types for the typed-relation-schema check below. The
+        # type fetch doubles as the existence probe (None ⇔ absent), so it adds no extra
+        # round-trip over the previous _sync_entry_exists call; see issue #515 for the
+        # asymmetry the single shared SQL shape prevents.
+        from_type = self._sync_entry_type(from_id)
+        if from_type is None:
             diag = self._sync_diagnose_missing_entry(from_id)
             logger.warning(
                 "add_relation rejected: from_id=%r not in entries; diagnostic=%s",
@@ -4095,7 +4112,8 @@ class DuckDBStore:
                 diag,
             )
             raise ValueError(f"Entry not found: from_id={from_id!r} (diagnostic={diag})")
-        if not self._sync_entry_exists(to_id):
+        to_type = self._sync_entry_type(to_id)
+        if to_type is None:
             diag = self._sync_diagnose_missing_entry(to_id)
             logger.warning(
                 "add_relation rejected: to_id=%r not in entries; diagnostic=%s",
@@ -4151,6 +4169,13 @@ class DuckDBStore:
                 len(set_parts),
             )
             return relation_id
+        # Typed relation-schema check (issue #653, ontology #1) — applied only to
+        # NEW edges. Re-asserts (existing is not None, handled above) skip it so
+        # attribute upserts on grandfathered edges — e.g. retiring an edge via
+        # invalid_at — never fail even if the triple predates the schema.
+        validate_relation_triple(
+            from_type, relation_type, to_type, enforce=self._enforce_relation_schema
+        )
         relation_id = str(uuid.uuid4())
         self._conn.execute(
             "INSERT INTO entry_relations "
@@ -4662,6 +4687,43 @@ class DuckDBStore:
             references) and ``total`` (sum across all mechanisms).
         """
         return await self._run_sync(self._sync_reconcile_relations)
+
+    def _sync_audit_relation_schema(self) -> list[dict[str, Any]]:
+        """Read-only audit of existing edges against the typed relation schema.
+
+        Groups every live edge by ``(from_type, relation_type, to_type)`` (via a
+        join to ``entries`` on both endpoints) and returns the groups that
+        :func:`distillery.relations.schema.triple_allowed` rejects, with counts.
+        Edges whose endpoints no longer exist are excluded by the join (a
+        separate integrity concern). Run this before flipping
+        ``relations.enforce_schema`` to ``True`` (issue #653, ontology #1).
+        """
+        assert self._conn is not None
+        rows = self._conn.execute(
+            "SELECT ef.entry_type AS from_type, r.relation_type AS rel, "
+            "       et.entry_type AS to_type, COUNT(*) AS n "
+            "FROM entry_relations r "
+            "JOIN entries ef ON ef.id = r.from_id "
+            "JOIN entries et ON et.id = r.to_id "
+            "GROUP BY 1, 2, 3"
+        ).fetchall()
+        violations: list[dict[str, Any]] = []
+        for from_type, rel, to_type, n in rows:
+            if not triple_allowed(str(from_type), str(rel), str(to_type)):
+                violations.append(
+                    {
+                        "from_type": str(from_type),
+                        "relation_type": str(rel),
+                        "to_type": str(to_type),
+                        "count": int(n),
+                    }
+                )
+        violations.sort(key=lambda v: v["count"], reverse=True)
+        return violations
+
+    async def audit_relation_schema(self) -> list[dict[str, Any]]:
+        """See :meth:`distillery.store.protocol.DistilleryStore.audit_relation_schema`."""
+        return await self._run_sync(self._sync_audit_relation_schema)
 
     # ------------------------------------------------------------------
     # Entity-node promotion (issue #653 step 1)

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -738,6 +738,18 @@ class DistilleryStore(Protocol):
         """
         ...
 
+    async def audit_relation_schema(self) -> list[dict[str, Any]]:
+        """Audit existing edges against the typed relation schema (issue #653).
+
+        Groups every live edge by ``(from_type, relation_type, to_type)`` and
+        returns the groups that violate
+        :data:`distillery.relations.schema.RELATION_SCHEMA`, each as a dict with
+        ``from_type``, ``relation_type``, ``to_type`` and ``count`` (descending
+        by count). An empty list means the corpus is schema-clean — the signal to
+        flip ``relations.enforce_schema`` to ``True``.
+        """
+        ...
+
     async def get_metadata(self, key: str) -> str | None:
         """Read a value from the ``_meta`` key-value table.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -684,6 +684,34 @@ class TestTagsConfig:
         assert "system" in cfg.tags.reserved_prefixes
 
 
+class TestRelationsConfig:
+    def test_enforce_schema_defaults_false(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+        cfg = load_config()
+        assert cfg.relations.enforce_schema is False
+
+    def test_enforce_schema_parsed_true(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            relations:
+              enforce_schema: true
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        cfg = load_config(str(p))
+        assert cfg.relations.enforce_schema is True
+
+    def test_enforce_schema_invalid_type_raises(self, tmp_path: Path) -> None:
+        yaml_content = """\
+            relations:
+              enforce_schema: "yes"
+        """
+        p = write_yaml(tmp_path, yaml_content)
+        with pytest.raises(ValueError, match="enforce_schema"):
+            load_config(str(p))
+
+
 # ---------------------------------------------------------------------------
 # FeedsConfig: dataclass defaults and loading
 # ---------------------------------------------------------------------------

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -135,28 +135,30 @@ async def test_add_relation_accepts_archived_entries(store) -> None:  # type: ig
 
 @pytest.mark.unit
 async def test_add_relation_uses_shared_existence_helper(store) -> None:  # type: ignore[no-untyped-def]
-    """_sync_add_relation routes its existence check through _sync_entry_exists.
+    """_sync_add_relation routes its existence check through _sync_entry_type.
 
-    Locks in the structural alignment that closes issue #515. If a future
-    refactor reintroduces a divergent SELECT in _sync_add_relation, this
-    test (which monkeypatches the helper) will fail.
+    Locks in the structural alignment that closes issue #515. _sync_add_relation
+    now fetches each endpoint's entry_type (which doubles as the existence probe,
+    same ``entries WHERE id = ?`` shape as the read path; issue #653 ontology #1).
+    If a future refactor reintroduces a divergent SELECT in _sync_add_relation,
+    this test (which monkeypatches the helper) will fail.
     """
     from_id = await _store_entry(store, content="entry A")
     to_id = await _store_entry(store, content="entry B")
 
-    # Force the helper to reject every id — _sync_add_relation must observe
-    # that and raise. If _sync_add_relation bypasses the helper with its
-    # own inline SELECT, the call would succeed and this test would fail.
-    def _always_missing(_entry_id: str) -> bool:
-        return False
+    # Force the helper to report every id missing (None) — _sync_add_relation
+    # must observe that and raise. If it bypasses the helper with its own inline
+    # SELECT, the call would succeed and this test would fail.
+    def _always_missing(_entry_id: str) -> str | None:
+        return None
 
-    store._sync_entry_exists = _always_missing  # type: ignore[method-assign]
+    store._sync_entry_type = _always_missing  # type: ignore[method-assign]
     try:
         with pytest.raises(ValueError, match="Entry not found"):
             await store.add_relation(from_id, to_id, "link")
     finally:
         # Restore the bound method so subsequent fixture teardown is clean.
-        del store._sync_entry_exists
+        del store._sync_entry_type
 
 
 @pytest.mark.unit

--- a/tests/test_relations_schema.py
+++ b/tests/test_relations_schema.py
@@ -1,0 +1,192 @@
+"""Tests for the typed relation schema (issue #653, ontology #1).
+
+Covers the pure validator in ``distillery.relations.schema`` plus its
+integration into the store's ``add_relation`` write path and the read-only
+``audit_relation_schema`` / MCP ``audit_schema`` action.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from distillery.models import EntryType
+from distillery.relations.schema import (
+    VALID_RELATION_TYPES,
+    RelationSchemaError,
+    triple_allowed,
+    validate_relation_triple,
+)
+from tests.conftest import make_entry
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Pure validator
+# ---------------------------------------------------------------------------
+
+
+def test_exact_triple_allowed() -> None:
+    assert triple_allowed("github", "depends_on", "github") is True
+
+
+def test_wildcard_from_match() -> None:
+    # (*, mentions, entity) covers any from-type.
+    assert triple_allowed("session", "mentions", "entity") is True
+
+
+def test_wildcard_to_match() -> None:
+    # (*, chunk, *) covers any endpoints.
+    assert triple_allowed("session", "chunk", "reference") is True
+
+
+def test_illegal_triple_rejected_in_strict() -> None:
+    """depends_on is constrained to github->github; session->session is illegal."""
+    with pytest.raises(RelationSchemaError):
+        validate_relation_triple("session", "depends_on", "session", enforce=True)
+
+
+def test_mentions_to_non_entity_rejected_in_strict() -> None:
+    with pytest.raises(RelationSchemaError):
+        validate_relation_triple("session", "mentions", "session", enforce=True)
+
+
+def test_unknown_relation_type_always_raises() -> None:
+    """An unknown relation_type is a hard error even in warn-only mode."""
+    with pytest.raises(RelationSchemaError):
+        validate_relation_triple("session", "teleports_to", "session", enforce=False)
+
+
+def test_warn_mode_allows_illegal_triple(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        # Must not raise.
+        validate_relation_triple("session", "depends_on", "session", enforce=False)
+    assert any("schema violation" in r.message.lower() for r in caplog.records)
+
+
+def test_valid_relation_types_shared_identity() -> None:
+    """The store and MCP layers must reference the one schema vocabulary."""
+    from distillery.mcp.tools import relations as mcp_rel
+    from distillery.store import duckdb as store_mod
+
+    assert mcp_rel._VALID_RELATION_TYPES is VALID_RELATION_TYPES
+    assert store_mod._VALID_RELATION_TYPES is VALID_RELATION_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Store integration: add_relation enforcement
+# ---------------------------------------------------------------------------
+
+
+async def _store_entry(store, **kwargs):  # type: ignore[no-untyped-def]
+    entry = make_entry(**kwargs)
+    await store.store(entry)
+    return entry.id
+
+
+async def test_add_relation_warn_mode_allows_illegal(store) -> None:  # type: ignore[no-untyped-def]
+    """Default (warn-only) store inserts an illegal triple and logs."""
+    a = await _store_entry(store, content="a")  # inbox
+    b = await _store_entry(store, content="b")  # inbox
+    rid = await store.add_relation(a, b, "depends_on")  # (inbox, depends_on, inbox) illegal
+    assert rid
+    related = await store.get_related(a, relation_type="depends_on")
+    assert len(related) == 1
+
+
+async def test_add_relation_strict_rejects_illegal(store) -> None:  # type: ignore[no-untyped-def]
+    """With enforce on, an illegal triple raises and inserts nothing."""
+    store._enforce_relation_schema = True
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    with pytest.raises(ValueError):
+        await store.add_relation(a, b, "depends_on")
+    related = await store.get_related(a, relation_type="depends_on")
+    assert related == []
+
+
+async def test_add_relation_strict_allows_legal(store) -> None:  # type: ignore[no-untyped-def]
+    """A legal triple inserts cleanly under strict enforcement."""
+    store._enforce_relation_schema = True
+    a = await _store_entry(
+        store,
+        content="pr",
+        entry_type=EntryType.GITHUB,
+        metadata={"repo": "o/r", "ref_type": "pr", "ref_number": 1},
+    )
+    b = await _store_entry(
+        store,
+        content="issue",
+        entry_type=EntryType.GITHUB,
+        metadata={"repo": "o/r", "ref_type": "issue", "ref_number": 2},
+    )
+    rid = await store.add_relation(a, b, "depends_on")  # github->depends_on->github
+    assert rid
+
+
+async def test_reassert_of_illegal_edge_skips_validation(store) -> None:  # type: ignore[no-untyped-def]
+    """An edge created in warn mode can be re-asserted (attribute upsert) under
+    strict mode without raising — only NEW inserts are validated."""
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    rid = await store.add_relation(a, b, "depends_on")  # warn mode: inserted
+
+    store._enforce_relation_schema = True
+    # Re-assert with a fresh attribute — must NOT raise despite the illegal triple.
+    rid2 = await store.add_relation(a, b, "depends_on", weight=0.5)
+    assert rid2 == rid
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+async def test_audit_relation_schema_reports_violations(store) -> None:  # type: ignore[no-untyped-def]
+    """The audit surfaces existing illegal edges grouped with counts."""
+    a = await _store_entry(store, content="a")  # inbox
+    b = await _store_entry(store, content="b")  # inbox
+    await store.add_relation(a, b, "depends_on")  # illegal (inbox->inbox)
+
+    violations = await store.audit_relation_schema()
+    assert len(violations) == 1
+    v = violations[0]
+    assert v["from_type"] == "inbox"
+    assert v["relation_type"] == "depends_on"
+    assert v["to_type"] == "inbox"
+    assert v["count"] == 1
+
+
+async def test_audit_relation_schema_clean_when_only_legal(store) -> None:  # type: ignore[no-untyped-def]
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    await store.add_relation(a, b, "related")  # (*, related, *) is allowed
+
+    violations = await store.audit_relation_schema()
+    assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# MCP action: audit_schema
+# ---------------------------------------------------------------------------
+
+
+async def test_mcp_audit_schema_action(store) -> None:  # type: ignore[no-untyped-def]
+    from distillery.mcp.tools.relations import _handle_relations
+
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    await store.add_relation(a, b, "depends_on")  # illegal
+
+    result = await _handle_relations(store, {"action": "audit_schema"})
+    data = json.loads(result[0].text)
+
+    assert data.get("error") is not True
+    assert data["action"] == "audit_schema"
+    assert data["clean"] is False
+    assert data["count"] == 1
+    assert data["violations"][0]["relation_type"] == "depends_on"


### PR DESCRIPTION
## What

Phase 2 of finishing epic #653 — **ontology #1, the typed relation schema** (the one item with zero prior implementation). Declares which entry types may sit on either end of each relation and validates edge creation against it. **Warn-only by default** — an already-populated graph is never retroactively rejected.

## Changes

- **`relations/schema.py`** (new): single source of truth for
  - `VALID_RELATION_TYPES` — the closed relation-type vocabulary, **de-duplicating** the two copies that were previously hand-synced in `store/duckdb.py` and `mcp/tools/relations.py`.
  - `RELATION_SCHEMA` — the legal `(from_type, relation, to_type)` triples, with a `"*"` wildcard and multi-target unions as multiple rows.
  - `validate_relation_triple()` / `triple_allowed()` / `RelationSchemaError(ValueError)`.
- **`store`** — `_sync_add_relation` validates **new** edges. The endpoint-type fetch is folded into the existence probe (`_sync_entry_type`, same `entries WHERE id = ?` shape as the read path → preserves the #515 invariant, no extra round-trip). Re-asserts (attribute upserts) **skip** validation so grandfathered edges can still be updated/retired. New `audit_relation_schema()` groups existing edges by triple and reports violations.
- **`config`** — `RelationsConfig.enforce_schema` (default `False` = warn-only), threaded into `DuckDBStore` at every config-bearing construction site (server ×2, webhooks, cli ×5).
- **`mcp`** — `distillery_relations action="audit_schema"` (run before flipping strict).
- **`distillery.yaml.example`** — documented `relations` section.

## Initial triple table (grandfathering)

Deliberately wildcard-heavy for the corpus-wide semantic relations (`related`, `link`, `citation`, `duplicate`, `merge_source`) so existing auto-link / reconcile / suggest_links / find_similar edges stay legal. Only `depends_on` (github→github) and `mentions` (→person|entity) are structurally constrained. The `audit_schema` action surfaces the real type-pair distribution to tighten unions later.

## Rollout (Phase 4)

Ships warn-only. Flip `relations.enforce_schema: true` only after `audit_schema` returns clean on the live KB. No production data is touched by this PR.

## Testing

- Pure validator: exact / wildcard-from / wildcard-to match, strict reject, warn-allow, unknown-type always-raises.
- Store: warn vs strict enforcement, legal triple passes strict, re-assert skips validation, audit reports + clean cases.
- MCP `audit_schema` action; shared-vocabulary identity (both layers reference one set); config parsing (default/true/invalid).
- Full suite: **3225 passed**, 79 skipped; `mypy --strict src/` clean (75 files); `ruff check src/ tests/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable relation-schema enforcement, letting relation edges be checked against allowed type triples.
  * Added a schema audit action to report invalid relation combinations and counts.
  * Added a new way to review relation-schema violations through the store and MCP tools.

* **Bug Fixes**
  * Relation type validation now uses a single shared source of truth.
  * Improved handling of missing entries during relation checks.

* **Documentation**
  * Updated the example configuration with the new relation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->