### PR TITLE
chore: 0.7.0 release-prep — auto-link opt-in, skill min_server_version, docs refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Distillery
 
-Distillery is a knowledge-base system for Claude Code. It stores, searches, and classifies knowledge entries using DuckDB with vector similarity search (VSS/HNSW). It includes ambient intelligence features that poll external feeds (GitHub, RSS) and score relevance using embeddings. It exposes functionality via an MCP server (stdio or streamable-HTTP transport) with 16 tools, orchestrated by 14 Claude Code skills (`/distill`, `/recall`, `/pour`, `/bookmark`, `/minutes`, `/classify`, `/watch`, `/radar`, `/tune`, `/digest`, `/gh-sync`, `/investigate`, `/briefing`, `/setup`). HTTP transport supports GitHub OAuth for team access. REST webhook endpoints (`/hooks/poll`, `/hooks/rescore`, `/hooks/classify-batch`, `/api/maintenance`) run alongside the MCP server for automated scheduling via GitHub Actions cron.
+Distillery is a knowledge-base system for Claude Code. It stores, searches, and classifies knowledge entries using DuckDB with vector similarity search (VSS/HNSW). It includes ambient intelligence features that poll external feeds (GitHub, RSS) and score relevance using embeddings. It exposes functionality via an MCP server (stdio or streamable-HTTP transport) with 16 tools, orchestrated by 15 Claude Code skills (`/distill`, `/recall`, `/pour`, `/compass`, `/bookmark`, `/minutes`, `/classify`, `/watch`, `/radar`, `/tune`, `/digest`, `/gh-sync`, `/investigate`, `/briefing`, `/setup`). HTTP transport supports GitHub OAuth for team access. REST webhook endpoints (`/hooks/poll`, `/hooks/rescore`, `/hooks/classify-batch`, `/api/maintenance`) run alongside the MCP server for automated scheduling via GitHub Actions cron.
 
 ## Commands
 
@@ -97,10 +97,10 @@ Always create a pull request for changes — never push directly to `main`. Crea
 
 ## Skills
 
-14 skills live in `skills/<name>/SKILL.md` with YAML frontmatter. Shared conventions are in `skills/CONVENTIONS.md`. All skills follow the same pattern: check MCP availability, determine author (git config > env > ask), determine project (git repo name > flag > ask), execute, confirm.
+15 skills live in `skills/<name>/SKILL.md` with YAML frontmatter. Shared conventions are in `skills/CONVENTIONS.md`. All skills follow the same pattern: check MCP availability, determine author (git config > env > ask), determine project (git repo name > flag > ask), execute, confirm.
 
 - **Knowledge capture**: `/distill`, `/bookmark`, `/minutes`
-- **Knowledge retrieval**: `/recall`, `/pour`, `/classify`
+- **Knowledge retrieval**: `/recall`, `/pour`, `/compass` (contrast internal knowledge vs. ambient intelligence for a directional assessment), `/classify`
 - **Ambient intelligence**: `/watch` (manage feed sources — `rss` and `github` types only), `/radar` (digest + source suggestions), `/tune` (adjust thresholds — alert >= digest)
 - **Team**: `/digest` (team activity summary), `/gh-sync` (GitHub issue/PR sync), `/investigate` (deep context builder), `/briefing` (team dashboard)
 - **Onboarding**: `/setup` (MCP connectivity wizard — local transport uses `CronCreate`; hosted/team uses GitHub Actions webhook scheduler)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Always create a pull request for changes — never push directly to `main`. Crea
 
 ## Skills
 
-15 skills live in `skills/<name>/SKILL.md` with YAML frontmatter. Shared conventions are in `skills/CONVENTIONS.md`. All skills follow the same pattern: check MCP availability, determine author (git config > env > ask), determine project (git repo name > flag > ask), execute, confirm.
+15 skills live in `skills/<name>/SKILL.md` with YAML frontmatter. Shared conventions are in `skills/CONVENTIONS.md`. All skills follow the same pattern: check MCP availability, determine project (git repo name > flag > ask), execute, confirm. Author (git config > env > ask) is resolved only by store-writing skills; display-only skills (`/recall`, `/pour`, `/compass`, …) skip it.
 
 - **Knowledge capture**: `/distill`, `/bookmark`, `/minutes`
 - **Knowledge retrieval**: `/recall`, `/pour`, `/compass` (contrast internal knowledge vs. ambient intelligence for a directional assessment), `/classify`

