### PR TITLE
feat(relations): bi-temporal curation — read filter + retire/revalidate (#653)

### DIFF
--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -1364,6 +1364,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         valid_at: str | None = None,
         invalid_at: str | None = None,
         metadata: dict[str, Any] | None = None,
+        include_retired: bool = False,
     ) -> list[types.TextContent]:
         """Manage typed relations between knowledge entries.
 
@@ -1373,7 +1374,12 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
         graph metrics (bridges, communities) on the relations subgraph.
 
         PARAMS:
-          - action (str, required): Operation. Valid: [add, get, remove, traverse, metrics, promote_entities].
+          - action (str, required): Operation. Valid: [add, get, remove, traverse, metrics,
+            reconcile, list_candidates, resolve_candidate, suggest_links, promote_entities,
+            retire, revalidate]. ``retire`` soft-retires an edge (sets invalid_at; pass
+            relation_id and optional invalid_at ISO 8601 — defaults to now); ``revalidate``
+            clears invalid_at. ``get`` accepts include_retired (default false) to include
+            soft-retired edges.
           - from_id (str, required for add): Source entry UUID.
           - to_id (str, required for add): Target entry UUID.
           - relation_type (str, required for add, optional for get/traverse): Relation type.
@@ -1452,6 +1458,7 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                     valid_at=valid_at,
                     invalid_at=invalid_at,
                     metadata=metadata,
+                    include_retired=include_retired,
                 ),
             ),
             cfg=c["config"],

--- a/src/distillery/mcp/tools/relations.py
+++ b/src/distillery/mcp/tools/relations.py
@@ -108,12 +108,14 @@ async def _handle_relations(
         "resolve_candidate",
         "suggest_links",
         "promote_entities",
+        "retire",
+        "revalidate",
     ):
         return error_response(
             "INVALID_PARAMS",
             "action must be one of 'add', 'get', 'remove', 'traverse', 'metrics', "
             "'reconcile', 'list_candidates', 'resolve_candidate', 'suggest_links', "
-            f"'promote_entities'; got: {action!r}",
+            f"'promote_entities', 'retire', 'revalidate'; got: {action!r}",
         )
 
     # ------------------------------------------------------------------
@@ -236,9 +238,14 @@ async def _handle_relations(
                 )
             get_relation_type = get_relation_type_raw.strip() or None
 
+        include_retired = bool(arguments.get("include_retired", False))
+
         try:
             relations = await store.get_related(
-                entry_id, direction=direction, relation_type=get_relation_type
+                entry_id,
+                direction=direction,
+                relation_type=get_relation_type,
+                include_retired=include_retired,
             )
         except Exception:  # noqa: BLE001
             logger.exception("distillery_relations get: unexpected error")
@@ -249,6 +256,7 @@ async def _handle_relations(
                 "entry_id": entry_id,
                 "direction": direction,
                 "relation_type": get_relation_type,
+                "include_retired": include_retired,
                 "relations": relations,
                 "count": len(relations),
             }
@@ -602,6 +610,49 @@ async def _handle_relations(
                 "mentions_created": counts.get("mentions_created", 0),
                 "threshold": threshold,
             }
+        )
+
+    # ------------------------------------------------------------------
+    # action == "retire" (soft-retire an edge via invalid_at)
+    # ------------------------------------------------------------------
+    if action == "retire":
+        retire_id_raw = arguments.get("relation_id")
+        if not isinstance(retire_id_raw, str) or not retire_id_raw.strip():
+            return error_response("INVALID_PARAMS", "relation_id is required for action='retire'")
+        retire_id = retire_id_raw.strip()
+        invalid_at_raw = arguments.get("invalid_at")
+        if invalid_at_raw is not None and not isinstance(invalid_at_raw, str):
+            return error_response("INVALID_PARAMS", "invalid_at must be an ISO 8601 string")
+        try:
+            retired = await store.retire_relation(retire_id, invalid_at_raw)
+        except ValueError as exc:
+            return error_response("INVALID_PARAMS", f"Cannot retire relation: {exc}")
+        except Exception:  # noqa: BLE001
+            logger.exception("distillery_relations retire: unexpected error")
+            return error_response("INTERNAL", "Failed to retire relation")
+
+        return success_response(
+            {"action": "retire", "relation_id": retire_id, "retired": retired}
+        )
+
+    # ------------------------------------------------------------------
+    # action == "revalidate" (clear invalid_at so an edge is live again)
+    # ------------------------------------------------------------------
+    if action == "revalidate":
+        reval_id_raw = arguments.get("relation_id")
+        if not isinstance(reval_id_raw, str) or not reval_id_raw.strip():
+            return error_response(
+                "INVALID_PARAMS", "relation_id is required for action='revalidate'"
+            )
+        reval_id = reval_id_raw.strip()
+        try:
+            revalidated = await store.revalidate_relation(reval_id)
+        except Exception:  # noqa: BLE001
+            logger.exception("distillery_relations revalidate: unexpected error")
+            return error_response("INTERNAL", "Failed to revalidate relation")
+
+        return success_response(
+            {"action": "revalidate", "relation_id": reval_id, "revalidated": revalidated}
         )
 
     # ------------------------------------------------------------------

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -101,6 +101,16 @@ _VALID_RELATION_TYPES = {
     "chunk",
 }
 
+# Bi-temporal "currently live" filter for relation reads (issue #653, curation).
+# An edge is live when it has started (valid_at null or in the past) and has not
+# been retired (invalid_at null or in the future). Soft-retired edges
+# (invalid_at set to now/past) are excluded from reads, traversal, and graph
+# metrics unless a caller explicitly asks to include them.
+_RELATION_LIVE_CLAUSE = (
+    "(valid_at IS NULL OR valid_at <= CURRENT_TIMESTAMP) "
+    "AND (invalid_at IS NULL OR invalid_at > CURRENT_TIMESTAMP)"
+)
+
 
 class EntriesIntegrityError(RuntimeError):
     """Raised when a post-bulk-rewrite read-back of ``entries`` fails.
