### PR TITLE
feat(observability): store cost-centre spans + stdlib log forwarding

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -51,6 +51,20 @@ ignore:
       type: apk
     reason: "CPython 3.14.6-r1 — High; bz2.BZ2Decompressor objects can be reused after a decompression error, leading to use-after-error if the application catches OSError and retries on the same object.  Not exploitable in Distillery: no bz2 usage anywhere in src/ or in declared dependencies (verified by grep on 2026-06-11) — the module merely ships in the base image's stdlib.  No fixed python-3.14 build released by Wolfi/CPython yet.  Revisit on the next Chainguard base-image rebuild.  Reviewed: 2026-06-18"
 
+  - vulnerability: CVE-2026-11940
+    package:
+      name: python-3.14
+      version: 3.14.6-r1
+      type: apk
+    reason: "CPython 3.14.6-r1 — High (7.8); tarfile.extractall() 'data'/'tar' filter bypass: a crafted archive with a hardlink referencing a symlink at a deeper path recreates the symlink at a shallower one, escaping the destination directory (incomplete fix of CVE-2025-4330).  Not exploitable in Distillery: no tarfile usage anywhere in src/ (verified by grep on 2026-07-06); the only runtime-dependency match is fastmcp's CLI dev-apps helper, which the server never imports — the module merely ships in the base image's stdlib and no untrusted archives are ever extracted.  No fixed python-3.14 build released by Wolfi/CPython yet (grype fix state empty).  Revisit on the next Chainguard base-image rebuild.  Reviewed: 2026-07-06"
+
+  - vulnerability: CVE-2026-11972
+    package:
+      name: python-3.14
+      version: 3.14.6-r1
+      type: apk
+    reason: "CPython 3.14.6-r1 — High (8.2); tarfile in streaming mode (mode='r|') mishandles EOF, so a truncated/crafted archive parses in an infinite loop (DoS).  Not exploitable in Distillery: no tarfile usage anywhere in src/ (verified by grep on 2026-07-06, same sweep as CVE-2026-11940) and the server never parses tar archives, trusted or otherwise.  No fixed python-3.14 build released by Wolfi/CPython yet (grype fix state empty).  Revisit on the next Chainguard base-image rebuild.  Reviewed: 2026-07-06"
+
 
 # Fail on critical and high severity vulnerabilities.
 # This is also enforced in the CI workflow via --severity-cutoff=high,

--- a/src/distillery/observability.py
+++ b/src/distillery/observability.py
@@ -25,13 +25,21 @@ Auto-instrumentation captures the high-value signals with no hot-path changes:
 * ``instrument_system_metrics`` — host/runtime CPU, memory and swap utilisation.
 * ``instrument_asgi`` (via :func:`instrument_asgi_app`) — one span per HTTP
   request (method, route, status, duration). Headers are not captured.
