### PR TITLE
perf(store) + /pour: engage HNSW index, instrument search, trim pour fan-out

### DIFF
--- a/skills/pour/SKILL.md
+++ b/skills/pour/SKILL.md
@@ -159,7 +159,7 @@ Heading `# Pour: <Topic>`, then sections Summary, Timeline, Key Decisions, Contr
 - `--sources` controls the Source Attribution table: default OFF → emit the one-line summary `Sources: <N> entries cited inline (run /pour <topic> --sources for the full table).` (when `--graph` is set, append `— <S> search, <G> structurally-related` so the search-vs-graph split survives without the Provenance column); ON → render the full per-entry table instead. The inline `[Entry <short-id>]` citations (and the `, structurally related` markers under `--graph`) are always present and are the default audit trail
 - Omit sections with no content
 - On MCP errors, see CONVENTIONS.md error handling -- display and stop
-- Loop limits (bounded to cap sequential-search latency): 2 follow-up + 2 tag-derived searches (Pass 2), 1 gap-filling search (Pass 3), 5 refinement rounds (Step 7) — worst case 7 searches per pour
+- Loop limits (bounded to cap sequential-search latency): Pass 1 = 2 (1a + 1b), Pass 2 = 2 follow-up + 2 tag-derived, Pass 3 = 1 gap-filling — worst case 7 searches for the initial synthesis. Step 7 adds up to 5 further on-demand refinement searches (user-driven, not part of the capped initial budget).
 - Apply `--project` filter to every `distillery_search` call when provided
 - `--graph` defaults OFF — never pass `expand_graph=true` without explicit user opt-in via the flag; without `--graph`, all `distillery_search` calls and synthesis behavior remain unchanged (no provenance column, no "structurally related" labels, no graph_expansion totals)
 - When `--graph` is set, apply `expand_graph=true, expand_hops=1` to every `distillery_search` call (Pass 1a, 1b, Pass 2 concept and tag-derived, Pass 3, and any Step 7 refinement search)

--- a/skills/pour/SKILL.md
+++ b/skills/pour/SKILL.md
@@ -64,17 +64,17 @@ With `--graph`: `distillery_search(query="<topic>", limit=20, project="<project 
 
 Deduplicate Pass 1a and 1b results by entry ID, keeping the higher similarity score. Record all entries and scores. When `--graph` is set, also record each entry's `provenance` (`search` or `graph`), `depth`, and `parent_id`; if the same entry appears via both provenances across passes, prefer `provenance="search"` (the stronger signal).
 
-**Pass 2 -- Follow-up Searches (up to 3) + Tag Expansion (up to 3):**
+**Pass 2 -- Follow-up Searches (up to 2) + Tag Expansion (up to 2):**
 
 Analyze Pass 1 for related concepts, people, sub-topics, or terms not directly covered by the original query. For each significant one:
 
 `distillery_search(query="<related concept>", limit=10, project="<project if specified>")` (add `expand_graph=true, expand_hops=1` when `--graph` is set)
 
-**Tag-based expansion:** Extract tags from Pass 1 results and identify their namespace prefixes (e.g., tags like `domain/authentication`, `domain/oauth` → namespace prefix `domain`). Call `distillery_list(group_by="tags", project="<project if specified>", limit=200)` to get tag frequencies across the knowledge base. From the returned tag groups, filter to those matching the namespace prefixes and rank by count. Convert the top-ranked tag segments to search queries by taking the leaf segment and replacing hyphens with spaces (e.g., `domain/oauth` → `"oauth"`, `domain/session-management` → `"session management"`). Run up to 3 `distillery_search` calls from these ranked tag-derived queries, skipping any that duplicate an existing Pass 2 concept query. (Add `expand_graph=true, expand_hops=1` when `--graph` is set.)
+**Tag-based expansion:** Extract tags from Pass 1 results and identify their namespace prefixes (e.g., tags like `domain/authentication`, `domain/oauth` → namespace prefix `domain`). Call `distillery_list(group_by="tags", project="<project if specified>", limit=200)` to get tag frequencies across the knowledge base. From the returned tag groups, filter to those matching the namespace prefixes and rank by count. Convert the top-ranked tag segments to search queries by taking the leaf segment and replacing hyphens with spaces (e.g., `domain/oauth` → `"oauth"`, `domain/session-management` → `"session management"`). Run up to 2 `distillery_search` calls from these ranked tag-derived queries, skipping any that duplicate an existing Pass 2 concept query. (Add `expand_graph=true, expand_hops=1` when `--graph` is set.)
 
 Report: `Tag expansion: discovered <N> related topics from tag vocabulary.` (Omit this line entirely if no tags are found in Pass 1 results — Pass 2 proceeds with concept-based queries only.)
 
-**Pass 3 -- Gap-filling (up to 2):**
+**Pass 3 -- Gap-filling (up to 1):**
 
 If earlier passes reveal references to specific projects, decisions, or events not yet returned:
 
@@ -159,7 +159,7 @@ Heading `# Pour: <Topic>`, then sections Summary, Timeline, Key Decisions, Contr
 - `--sources` controls the Source Attribution table: default OFF → emit the one-line summary `Sources: <N> entries cited inline (run /pour <topic> --sources for the full table).` (when `--graph` is set, append `— <S> search, <G> structurally-related` so the search-vs-graph split survives without the Provenance column); ON → render the full per-entry table instead. The inline `[Entry <short-id>]` citations (and the `, structurally related` markers under `--graph`) are always present and are the default audit trail
 - Omit sections with no content
 - On MCP errors, see CONVENTIONS.md error handling -- display and stop
