### PR TITLE
release: v0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "distillery",
       "source": "./",
       "description": "Knowledge base skills — capture, search, and synthesize project knowledge",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "keywords": ["knowledge-base", "second-brain", "mcp", "embeddings"],
       "category": "knowledge-management"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "distillery",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Knowledge base skills for Claude Code — capture, search, and synthesize project knowledge",
   "author": {
     "name": "norrietaylor",
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '[Distillery] Knowledge base available. Skills: /recall (search), /pour (synthesize), /distill (capture), /classify (review queue), /radar (feed digest).'"
+            "command": "echo '[Distillery] Knowledge base available. Skills: /recall (search), /pour (synthesize), /compass (internal vs ambient), /distill (capture), /classify (review queue), /radar (feed digest).'"
           }
         ]
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distillery-mcp"
-version = "0.6.2"
+version = "0.7.0"
 description = "Persistent shared memory for Claude Code — MCP server with DuckDB vector search, semantic dedup, and ambient intelligence for team knowledge"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.norrietaylor/distillery-mcp",
   "title": "Distillery",
   "description": "Knowledge base for Claude Code with semantic search, feed intelligence, and teams",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "repository": {
     "url": "https://github.com/norrietaylor/distillery",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     {
       "registryType": "pypi",
       "identifier": "distillery-mcp",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "transport": {
         "type": "streamable-http",
         "url": "https://distillery-mcp.fly.dev/mcp"

--- a/src/distillery/__init__.py
+++ b/src/distillery/__init__.py
@@ -2,5 +2,5 @@
 
 import os
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"
 __build_sha__ = os.environ.get("DISTILLERY_BUILD_SHA", "dev")

--- a/uv.lock
+++ b/uv.lock
@@ -744,7 +744,7 @@ wheels = [
 
 [[package]]
 name = "distillery-mcp"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
Version bump and release validation for **v0.7.0**. Cut from `main` per RELEASING.md.

## Version bump (6 source-of-truth refs + lockfile)
- `pyproject.toml` → 0.7.0
- `src/distillery/__init__.py` `__version__` → 0.7.0
- `.claude-plugin/plugin.json` `version` + SessionStart echo (surfaces `/compass`)
- `.claude-plugin/marketplace.json` `plugins[0].version` → 0.7.0 (`metadata.version` left at 1.0.0 — separate schema)
- `server.json` `version` + both `packages[*].version` → 0.7.0
- `uv.lock` regenerated (`uv lock`): distillery-mcp 0.6.2 → 0.7.0

## Highlights since v0.6.2
- New `/compass` skill — internal vs ambient directional assessment.
- `distillery_relations` gains `suggest_links` / `list_candidates` / `resolve_candidate` / `metrics` actions + relation-candidate review queue.
- `distillery_search` `entry_type` accepts `str | list[str]`.
- Logfire/OTLP observability (dark by default).
- Store concurrency: reads taken off the single writer lock; idle WAL-checkpoint backstop ([#655](https://github.com/norrietaylor/distillery/issues/655) code-resolved).
- gh-sync captures source `created_at` as `metadata.published_at`; pour/investigate/briefing render effective date ([#669](https://github.com/norrietaylor/distillery/issues/669)).
- Semantic auto-link ships **opt-in / off by default** (re-enable tracked in [#688](https://github.com/norrietaylor/distillery/issues/688)).

## Validation (local)
- `pytest --cov=src/distillery --cov-fail-under=80`: 3218 passed, 76 skipped, coverage 87.77%.
- `mypy --strict src/distillery/`: clean (73 files).
- `ruff check src/ tests/`: clean.

## Remaining before tag
- CI green on this PR.
- (Operator) hosted smoke-test — `fly deploy` from distill_ops + verify `distillery_status` reports 0.7.0. Out of this repo's scope.

After merge: tag `v0.7.0` from `main` → `gh release create` triggers `pypi-publish.yml` + `changelog.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new available skill to the startup message.

* **Chores**
  * Bumped the app, plugin, and server versions to 0.7.0 across the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->