--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ Distillery captures the highest-value transformation — from noise to signal �
 
 ## Skills
 
-Distillery provides 14 Claude Code slash commands:
+Distillery provides 15 Claude Code slash commands:
 
 | Skill | Purpose | Example |
 |-------|---------|---------|
 | `/distill` | Capture session knowledge with dedup detection | `/distill "We decided to use DuckDB for local storage"` |
 | `/recall` | Semantic search with provenance | `/recall distributed caching strategies` |
 | `/pour` | Multi-entry synthesis with citations | `/pour how does our auth system work?` |
+| `/compass` | Contrast internal knowledge vs. ambient intelligence for a directional assessment | `/compass our caching strategy` |
 | `/bookmark` | Store URLs with auto-generated summaries | `/bookmark https://example.com/article #caching` |
 | `/minutes` | Meeting notes with append updates | `/minutes --update standup-2026-03-22` |
 | `/classify` | Classify entries and triage review queue | `/classify --inbox` |
@@ -74,7 +75,7 @@ claude plugin marketplace add norrietaylor/distillery
 claude plugin install distillery
 ```
 
-This installs all 14 skills. The plugin **does not configure an MCP server automatically** — run `/setup` (below) to add one. The recommended setup runs **locally** via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp` — a private, self-contained knowledge base on your machine, with on-device `fastembed` embeddings (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/) (install: `curl -LsSf https://astral.sh/uv/install.sh | sh`).
+This installs all 15 skills. The plugin **does not configure an MCP server automatically** — run `/setup` (below) to add one. The recommended setup runs **locally** via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp` — a private, self-contained knowledge base on your machine, with on-device `fastembed` embeddings (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/) (install: `curl -LsSf https://astral.sh/uv/install.sh | sh`).
 
 ### Step 2 (Optional): Use Jina or OpenAI Instead
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ Distillery is built as a 4-layer system where skills (SKILL.md files) drive all 
 
   <!-- Layer 1: Skills -->
   <rect class="d-layer" x="30" y="16" width="700" height="96" rx="12"/>
-  <text class="d-label" x="50" y="36">14 Claude Code Skills</text>
+  <text class="d-label" x="50" y="36">15 Claude Code Skills</text>
   <rect class="d-pill" x="50" y="44" width="62" height="26" rx="6"/><text class="d-pill-text" x="81" y="61" text-anchor="middle">/distill</text>
   <rect class="d-pill" x="120" y="44" width="56" height="26" rx="6"/><text class="d-pill-text" x="148" y="61" text-anchor="middle">/recall</text>
   <rect class="d-pill" x="184" y="44" width="50" height="26" rx="6"/><text class="d-pill-text" x="209" y="61" text-anchor="middle">/pour</text>
@@ -49,6 +49,7 @@ Distillery is built as a 4-layer system where skills (SKILL.md files) drive all 
   <rect class="d-pill" x="114" y="76" width="70" height="26" rx="6"/><text class="d-pill-text" x="149" y="93" text-anchor="middle">/gh-sync</text>
   <rect class="d-pill" x="192" y="76" width="86" height="26" rx="6"/><text class="d-pill-text" x="235" y="93" text-anchor="middle">/investigate</text>
   <rect class="d-pill" x="286" y="76" width="68" height="26" rx="6"/><text class="d-pill-text" x="320" y="93" text-anchor="middle">/briefing</text>
+  <rect class="d-pill" x="362" y="76" width="76" height="26" rx="6"/><text class="d-pill-text" x="400" y="93" text-anchor="middle">/compass</text>
 
   <!-- Connector -->
   <line class="d-line" x1="380" y1="112" x2="380" y2="128"/>
@@ -144,7 +145,7 @@ Distillery is built as a 4-layer system where skills (SKILL.md files) drive all 
 
 | Layer | What it does | Key files |
 |-------|-------------|-----------|
