### PR TITLE
fix(feeds): capture GitHub created_at as published_at, render effective date (#669)

### DIFF
--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -420,9 +420,15 @@ are rejected.  Pre-existing entries have no `kind/*` tag; *absence of
 
 ## Provenance
 
-Search results must include: entry ID, `[type]` badge, author, created date, similarity %.
+Search results must include: entry ID, `[type]` badge, author, effective date (see below), similarity %.
 
 Format: `ID: <uuid> | Author: <name> | Project: <project> | <date>`
+
+## Effective Date (chronology)
+
+Whenever a skill renders, sorts, or groups entries by date, use the entry's **effective date**: `metadata.published_at` when present, else `created_at`.
+
+`metadata.published_at` is the source's real creation/publication time — gh-sync sets it to the GitHub object's `created_at`, and the feed poller sets it to the item's publish time. The bare `created_at` of an imported entry is the *ingest* timestamp; a batch import (all of gh-sync) collapses every entry onto the import day, so using it for chronology produces silently-wrong timelines (issue #669). Native entries (`/distill`, `/minutes`, etc.) have no `published_at`, so they correctly fall back to `created_at`.
 
 ## Corrections
 

--- a/skills/briefing/SKILL.md
+++ b/skills/briefing/SKILL.md
@@ -161,7 +161,7 @@ Generated: <YYYY-MM-DD HH:MM> UTC
 
 Take the 10 most recent entries from Step 4a and re-sort them by **effective date** descending (see the Effective Date convention in CONVENTIONS.md — `metadata.published_at` when present, else `created_at`), so gh-sync/feed imports order by their true source time rather than the shared ingest timestamp. Show one line each:
 
-```
+```text
 - [<TYPE>] <content preview, max 100 chars> — <relative timestamp>
 ```
 

--- a/skills/briefing/SKILL.md
+++ b/skills/briefing/SKILL.md
@@ -159,7 +159,7 @@ Generated: <YYYY-MM-DD HH:MM> UTC
 
 **Section 1 — Recent Entries:**
 
-For each of the 10 most recent entries from Step 4a, show one line:
+Take the 10 most recent entries from Step 4a and re-sort them by **effective date** descending (see the Effective Date convention in CONVENTIONS.md — `metadata.published_at` when present, else `created_at`), so gh-sync/feed imports order by their true source time rather than the shared ingest timestamp. Show one line each:
 
 ```
 - [<TYPE>] <content preview, max 100 chars> — <relative timestamp>
@@ -167,7 +167,7 @@ For each of the 10 most recent entries from Step 4a, show one line:
 
 - `[TYPE]` badge: entry type in uppercase, e.g., `[SESSION]`, `[BOOKMARK]`, `[MINUTES]`
 - Content preview: first 100 characters of entry content, truncated with `…` if longer
-- Relative timestamp: human-readable age, e.g., "2 hours ago", "3 days ago", "just now"
+- Relative timestamp: human-readable age computed from the entry's **effective date** (`metadata.published_at` when present, else `created_at`), e.g., "2 hours ago", "3 days ago", "just now" — never the bare ingest `created_at` for imported entries
 
 **Section 2 — Corrections:**
 

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -227,7 +227,7 @@ List each entry that has at least one relation. Show relation type and a short l
 
 **c. Timeline (omit if all entries same day or fewer than 3 entries):**
 
-Chronological list of entries, ordered by `created_at`:
+Chronological list of entries, ordered by each entry's **effective date**: `metadata.published_at` when present, else `created_at`. gh-sync sets `published_at` to the GitHub object's real creation time and feed entries to the item's publish time; the bare `created_at` of an imported entry is the batch *ingest* timestamp and collapses every imported entry onto one day, corrupting the timeline (issue #669).
 
 | Date | Short ID | Type | Author | Summary |
 |------|----------|------|--------|---------|
@@ -262,6 +262,7 @@ Table of all entries in the result set:
 
 - **Phase**: discovery phase (`1`, `2`, `2b`, `3`, `4`)
 - **Short ID**: first 8 chars of UUID
+- **Date**: the entry's effective date — `metadata.published_at` when present, else `created_at` (see Timeline note; avoids the ingest date for gh-sync/feed entries)
 - **Relation Edges**: number of relation edges this entry participates in. For Phase 2b entries this is `0 (potentially related)` — they are similarity-only candidates with no stored relation.
 - **Preview**: first 40 chars of content, or `title` metadata field if present
 

--- a/skills/pour/SKILL.md
+++ b/skills/pour/SKILL.md
@@ -106,7 +106,9 @@ Example: `The team adopted DuckDB after evaluating SQLite and PostgreSQL [Entry 
 
 **Provenance distinction (when `--graph` is set):** Entries with `provenance="search"` matched the query semantically; entries with `provenance="graph"` did not match the query directly but were pulled in as 1-hop structural neighbours of a search-matched entry. In the prose, label graph-only entries as "structurally related" (e.g., `[Entry abc12345, structurally related]`) and call out *why* they appear — e.g., "linked to [Entry 550e8400] via `entry_relations`". Treat search-matched entries as primary signal; graph-only entries provide supporting context (downstream impacts, prior decisions a search-matched entry references, etc.). The synthesis should make this distinction visible to the user so they understand why each entry appears.
 
-**b. Timeline (omit if all entries same day)** -- Chronological evolution with dates, descriptions, and citations.
+**b. Timeline (omit if all entries same day)** -- Chronological evolution with dates, descriptions, and citations. Order by and render each entry's **effective date** (see below), not the raw `created_at`.
+
+> **Effective date:** use `metadata.published_at` when present, else fall back to `created_at`. gh-sync sets `published_at` to the GitHub object's real creation time and feed entries to the item's publication time; the bare `created_at` of an imported entry is the batch *ingest* timestamp, which collapses every imported entry onto one day and corrupts chronology (issue #669).
 
 **c. Key Decisions (omit if none)** -- Bullet list: what was decided, by whom, when, rationale, citation.
 
@@ -123,6 +125,7 @@ Table of all cited entries:
 | 1 | 550e8400 | [session] | Alice Smith | 2026-03-15 | We decided to use DuckDB for... | 92% |
 
 - **Short ID**: first 8 chars of UUID
+- **Date**: the entry's effective date — `metadata.published_at` when present, else `created_at` (see Timeline note; avoids showing the ingest date for gh-sync/feed entries)
 - **Preview**: first 40 chars of content
 - **Similarity**: highest score from any pass, as percentage
 

--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -614,6 +614,20 @@ class GitHubSyncAdapter:
             if isinstance(top_merged, str) and top_merged:
                 merged_at = top_merged
 
+        # The GitHub object's own timestamps. ``published_at`` mirrors the feed
+        # convention (``metadata.published_at`` = real publication time) so
+        # synthesis skills can render true chronology instead of the batch
+        # ingest timestamp, which collapses every imported entry onto the import
+        # day (issue #669).
+        published_at: str | None = None
+        gh_created = issue.get("created_at")
+        if isinstance(gh_created, str) and gh_created:
+            published_at = gh_created
+        gh_updated_at: str | None = None
+        gh_updated = issue.get("updated_at")
+        if isinstance(gh_updated, str) and gh_updated:
+            gh_updated_at = gh_updated
+
         metadata: dict[str, Any] = {
             "repo": f"{self._owner}/{self._repo}",
             "ref_type": ref_type,
@@ -631,6 +645,11 @@ class GitHubSyncAdapter:
             "gh_number": number,
             "gh_url": html_url,
             "merged_at": merged_at,
+            # Real GitHub creation/update times (issue #669). published_at is the
+            # chronology source for synthesis skills; mirrors the feed poller's
+            # metadata.published_at convention.
+            "published_at": published_at,
+            "updated_at": gh_updated_at,
             # Persisted so ``_compute_backfill_updates`` can heal older entries
             # that lost author attribution (see legacy_authors branch below).
             # Store the raw GitHub login (or ``None`` when missing) so an

--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -114,6 +114,24 @@ def _sanitize_tag_segment(raw: str) -> str:
     return collapsed
 
 
+def _normalize_github_ts(raw: Any) -> str | None:
+    """Normalise a GitHub ISO-8601 timestamp to the feed poller's ``+00:00`` form.
+
+    The store compares ``metadata.published_at`` lexicographically (``/radar``'s
+    published_after bound, ``duckdb.py``), and the poller stores
+    ``datetime.isoformat()`` (``+00:00``).  GitHub returns the ``...Z`` form, so
+    re-emit it in the same offset form to keep equal instants string-comparable
+    (issue #669).  Returns ``None`` for missing/blank input and the original
+    string when it is unparseable — better to keep the value than drop it.
+    """
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).isoformat()
+    except ValueError:
+        return raw
+
+
 def _derive_state_tag_value(issue: dict[str, Any]) -> str | None:
     """Return ``"merged"``/``"closed"``/``"open"`` for the issue, or ``None``.
 
@@ -618,15 +636,10 @@ class GitHubSyncAdapter:
         # convention (``metadata.published_at`` = real publication time) so
         # synthesis skills can render true chronology instead of the batch
         # ingest timestamp, which collapses every imported entry onto the import
-        # day (issue #669).
-        published_at: str | None = None
-        gh_created = issue.get("created_at")
-        if isinstance(gh_created, str) and gh_created:
-            published_at = gh_created
-        gh_updated_at: str | None = None
-        gh_updated = issue.get("updated_at")
-        if isinstance(gh_updated, str) and gh_updated:
-            gh_updated_at = gh_updated
+        # day (issue #669).  Normalised to the poller's ``+00:00`` form so the
+        # store's lexicographic published_at compare stays consistent.
+        published_at = _normalize_github_ts(issue.get("created_at"))
+        gh_updated_at = _normalize_github_ts(issue.get("updated_at"))
 
         metadata: dict[str, Any] = {
             "repo": f"{self._owner}/{self._repo}",

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -743,8 +743,11 @@ class TestSyncAutoPopulatesFields:
         entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
         entry = entries[0]
 
-        assert entry.metadata["published_at"] == "2026-04-01T08:00:00Z"
-        assert entry.metadata["updated_at"] == "2026-04-02T09:30:00Z"
+        # Normalised to the poller's +00:00 form (not the raw GitHub ...Z) so the
+        # store's lexicographic published_at compare stays consistent (#669).
+        assert entry.metadata["published_at"] == "2026-04-01T08:00:00+00:00"
+        assert entry.metadata["updated_at"] == "2026-04-02T09:30:00+00:00"
+        assert not entry.metadata["published_at"].endswith("Z")
         # The GitHub object's own creation time is distinct from the ingest time.
         assert entry.metadata["published_at"] != entry.created_at.isoformat()
 

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -280,6 +280,8 @@ def _mock_issue(
     is_pr: bool = False,
     labels: list[dict[str, str]] | None = None,
     assignees: list[dict[str, str]] | None = None,
+    created_at: str = "2026-04-01T08:00:00Z",
+    updated_at: str = "2026-04-02T09:30:00Z",
 ) -> dict:
     """Build a mock GitHub issue API response."""
     issue: dict = {
@@ -291,6 +293,8 @@ def _mock_issue(
         "labels": labels or [],
         "assignees": assignees or [],
         "user": {"login": "author"},
+        "created_at": created_at,
+        "updated_at": updated_at,
     }
     if is_pr:
         issue["pull_request"] = {"url": f"https://api.github.com/repos/test/repo/pulls/{number}"}
@@ -705,6 +709,44 @@ class TestSyncAutoPopulatesFields:
         # Convenience metadata fields requested by the issue.
         assert entry.metadata["gh_number"] == 42
         assert entry.metadata["gh_url"].endswith("/issues/42")
+
+    @pytest.mark.integration
+    async def test_metadata_captures_github_timestamps(
+        self,
+        store,
+        httpx_mock,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """published_at/updated_at mirror the GitHub object's real times (issue #669).
+
+        The entry's own created_at is the ingest timestamp; chronology must come
+        from metadata.published_at (the GitHub object's created_at).
+        """
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/acme/widgets/issues\?.*"),
+            json=[
+                _mock_issue(
+                    number=42,
+                    created_at="2026-04-01T08:00:00Z",
+                    updated_at="2026-04-02T09:30:00Z",
+                )
+            ],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/acme/widgets/issues/42/comments.*"),
+            json=[],
+        )
+
+        adapter = GitHubSyncAdapter(store=store, url="acme/widgets")
+        result = await adapter.sync()
+        assert result.created == 1
+
+        entries = await store.list_entries(filters={"entry_type": "github"}, limit=10, offset=0)
+        entry = entries[0]
+
+        assert entry.metadata["published_at"] == "2026-04-01T08:00:00Z"
+        assert entry.metadata["updated_at"] == "2026-04-02T09:30:00Z"
+        # The GitHub object's own creation time is distinct from the ingest time.
+        assert entry.metadata["published_at"] != entry.created_at.isoformat()
 
     @pytest.mark.integration
     async def test_pr_gets_merged_state_tag(


### PR DESCRIPTION
Closes #669.

gh-sync recorded the batch *ingest* timestamp as each entry's `created_at` and dropped the GitHub object's own `created_at`, so `/pour` and `/investigate` timelines collapsed every imported entry onto the import day — silently wrong chronology for all GitHub entries.

## Root cause
`_issue_to_entry` captured `merged_at` but not the GitHub object's `created_at`/`updated_at`. Synthesis skills then rendered `entry.created_at` (the ingest time) for the Date column and Timeline ordering.

## Fix
**Ingestion (`feeds/github_sync.py`)** — capture the GitHub object's real timestamps, mirroring the feed poller's `metadata.published_at` convention:
- `metadata.published_at` = GitHub object's `created_at`
- `metadata.updated_at` = GitHub object's `updated_at`
- `merged_at` unchanged

**Rendering (skills)** — new shared **Effective Date** convention in `skills/CONVENTIONS.md`: use `metadata.published_at` when present, else `created_at`. Applied to:
- `pour`: Timeline ordering + Sources `Date` column
- `investigate`: Timeline ordering + Sources `Date` column
- briefing: no per-entry Date column to fix — it only uses `created_at` as the 7-day window filter (`date_from`, a store-level concern), so it inherits the convention for any future date rendering but needs no change here.

## Backfill
Out of scope per the issue ("let a re-sync repopulate going forward"). `_compute_backfill_updates` heals from existing metadata only and can't recover `published_at` since it was never stored; a re-sync now repopulates it. Existing entries re-date on their next sync.

## Tests
- `_mock_issue` now carries `created_at`/`updated_at`.
- New `test_metadata_captures_github_timestamps`: asserts `metadata.published_at`/`updated_at` come from the GitHub object and differ from the ingest `created_at`.
- Full suite: 3218 passed, 76 skipped; ruff + mypy --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entry ordering and displayed timestamps now use an **effective date** (prefer `metadata.published_at`, fall back to `created_at`) for more accurate chronology.
  * GitHub sync now captures and preserves source `created_at`/`updated_at` as entry metadata, including normalized timestamp formatting.
* **Bug Fixes**
  * Fixed Timeline, Sources, and “Recent Entries” date sorting/display so imported or synced items no longer show distorted ingest-based dates.
* **Documentation**
  * Updated skill guidance to define and consistently apply the effective-date rule.
* **Tests**
  * Added/updated tests to verify GitHub timestamp normalization and effective-date behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->