@@ -4370,6 +4380,7 @@ class DuckDBStore:
         entry_id: str,
         direction: str,
         relation_type: str | None,
+        include_retired: bool = False,
     ) -> list[dict[str, Any]]:
         """Synchronous implementation of get_related(); called via asyncio.to_thread."""
         assert self._conn is not None
@@ -4401,6 +4412,10 @@ class DuckDBStore:
             "json_extract_string(metadata, '$.review_status') IS DISTINCT FROM 'pending')"
         )
 
+        # Exclude soft-retired edges (bi-temporal window) unless asked otherwise.
+        if not include_retired:
+            conditions.append(_RELATION_LIVE_CLAUSE)
+
         where_clause = " AND ".join(conditions)
         sql = (
             f"SELECT {self._RELATION_SELECT_COLUMNS} "
@@ -4414,6 +4429,7 @@ class DuckDBStore:
         entry_id: str,
         direction: str = "both",
         relation_type: str | None = None,
+        include_retired: bool = False,
     ) -> list[dict[str, Any]]:
         """Return relations for an entry, optionally filtered by direction and type.
 
@@ -4422,6 +4438,10 @@ class DuckDBStore:
             direction: One of ``"outgoing"``, ``"incoming"``, or ``"both"``
                 (default).
             relation_type: Optional filter restricting results to this type.
+            include_retired: When ``False`` (default), soft-retired edges (those
+                whose bi-temporal window has closed — ``invalid_at`` in the past,
+                or ``valid_at`` in the future) are excluded. Pass ``True`` to
+                include them (issue #653 curation).
 
         Returns:
             List of dicts with keys: ``id``, ``from_id``, ``to_id``,
@@ -4429,7 +4449,9 @@ class DuckDBStore:
             (float | None), ``valid_at`` / ``invalid_at`` (ISO 8601 str | None),
             ``metadata`` (dict | None).
         """
-        return await self._run_sync(self._sync_get_related, entry_id, direction, relation_type)
+        return await self._run_sync(
+            self._sync_get_related, entry_id, direction, relation_type, include_retired
+        )
 
     def _sync_remove_relation(self, relation_id: str) -> bool:
         """Synchronous implementation of remove_relation(); called via asyncio.to_thread."""
