### PR TITLE
feat(store): canonicalize tags on the write path (#653 choke-point)

### DIFF
--- a/src/distillery/cli.py
+++ b/src/distillery/cli.py
@@ -689,6 +689,9 @@ def _cmd_poll(config_path: str | None, fmt: str, source_url: str | None) -> int:
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            tag_aliases=cfg.tags.aliases,
+            tag_reserved_prefixes=cfg.tags.reserved_prefixes,
+            tag_normalize_namespaces=cfg.tags.enforce_namespaces,
         )
         await store.initialize()
 
@@ -845,6 +848,9 @@ def _cmd_retag(
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            tag_aliases=cfg.tags.aliases,
+            tag_reserved_prefixes=cfg.tags.reserved_prefixes,
+            tag_normalize_namespaces=cfg.tags.enforce_namespaces,
         )
         await store.initialize()
 
@@ -970,6 +976,9 @@ def _cmd_gh_backfill(
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            tag_aliases=cfg.tags.aliases,
+            tag_reserved_prefixes=cfg.tags.reserved_prefixes,
+            tag_normalize_namespaces=cfg.tags.enforce_namespaces,
         )
         await store.initialize()
         try:
@@ -1293,6 +1302,9 @@ def _cmd_import(
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            tag_aliases=cfg.tags.aliases,
+            tag_reserved_prefixes=cfg.tags.reserved_prefixes,
+            tag_normalize_namespaces=cfg.tags.enforce_namespaces,
         )
         await store.initialize()
 
@@ -1994,6 +2006,9 @@ def _cmd_maintenance_classify(
             auto_link_enabled=cfg.auto_link.enabled,
             auto_link_threshold=cfg.auto_link.threshold,
             auto_link_max_links=cfg.auto_link.max_links,
+            tag_aliases=cfg.tags.aliases,
+            tag_reserved_prefixes=cfg.tags.reserved_prefixes,
+            tag_normalize_namespaces=cfg.tags.enforce_namespaces,
         )
         try:
             await store.initialize()

--- a/src/distillery/mcp/server.py
+++ b/src/distillery/mcp/server.py
@@ -183,6 +183,9 @@ def _build_background_store_factory(
             auto_link_enabled=config.auto_link.enabled,
             auto_link_threshold=config.auto_link.threshold,
             auto_link_max_links=config.auto_link.max_links,
+            tag_aliases=config.tags.aliases,
+            tag_reserved_prefixes=config.tags.reserved_prefixes,
+            tag_normalize_namespaces=config.tags.enforce_namespaces,
         )
         await store.initialize()
         return store
@@ -235,6 +238,9 @@ def create_server(config: DistilleryConfig | None = None, auth: Any | None = Non
                 auto_link_enabled=config.auto_link.enabled,
                 auto_link_threshold=config.auto_link.threshold,
                 auto_link_max_links=config.auto_link.max_links,
+                tag_aliases=config.tags.aliases,
+                tag_reserved_prefixes=config.tags.reserved_prefixes,
+                tag_normalize_namespaces=config.tags.enforce_namespaces,
             )
             await store.initialize()
             # Flush the WAL during quiet windows so it never grows unbounded

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -478,6 +478,9 @@ async def _ensure_store(
             auto_link_enabled=config.auto_link.enabled,
             auto_link_threshold=config.auto_link.threshold,
             auto_link_max_links=config.auto_link.max_links,
+            tag_aliases=config.tags.aliases,
+            tag_reserved_prefixes=config.tags.reserved_prefixes,
+            tag_normalize_namespaces=config.tags.enforce_namespaces,
         )
         await store.initialize()
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -228,6 +228,9 @@ class DuckDBStore:
         auto_link_enabled: bool = False,
         auto_link_threshold: float = 0.85,
         auto_link_max_links: int = 5,
+        tag_aliases: dict[str, str] | None = None,
+        tag_reserved_prefixes: list[str] | None = None,
+        tag_normalize_namespaces: bool = False,
         memory_limit_mb: int | None = _DEFAULT_MEMORY_LIMIT_MB,
         threads: int | None = _DEFAULT_THREADS,
     ) -> None:
@@ -274,6 +277,12 @@ class DuckDBStore:
         self._auto_link_enabled: bool = auto_link_enabled
         self._auto_link_threshold: float = auto_link_threshold
         self._auto_link_max_links: int = auto_link_max_links