-| **Skills** | 14 SKILL.md files — portable, version-controlled slash commands. Not Python code. | `skills/*/SKILL.md` |
+| **Skills** | 15 SKILL.md files — portable, version-controlled slash commands. Not Python code. | `skills/*/SKILL.md` |
 | **MCP Server** | Tools exposed over stdio (local) or streamable-HTTP (team). Built on FastMCP 2.x/3.x with `@server.tool` decorators. | `src/distillery/mcp/server.py` |
 | **Webhook API** | REST endpoints mounted under `/api/*` for orchestrated operations. The active endpoint is `POST /api/maintenance` (full poll → rescore → classify-batch pipeline). Individual scheduling endpoints — `POST /api/poll`, `POST /api/rescore`, `POST /api/classify-batch` (also reachable at `POST /api/hooks/poll`, `/api/hooks/rescore`, `/api/hooks/classify-batch` during the deprecation window) — are deprecated in favour of Claude Code routines and the orchestrated maintenance endpoint. Bearer token auth, per-endpoint cooldowns persisted to DuckDB. Mounted alongside MCP in HTTP mode. | `src/distillery/mcp/webhooks.py` |
 | **Auth** | MCP: GitHub OAuth with org-restricted access. Webhooks: bearer token via `DISTILLERY_WEBHOOK_SECRET`. Middleware handles logging, rate limiting, security headers, budget tracking. | `src/distillery/mcp/auth.py`, `middleware.py`, `budget.py` |
@@ -214,6 +215,7 @@ distillery/
 │   ├── gh-sync/SKILL.md
 │   ├── investigate/SKILL.md
 │   ├── briefing/SKILL.md
+│   ├── compass/SKILL.md
 │   └── CONVENTIONS.md
 ├── src/distillery/
 │   ├── models.py            # Entry, SearchResult, enums

--- a/docs/getting-started/plugin-install.md
+++ b/docs/getting-started/plugin-install.md
@@ -1,6 +1,6 @@
 # Plugin Install
 
-The Distillery plugin packages all fourteen knowledge-base skills for distribution and installation via the Claude Code plugin mechanism. Once installed, the skills are available in every project without copying files.
+The Distillery plugin packages all fifteen knowledge-base skills for distribution and installation via the Claude Code plugin mechanism. Once installed, the skills are available in every project without copying files.
 
 ## Install via Plugin Marketplace (Recommended)
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -18,13 +18,14 @@ Runs locally over stdio or as a hosted HTTP service with GitHub OAuth for team a
 
 ## Skills
 
-Distillery provides 14 Claude Code slash commands:
+Distillery provides 15 Claude Code slash commands:
 
 | Skill | Purpose | Example |
 |-------|---------|---------|
 | [`/distill`](skills/distill.md) | Capture session knowledge with dedup detection | `/distill "We decided to use DuckDB for local storage"` |
 | [`/recall`](skills/recall.md) | Semantic search with provenance | `/recall distributed caching strategies` |
 | [`/pour`](skills/pour.md) | Multi-entry synthesis with citations | `/pour how does our auth system work?` |
+| [`/compass`](skills/compass.md) | Internal vs ambient directional assessment | `/compass agent eval harnesses` |
 | [`/bookmark`](skills/bookmark.md) | Store URLs with auto-generated summaries | `/bookmark https://example.com/article #caching` |
 | [`/minutes`](skills/minutes.md) | Meeting notes with append updates | `/minutes --update standup-2026-03-22` |
 | [`/classify`](skills/classify.md) | Classify entries and triage review queue | `/classify --inbox` |