@@ -4455,22 +4477,29 @@ class DuckDBStore:
         """
         return await self._run_sync(self._sync_remove_relation, relation_id)
 
-    def _sync_list_relations(self) -> list[dict[str, Any]]:
+    def _sync_list_relations(self, include_retired: bool = False) -> list[dict[str, Any]]:
         """Synchronous implementation of list_relations(); called via asyncio.to_thread."""
         assert self._conn is not None
+        where = "" if include_retired else f" WHERE {_RELATION_LIVE_CLAUSE}"
         rows = self._conn.execute(
-            f"SELECT {self._RELATION_SELECT_COLUMNS} FROM entry_relations ORDER BY created_at ASC"
+            f"SELECT {self._RELATION_SELECT_COLUMNS} FROM entry_relations{where} "
+            "ORDER BY created_at ASC"
         ).fetchall()
         return [self._relation_row_to_dict(row) for row in rows]
 
-    async def list_relations(self) -> list[dict[str, Any]]:
-        """Return every row from ``entry_relations`` as a list of dicts.
+    async def list_relations(self, include_retired: bool = False) -> list[dict[str, Any]]:
+        """Return rows from ``entry_relations`` as a list of dicts.
 
         Used by graph metrics (``distillery_relations`` action="metrics") to
-        assemble the full subgraph for global-scope analysis. Goes through
+        assemble the subgraph for global-scope analysis. Goes through
         :meth:`_run_sync` so the async event loop is never blocked by sync
         DuckDB I/O and the shared connection is serialised under the same
         lock as every other store operation.
+
+        Args:
+            include_retired: When ``False`` (default), soft-retired edges (closed
+                bi-temporal window) are excluded so graph metrics reflect only
+                live structure (issue #653 curation).
 
         Returns:
             List of dicts with keys: ``id``, ``from_id``, ``to_id``,
@@ -4478,7 +4507,54 @@ class DuckDBStore:
             (float | None), ``valid_at`` / ``invalid_at`` (ISO 8601 str | None),
             ``metadata`` (dict | None).  Ordered by ascending ``created_at``.
         """
-        return await self._run_sync(self._sync_list_relations)
+        return await self._run_sync(self._sync_list_relations, include_retired)
+
+    def _sync_retire_relation(self, relation_id: str, invalid_at: str | datetime | None) -> bool:
+        """Soft-retire a relation by setting ``invalid_at`` (default: now).
+
+        Idempotent: re-retiring an already-retired edge just resets the
+        timestamp. Returns whether the row existed. Preferred over
+        :meth:`remove_relation` (a hard delete) so the edge stays auditable and
+        can be revalidated.
+        """
+        assert self._conn is not None
+        invalid_dt = self._coerce_relation_timestamp(invalid_at) or datetime.now(UTC)
+        found = (
+            self._conn.execute(
+                "UPDATE entry_relations SET invalid_at = ? WHERE id = ? RETURNING id",
+                [invalid_dt, relation_id],
+            ).fetchone()
+            is not None
+        )
+        if found:
+            self._checkpoint_after_write(self._conn)
+            logger.debug("Retired relation id=%s invalid_at=%s", relation_id, invalid_dt)
+        return found
+
+    async def retire_relation(
+        self, relation_id: str, invalid_at: str | datetime | None = None
+    ) -> bool:
+        """Soft-retire a relation (set its ``invalid_at``). See protocol."""
+        return await self._run_sync(self._sync_retire_relation, relation_id, invalid_at)
+
+    def _sync_revalidate_relation(self, relation_id: str) -> bool:
+        """Clear ``invalid_at`` so a retired relation becomes live again."""
+        assert self._conn is not None
+        found = (
+            self._conn.execute(
+                "UPDATE entry_relations SET invalid_at = NULL WHERE id = ? RETURNING id",
+                [relation_id],
+            ).fetchone()
+            is not None
+        )
+        if found:
+            self._checkpoint_after_write(self._conn)
+            logger.debug("Revalidated relation id=%s", relation_id)
+        return found
+
+    async def revalidate_relation(self, relation_id: str) -> bool:
+        """Clear a relation's ``invalid_at`` so it is live again. See protocol."""
+        return await self._run_sync(self._sync_revalidate_relation, relation_id)
 
     def _sync_add_relation_candidate(
         self,

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -590,6 +590,7 @@ class DistilleryStore(Protocol):
         entry_id: str,
         direction: str = "both",
         relation_type: str | None = None,
+        include_retired: bool = False,
     ) -> list[dict[str, Any]]:
         """Return relations for an entry, optionally filtered by direction and type.
 
@@ -600,6 +601,9 @@ class DistilleryStore(Protocol):
                 (default, returns all).
             relation_type: Optional filter restricting results to rows with
                 this ``relation_type`` value.  ``None`` returns all types.
+            include_retired: When ``False`` (default), soft-retired edges whose
+                bi-temporal window has closed (``invalid_at`` in the past, or
+                ``valid_at`` in the future) are excluded (issue #653 curation).
 
         Returns:
             List of dicts, each containing keys: ``id``, ``from_id``,
@@ -622,18 +626,54 @@ class DistilleryStore(Protocol):
         """
         ...
 