+* ``LogfireLoggingHandler`` on the root logger — stdlib log records (the
+  server's existing ``logger.info/warning/exception`` calls) are forwarded as
+  Logfire logs correlated with the active span; ``logger.exception`` records
+  carry the traceback and group into exception issues.
 
-DuckDB and NetworkX have no OTel instrumentor; :func:`span` is the seam for the
-store/graph cost-centre spans (added separately).
+DuckDB and NetworkX have no OTel instrumentor; :func:`span` is the seam for
+such cost-centre spans. The store funnels (``DuckDBStore._run_sync`` /
+``_run_read``) use it to emit one ``db {operation}`` span per store operation,
+covering lock wait plus execution.
 
 Secret safety: Logfire's default scrubber redacts secret-shaped attributes
 (authorization, api-key, token, cookie, ...) and runs upstream of the OTLP
-fan-out, so secrets are redacted on both the Logfire and collector paths.
+fan-out, so secrets are redacted on both the Logfire and collector paths. The
+logging handler additionally carries :class:`distillery.security.SecretRedactFilter`
+so known API-key formats are redacted from log messages before export.
 """
 
 from __future__ import annotations
@@ -118,6 +126,24 @@ def configure_observability() -> bool:
             logger.warning(
                 "logfire.instrument_%s failed; that signal is disabled", name, exc_info=True
             )
+
+    try:
+        # Forward stdlib logging to Logfire so the server's existing
+        # logger.info/warning/exception calls appear as logs (and grouped
+        # exception issues) correlated with the active span. The stderr
+        # handler from basicConfig is untouched. The handler carries its own
+        # SecretRedactFilter: the one _configure_logging attaches to the
+        # "distillery" logger does not run for records propagated from child
+        # loggers, and handler-level filters do.
+        from distillery.security import SecretRedactFilter
+
+        handler = logfire.LogfireLoggingHandler()
+        handler.addFilter(SecretRedactFilter())
+        logging.getLogger().addHandler(handler)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "LogfireLoggingHandler attach failed; stdlib logs are not forwarded", exc_info=True
+        )
 
     logger.info(
         "Observability configured (logfire=%s, otlp_endpoint=%s)",

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -33,6 +33,7 @@ import duckdb
 
 from distillery.feeds.tags import normalize_tag
 from distillery.models import Entry, EntrySource, EntryStatus, EntryType, validate_metadata
+from distillery.observability import span
 from distillery.store.migrations import (
     _CREATE_META_TABLE,
     backfill_relations_from_content_refs,
@@ -115,6 +116,23 @@ class EntriesIntegrityError(RuntimeError):
     unreadable column and the caller must fail loud rather than report
     success.
     """
+
+
+def _op_name(fn: Callable[..., Any]) -> str:
+    """Low-cardinality operation label for the ``db {operation}`` spans.
+
+    The store funnels receive three callable shapes: bound ``_sync_*`` methods
+    (``DuckDBStore._sync_store`` → ``_sync_store``), closures defined inside the
+    public coroutine (``DuckDBStore.search.<locals>._sync`` → ``search``), and
+    lambdas (``DuckDBStore.get.<locals>.<lambda>`` → ``get``).  For closures the
+    enclosing method name is the meaningful one.
+    """
+    qualname = getattr(fn, "__qualname__", None) or repr(fn)
+    parts = qualname.split(".")
+    if "<locals>" in parts:
+        # Last occurrence: the innermost enclosing function names the operation.
+        return parts[len(parts) - 1 - parts[::-1].index("<locals>") - 1]
+    return parts[-1]
 
 
 def _sql_escape(value: str) -> str:
@@ -1507,62 +1525,67 @@ class DuckDBStore:
         path when a prior uncaught exception poisoned the connection;
         running ``ROLLBACK`` after the failed read restores the connection
         so the next call succeeds rather than cascading the same error.
+
+        Emits a ``db {operation}`` span (no-op when telemetry is off) that
+        covers lock wait plus execution, so writer-lock contention (issues
+        #416/#558) is visible per operation in the trace timeline.
         """
-        async with self._get_conn_lock():
-            try:
-                return await asyncio.to_thread(fn, *args, **kwargs)
-            except duckdb.FatalException as exc:
-                # A ``FatalException`` carrying "has been invalidated"
-                # permanently poisons the connection: every later operation
-                # raises the same fatal forever, so a ``ROLLBACK`` cannot
-                # recover it.  Rather than loop 500s indefinitely (one
-                # incident ran 7.5 days writing 32 MB of identical stacks —
-                # issue #583), record the failure, log at CRITICAL, and ask
-                # the supervisor (launchd/systemd) to restart us via SIGTERM.
-                # The fresh process either replays the WAL cleanly or fails
-                # visibly at startup.  Non-invalidating fatals fall through to
-                # the generic rollback path below.
-                if "has been invalidated" in str(exc):
-                    self._signal_supervisor_restart(exc, "connection terminally invalidated")
+        with span("db {operation}", operation=_op_name(fn), lock="conn"):
+            async with self._get_conn_lock():
+                try:
+                    return await asyncio.to_thread(fn, *args, **kwargs)
+                except duckdb.FatalException as exc:
+                    # A ``FatalException`` carrying "has been invalidated"
+                    # permanently poisons the connection: every later operation
+                    # raises the same fatal forever, so a ``ROLLBACK`` cannot
+                    # recover it.  Rather than loop 500s indefinitely (one
+                    # incident ran 7.5 days writing 32 MB of identical stacks —
+                    # issue #583), record the failure, log at CRITICAL, and ask
+                    # the supervisor (launchd/systemd) to restart us via SIGTERM.
+                    # The fresh process either replays the WAL cleanly or fails
+                    # visibly at startup.  Non-invalidating fatals fall through to
+                    # the generic rollback path below.
+                    if "has been invalidated" in str(exc):
+                        self._signal_supervisor_restart(exc, "connection terminally invalidated")
+                        raise
+                    conn = self._conn
+                    if conn is not None:
+                        await asyncio.to_thread(self._rollback_quietly, conn)
                     raise
-                conn = self._conn
-                if conn is not None:
-                    await asyncio.to_thread(self._rollback_quietly, conn)
-                raise
-            except duckdb.IOException as exc:
-                # A stale file handle (the GCS FUSE object generation changed
-                # under our open handle — see ``_is_stale_file_handle``) cannot
-                # be recovered by ``ROLLBACK``: the OS-level handle is dead, so
-                # every later read fails identically until the file is
-                # re-opened.  Restart the process rather than loop 500s; the
-                # fresh instance opens a clean handle.  Other IO errors fall
-                # through to the generic rollback path below.
-                if self._is_stale_file_handle(exc):
-                    self._signal_supervisor_restart(
-                        exc, "file handle is stale (FUSE object generation changed)"
-                    )
+                except duckdb.IOException as exc:
+                    # A stale file handle (the GCS FUSE object generation changed
+                    # under our open handle — see ``_is_stale_file_handle``) cannot
+                    # be recovered by ``ROLLBACK``: the OS-level handle is dead, so
+                    # every later read fails identically until the file is
+                    # re-opened.  Restart the process rather than loop 500s; the
+                    # fresh instance opens a clean handle.  Other IO errors fall
+                    # through to the generic rollback path below.
+                    if self._is_stale_file_handle(exc):
+                        self._signal_supervisor_restart(
+                            exc, "file handle is stale (FUSE object generation changed)"
+                        )
+                        raise
+                    conn = self._conn
+                    if conn is not None:
+                        await asyncio.to_thread(self._rollback_quietly, conn)
                     raise
-                conn = self._conn
-                if conn is not None:
-                    await asyncio.to_thread(self._rollback_quietly, conn)
-                raise
-            except Exception:
-                # Catching ``Exception`` — not ``BaseException`` — so that
-                # ``asyncio.CancelledError`` does not trigger rollback.
-                # When a task is cancelled while awaiting
-                # ``asyncio.to_thread(fn, …)`` the worker thread executing
-                # *fn* keeps running (Python has no safe way to forcibly
-                # stop a thread), so issuing ``conn.rollback()`` from a
-                # second worker thread would race against the still-live
-                # first one on the shared DuckDB connection.  On
-                # cancellation we simply re-raise; on ordinary exceptions
-                # *fn* has already returned control so the rollback is
-                # safe.  The rollback runs while we still hold the lock
-                # so the connection is single-threaded throughout.
-                conn = self._conn
-                if conn is not None:
-                    await asyncio.to_thread(self._rollback_quietly, conn)
-                raise
+                except Exception:
+                    # Catching ``Exception`` — not ``BaseException`` — so that
+                    # ``asyncio.CancelledError`` does not trigger rollback.
+                    # When a task is cancelled while awaiting
+                    # ``asyncio.to_thread(fn, …)`` the worker thread executing
+                    # *fn* keeps running (Python has no safe way to forcibly
+                    # stop a thread), so issuing ``conn.rollback()`` from a
+                    # second worker thread would race against the still-live
+                    # first one on the shared DuckDB connection.  On
+                    # cancellation we simply re-raise; on ordinary exceptions
+                    # *fn* has already returned control so the rollback is
+                    # safe.  The rollback runs while we still hold the lock
+                    # so the connection is single-threaded throughout.
+                    conn = self._conn
+                    if conn is not None:
+                        await asyncio.to_thread(self._rollback_quietly, conn)
+                    raise
 
     async def _run_read(self, fn: Callable[[duckdb.DuckDBPyConnection], _T]) -> _T:
         """Run a read-only *fn* against the independent read handle.
@@ -1590,26 +1613,31 @@ class DuckDBStore:
         *fn* must be read-only.  Any error leaves the read handle untouched
         (no rollback): a SELECT cannot poison ``_read_conn`` the way a failed
         write poisons ``_conn``.
+
+        Emits a ``db {operation}`` span (no-op when telemetry is off) that
+        covers read-lock wait plus execution, so a slow search delaying the
+        readiness probe (see above) shows up per operation in the trace.
         """
         read_conn = self._read_conn
         if read_conn is None:
             raise RuntimeError(
                 "DuckDBStore has not been initialized. Call 'await store.initialize()' first."
             )
-        async with self._get_read_lock():
-            try:
-                return await asyncio.to_thread(fn, read_conn)
-            except duckdb.IOException as exc:
-                # The read handle is a ``cursor()`` of ``_conn`` over the same
-                # backing file, so it goes stale together with it when the
-                # FUSE object generation changes.  No rollback (a SELECT never
-                # poisons the read handle); restart so a fresh process re-opens
-                # the file, then re-raise for this request.
-                if self._is_stale_file_handle(exc):
-                    self._signal_supervisor_restart(
-                        exc, "read handle is stale (FUSE object generation changed)"
-                    )
-                raise
+        with span("db {operation}", operation=_op_name(fn), lock="read"):
+            async with self._get_read_lock():
+                try:
+                    return await asyncio.to_thread(fn, read_conn)
+                except duckdb.IOException as exc:
+                    # The read handle is a ``cursor()`` of ``_conn`` over the same
+                    # backing file, so it goes stale together with it when the
+                    # FUSE object generation changes.  No rollback (a SELECT never
+                    # poisons the read handle); restart so a fresh process re-opens
+                    # the file, then re-raise for this request.
+                    if self._is_stale_file_handle(exc):
+                        self._signal_supervisor_restart(
+                            exc, "read handle is stale (FUSE object generation changed)"
+                        )
+                    raise
 
     # ------------------------------------------------------------------
     # Deferred accessed_at tracking (issue #663 follow-up)

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -127,7 +127,12 @@ def _op_name(fn: Callable[..., Any]) -> str:
     lambdas (``DuckDBStore.get.<locals>.<lambda>`` → ``get``).  For closures the
     enclosing method name is the meaningful one.
     """
-    qualname = getattr(fn, "__qualname__", None) or repr(fn)
+    qualname: str | None = getattr(fn, "__qualname__", None)
+    if qualname is None:
+        # repr text can itself contain dots and "<locals>" (e.g. a callable
+        # instance of a locally defined class) — return it verbatim rather
+        # than splitting it like a qualname.
+        return repr(fn)
     parts = qualname.split(".")
     if "<locals>" in parts:
         # Last occurrence: the innermost enclosing function names the operation.

--- a/tests/test_duckdb_op_name.py
+++ b/tests/test_duckdb_op_name.py
@@ -8,6 +8,8 @@ selection unreliable.
 
 from __future__ import annotations
 
+import functools
+
 import pytest
 
 from distillery.store.duckdb import DuckDBStore, _op_name
@@ -36,10 +38,21 @@ def test_lambda_uses_enclosing_function_name() -> None:
     assert _op_name(get()) == "get"
 
 
-def test_callable_without_qualname_falls_back_to_repr() -> None:
-    class _Op:
-        def __call__(self) -> None:
-            pass
+def test_callable_without_qualname_falls_back_to_verbatim_repr() -> None:
+    # functools.partial instances expose no __qualname__.
+    fn = functools.partial(sorted)
+    assert _op_name(fn) == repr(fn)
 
-    name = _op_name(_Op())
-    assert name  # repr-derived, never empty
+
+def test_local_callable_instance_repr_is_not_split_like_a_qualname() -> None:
+    # The instance repr contains dots and "<locals>"; it must come back
+    # verbatim, not collapse to the enclosing function name ("outer").
+    def outer():
+        class _Op:
+            def __call__(self) -> None:
+                pass
+
+        return _Op()
+
+    inst = outer()
+    assert _op_name(inst) == repr(inst)

--- a/tests/test_duckdb_op_name.py
+++ b/tests/test_duckdb_op_name.py
@@ -1,0 +1,45 @@
+"""Unit tests for ``distillery.store.duckdb._op_name``.
+
+Lives in its own module (not ``test_duckdb_store.py``) because that module
+applies ``pytestmark = pytest.mark.integration``. Double-marking these
+pure-helper tests as both ``unit`` and ``integration`` makes marker-based
+selection unreliable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distillery.store.duckdb import DuckDBStore, _op_name
+
+pytestmark = pytest.mark.unit
+
+
+def test_bound_method_uses_method_name() -> None:
+    assert _op_name(DuckDBStore._sync_delete) == "_sync_delete"
+
+
+def test_closure_uses_enclosing_function_name() -> None:
+    def search():
+        def _sync():
+            pass
+
+        return _sync
+
+    assert _op_name(search()) == "search"
+
+
+def test_lambda_uses_enclosing_function_name() -> None:
+    def get():
+        return lambda conn: conn
+
+    assert _op_name(get()) == "get"
+
+
+def test_callable_without_qualname_falls_back_to_repr() -> None:
+    class _Op:
+        def __call__(self) -> None:
+            pass
+
+    name = _op_name(_Op())
+    assert name  # repr-derived, never empty

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -2602,3 +2602,26 @@ class TestIdleCheckpoint:
 # ``pytestmark = pytest.mark.integration`` at the top, and double-marking
 # makes marker-based selection unreliable.
 # ---------------------------------------------------------------------------
+
+
+class TestObservabilitySpans:
+    """The store funnels emit one ``db {operation}`` span per operation."""
+
+    async def test_funnels_emit_db_operation_spans(self, store, monkeypatch) -> None:
+        import distillery.store.duckdb as duckdb_mod
+
+        recorded: list[tuple[str, str]] = []
+
+        def _recording_span(name: str, **attributes):
+            assert name == "db {operation}"
+            recorded.append((attributes["operation"], attributes["lock"]))
+            return contextlib.nullcontext()
+
+        monkeypatch.setattr(duckdb_mod, "span", _recording_span)
+
+        entry = make_entry(content="span probe")
+        await store.store(entry)  # bound method through _run_sync
+        await store.get(entry.id)  # lambda through _run_read
+
+        assert ("_sync_store", "conn") in recorded
+        assert ("get", "read") in recorded


### PR DESCRIPTION
## Summary

Closes two coverage gaps in the existing Logfire instrumentation (both dark by default, per the `[otel]` extra's contract):

- **Store cost-centre spans** — the store funnels `DuckDBStore._run_sync` / `_run_read` now emit one `db {operation}` span per store operation via the existing (previously unused) `span()` seam. The span covers lock wait plus execution, so writer-lock contention ([#416](https://github.com/norrietaylor/distillery/issues/416) / [#558](https://github.com/norrietaylor/distillery/issues/558)) is visible per operation in the trace timeline. DuckDB has no OTel auto-instrumentor; the observability module docstring named these funnels as the seam's intended use.
- **Stdlib log forwarding** — `configure_observability()` attaches `logfire.LogfireLoggingHandler` to the root logger, so the server's existing `logger.info/warning/exception` calls appear as Logfire logs correlated with the active span, and `logger.exception` records group into exception issues. The handler carries its own `SecretRedactFilter`: handler-level filters run for records propagated from child loggers, logger-level ones do not.

A new `_op_name()` helper normalises the three callable shapes reaching the funnels (bound `_sync_*` methods, `_sync` closures, lambdas) into low-cardinality span labels (`_sync_store`, `search`, `get`, …).

## Safety

- Disabled path unchanged: `span()` still returns `nullcontext`, the handler is only attached when `LOGFIRE_TOKEN` / `OTEL_EXPORTER_OTLP_ENDPOINT` is set, and the attach is guarded like the instrumentors — telemetry setup can never take down the server.
- Secrets: known API-key formats (`jina_`, `sk-`, `ghp_`, …) are redacted from log messages before export, on top of Logfire's default attribute scrubber.

## Verification

- `ruff check` + `ruff format --check` clean; `mypy --strict src/distillery/` clean.
- Full suite: 3217 passed, 3 skipped.
- New tests: `tests/test_duckdb_op_name.py` (unit) and `TestObservabilitySpans` in `tests/test_duckdb_store.py` (integration) assert the funnels emit `db {operation}` spans with the normalised names.
- Enabled path smoke-tested against real logfire 4.37 in a scratch venv with all sub-extras: `configure_observability()` succeeds, the seam yields real `LogfireSpan`s, the handler attaches with the filter, `jina_…`/`sk-…` keys arrive at the handler as `jina_abcd****`/`sk-XYZ1****`, and `instrument_asgi_app` wraps while configured.

## Note (pre-existing, not touched)

The `SecretRedactFilter` that `_configure_logging` attaches to the `"distillery"` *logger* never runs for records emitted by child loggers (`distillery.store.duckdb`, …) — Python only applies logger-level filters at the originating logger, so the stderr path is effectively unredacted for most records today. The new Logfire handler is not affected (its filter is handler-level). Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced observability by forwarding root-logger output into Logfire with active-span correlation and improved exception grouping.
  * Added detailed database tracing spans for storage and read operations using low-cardinality operation names.
* **Bug Fixes**
  * Instrumentation continues even if log forwarding can’t be attached.
  * Strengthened sensitive-data redaction for log paths.
* **Tests**
  * Added unit tests covering database operation-name derivation and span emission.
* **Chores**
  * Updated vulnerability suppressions for python-3.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->