+        # Controlled-vocabulary tag canonicalization on the write path (issue
+        # #653, ontology #3). Empty alias map + normalize disabled is a no-op, so
+        # the store behaves byte-for-byte as before unless a deployment opts in.
+        self._tag_aliases: dict[str, str] = tag_aliases or {}
+        self._tag_reserved_prefixes: list[str] = tag_reserved_prefixes or []
+        self._tag_normalize_namespaces: bool = tag_normalize_namespaces
         # Serializes access to the shared ``DuckDBPyConnection``.  DuckDB
         # connections are **not** thread-safe for concurrent use, but every
         # store operation funnels through ``asyncio.to_thread`` which runs
@@ -1882,6 +1891,25 @@ class DuckDBStore:
                 inserted += 1
         return inserted
 
+    def _canonicalize_entry_tags(self, tags: list[str]) -> list[str]:
+        """Apply the configured controlled vocabulary to a tag list (issue #653).
+
+        Alias substitution, optional namespace normalization, and an
+        order-preserving dedupe — the single write-path choke-point that keeps
+        the tag vocabulary controlled for *new* writes (complementing the
+        one-time ``canonicalize_existing_tags`` backfill). Inert (returns the
+        tags unchanged) when no alias map and no namespace normalization are
+        configured, so an un-configured store writes byte-for-byte as before.
+        """
+        if not self._tag_aliases and not self._tag_normalize_namespaces:
+            return list(tags)
+        return canonicalize_tags(
+            tags,
+            aliases=self._tag_aliases,
+            reserved_prefixes=self._tag_reserved_prefixes,
+            normalize_namespaces=self._tag_normalize_namespaces,
+        )
+
     def _sync_store(self, entry: Entry, embedding: list[float]) -> str:
         """Synchronous implementation of store(); called via asyncio.to_thread.
 
@@ -1907,7 +1935,7 @@ class DuckDBStore:
             entry.source.value,
             entry.author,
             entry.project,
-            list(entry.tags),
+            self._canonicalize_entry_tags(entry.tags),
             entry.status.value,
             entry.verification.value,
             json.dumps(entry.metadata),
@@ -1995,7 +2023,7 @@ class DuckDBStore:
                     entry.source.value,
                     entry.author,
                     entry.project,
-                    list(entry.tags),
+                    self._canonicalize_entry_tags(entry.tags),
                     entry.status.value,
                     entry.verification.value,
                     json.dumps(entry.metadata),
@@ -2202,7 +2230,7 @@ class DuckDBStore:
             elif key == "metadata" and isinstance(value, dict):
                 set_params.append(json.dumps(value))
             elif key == "tags" and isinstance(value, list):
-                set_params.append(list(value))
+                set_params.append(self._canonicalize_entry_tags(value))
             else:
                 set_params.append(value)
 

--- a/tests/test_write_path_chokepoint.py
+++ b/tests/test_write_path_chokepoint.py
@@ -1,0 +1,82 @@
+"""Tests for the write-path tag canonicalization choke-point (issue #653).
+
+Phase 1 backfilled existing tags one-time; this is the complementary guarantee
+that *new* writes stay canonical. Every entry persisted through the store
+(store / store_batch / update) has its tags run through the configured controlled
+vocabulary, so the graph cannot silently re-fragment as new feed items arrive.
+
+The choke-point is configured via the DuckDBStore constructor; tests set the
+private attributes directly on the in-memory fixture store to exercise the same
+code path without standing up a second store.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import make_entry
+
+pytestmark = pytest.mark.unit
+
+_ALIASES = {"domain/sandbox": "domain/build/sandboxing"}
+
+
+async def test_store_canonicalizes_tags(store) -> None:  # type: ignore[no-untyped-def]
+    store._tag_aliases = _ALIASES
+    e = make_entry(content="x", tags=["domain/sandbox", "tech/duckdb"])
+    await store.store(e)
+
+    got = await store.get(e.id)
+    assert set(got.tags) == {"domain/build/sandboxing", "tech/duckdb"}
+
+
+async def test_store_dedupes_alias_and_target(store) -> None:  # type: ignore[no-untyped-def]
+    """An entry carrying both an alias and its canonical target collapses to one."""
+    store._tag_aliases = _ALIASES
+    e = make_entry(content="x", tags=["domain/sandbox", "domain/build/sandboxing"])
+    await store.store(e)
+
+    got = await store.get(e.id)
+    assert got.tags == ["domain/build/sandboxing"]
+
+
+async def test_store_batch_canonicalizes(store) -> None:  # type: ignore[no-untyped-def]
+    store._tag_aliases = _ALIASES
+    e1 = make_entry(content="a", tags=["domain/sandbox"])
+    e2 = make_entry(content="b", tags=["tech/duckdb"])
+    await store.store_batch([e1, e2])
+
+    assert (await store.get(e1.id)).tags == ["domain/build/sandboxing"]
+    assert (await store.get(e2.id)).tags == ["tech/duckdb"]
+
+
+async def test_update_canonicalizes_and_returns_canonical(store) -> None:  # type: ignore[no-untyped-def]
+    """update() canonicalizes the new tags AND the returned Entry reflects them."""
+    store._tag_aliases = _ALIASES
+    e = make_entry(content="x", tags=["tech/duckdb"])
+    await store.store(e)
+
+    updated = await store.update(e.id, {"tags": ["domain/sandbox", "tech/duckdb"]})
+    assert set(updated.tags) == {"domain/build/sandboxing", "tech/duckdb"}
+    # And it is what was persisted.
+    assert set((await store.get(e.id)).tags) == {"domain/build/sandboxing", "tech/duckdb"}
+
+
+async def test_inert_by_default_preserves_tags(store) -> None:  # type: ignore[no-untyped-def]
+    """With no alias map and no namespace normalization, tags are stored verbatim."""
+    e = make_entry(content="x", tags=["domain/sandbox", "tech/duckdb"])
+    await store.store(e)
+
+    got = await store.get(e.id)
+    assert got.tags == ["domain/sandbox", "tech/duckdb"]
+
+
+async def test_namespace_normalization_on_write(store) -> None:  # type: ignore[no-untyped-def]
+    """When configured, separator variants of a reserved-prefix tag collapse on write."""
+    store._tag_normalize_namespaces = True
+    store._tag_reserved_prefixes = ["entity"]
+    e = make_entry(content="x", tags=["entity/cloudflare/workers"])
+    await store.store(e)
+
+    got = await store.get(e.id)
+    assert got.tags == ["entity/cloudflare-workers"]


### PR DESCRIPTION
## What

Follow-up to #680 (Phase 1). Phase 1 backfilled existing tags **once**; this is the complementary guarantee that **new** writes stay canonical — without it, the graph silently re-fragments as the feed poller ingests new items (it currently never applies the alias map).

> **Stacked on #680.** Base is `feat/653-tag-controlled-vocab` because this needs `canonicalize_tags` + `config.tags.aliases`. Retarget to `main` once #680 merges.

## Changes

- **Single write-path choke-point in `DuckDBStore`**: `store` / `store_batch` / `update` run each entry's tags through `_canonicalize_entry_tags` (alias substitution + optional namespace normalization + order-preserving dedupe). `update()` re-fetches to build its return, so the returned `Entry` reflects the canonical tags.
- **Three new constructor params** (`tag_aliases`, `tag_reserved_prefixes`, `tag_normalize_namespaces`), wired from `config.tags.*` at all eight config-bearing construction sites (server ×2, webhooks, cli ×5). **Empty alias map + normalization off is a true no-op** → an un-configured store writes byte-for-byte as before.

## Why just the store (not the merge sites too)

The original design floated also canonicalizing at the poller / classify / gh-sync merge sites. That turns out to be **redundant for correctness**: every ingest path persists through the store, and the choke-point canonicalizes *and dedupes on the canonical form* at persist time. So one choke-point gives the full guarantee with far less surface than touching three call sites. (`Entry` stays validate-only — no config in the model layer.)

## Deferred

Namespace-membership enforcement (`known_namespaces` + off/warn/strict gating of unknown namespaces) is split to a follow-up. This PR is pure canonicalization.

## Testing

- `store` / `store_batch` / `update` canonicalize + dedupe; `update` return reflects canonical tags; namespace-normalization path; **inert-by-default** (tags verbatim with no config).
- Full suite: **3235 passed**, 79 skipped; `mypy --strict src/` clean; `ruff check src/ tests/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)