-    async def list_relations(self) -> list[dict[str, Any]]:
-        """Return every row from ``entry_relations`` as a list of dicts.
+    async def list_relations(self, include_retired: bool = False) -> list[dict[str, Any]]:
+        """Return rows from ``entry_relations`` as a list of dicts.
 
-        Intended for graph metrics computation that needs the entire relations
-        subgraph in one shot.  Implementations must run any underlying sync
-        I/O off the event loop so async callers are not blocked.
+        Intended for graph metrics computation that needs the relations subgraph
+        in one shot.  Implementations must run any underlying sync I/O off the
+        event loop so async callers are not blocked.
+
+        Args:
+            include_retired: When ``False`` (default), soft-retired edges (closed
+                bi-temporal window) are excluded so metrics reflect live
+                structure (issue #653 curation).
 
         Returns:
             List of dicts with keys: ``id``, ``from_id``, ``to_id``,
             ``relation_type``, ``created_at`` (ISO 8601 str), ``weight``
             (float | None), ``valid_at`` / ``invalid_at`` (ISO 8601 str | None),
             ``metadata`` (dict | None).  Ordered by ascending ``created_at``.
+        """
+        ...
+
+    async def retire_relation(
+        self, relation_id: str, invalid_at: str | datetime | None = None
+    ) -> bool:
+        """Soft-retire a relation by setting its ``invalid_at`` (issue #653 curation).
+
+        Preferred over :meth:`remove_relation` (a hard delete): the edge stays in
+        the table and is excluded from default reads/metrics, but remains
+        auditable and can be brought back with :meth:`revalidate_relation`.
+        Idempotent — re-retiring resets the timestamp.
+
+        Args:
+            relation_id: UUID of the ``entry_relations`` row to retire.
+            invalid_at: Instant the edge stopped being true; ``None`` means now.
+
+        Returns:
+            ``True`` if the row existed, ``False`` otherwise.
+        """
+        ...
+
+    async def revalidate_relation(self, relation_id: str) -> bool:
+        """Clear a relation's ``invalid_at`` so it is live again (issue #653).
+
+        The inverse of :meth:`retire_relation`. ``add_relation``'s attribute
+        upsert cannot reset ``invalid_at`` to NULL, so this is the supported way
+        to un-retire an edge.
+
+        Returns:
+            ``True`` if the row existed, ``False`` otherwise.
         """
         ...
 

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -356,14 +356,16 @@ async def test_add_relation_edge_attributes_round_trip(store) -> None:  # type: 
         metadata={"source": "spike", "n": 3},
     )
 
-    (row,) = await store.get_related(a)
+    # invalid_at is in the past, so the edge is soft-retired — read it back with
+    # include_retired to verify attribute persistence (issue #653 curation).
+    (row,) = await store.get_related(a, include_retired=True)
     assert row["weight"] == 0.75
     assert row["valid_at"] == "2026-01-01T00:00:00Z"
     assert row["invalid_at"] == "2026-06-01T12:30:00Z"
     assert row["metadata"] == {"source": "spike", "n": 3}
 
     # list_relations returns the same shape.
-    (listed,) = await store.list_relations()
+    (listed,) = await store.list_relations(include_retired=True)
     assert listed["weight"] == 0.75
     assert listed["metadata"] == {"source": "spike", "n": 3}
 
@@ -394,7 +396,8 @@ async def test_add_relation_reassert_upserts_attributes(store) -> None:  # type:
     second = await store.add_relation(a, b, "related", weight=0.9, invalid_at="2026-06-01T00:00:00")
 
     assert first == second  # same row, no duplicate
-    (row,) = await store.get_related(a)
+    # The upserted invalid_at is in the past -> retired; read with include_retired.
+    (row,) = await store.get_related(a, include_retired=True)
     assert row["weight"] == 0.9  # upserted
     assert row["invalid_at"] == "2026-06-01T00:00:00Z"
 

--- a/tests/test_relations_curation.py
+++ b/tests/test_relations_curation.py
@@ -1,0 +1,149 @@
+"""Tests for relation curation: bi-temporal read filter + retire/revalidate.
+
+Issue #653 graph-maintenance #4. The key property: ``invalid_at`` was previously
+write-only — no read path honored it. These tests lock in that soft-retiring an
+edge removes it from default reads, traversal, and the metrics subgraph, while
+``include_retired`` still surfaces it and ``revalidate`` brings it back.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.conftest import make_entry
+
+pytestmark = pytest.mark.unit
+
+
+async def _store_entry(store, **kwargs):  # type: ignore[no-untyped-def]
+    entry = make_entry(**kwargs)
+    await store.store(entry)
+    return entry.id
+
+
+async def _edge(store, a, b, rel="related"):  # type: ignore[no-untyped-def]
+    return await store.add_relation(a, b, rel)
+
+
+# ---------------------------------------------------------------------------
+# Store-level read filter
+# ---------------------------------------------------------------------------
+
+
+async def test_retired_edge_excluded_from_get_related(store) -> None:  # type: ignore[no-untyped-def]
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    rid = await _edge(store, a, b)
+
+    assert len(await store.get_related(a)) == 1
+    assert await store.retire_relation(rid) is True
+
+    # Default read excludes the retired edge ...
+    assert await store.get_related(a) == []
+    # ... but include_retired surfaces it.
+    assert len(await store.get_related(a, include_retired=True)) == 1
+
+
+async def test_retired_edge_excluded_from_list_relations(store) -> None:  # type: ignore[no-untyped-def]
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    rid = await _edge(store, a, b)
+    await store.retire_relation(rid)
+
+    assert await store.list_relations() == []
+    assert len(await store.list_relations(include_retired=True)) == 1
+
+
+async def test_revalidate_restores_edge(store) -> None:  # type: ignore[no-untyped-def]
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    rid = await _edge(store, a, b)
+    await store.retire_relation(rid)
+    assert await store.get_related(a) == []
+
+    assert await store.revalidate_relation(rid) is True
+    assert len(await store.get_related(a)) == 1
+
+
+async def test_future_invalid_at_stays_live(store) -> None:  # type: ignore[no-untyped-def]
+    """An edge whose invalid_at is in the future is still live."""
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    rid = await _edge(store, a, b)
+    await store.retire_relation(rid, invalid_at="2999-01-01T00:00:00Z")
+
+    assert len(await store.get_related(a)) == 1
+
+
+async def test_retire_is_idempotent_and_reports_missing(store) -> None:  # type: ignore[no-untyped-def]
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    rid = await _edge(store, a, b)
+
+    assert await store.retire_relation(rid) is True
+    assert await store.retire_relation(rid) is True  # idempotent
+    assert await store.retire_relation("no-such-id") is False
+
+
+async def test_traverse_excludes_retired(store) -> None:  # type: ignore[no-untyped-def]
+    """BFS traversal (built on get_related) drops retired edges by default."""
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    rid = await _edge(store, a, b)
+    await store.retire_relation(rid)
+
+    # get_related is the traversal primitive — both directions, no type filter.
+    assert await store.get_related(a, direction="both") == []
+
+
+# ---------------------------------------------------------------------------
+# MCP actions
+# ---------------------------------------------------------------------------
+
+
+async def test_mcp_retire_and_revalidate_roundtrip(store) -> None:  # type: ignore[no-untyped-def]
+    from distillery.mcp.tools.relations import _handle_relations
+
+    a = await _store_entry(store, content="a")
+    b = await _store_entry(store, content="b")
+    rid = await _edge(store, a, b)
+
+    retire = json.loads(
+        (await _handle_relations(store, {"action": "retire", "relation_id": rid}))[0].text
+    )
+    assert retire["retired"] is True
+
+    # get excludes it by default ...
+    got = json.loads(
+        (await _handle_relations(store, {"action": "get", "entry_id": a}))[0].text
+    )
+    assert got["count"] == 0
+    # ... and surfaces it with include_retired.
+    got_all = json.loads(
+        (
+            await _handle_relations(
+                store, {"action": "get", "entry_id": a, "include_retired": True}
+            )
+        )[0].text
+    )
+    assert got_all["count"] == 1
+    assert got_all["include_retired"] is True
+
+    reval = json.loads(
+        (await _handle_relations(store, {"action": "revalidate", "relation_id": rid}))[0].text
+    )
+    assert reval["revalidated"] is True
+    got2 = json.loads(
+        (await _handle_relations(store, {"action": "get", "entry_id": a}))[0].text
+    )
+    assert got2["count"] == 1
+
+
+async def test_mcp_retire_requires_relation_id(store) -> None:  # type: ignore[no-untyped-def]
+    from distillery.mcp.tools.relations import _handle_relations
+
+    data = json.loads((await _handle_relations(store, {"action": "retire"}))[0].text)
+    assert data["error"] is True
+    assert data["code"] == "INVALID_PARAMS"


### PR DESCRIPTION
## What

Phase 3 of finishing epic #653 — **graph-maintenance #4 (curation)**. 

**Crux finding:** `invalid_at` was write-only. No read path (`get_related`, `list_relations`, the metrics subgraph, traversal) filtered on it, so soft-retiring an edge was a complete no-op. This PR makes the bi-temporal window actually govern reads.

## Changes

- **`store` read filter** — `get_related` and `list_relations` exclude soft-retired edges by default via a shared `_RELATION_LIVE_CLAUSE` (`invalid_at` null/future **and** `valid_at` null/past). Pass `include_retired=True` to surface them. Because the metrics subgraph (`list_relations`) and BFS traversal (`get_related`) build on these, retired edges drop out of metrics/traverse **automatically** — no separate change needed.
- **`store` retire/revalidate** — `retire_relation(relation_id, invalid_at=now)` soft-retires (idempotent; preferred over the hard `remove`), and `revalidate_relation(relation_id)` clears `invalid_at` (the `add_relation` upsert cannot reset it to NULL, so this is the supported un-retire path).
- **`mcp`** — `distillery_relations action="retire"` / `"revalidate"`; the `get` action gains an `include_retired` passthrough.

## Safe by construction

Every existing edge has `invalid_at IS NULL`, so the new filter changes nothing until something is explicitly retired.

## Deferred to a follow-up PR (tracked)

Auto-retiring an entry's edges when it is `supersedes`/`corrects`-ed (cascade), and scheduled threshold-based retirement. The primitives (`retire_relation` + read filter) land here; the policy layer follows.

## Testing

- Retired edge excluded from `get_related` / `list_relations` / traversal; surfaced with `include_retired`; `revalidate` restores it.
- Future `invalid_at` stays live (bi-temporal correctness); retire idempotent + missing-id returns False; MCP retire/revalidate roundtrip + validation.
- Two existing attribute-round-trip tests updated to read with `include_retired` (their fixtures set a past `invalid_at`, so the edge is legitimately retired now).
- Full suite: **3215 passed**, 79 skipped; `mypy --strict src/` clean; `ruff check src/ tests/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)