@@ -46,7 +47,7 @@ claude plugin marketplace add norrietaylor/distillery
 claude plugin install distillery
 ```
 
-This installs all 14 skills. The plugin **does not configure an MCP server automatically** — run `/setup` to add one. The recommended setup runs **locally** via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp` — a private, self-contained knowledge base on your machine, with on-device `fastembed` embeddings (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/).
+This installs all 15 skills. The plugin **does not configure an MCP server automatically** — run `/setup` to add one. The recommended setup runs **locally** via `uvx --from 'distillery-mcp[fastembed]>=0.6.0' distillery-mcp` — a private, self-contained knowledge base on your machine, with on-device `fastembed` embeddings (no API key required). Requires Python 3.11+ and [`uv`](https://docs.astral.sh/uv/).
 
 !!! tip "Install uv"
     `curl -LsSf https://astral.sh/uv/install.sh | sh`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,6 +47,7 @@
 - [x] `/radar` — interest-driven feed digest with AI source suggestions
 - [x] `/watch` — add/remove/list monitored feed sources
 - [x] `/tune` — adjust relevance thresholds and trust weights
+- [x] `/compass` — contrast internal knowledge against ambient intelligence; emit a directional assessment (ahead / exposed / decide / confirm)
 - [x] Feed polling architecture — `FeedPoller` with configurable intervals
 - [x] Source adapters — GitHub events (REST API) and RSS/Atom
 - [x] Relevance scoring pipeline — embedding-based cosine similarity
@@ -68,7 +69,7 @@
 ### Entry Relations & Corrections
 - [x] `entry_relations` table with backfill migration
 - [x] `distillery_correct` tool for structured corrections
-- [x] `distillery_relations` tool for managing entry links
+- [x] `distillery_relations` tool for managing entry links, graph traversal, and structural metrics (bridges, communities, constraint, link prediction, orphans)
 
 ### New Entry Fields
 - [x] `expires_at` — time-limited entries with UTC normalization

--- a/docs/skills/compass.md
+++ b/docs/skills/compass.md
@@ -1,0 +1,97 @@
+# /compass — Internal vs Ambient Directional Assessment
+
+Contrasts your **internal implementation** knowledge (sessions, GitHub, minutes, reference, idea) against **ambient intelligence** (feeds + bookmarks), locates where the two corpora connect, and emits a **directional assessment** — Ahead / Exposed / Decide / Confirm — *first*, before the supporting detail. The assessment is the product; the corpus sections are the evidence.
+
+Where `/radar` senses the surroundings and `/investigate` maps the internal terrain, `/compass` puts the two together and points somewhere.
+
+## Usage
+
+```text
+/compass sandbox networking            # Orient on a topic
+/compass agent eval harnesses --days 14 # Custom ambient window (default 30)
+/compass --entry <uuid>                 # Seed from a specific entry instead of a topic
+/compass build hermeticity --project distillery  # Scope every search to a project
+/compass --include-evergreen            # Include first-poll backfill in ambient signal
+/compass sandbox networking --store     # Persist the assessment (default: display-only)
+```
+
+**Trigger phrases:** "compass", "where do we stand vs the field", "ahead or behind on X", "what should we do about X"
+
+## When to Use
+
+- "Where do we stand on X vs. the field, and what should we do?"
+- Comparing internal progress against external/ambient signal to surface gaps and risks
+- Pre-decision check: is the field discussing something you have no captured position on?
+- Orienting a specific entry against ambient signal (`--entry <uuid>`)
+
+## What It Does
+
+### Internal Position (non-graph search)
+
+Maps the internal terrain with **one** plain semantic search scoped to the implementation corpora (`session`, `github`, `minutes`, `reference`, `idea`) in `summary` mode. There is **no graph expansion** — the knowledge graph is sparse (orphan-heavy), so a graph walk adds latency without signal. The `--entry <uuid>` variant loads the seed entry directly, derives a topic from it, then runs the same scoped search to gather the surrounding terrain.
+
+### Ambient Signal (radar-style, windowed)
+
+Senses the surroundings with two windowed searches — feeds and bookmarks — bounded by the ambient window (default 30 days). The window is bounded by `metadata.published_at` (publication time), not ingest time, so older items polled today are not counted as new intelligence. First-poll backfill (`metadata.backfill = true`) is excluded unless `--include-evergreen` is passed.
+
+### Where They Meet (cross-corpus seam)
+
+The comparative step uses **cross-vocabulary search**, not embedding similarity or graph edges. Internal entries speak implementation-language (symbols, file paths, library names); ambient entries speak product-language (patterns, product names, capabilities) — the two occupy different embedding neighborhoods. Compass extracts up to 2 concrete entities/terms from each cluster and queries the *other* corpus with them (≤4 cross-queries total). A cross-query **hit** is a seam — the corpora connect on a shared concept expressed in different vocabulary. A **disjoint** result (the field discusses X, you have no captured position on X) is itself a finding and becomes an *Exposed* candidate.
+
+### Assessment
+
+The verdict leads. Each bullet cites entries with `[Entry <short-id>]` (first 8 chars of the UUID), marked `internal` or `ambient`, across four categories (any empty category is omitted):
+
+- **Ahead** — you lead, or already have what the field is converging on.
+- **Exposed** — the field has it; you don't. A gap or risk.
+- **Decide** — an open question both corpora touch but no settled internal decision exists.
+- **Confirm** — an internal assumption the ambient signal validates or challenges.
+
+## Output Format
+
+```text
+# Compass: sandbox networking
+
+Oriented "sandbox networking": 6 internal + 4 ambient entries, 2 seams (window=30d).
+
+## Assessment
+
+**Ahead**
+- We already ship the vsock transport the field is now converging on [Entry 9f8e7d6c, internal]
+
+**Exposed**
+- The now-GA egress-proxy-for-credentials pattern [Entry 1a2b3c4d, ambient] is not a captured requirement in the still-open egress issue [Entry 9f8e7d6c, internal] — add it
+
+## Internal Position
+<2–3 paragraph narrative with [Entry <short-id>] citations>
+
+## Ambient Signal
+<2–3 paragraph narrative of what feeds + bookmarks are saying in the window>
+
+## Where They Meet
+<Cross-vocabulary seams and disjoint ambient terms>
+
+## Sources
+| Short ID | Type | Author | Date | Provenance |
+|----------|------|--------|------|------------|
+| 1a2b3c4d | [feed] | — | 2026-06-12 | ambient |
+| 9f8e7d6c | [github] | Alice | 2026-05-30 | internal |
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--days <n>` | Ambient look-back window in days (default 30), applied via `published_after` |
+| `--project <name>` | Scope every search (internal and ambient) to this project |
+| `--entry <uuid>` | Seed the Internal Position from a specific entry instead of a topic search |
+| `--include-evergreen` | Include older / first-poll backfill items in the ambient candidate set |
+| `--store` | Store the assessment as a `digest` entry (default: display-only) |
+
+## Tips
+
+- The verdict comes **first** — read the Assessment, then dig into the evidence sections below it.
+- A disjoint result is a feature, not a miss: "the field is discussing X; we have no captured position on X" is exactly the kind of gap `/compass` exists to surface.
+- When the project is only inferred from your cwd (no `--project`), compass scopes softly and auto-widens to all projects if the internal search comes up empty — the topic often lives in another repo.
+- Display-only by default; pass `--store` to persist with tags `compass/assessment/ambient` for later retrieval.
+- Pairs with `/radar` (ambient digest) and `/investigate` (internal deep context) — `/compass` is the directional synthesis of the two.

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,6 +1,6 @@
 # Skills Overview
 
-Distillery provides 14 Claude Code slash commands organized into five categories: knowledge capture, knowledge retrieval, ambient intelligence, team skills, and onboarding.
+Distillery provides 15 Claude Code slash commands organized into five categories: knowledge capture, knowledge retrieval, ambient intelligence, team skills, and onboarding.
 
 ## Knowledge Capture
 
@@ -16,6 +16,7 @@ Distillery provides 14 Claude Code slash commands organized into five categories
 |-------|---------|
 | [`/recall`](recall.md) | Semantic search over the knowledge base |
 | [`/pour`](pour.md) | Multi-entry synthesis with citations and gap analysis |
+| [`/compass`](compass.md) | Contrast internal knowledge against ambient signal; emit a directional assessment |
 | [`/classify`](classify.md) | Classify entries by type and triage the review queue |
 
 ## Ambient Intelligence

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - /classify: skills/classify.md
     - /watch: skills/watch.md
     - /radar: skills/radar.md
+    - /compass: skills/compass.md
     - /tune: skills/tune.md
     - /setup: skills/setup.md
     - /digest: skills/digest.md

--- a/skills/compass/SKILL.md
+++ b/skills/compass/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: compass
 description: "Contrast internal implementation knowledge against ambient intelligence, find where they meet, and emit a directional assessment (ahead / exposed / decide / confirm)"
+min_server_version: "0.7.0"  # distillery_search entry_type list form
 allowed-tools:
   - "mcp__*__distillery_status"
   - "mcp__*__distillery_search"

--- a/skills/radar/SKILL.md
+++ b/skills/radar/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: radar
 description: "Generate an ambient intelligence digest from recent feed activity with source suggestions"
+min_server_version: "0.7.0"  # distillery_relations action="metrics" (bridges/communities)
 allowed-tools:
   - "mcp__*__distillery_status"
   - "mcp__*__distillery_search"

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -174,19 +174,19 @@ class AutoLinkConfig:
     index, and capped at :attr:`max_links` edges per entry to respect the
     embedding/query budget.
 
-    Enabled by default — set :attr:`enabled` ``False`` to disable semantic
-    edge creation so the write path behaves exactly as before.
+    Disabled by default — set :attr:`enabled` ``True`` to enable semantic
+    edge creation; while off, the write path behaves exactly as before.
 
     Attributes:
         enabled: Whether to create semantic ``related`` edges on ingest.
-            Defaults to ``True``.
+            Defaults to ``False``.
         threshold: Normalised cosine similarity score in ``[0.0, 1.0]`` at or
             above which a neighbour is linked.  Defaults to ``0.85``.
         max_links: Maximum number of ``related`` edges to create per stored
             entry (throttle).  Must be a positive integer.  Defaults to ``5``.
     """
 
-    enabled: bool = True
+    enabled: bool = False
     threshold: float = 0.85
     max_links: int = 5
 

--- a/tests/test_auto_link_on_write.py
+++ b/tests/test_auto_link_on_write.py
@@ -247,53 +247,44 @@ async def test_store_batch_auto_links_each_entry(
     assert {r["relation_type"] for r in rows2} == {"related"}
 
 
-async def test_default_config_enables_auto_link(
+async def test_default_config_disables_auto_link(
     controlled_embedding_provider: ControlledEmbeddingProvider,
 ) -> None:
-    """Store instantiated with defaults (no args) has auto_link enabled (edge-by-default)."""
+    """Defaults are OFF at both layers: store __init__ and AutoLinkConfig (kill switch is opt-in)."""
     controlled_embedding_provider.register("source", _NEAR)
     controlled_embedding_provider.register("near one", _NEAR)
 
-    # Instantiate with no explicit auto_link arguments — should use defaults
-    # from DuckDBStore.__init__ signature (auto_link_enabled=False param default).
-    # However, the config module now defaults AutoLinkConfig.enabled to True,
-    # and when a config is loaded (or created with defaults), the server passes
-    # enabled=True to DuckDBStore. This test verifies that default-construction
-    # preserves backwards-compat: no args → enabled=False (store layer default).
-    # But when created via config (the production path), enabled=True (config default).
-
-    # For this test, we verify the store-level default (no args) is still False
-    # to ensure we don't break stateless unit tests that rely on the old behaviour.
+    # Store-level default (no auto_link args) is False: stateless unit tests
+    # that rely on the old behaviour keep working.
     default_store = DuckDBStore(
         db_path=":memory:",
         embedding_provider=controlled_embedding_provider,
     )
     await default_store.initialize()
     try:
-        # Verify the store-level default is still False (for test compatibility)
         assert default_store._auto_link_enabled is False
     finally:
         await default_store.close()
 
-    # But when config loads with defaults, it now returns enabled=True
+    # Config-level default is also False — auto-link is opt-in, not edge-by-default.
     from distillery.config import AutoLinkConfig
 
     cfg = AutoLinkConfig()
-    assert cfg.enabled is True
+    assert cfg.enabled is False
 
 
-async def test_config_default_enabled_true_creates_edges(
+async def test_config_enabled_creates_edges(
     controlled_embedding_provider: ControlledEmbeddingProvider,
 ) -> None:
-    """With config default (enabled=True), a store created via config creates edges."""
+    """With auto_link explicitly enabled, a store created via config creates edges."""
     controlled_embedding_provider.register("source", _NEAR)
     controlled_embedding_provider.register("near one", _NEAR)
 
-    # Simulate what the MCP server does: load config (which now defaults
-    # enabled=True), then pass it to DuckDBStore.
+    # Simulate the MCP server with a deployment that opts in (enabled=True),
+    # then pass it to DuckDBStore.
     from distillery.config import AutoLinkConfig
 
-    cfg = AutoLinkConfig()
+    cfg = AutoLinkConfig(enabled=True)
     assert cfg.enabled is True
 
     # Create store with config-provided value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1325,12 +1325,12 @@ class TestWebhookConfigParsing:
 class TestAutoLinkConfig:
     """Semantic auto-link config parsing / defaults / validation (issue #629)."""
 
-    def test_defaults_enabled(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """No config file → auto-link is on by default, with default threshold and cap."""
+    def test_defaults_disabled(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """No config file → auto-link is off by default, with default threshold and cap."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
         cfg = load_config()
-        assert cfg.auto_link.enabled is True
+        assert cfg.auto_link.enabled is False
         assert cfg.auto_link.threshold == pytest.approx(0.85)
         assert cfg.auto_link.max_links == 5
 


### PR DESCRIPTION
Release-prep for v0.7.0. Does **not** bump versions — tagging happens separately when the release is ready. Resolves the two items a pre-tag review flagged as fix-before-tag, plus the docs-freshness pass.

## Changes

### 1. Auto-link defaults to opt-in — `fix(config)`
The edge-by-default flip (`3eef0ef`) changed only the `AutoLinkConfig` dataclass default. The YAML parser `_parse_auto_link` still defaulted `enabled=False`, and `load_config` routes every file-based config through it — so every `DISTILLERY_CONFIG` deployment (prod + local) ingested with auto-link OFF. The feature no-opped for exactly the deployments it targeted, while the link-suggestion maintenance sweep ran.

Resolution: ship 0.7.0 with auto-link consistently OFF (opt-in) at all layers (dataclass, parser, store `__init__`). Docstring + 3 tests updated. Re-enabling correctly — parser default, `_auto_link_semantic` rollback guard on the durable write path, write-path load test — is tracked in [#688](https://github.com/norrietaylor/distillery/issues/688).

### 2. `min_server_version: "0.7.0"` on /compass and /radar — `fix(skills)`
Both skills call MCP features introduced in 0.7.0 — `/compass` uses the `distillery_search` `entry_type` list form, `/radar` uses `distillery_relations` `action=metrics` (bridges/communities). Declares the floor per `skills/CONVENTIONS.md` so a version-skewed server surfaces the compatibility warning.

### 3. Docs refresh for 0.7.0 — `docs`
- New `docs/skills/compass.md` page + mkdocs nav entry.
- Skill count 14 → 15 across README, CLAUDE.md, home, skills index, plugin-install, architecture (label + layers table + diagram pill + project tree).
- `/compass` added to skill tables (grouped with knowledge retrieval) and the roadmap.
- Roadmap `distillery_relations` entry notes the new traverse/metrics actions.
- Tool count stays **16** (relations gained actions, not tools). No auto-link "on by default" language.

## Not in scope
- Version bump — happens at tag time on the release branch.
- [#688](https://github.com/norrietaylor/distillery/issues/688) auto-link re-enable.

## Test plan
- `pytest` — 3218 passed, 76 skipped.
- `ruff check src/ tests/`, `mypy --strict src/distillery/` — clean.
- `mkdocs build --strict` — clean.

## Related
- Deferred follow-up: [#688](https://github.com/norrietaylor/distillery/issues/688)
- Release-readiness triage also flagged: [#655](https://github.com/norrietaylor/distillery/issues/655) (code-resolved — close), [#669](https://github.com/norrietaylor/distillery/issues/669) (merged via [#683](https://github.com/norrietaylor/distillery/pull/683)), [#112](https://github.com/norrietaylor/distillery/issues/112) (stale; residual gaps pre-existing, defer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `/compass` skill across the documentation and skills catalog, including a dedicated reference page.
  * Updated the skills list and counts to show 15 available skills (up from 14).

* **Bug Fixes / Behavior Changes**
  * Disabled semantic auto-linking on ingest by default.
  * Updated configuration and tests to reflect the new default behavior.

* **Documentation**
  * Refreshed installation, architecture, roadmap, and getting-started content to include `/compass` and the updated skill count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->