-- Loop limits: 3 follow-up searches (Pass 2), 2 gap-filling searches (Pass 3), 5 refinement rounds (Step 7)
+- Loop limits (bounded to cap sequential-search latency): 2 follow-up + 2 tag-derived searches (Pass 2), 1 gap-filling search (Pass 3), 5 refinement rounds (Step 7) — worst case 7 searches per pour
 - Apply `--project` filter to every `distillery_search` call when provided
 - `--graph` defaults OFF — never pass `expand_graph=true` without explicit user opt-in via the flag; without `--graph`, all `distillery_search` calls and synthesis behavior remain unchanged (no provenance column, no "structurally related" labels, no graph_expansion totals)
 - When `--graph` is set, apply `expand_graph=true, expand_hops=1` to every `distillery_search` call (Pass 1a, 1b, Pass 2 concept and tag-derived, Pass 3, and any Step 7 refinement search)

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -31,6 +31,7 @@ from urllib.parse import unquote, urlparse
 
 import duckdb
 
+from distillery import observability
 from distillery.feeds.tags import normalize_tag
 from distillery.models import Entry, EntrySource, EntryStatus, EntryType, validate_metadata
 from distillery.store.migrations import (
@@ -2596,7 +2597,8 @@ class DuckDBStore:
         # 429/5xx) does not block the event loop — mirrors ``store`` (issue
         # #558). On the event loop a blocking embed starves the Fly health
         # check during concurrent feed polls, which de-routes the machine.
-        embedding = await asyncio.to_thread(self._embedding_provider.embed, query)
+        with observability.span("store.search.embed"):
+            embedding = await asyncio.to_thread(self._embedding_provider.embed, query)
         use_hybrid = self._hybrid_search and self._fts_available
 
         def _sync(conn: duckdb.DuckDBPyConnection) -> list[SearchResult]:
@@ -2606,12 +2608,16 @@ class DuckDBStore:
                 where_sql = "WHERE " + " AND ".join(where_clauses)
 
             # --- Vector search (always performed) ---
+            # Use array_cosine_distance + ASC ordering so DuckDB's HNSW cosine
+            # index (migration 6) can serve the top-k via an index scan instead
+            # of a full-table cosine scan. distance = 1 - cosine_similarity, so
+            # ascending distance is the same ordering as descending similarity.
             sql = (
                 f"SELECT {self._ENTRY_COLUMNS}, "
-                f"array_cosine_similarity(embedding, ?::FLOAT[{self._embedding_provider.dimensions}]) AS score "
+                f"array_cosine_distance(embedding, ?::FLOAT[{self._embedding_provider.dimensions}]) AS distance "
                 f"FROM entries "
                 f"{where_sql} "
-                f"ORDER BY score DESC "
+                f"ORDER BY distance ASC "
                 f"LIMIT ?"
             )
             # Fetch more candidates for fusion when hybrid is active.
@@ -2628,7 +2634,7 @@ class DuckDBStore:
             cosine_score: dict[str, float] = {}
             for rank, row in enumerate(rows, start=1):
                 row_dict = dict(zip(col_names, row, strict=True))
-                raw_cosine = float(row_dict.pop("score"))
+                distance = float(row_dict.pop("distance"))
                 entry = self._row_to_entry(
                     tuple(row_dict.values()),
                     list(row_dict.keys()),
@@ -2636,8 +2642,10 @@ class DuckDBStore:
                 entry_map[entry.id] = entry
                 vector_ranks[entry.id] = rank
                 entry_created[entry.id] = entry.created_at
-                # Map raw cosine similarity in [-1, 1] to a displayed score in [0, 1].
-                cosine_score[entry.id] = (raw_cosine + 1.0) / 2.0
+                # distance = 1 - cosine_similarity; map similarity [-1, 1] to a
+                # displayed score in [0, 1] => (2 - distance) / 2. Identical to
+                # the previous (raw_cosine + 1) / 2 mapping.
+                cosine_score[entry.id] = (2.0 - distance) / 2.0
 
             if not use_hybrid:
                 # Vector-only: return raw cosine similarity (mapped to [0, 1]).
@@ -2646,7 +2654,7 @@ class DuckDBStore:
                 results: list[SearchResult] = []
                 for row in rows[:limit]:
                     row_dict = dict(zip(col_names, row, strict=True))
-                    row_dict.pop("score")
+                    row_dict.pop("distance")
                     eid = row_dict["id"]
                     results.append(SearchResult(entry=entry_map[eid], score=cosine_score[eid]))
                 return results
@@ -2724,7 +2732,8 @@ class DuckDBStore:
         # Reads run on the independent read handle so a search never queues
         # behind a write on ``_conn_lock`` (#663 follow-up). ``accessed_at`` is
         # stamped out of band via the deferred flusher.
-        results = await self._run_read(_sync)
+        with observability.span("store.search.rank", hybrid=use_hybrid, limit=limit):
+            results = await self._run_read(_sync)
         self._mark_accessed(r.entry.id for r in results)
         return results
 

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2608,16 +2608,28 @@ class DuckDBStore:
                 where_sql = "WHERE " + " AND ".join(where_clauses)
 
             # --- Vector search (always performed) ---
-            # Use array_cosine_distance + ASC ordering so DuckDB's HNSW cosine
-            # index (migration 6) can serve the top-k via an index scan instead
-            # of a full-table cosine scan. distance = 1 - cosine_similarity, so
-            # ascending distance is the same ordering as descending similarity.
+            # Unfiltered cosine queries order by array_cosine_distance ASC so
+            # DuckDB's HNSW cosine index (migration 6) can serve the top-k via
+            # an index scan. DuckDB's HNSW applies WHERE predicates AFTER the
+            # index scan (post-filtering), which can return fewer than `limit`
+            # rows once a filter is present, so filtered queries stay on the
+            # exact array_cosine_similarity scan to preserve the full result
+            # count and ordering (CR review, PR #693). Both expressions yield
+            # the same displayed cosine similarity in [0, 1].
+            dims = self._embedding_provider.dimensions
+            if where_sql:
+                score_select = f"array_cosine_similarity(embedding, ?::FLOAT[{dims}]) AS score"
+                order_sql = "ORDER BY score DESC"
+                score_col = "score"
+            else:
+                score_select = f"array_cosine_distance(embedding, ?::FLOAT[{dims}]) AS distance"
+                order_sql = "ORDER BY distance ASC"
+                score_col = "distance"
             sql = (
-                f"SELECT {self._ENTRY_COLUMNS}, "
-                f"array_cosine_distance(embedding, ?::FLOAT[{self._embedding_provider.dimensions}]) AS distance "
+                f"SELECT {self._ENTRY_COLUMNS}, {score_select} "
                 f"FROM entries "
                 f"{where_sql} "
-                f"ORDER BY distance ASC "
+                f"{order_sql} "
                 f"LIMIT ?"
             )
             # Fetch more candidates for fusion when hybrid is active.
@@ -2634,7 +2646,11 @@ class DuckDBStore:
             cosine_score: dict[str, float] = {}
             for rank, row in enumerate(rows, start=1):
                 row_dict = dict(zip(col_names, row, strict=True))
-                distance = float(row_dict.pop("distance"))
+                raw = float(row_dict.pop(score_col))
+                # Map cosine similarity in [-1, 1] to a displayed score in
+                # [0, 1]. array_cosine_distance = 1 - similarity, so both paths
+                # produce identical scores: (similarity + 1) / 2.
+                similarity = raw if score_col == "score" else 1.0 - raw
                 entry = self._row_to_entry(
                     tuple(row_dict.values()),
                     list(row_dict.keys()),
@@ -2642,10 +2658,7 @@ class DuckDBStore:
                 entry_map[entry.id] = entry
                 vector_ranks[entry.id] = rank
                 entry_created[entry.id] = entry.created_at
-                # distance = 1 - cosine_similarity; map similarity [-1, 1] to a
-                # displayed score in [0, 1] => (2 - distance) / 2. Identical to
-                # the previous (raw_cosine + 1) / 2 mapping.
-                cosine_score[entry.id] = (2.0 - distance) / 2.0
+                cosine_score[entry.id] = (similarity + 1.0) / 2.0
 
             if not use_hybrid:
                 # Vector-only: return raw cosine similarity (mapped to [0, 1]).
@@ -2654,7 +2667,7 @@ class DuckDBStore:
                 results: list[SearchResult] = []
                 for row in rows[:limit]:
                     row_dict = dict(zip(col_names, row, strict=True))
-                    row_dict.pop("distance")
+                    row_dict.pop(score_col)
                     eid = row_dict["id"]
                     results.append(SearchResult(entry=entry_map[eid], score=cosine_score[eid]))
                 return results


### PR DESCRIPTION
Implements recommendations 3 and 4 from the instance health investigation (the slow `/pour` and `/radar` incident).

## Context
A `/pour` run took ~10 min. Tracing showed each `distillery_search` embedding was fast (Jina, 0.2–2.3s) but the **post-embedding rank step was untraced** and ballooned to 173–257s. Root cause was CPU starvation (system CPU 80–92%, process throttled to ~10%) during a concurrent feed poll — addressed operationally (recs 1–2). This PR lands the durability/observability follow-ups.

## Rec 4 — `perf(store)`: engage HNSW index + instrument search
- Vector search ordered by `array_cosine_similarity(...) DESC`, which DuckDB's HNSW optimizer cannot match → every search was a **full-table cosine scan**, never using the existing `idx_entries_embedding` HNSW cosine index (migration 6). Switched the ranked query to `array_cosine_distance(...) ASC LIMIT`, which the optimizer can serve via an HNSW index scan.
  - `distance = 1 - cosine_similarity`, so ordering and the displayed score (`(2 - distance)/2 == (raw_cosine + 1)/2`) are **mathematically identical** — no result/score change. Filtered queries fall back to the same exact scan as before.
- Added Logfire spans `store.search.embed` and `store.search.rank` via the existing `observability.span` seam (which had **zero callers**). This makes the embed-vs-rank split visible — the gap that hid the 200s+ stalls.

## Rec 3 — `feat(skills)`: trim `/pour` fan-out
- `/pour` issued up to **10 sequential** searches (Pass 2: 3 follow-up + 3 tag-derived; Pass 3: 2 gap-filling). Trimmed to 2 + 2 + 1 → worst case **7** (~30% fewer round-trips), keeping the multi-pass structure. Fewer sequential round-trips = proportionally less wall-clock and less self-inflicted CPU load.

## Note on scope
At the current corpus size (~3969 entries) a full cosine scan is sub-second, so the HNSW change is primarily a **scalability + correctness-of-intent** fix (the eval harness already assumes HNSW is active); the 10-min stalls were CPU contention. The instrumentation is the high-value piece for diagnosing recurrence.

## Acceptance
- `pytest tests/test_duckdb_store.py tests/test_store_protocol.py` → 161 passed
- `pytest tests/test_plugin.py tests/test_mcp_server.py tests/test_metrics.py` → 127 passed
- `ruff check src/ tests/` → clean
- `mypy --strict src/distillery/` → clean (73 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector search ranking and result scoring consistency, including correct behavior when metadata filters are applied.
  * Updated result parsing to properly normalize similarity scores based on the underlying distance/scoring method used.
* **Chores**
  * Reduced capped retrieval budgets for follow-up/tag-derived searches and gap-filling, lowering worst-case total retrieval search calls per run.
* **Observability**
  * Added additional tracing spans around embedding generation and rank execution during search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->