### PR TITLE
feat(auth): GitLab (self-hosted or gitlab.com) as an identity provider

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# Distillery
+
+A knowledge-base system for Claude Code: stores, searches, and classifies knowledge entries, exposed via an MCP server with skills on top.
+
+## Language
+
+### Authentication
+
+**Identity Provider**:
+The external service (GitHub, or a GitLab instance) that proves who a caller is. Exactly one per deployment.
+_Avoid_: auth backend, login service
+
+**Identity Gate**:
+The yes/no decision of whether an authenticated identity may use this Distillery server at all. Distillery never accesses the provider's resources; authentication is used for identity only.
+_Avoid_: permissions, access control (both imply resource-level authorization that does not exist here)
+
+**Allowed Memberships**:
+The normalized list of provider-side collectives (GitHub organizations, GitLab groups) that satisfy the Identity Gate. Empty list means instance login alone is sufficient (open-access mode). Spelled `allowed_orgs` for GitHub and `allowed_groups` for GitLab in config.
+
+**GitLab Group**:
+A GitLab collective identified by its full path (e.g. `affinitybridge/dev`). Membership arrives in the OIDC `groups` claim at login; no API lookup. An allowed group admits its whole subtree (`acme` admits `acme/dev`).
+_Avoid_: org (GitHub-only term), team
+
+**Login**:
+The provider-side username carried in the `login` token claim; the single identity namespace for authorship and audit. GitLab's OIDC `nickname` maps onto it.
+_Avoid_: user id, handle
+
+**Machine Token**:
+A pre-shared bearer token authenticating non-interactive clients (CI). Its own credential: bypasses the OAuth flow and the Identity Gate by design.

--- a/docs/adr/0001-gitlab-auth-claim-based-group-gating.md
+++ b/docs/adr/0001-gitlab-auth-claim-based-group-gating.md
@@ -14,10 +14,12 @@ deployments.
 ## Consequences
 
 - **Revocation latency:** removing a user from an allowed group only takes
-  effect when their token expires and they re-authenticate. The immediate
-  lockout lever is blocking the user in GitLab, which kills authentication
-  itself. This is accepted deliberately — do not "fix" it by adding a
-  per-request GitLab API membership check without revisiting this ADR.
+  effect when their token expires and they re-authenticate. The fastest
+  lockout lever is blocking the user in GitLab: it prevents new logins and
+  stops token refresh, ending existing sessions at the current token
+  lifetime — nothing revokes an already-issued token instantly. This is
+  accepted deliberately — do not "fix" it by adding a per-request GitLab API
+  membership check without revisiting this ADR.
 - Exactly one identity provider per deployment (`github` | `gitlab` | `none`);
   the `login` claim is a single namespace (GitLab OIDC `nickname` maps onto it).
 - `allowed_groups` (GitLab group full-paths) uses subtree matching: `acme`

--- a/docs/adr/0001-gitlab-auth-claim-based-group-gating.md
+++ b/docs/adr/0001-gitlab-auth-claim-based-group-gating.md
@@ -1,0 +1,27 @@
+# GitLab auth gates on the OIDC groups claim, not an API-backed membership checker
+
+Status: accepted
+
+When `server.auth.provider` is `gitlab`, the identity gate reads the user's
+GitLab group memberships from the OpenID Connect (OIDC) `groups` claim at
+login and bakes the result into the FastMCP-issued token — unlike the GitHub
+provider, which re-verifies org membership against the GitHub API per request
+via `OrgMembershipChecker` (TTL cache, optional server PAT). We chose the
+claim because GitLab delivers memberships in the token for free, which
+eliminates the checker/cache/server-token machinery entirely for GitLab
+deployments.
+
+## Consequences
+
+- **Revocation latency:** removing a user from an allowed group only takes
+  effect when their token expires and they re-authenticate. The immediate
+  lockout lever is blocking the user in GitLab, which kills authentication
+  itself. This is accepted deliberately — do not "fix" it by adding a
+  per-request GitLab API membership check without revisiting this ADR.
+- Exactly one identity provider per deployment (`github` | `gitlab` | `none`);
+  the `login` claim is a single namespace (GitLab OIDC `nickname` maps onto it).
+- `allowed_groups` (GitLab group full-paths) uses subtree matching: `acme`
+  admits members of `acme/dev` etc. Empty `allowed_groups` is permitted for
+  self-hosted instances (instance login is the boundary) but the server
+  refuses to start with an empty list when the instance URL is gitlab.com,
+  where "authenticated" means anyone on the internet.

--- a/docs/specs/19-spec-gitlab-auth/19-spec-gitlab-auth.md
+++ b/docs/specs/19-spec-gitlab-auth/19-spec-gitlab-auth.md
@@ -1,0 +1,58 @@
+# 19-spec-gitlab-auth
+
+## Introduction/Overview
+
+Distillery's HTTP transport currently supports one identity provider: GitHub OAuth (`server.auth.provider: github`), with an optional API-backed org-membership gate. This spec adds GitLab — both self-hosted instances and gitlab.com — as an alternative identity provider via OpenID Connect (OIDC), using FastMCP's generic `OIDCProxy`. GitLab is an identity gate only, exactly like GitHub today: the server never accesses the user's GitLab resources.
+
+Design decisions were settled in a grilling session on 2026-07-06; the load-bearing one is recorded in [ADR-0001](../../adr/0001-gitlab-auth-claim-based-group-gating.md). Vocabulary is in the root `CONTEXT.md`.
+
+## Goals
+
+1. **`server.auth.provider: gitlab`** — a per-deployment alternative to `github`. Exactly one identity provider per deployment; no mixed-provider support.
+2. **OIDC-based, no bespoke API client** — use FastMCP's `OIDCProxy` against GitLab's discovery document (`https://<instance>/.well-known/openid-configuration`), scopes `openid profile email`.
+3. **Claim-based group gating** — authorization reads the OIDC `groups` claim at login. No GitLab equivalent of `OrgMembershipChecker` (see ADR-0001 for the revocation-latency trade-off, accepted).
+4. **Single identity namespace** — GitLab's `nickname` (username) maps into the existing `login` claim so authorship, audit, and the machine-token path work unchanged.
+5. **Machine tokens unchanged** — the pre-shared machine-token path is provider-agnostic and must keep working under `provider: gitlab`.
+
+## Configuration
+
+```yaml
+server:
+  auth:
+    provider: gitlab                  # new value alongside 'github' | 'none'
+    instance_url: https://gitlab.example.com   # new; default https://gitlab.com
+    client_id_env: DISTILLERY_GITLAB_CLIENT_ID
+    client_secret_env: DISTILLERY_GITLAB_CLIENT_SECRET
+    allowed_groups: [acme]            # GitLab group full-paths; gitlab-only key
+```
+
+- `allowed_groups` is the GitLab spelling of the gate list; `allowed_orgs` stays GitHub-only. Internally both normalize to one "allowed memberships" concept — the gate logic is not duplicated, only the claim/source plumbing differs.
+- **Subtree matching**: an allowed group admits itself and all descendants by path segment (`acme` matches `acme/dev`, not `acme-corp`).
+- **Empty `allowed_groups`**: permitted for self-hosted instances (instance login is the boundary — open-access mode, same semantics as empty `allowed_orgs` today).
+- **Startup validation**: when `instance_url` resolves to gitlab.com, the server refuses to start with an empty `allowed_groups` (an authenticated gitlab.com user is anyone on the internet).
+- `DISTILLERY_BASE_URL` remains required, as for GitHub.
+
+## Functional Requirements
+
+1. Config parsing/validation accepts `provider: gitlab`, `instance_url`, `allowed_groups`; rejects `allowed_groups` under `provider: github` and `allowed_orgs` under `provider: gitlab`; enforces the gitlab.com non-empty-groups rule.
+2. A GitLab provider builder (parallel to `build_github_auth`) constructs an `OIDCProxy` against `instance_url`, reading client id/secret from the configured env vars, wiring machine tokens and the audit callback identically to the GitHub path.
+3. Claims extraction maps `nickname` → `login` (plus `name`, `email`) and evaluates the `groups` claim against `allowed_groups` with subtree matching; a user matching no allowed group is denied at login (audit event emitted).
+4. Token lifetime is bounded (hours, not weeks) so group removal takes effect on expiry; immediate lockout is "block the user in GitLab" — documented, not coded.
+5. `mypy --strict` clean; unit tests cover claim mapping, subtree matching (incl. the `acme-corp` non-match), empty-groups self-hosted pass-through, gitlab.com validation failure, and machine-token bypass.
+
+### Verification note (resolve during implementation, before building on it)
+
+Confirm how FastMCP's `OIDCProxy` exposes userinfo/id_token claims for embedding into the issued JWT (the GitHub path overrides `_extract_upstream_claims`), and confirm which claim GitLab populates with full group paths for the target versions (`groups` in userinfo vs `groups_direct` in the id_token). Do this as a thin tracer slice against a real GitLab instance first.
+
+## Out of Scope
+
+- Mixed GitHub+GitLab logins on one deployment.
+- Per-request membership re-verification for GitLab (rejected — ADR-0001).
+- GitLab access-level distinctions (Guest vs Developer etc.) — any group member passes the gate.
+- `distill_ops` deployment configs (separate repo, separate change).
+
+## Deliverables
+
+- Code + tests as above.
+- Docs site: GitLab setup page alongside the GitHub auth docs.
+- `/setup` skill: hosted-transport onboarding must handle a GitLab-backed server, not assume GitHub.

--- a/docs/team/deployment.md
+++ b/docs/team/deployment.md
@@ -84,9 +84,9 @@ classification:
 
 | Field | Values | Description |
 |-------|--------|-------------|
-| `provider` | `github`, `none` | Auth provider. `none` allows unauthenticated access (dev only) |
-| `client_id_env` | env var name | Environment variable holding GitHub Client ID |
-| `client_secret_env` | env var name | Environment variable holding GitHub Client Secret |
+| `provider` | `github`, `gitlab`, `none` | Auth provider. `none` allows unauthenticated access (dev only). For `gitlab`, see [GitLab Authentication](gitlab-auth.md) |
+| `client_id_env` | env var name | Environment variable holding the OAuth Client ID |
+| `client_secret_env` | env var name | Environment variable holding the OAuth Client Secret |
 
 **storage**
 

--- a/docs/team/gitlab-auth.md
+++ b/docs/team/gitlab-auth.md
@@ -57,7 +57,7 @@ server:
 
 ### Revocation semantics
 
-Group membership is read once, at login, from the OIDC `groups` claim; there are no per-request GitLab API calls. Removing a user from an allowed group takes effect when their token expires and they re-authenticate. For **immediate** lockout, block (or deactivate) the user in GitLab — that disables authentication itself.
+Group membership is read once, at login, from the OIDC `groups` claim; there are no per-request GitLab API calls. Removing a user from an allowed group takes effect when their token expires and they re-authenticate. The fastest lockout lever is blocking (or deactivating) the user in GitLab: it prevents any new login, and existing sessions end when the current GitLab token lifetime runs out — a blocked user's token can no longer be refreshed. No lever revokes an already-issued token instantly.
 
 ## Notes
 

--- a/docs/team/gitlab-auth.md
+++ b/docs/team/gitlab-auth.md
@@ -1,0 +1,67 @@
+# GitLab Authentication
+
+Deploy the Distillery MCP server in HTTP mode using a GitLab instance — self-hosted or gitlab.com — as the identity provider, instead of GitHub OAuth.
+
+GitLab authentication uses OpenID Connect (OIDC). Like the GitHub provider, it is an **identity gate only**: Distillery requests the `openid profile email` scopes and never accesses your projects, repositories, or other GitLab data.
+
+## Step 1: Register a GitLab OAuth Application
+
+1. On your GitLab instance, go to **Admin Area → Applications** (instance-wide) or **Group → Settings → Applications**. On gitlab.com, use **User Settings → Applications** or a group-owned application.
+2. Create a new application:
+    - **Name**: `Distillery`
+    - **Redirect URI**: `https://distillery.myteam.com/mcp/auth/callback`
+    - **Confidential**: yes
+    - **Scopes**: `openid`, `profile`, `email`
+3. Note the **Application ID** and **Secret**.
+
+!!! warning
+    The redirect URI must match exactly. The path is always `/mcp/auth/callback` (managed by FastMCP). HTTPS is required for production.
+
+## Step 2: Environment Variables
+
+```bash
+# GitLab OAuth application credentials
+export GITLAB_CLIENT_ID="<application-id>"
+export GITLAB_CLIENT_SECRET="<secret>"
+
+# Base URL for the OAuth callback (must be publicly accessible)
+export DISTILLERY_BASE_URL="https://distillery.myteam.com"
+```
+
+## Step 3: Configuration
+
+```yaml
+server:
+  auth:
+    provider: gitlab
+    instance_url: https://gitlab.myteam.com   # omit for gitlab.com
+    client_id_env: GITLAB_CLIENT_ID
+    client_secret_env: GITLAB_CLIENT_SECRET
+    allowed_groups:
+      - myteam          # GitLab group full-paths
+```
+
+**server.auth (GitLab-specific keys)**
+
+| Key | Values | Description |
+|-----|--------|-------------|
+| `provider` | `gitlab` | Selects GitLab OIDC authentication |
+| `instance_url` | URL | Base URL of the GitLab instance. Default `https://gitlab.com` |
+| `allowed_groups` | list of group full-paths | Members of any listed group (or its subgroups) may access the server |
+
+### Group access rules
+
+- **Subtree matching**: an allowed group admits its whole subtree — `myteam` admits members of `myteam/dev` and `myteam/dev/platform`, but not `myteam-other`.
+- **Self-hosted**: `allowed_groups` may be empty. Anyone who can sign in to your instance may use the server (instance login is the boundary).
+- **gitlab.com**: `allowed_groups` **must** be non-empty — the server refuses to start otherwise, because an authenticated gitlab.com user is anyone on the internet.
+
+### Revocation semantics
+
+Group membership is read once, at login, from the OIDC `groups` claim; there are no per-request GitLab API calls. Removing a user from an allowed group takes effect when their token expires and they re-authenticate. For **immediate** lockout, block (or deactivate) the user in GitLab — that disables authentication itself.
+
+## Notes
+
+- Exactly one identity provider per deployment: `github`, `gitlab`, or `none`.
+- The GitLab username (`nickname` claim) is used for authorship and audit, the same way the GitHub login is.
+- Pre-shared machine tokens (`DISTILLERY_MCP_MACHINE_TOKEN`) work unchanged for CI clients.
+- Everything else in [Operator Deployment](deployment.md) (rate limits, webhooks, hosting) applies as-is.

--- a/docs/team/team-setup.md
+++ b/docs/team/team-setup.md
@@ -4,9 +4,9 @@ Connect your Claude Code installation to a hosted Distillery MCP server and auth
 
 ## Prerequisites
 
-- A hosted Distillery instance running with GitHub OAuth or GitLab authentication enabled (this guide shows the GitHub flow; the GitLab flow is identical with GitLab in place of GitHub — see [GitLab Authentication](gitlab-auth.md))
+- A hosted Distillery instance running with either GitHub OAuth or GitLab authentication enabled. This guide covers GitHub deployments; for a GitLab-backed server, see [GitLab Authentication](gitlab-auth.md) for the operator setup — as a team member you follow the same steps below, with your browser opening GitLab instead of GitHub
 - The **server URL** from your team operator (e.g., `https://distillery.myteam.com/mcp`)
-- A GitHub account
+- A GitHub account (or an account on your team's GitLab instance, for GitLab deployments)
 - Claude Code installed locally
 
 ## Step 1: Add the Server to Claude Code

--- a/docs/team/team-setup.md
+++ b/docs/team/team-setup.md
@@ -4,7 +4,7 @@ Connect your Claude Code installation to a hosted Distillery MCP server and auth
 
 ## Prerequisites
 
-- A hosted Distillery instance running with GitHub OAuth enabled
+- A hosted Distillery instance running with GitHub OAuth or GitLab authentication enabled (this guide shows the GitHub flow; the GitLab flow is identical with GitLab in place of GitHub — see [GitLab Authentication](gitlab-auth.md))
 - The **server URL** from your team operator (e.g., `https://distillery.myteam.com/mcp`)
 - A GitHub account
 - Claude Code installed locally

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ theme:
 
 exclude_docs: |
   specs/
+  adr/
 
 plugins:
   - search
@@ -89,6 +90,7 @@ nav:
   - Team Access:
     - Team Member Guide: team/team-setup.md
     - Operator Deployment: team/deployment.md
+    - GitLab Authentication: team/gitlab-auth.md
   - Architecture: architecture.md
   - Benchmarks: benchmarks.md
   - Contributing: contributing.md

--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -71,7 +71,7 @@ Skills that exceed 150 lines should move detailed or mode-specific content into 
 
 ## API Key Configuration
 
-API keys required by Distillery (embedding provider, GitHub OAuth) are supplied to the MCP server via environment variables: `JINA_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`.
+API keys required by Distillery (embedding provider, GitHub/GitLab OAuth) are supplied to the MCP server via environment variables: `JINA_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` (or `GITLAB_CLIENT_ID`, `GITLAB_CLIENT_SECRET`).
 
 **Recommended (local):** run `/setup`, which configures the MCP server and writes its `env` block to `~/.claude.json` (see `skills/setup/SKILL.md`).
 

--- a/skills/setup/references/transport-detection.md
+++ b/skills/setup/references/transport-detection.md
@@ -14,7 +14,7 @@ Look for any Distillery MCP server entry in these config files to determine if a
 
 ## State: Needs Authentication
 
-A Distillery MCP server entry exists (in `plugin.json`, `.mcp.json`, or `~/.claude.json`) but `distillery_list(limit=1)` is unavailable or fails (including auth-related failures). This typically means the server is configured with HTTP transport and GitHub OAuth, but the user has not completed the OAuth flow yet.
+A Distillery MCP server entry exists (in `plugin.json`, `.mcp.json`, or `~/.claude.json`) but `distillery_list(limit=1)` is unavailable or fails (including auth-related failures). This typically means the server is configured with HTTP transport and OAuth (GitHub or GitLab, per the server's `server.auth.provider`), but the user has not completed the OAuth flow yet.
 
 Display:
 
@@ -27,7 +27,7 @@ The MCP server is configured but needs authentication.
 To authenticate:
 1. Press Ctrl+. (or Cmd+.) to open the MCP server menu
 2. Select the Distillery server (it will show "needs authentication")
-3. Press Enter — your browser will open for GitHub OAuth
+3. Press Enter — your browser will open for the server's OAuth provider (GitHub or GitLab)
 4. Authorize the app in your browser
 5. Return here and run /distillery:setup again
 

--- a/src/distillery/config.py
+++ b/src/distillery/config.py
@@ -11,6 +11,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import yaml
 
@@ -457,7 +458,8 @@ class ServerAuthConfig:
     """Server authentication configuration.
 
     Attributes:
-        provider: Authentication provider. One of ``'github'`` or ``'none'``.
+        provider: Authentication provider. One of ``'github'``, ``'gitlab'``
+            or ``'none'``.
         client_id_env: Name of the environment variable holding the OAuth
             client ID.
         client_secret_env: Name of the environment variable holding the OAuth
@@ -467,9 +469,17 @@ class ServerAuthConfig:
             any GitHub user can authenticate (open-access mode).  Can also be
             set via the ``DISTILLERY_ALLOWED_ORGS`` environment variable
             (comma-separated); env values are merged with YAML values.
+            GitHub-only.
         membership_cache_ttl_seconds: How long to cache org-membership results
             in seconds.  Default is 3600 (1 hour).  Set to a smaller value if
             you need revoked memberships to take effect sooner.
+        instance_url: Base URL of the GitLab instance (``provider: gitlab``
+            only).  Default is ``https://gitlab.com``.
+        allowed_groups: GitLab group full-paths whose members may access the
+            server (``provider: gitlab`` only).  An allowed group admits its
+            whole subtree (``acme`` admits ``acme/dev``).  Empty list means
+            instance login alone is sufficient — permitted for self-hosted
+            instances, rejected for gitlab.com (see docs/adr/0001).
     """
 
     provider: str = "none"
@@ -477,6 +487,8 @@ class ServerAuthConfig:
     client_secret_env: str = "GITHUB_CLIENT_SECRET"
     allowed_orgs: list[str] = field(default_factory=list)
     membership_cache_ttl_seconds: int = 3600
+    instance_url: str = "https://gitlab.com"
+    allowed_groups: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -868,17 +880,13 @@ def _parse_link_suggestion(raw: dict[str, Any]) -> LinkSuggestionConfig:
 
     enabled_raw = raw.get("enabled", True)
     if not isinstance(enabled_raw, bool):
-        raise ValueError(
-            f"link_suggestion.enabled must be a boolean, got: {enabled_raw!r}"
-        )
+        raise ValueError(f"link_suggestion.enabled must be a boolean, got: {enabled_raw!r}")
 
     auto_create_threshold = _parse_float_field(
         raw, "auto_create_threshold", 0.85, "link_suggestion.auto_create_threshold"
     )
 
-    review_floor = _parse_float_field(
-        raw, "review_floor", 0.60, "link_suggestion.review_floor"
-    )
+    review_floor = _parse_float_field(raw, "review_floor", 0.60, "link_suggestion.review_floor")
 
     max_candidates_per_run_raw = raw.get("max_candidates_per_run", 200)
     max_candidates_per_run = _parse_strict_int(
@@ -1408,6 +1416,11 @@ def _parse_server(raw: dict[str, Any]) -> ServerConfig:
         raise ValueError("server.auth.allowed_orgs must be a YAML list")
     allowed_orgs = [str(o).strip() for o in allowed_orgs_raw if str(o).strip()]
 
+    allowed_groups_raw = auth_raw.get("allowed_groups", []) or []
+    if not isinstance(allowed_groups_raw, list):
+        raise ValueError("server.auth.allowed_groups must be a YAML list")
+    allowed_groups = [str(g).strip().strip("/") for g in allowed_groups_raw if str(g).strip()]
+
     ttl_raw = auth_raw.get("membership_cache_ttl_seconds", 3600)
     membership_cache_ttl_seconds = _parse_strict_int(
         ttl_raw, "server.auth.membership_cache_ttl_seconds"
@@ -1420,6 +1433,8 @@ def _parse_server(raw: dict[str, Any]) -> ServerConfig:
             client_secret_env=str(auth_raw.get("client_secret_env", "GITHUB_CLIENT_SECRET")),
             allowed_orgs=allowed_orgs,
             membership_cache_ttl_seconds=membership_cache_ttl_seconds,
+            instance_url=str(auth_raw.get("instance_url", "https://gitlab.com")).rstrip("/"),
+            allowed_groups=allowed_groups,
         ),
         http_rate_limit=_parse_http_rate_limit(rl_raw),
         webhooks=_parse_webhooks(webhooks_raw),
@@ -1602,8 +1617,7 @@ def _validate(config: DistilleryConfig) -> None:
     threshold = config.tags.entity_promotion_threshold
     if not isinstance(threshold, int) or isinstance(threshold, bool) or threshold <= 0:
         raise ValueError(
-            "tags.entity_promotion_threshold must be a positive integer, "
-            f"got: {threshold}"
+            f"tags.entity_promotion_threshold must be a positive integer, got: {threshold}"
         )
 
     # Validate feeds thresholds.
@@ -1644,7 +1658,7 @@ def _validate(config: DistilleryConfig) -> None:
         )
 
     # Validate server.auth.provider
-    valid_auth_providers = {"github", "none"}
+    valid_auth_providers = {"github", "gitlab", "none"}
     if config.server.auth.provider not in valid_auth_providers:
         raise ValueError(
             f"server.auth.provider must be one of {sorted(valid_auth_providers)}, "
@@ -1659,6 +1673,29 @@ def _validate(config: DistilleryConfig) -> None:
             "server.auth.allowed_orgs requires server.auth.provider = 'github', "
             f"got: {config.server.auth.provider!r}"
         )
+
+    # Validate allowed_groups: non-empty list requires GitLab auth provider.
+    if config.server.auth.allowed_groups and config.server.auth.provider != "gitlab":
+        raise ValueError(
+            "server.auth.allowed_groups requires server.auth.provider = 'gitlab', "
+            f"got: {config.server.auth.provider!r}"
+        )
+
+    if config.server.auth.provider == "gitlab":
+        instance_host = urlparse(config.server.auth.instance_url).hostname or ""
+        if not instance_host:
+            raise ValueError(
+                "server.auth.instance_url must be a valid absolute http(s) URL, "
+                f"got: {config.server.auth.instance_url!r}"
+            )
+        # On gitlab.com an authenticated user is anyone on the internet, so a
+        # group restriction is mandatory (ADR-0001). Self-hosted instances may
+        # leave allowed_groups empty: instance login is the boundary.
+        if instance_host == "gitlab.com" and not config.server.auth.allowed_groups:
+            raise ValueError(
+                "server.auth.allowed_groups must be non-empty when instance_url is "
+                "gitlab.com: an authenticated gitlab.com user is anyone on the internet."
+            )
 
     if config.server.auth.membership_cache_ttl_seconds <= 0:
         raise ValueError(

--- a/src/distillery/mcp/__main__.py
+++ b/src/distillery/mcp/__main__.py
@@ -135,7 +135,9 @@ def main(argv: list[str] | None = None) -> int:
             port_env = os.environ.get("DISTILLERY_PORT")
             port = args.port if args.port is not None else (int(port_env) if port_env else 8000)
 
-            auth = None
+            from fastmcp.server.auth.oauth_proxy import OAuthProxy
+
+            auth: OAuthProxy | None = None
             org_checker = None
             provider_name = config.server.auth.provider
             if provider_name == "github":
@@ -156,6 +158,16 @@ def main(argv: list[str] | None = None) -> int:
                 from distillery.mcp.auth import pre_register_claude_code_client
 
                 asyncio.run(pre_register_claude_code_client(auth))
+            elif provider_name == "gitlab":
+                from distillery.mcp.auth import (
+                    _patch_cimd_localhost_redirect,
+                    pre_register_claude_code_client,
+                )
+                from distillery.mcp.gitlab_auth import build_gitlab_auth
+
+                _patch_cimd_localhost_redirect()
+                auth = build_gitlab_auth(config)
+                asyncio.run(pre_register_claude_code_client(auth))
             elif provider_name == "none":
                 logger.warning(
                     "HTTP server running without authentication (server.auth.provider is 'none')",
@@ -163,7 +175,7 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 raise ValueError(
                     f"Unknown auth provider {provider_name!r} for HTTP transport. "
-                    f"Supported values: 'github', 'none'."
+                    f"Supported values: 'github', 'gitlab', 'none'."
                 )
 
             server = create_server(config=config, auth=auth)
@@ -186,10 +198,11 @@ def main(argv: list[str] | None = None) -> int:
                     return
                 await store.write_audit_log(user_id, operation, entry_id, action, outcome)
 
-            # Attach callback to auth provider (if org-restricted).
+            # Attach callback to auth provider (if org- or group-gated).
             from distillery.mcp.auth import OrgRestrictedGitHubProvider
+            from distillery.mcp.gitlab_auth import GitLabProvider
 
-            if isinstance(auth, OrgRestrictedGitHubProvider):
+            if isinstance(auth, OrgRestrictedGitHubProvider | GitLabProvider):
                 auth._audit_callback = _auth_audit_cb
             http_app = server.http_app(
                 path="/mcp",

--- a/src/distillery/mcp/auth.py
+++ b/src/distillery/mcp/auth.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 
 import httpx
 from fastmcp.server.auth import AccessToken
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.providers.github import GitHubProvider
 
 from distillery.config import DistilleryConfig, parse_env_allowed_orgs
@@ -92,6 +93,21 @@ def _load_machine_tokens() -> list[tuple[str, AccessToken]]:
     return [(raw, access)]
 
 
+def match_machine_token(
+    machine_tokens: list[tuple[str, AccessToken]], token: str
+) -> AccessToken | None:
+    """Return the AccessToken for a matching pre-shared machine token, else None.
+
+    Constant-time comparison. Shared by the GitHub and GitLab providers so the
+    machine-token path stays provider-agnostic.
+    """
+    for candidate, access in machine_tokens:
+        if hmac.compare_digest(token.encode(), candidate.encode()):
+            logger.debug("Authenticated machine token (identity=%s)", access.client_id)
+            return access
+    return None
+
+
 class _MachineTokenGitHubProvider(GitHubProvider):
     """``GitHubProvider`` that also accepts pre-shared machine tokens.
 
@@ -118,10 +134,9 @@ class _MachineTokenGitHubProvider(GitHubProvider):
 
     async def verify_token(self, token: str) -> AccessToken | None:
         """Verify a bearer token: machine tokens first, then the OAuth proxy."""
-        for candidate, access in self._machine_tokens:
-            if hmac.compare_digest(token.encode(), candidate.encode()):
-                logger.debug("Authenticated machine token (identity=%s)", access.client_id)
-                return access
+        access = match_machine_token(self._machine_tokens, token)
+        if access is not None:
+            return access
         return await super().verify_token(token)
 
 
@@ -343,7 +358,7 @@ _CLAUDE_CODE_CLIENT_METADATA = {
 }
 
 
-async def pre_register_claude_code_client(provider: GitHubProvider) -> None:
+async def pre_register_claude_code_client(provider: OAuthProxy) -> None:
     """Seed the OAuth client store with the Claude Code CIMD metadata.
 
     This avoids a runtime CIMD fetch to ``claude.ai`` which can fail when

--- a/src/distillery/mcp/gitlab_auth.py
+++ b/src/distillery/mcp/gitlab_auth.py
@@ -14,7 +14,9 @@ result into the FastMCP-issued token — there is no GitLab equivalent of
 ``OrgMembershipChecker`` and no per-request GitLab API call. A user matching
 no allowed group gets no identity claims embedded, and :meth:`verify_token`
 fails closed on every request. Group removal therefore takes effect at token
-expiry; immediate lockout is "block the user in GitLab".
+expiry; the fastest lockout lever is blocking the user in GitLab, which
+prevents new logins and token refresh (nothing revokes an issued token
+instantly).
 
 GitLab OAuth access tokens are opaque (not JWTs), so the proxy verifies the
 OIDC ``id_token`` against the instance's JWKS instead

--- a/src/distillery/mcp/gitlab_auth.py
+++ b/src/distillery/mcp/gitlab_auth.py
@@ -1,0 +1,262 @@
+"""GitLab OIDC authentication for the Distillery MCP HTTP transport.
+
+Provides :func:`build_gitlab_auth`, which returns a :class:`GitLabProvider` —
+a FastMCP ``OIDCProxy`` configured against a GitLab instance's OpenID Connect
+(OIDC) discovery document. Works with self-hosted GitLab and gitlab.com.
+
+**Authentication model:** GitLab is an identity gate only, exactly like the
+GitHub provider. Scopes ``openid profile email`` are requested; the server
+never accesses the user's GitLab projects or other resources.
+
+**Group gating (ADR-0001):** authorization reads the ``groups`` claim from
+GitLab's userinfo endpoint once, at login, and bakes the allowed/denied
+result into the FastMCP-issued token — there is no GitLab equivalent of
+``OrgMembershipChecker`` and no per-request GitLab API call. A user matching
+no allowed group gets no identity claims embedded, and :meth:`verify_token`
+fails closed on every request. Group removal therefore takes effect at token
+expiry; immediate lockout is "block the user in GitLab".
+
+GitLab OAuth access tokens are opaque (not JWTs), so the proxy verifies the
+OIDC ``id_token`` against the instance's JWKS instead
+(``verify_id_token=True``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from fastmcp.server.auth import AccessToken
+from fastmcp.server.auth.oidc_proxy import OIDCProxy
+
+from distillery.config import DistilleryConfig
+from distillery.mcp.auth import _load_machine_tokens, match_machine_token
+from distillery.mcp.types import AuditCallback
+
+logger = logging.getLogger(__name__)
+
+_OIDC_SCOPES = ["openid", "profile", "email"]
+
+
+def matches_allowed_groups(user_groups: list[str], allowed_groups: list[str]) -> bool:
+    """Return ``True`` if any user group falls inside an allowed group's subtree.
+
+    Matching is by path segment: allowed group ``acme`` matches ``acme`` and
+    ``acme/dev`` but not ``acme-corp``. An empty *allowed_groups* means open
+    access (instance login is the boundary) and always matches.
+    """
+    if not allowed_groups:
+        return True
+    for group in user_groups:
+        norm = group.strip().strip("/")
+        for allowed in allowed_groups:
+            if norm == allowed or norm.startswith(allowed + "/"):
+                return True
+    return False
+
+
+class GitLabProvider(OIDCProxy):
+    """OIDC proxy for a GitLab instance with claim-based group gating.
+
+    Overrides :meth:`_extract_upstream_claims` to fetch the userinfo endpoint,
+    map GitLab's ``nickname`` (username) onto the ``login`` claim — the single
+    identity namespace shared with the GitHub provider — and evaluate the
+    ``groups`` claim against *allowed_groups* with subtree matching.
+
+    A group-mismatched login is audited and gets **no** claims embedded;
+    :meth:`verify_token` then rejects every request carrying that token
+    because it has no ``login`` (fail closed).
+
+    Also accepts pre-shared machine tokens, identical to the GitHub path.
+    """
+
+    def __init__(
+        self,
+        *,
+        instance_url: str,
+        client_id: str,
+        client_secret: str,
+        base_url: str,
+        allowed_groups: list[str] | None = None,
+        audit_callback: AuditCallback | None = None,
+        machine_tokens: list[tuple[str, AccessToken]] | None = None,
+    ) -> None:
+        super().__init__(
+            config_url=f"{instance_url.rstrip('/')}/.well-known/openid-configuration",
+            client_id=client_id,
+            client_secret=client_secret,
+            base_url=base_url,
+            # GitLab access tokens are opaque; verify the id_token via JWKS.
+            verify_id_token=True,
+            required_scopes=_OIDC_SCOPES,
+        )
+        self._instance_url = instance_url.rstrip("/")
+        self._allowed_groups = list(allowed_groups or [])
+        self._audit_callback = audit_callback
+        self._machine_tokens: list[tuple[str, AccessToken]] = machine_tokens or []
+
+    async def _extract_upstream_claims(self, idp_tokens: dict[str, Any]) -> dict[str, Any] | None:
+        """Fetch GitLab userinfo, gate on groups, and map identity claims."""
+        access_token = idp_tokens.get("access_token")
+        if not access_token or not isinstance(access_token, str):
+            await self._audit("unknown", "auth_login_failed", "missing_or_invalid_access_token")
+            return None
+
+        userinfo_url = (
+            str(self.oidc_config.userinfo_endpoint)
+            if self.oidc_config.userinfo_endpoint
+            else f"{self._instance_url}/oauth/userinfo"
+        )
+        try:
+            async with httpx.AsyncClient(timeout=10, verify=True) as client:
+                resp = await client.get(
+                    userinfo_url,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+            if resp.status_code != 200:
+                logger.warning(
+                    "Failed to fetch GitLab userinfo during OAuth exchange: %d",
+                    resp.status_code,
+                )
+                await self._audit(
+                    "unknown", "auth_login_failed", f"gitlab_userinfo_status_{resp.status_code}"
+                )
+                return None
+
+            user_data = resp.json()
+            login = str(user_data.get("nickname") or "")
+            raw_groups = user_data.get("groups") or []
+            groups = [str(g) for g in raw_groups if isinstance(g, str)]
+
+            if not login:
+                await self._audit("unknown", "auth_login_failed", "missing_nickname_claim")
+                return None
+
+            if not matches_allowed_groups(groups, self._allowed_groups):
+                logger.info(
+                    "GitLab login denied for %s: no membership in allowed groups %s",
+                    login,
+                    self._allowed_groups,
+                )
+                await self._audit(login, "auth_group_denied", "denied")
+                # No claims embedded -> verify_token fails closed on every
+                # request made with this token.
+                return None
+
+            await self._audit(login, "auth_login", "success")
+            return {
+                "login": login,
+                "name": user_data.get("name"),
+                "email": user_data.get("email"),
+                "groups": groups,
+            }
+        except Exception:
+            logger.warning("Error extracting GitLab upstream claims", exc_info=True)
+            await self._audit("unknown", "auth_login_failed", "exception_during_claims_extraction")
+            return None
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Verify a bearer token: machine tokens, then OIDC proxy, then the gate.
+
+        The OIDC proxy nests the claims from
+        :meth:`_extract_upstream_claims` under ``claims["upstream_claims"]``;
+        the rest of the codebase (middleware, tool handlers) reads ``login``
+        at the top level, so promote them. A verified token without a
+        ``login`` claim — including one issued to a group-denied user — is
+        rejected.
+        """
+        machine_access = match_machine_token(self._machine_tokens, token)
+        if machine_access is not None:
+            return machine_access
+
+        access = await super().verify_token(token)
+        if access is None:
+            return None
+
+        claims = access.claims or {}
+        upstream = claims.get("upstream_claims")
+        if isinstance(upstream, dict):
+            claims = {**upstream, **{k: v for k, v in claims.items() if k != "upstream_claims"}}
+            access.claims = claims
+
+        login = claims.get("login")
+        if not (isinstance(login, str) and login.strip()):
+            logger.debug("Rejecting verified GitLab token without login claim (fail closed)")
+            return None
+        return access
+
+    async def _audit(self, user: str, operation: str, outcome: str) -> None:
+        """Fire the audit callback for an authentication event (best-effort)."""
+        if self._audit_callback is None:
+            return
+        try:
+            await self._audit_callback(user, operation, "", operation, outcome)
+        except Exception:  # noqa: BLE001
+            logger.debug("auth audit_log write failed (ignored)", exc_info=True)
+
+
+def build_gitlab_auth(
+    config: DistilleryConfig,
+    audit_callback: AuditCallback | None = None,
+) -> GitLabProvider:
+    """Build a :class:`GitLabProvider` from config and environment.
+
+    Reads the OAuth application ID and secret from the environment variable
+    names in ``config.server.auth`` (same keys the GitHub path uses), the
+    GitLab instance from ``config.server.auth.instance_url``, and the public
+    server URL from ``DISTILLERY_BASE_URL``.
+
+    Raises:
+        ValueError: If a required environment variable is missing or invalid.
+    """
+    auth = config.server.auth
+    client_id = os.environ.get(auth.client_id_env, "").strip()
+    client_secret = os.environ.get(auth.client_secret_env, "").strip()
+
+    if not client_id:
+        raise ValueError(
+            f"GitLab OAuth application ID env var {auth.client_id_env!r} is not set or empty. "
+            "Set the environment variable before starting the server."
+        )
+    if not client_secret:
+        raise ValueError(
+            f"GitLab OAuth secret env var {auth.client_secret_env!r} is not set or empty. "
+            "Set the environment variable before starting the server."
+        )
+
+    base_url = os.environ.get("DISTILLERY_BASE_URL", "").strip()
+    if not base_url:
+        raise ValueError(
+            "DISTILLERY_BASE_URL env var is required when server.auth.provider is 'gitlab'. "
+            "Set it to the publicly accessible URL of the server "
+            "(e.g. 'https://distillery.example.com')."
+        )
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(
+            f"DISTILLERY_BASE_URL must be a valid absolute http(s) URL, got: {base_url!r}. "
+            "Example: 'https://distillery.example.com'."
+        )
+
+    # Log that auth is being configured, but NEVER log secret values.
+    logger.info(
+        "Configuring GitLab OIDC (instance_url=%s, client_id_env=%s, base_url=%s, "
+        "allowed_groups=%s)",
+        auth.instance_url,
+        auth.client_id_env,
+        base_url,
+        auth.allowed_groups or "<open: instance login>",
+    )
+
+    return GitLabProvider(
+        instance_url=auth.instance_url,
+        client_id=client_id,
+        client_secret=client_secret,
+        base_url=base_url,
+        allowed_groups=auth.allowed_groups,
+        audit_callback=audit_callback,
+        machine_tokens=_load_machine_tokens(),
+    )

--- a/tests/test_gitlab_auth.py
+++ b/tests/test_gitlab_auth.py
@@ -1,0 +1,312 @@
+"""Tests for distillery.mcp.gitlab_auth: GitLab OIDC authentication wiring."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from distillery.config import (
+    DistilleryConfig,
+    ServerAuthConfig,
+    ServerConfig,
+    StorageConfig,
+    _validate,
+)
+from distillery.mcp.gitlab_auth import (
+    GitLabProvider,
+    build_gitlab_auth,
+    matches_allowed_groups,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    provider: str = "gitlab",
+    instance_url: str = "https://gitlab.example.com",
+    allowed_groups: list[str] | None = None,
+) -> DistilleryConfig:
+    return DistilleryConfig(
+        storage=StorageConfig(database_path=":memory:"),
+        server=ServerConfig(
+            auth=ServerAuthConfig(
+                provider=provider,
+                client_id_env="GITLAB_CLIENT_ID",
+                client_secret_env="GITLAB_CLIENT_SECRET",
+                instance_url=instance_url,
+                allowed_groups=allowed_groups or [],
+            )
+        ),
+    )
+
+
+_FAKE_OIDC_CONFIG = MagicMock(
+    authorization_endpoint="https://gitlab.example.com/oauth/authorize",
+    token_endpoint="https://gitlab.example.com/oauth/token",
+    userinfo_endpoint="https://gitlab.example.com/oauth/userinfo",
+    revocation_endpoint=None,
+    service_documentation=None,
+    jwks_uri="https://gitlab.example.com/oauth/discovery/keys",
+    issuer="https://gitlab.example.com",
+    scopes_supported=["openid", "profile", "email"],
+    id_token_signing_alg_values_supported=["RS256"],
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent OIDCProxy.__init__ from fetching the discovery document."""
+    monkeypatch.setattr(
+        GitLabProvider,
+        "get_oidc_configuration",
+        classmethod(lambda cls, *a, **kw: _FAKE_OIDC_CONFIG),
+    )
+
+
+def _make_provider(
+    allowed_groups: list[str] | None = None,
+    audit_cb: AsyncMock | None = None,
+    machine_tokens: list[Any] | None = None,
+) -> GitLabProvider:
+    return GitLabProvider(
+        instance_url="https://gitlab.example.com",
+        client_id="app-id",
+        client_secret="app-secret",
+        base_url="https://distillery.example.com",
+        allowed_groups=allowed_groups,
+        audit_callback=audit_cb,
+        machine_tokens=machine_tokens,
+    )
+
+
+def _mock_userinfo(monkeypatch: pytest.MonkeyPatch, payload: dict[str, Any], status: int = 200):
+    resp = MagicMock(status_code=status)
+    resp.json.return_value = payload
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(httpx, "AsyncClient", MagicMock(return_value=client))
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Subtree matching
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesAllowedGroups:
+    def test_exact_match(self) -> None:
+        assert matches_allowed_groups(["acme"], ["acme"])
+
+    def test_subgroup_matches_parent(self) -> None:
+        assert matches_allowed_groups(["acme/dev"], ["acme"])
+        assert matches_allowed_groups(["acme/dev/platform"], ["acme"])
+
+    def test_sibling_prefix_does_not_match(self) -> None:
+        assert not matches_allowed_groups(["acme-corp"], ["acme"])
+
+    def test_parent_membership_does_not_match_allowed_subgroup(self) -> None:
+        assert not matches_allowed_groups(["acme"], ["acme/dev"])
+
+    def test_no_groups_denied(self) -> None:
+        assert not matches_allowed_groups([], ["acme"])
+
+    def test_empty_allowed_is_open_access(self) -> None:
+        assert matches_allowed_groups([], [])
+        assert matches_allowed_groups(["anything"], [])
+
+    def test_trailing_slashes_normalized(self) -> None:
+        assert matches_allowed_groups(["acme/dev/"], ["acme"])
+
+
+# ---------------------------------------------------------------------------
+# Claims extraction and login-time gating
+# ---------------------------------------------------------------------------
+
+
+class TestExtractUpstreamClaims:
+    async def test_maps_nickname_to_login(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        _mock_userinfo(
+            monkeypatch,
+            {
+                "nickname": "mark",
+                "name": "Mark L",
+                "email": "mark@example.com",
+                "groups": ["acme/dev"],
+            },
+        )
+        claims = await provider._extract_upstream_claims({"access_token": "tok"})
+        assert claims is not None
+        assert claims["login"] == "mark"
+        assert claims["groups"] == ["acme/dev"]
+
+    async def test_group_member_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        audit = AsyncMock()
+        provider = _make_provider(allowed_groups=["acme"], audit_cb=audit)
+        _mock_userinfo(monkeypatch, {"nickname": "mark", "groups": ["acme/dev"]})
+        claims = await provider._extract_upstream_claims({"access_token": "tok"})
+        assert claims is not None and claims["login"] == "mark"
+        audit.assert_awaited_once_with("mark", "auth_login", "", "auth_login", "success")
+
+    async def test_group_mismatch_denied_and_audited(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        audit = AsyncMock()
+        provider = _make_provider(allowed_groups=["acme"], audit_cb=audit)
+        _mock_userinfo(monkeypatch, {"nickname": "eve", "groups": ["other"]})
+        claims = await provider._extract_upstream_claims({"access_token": "tok"})
+        assert claims is None
+        audit.assert_awaited_once_with(
+            "eve", "auth_group_denied", "", "auth_group_denied", "denied"
+        )
+
+    async def test_missing_access_token_fails(self) -> None:
+        provider = _make_provider()
+        assert await provider._extract_upstream_claims({}) is None
+
+    async def test_userinfo_error_status_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        _mock_userinfo(monkeypatch, {}, status=401)
+        assert await provider._extract_upstream_claims({"access_token": "tok"}) is None
+
+    async def test_missing_nickname_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        _mock_userinfo(monkeypatch, {"groups": ["acme"]})
+        assert await provider._extract_upstream_claims({"access_token": "tok"}) is None
+
+
+# ---------------------------------------------------------------------------
+# verify_token: flattening, fail-closed, machine tokens
+# ---------------------------------------------------------------------------
+
+
+def _access_token(claims: dict[str, Any] | None) -> Any:
+    token = MagicMock()
+    token.claims = claims
+    return token
+
+
+class TestVerifyToken:
+    async def test_flattens_upstream_claims(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        inner = _access_token({"upstream_claims": {"login": "mark", "groups": ["acme"]}})
+        monkeypatch.setattr(
+            "fastmcp.server.auth.oidc_proxy.OIDCProxy.verify_token",
+            AsyncMock(return_value=inner),
+        )
+        result = await provider.verify_token("bearer-token")
+        assert result is not None
+        assert result.claims["login"] == "mark"
+        assert "upstream_claims" not in result.claims
+
+    async def test_no_login_claim_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        # A group-denied login gets a token with no upstream claims embedded.
+        inner = _access_token({})
+        monkeypatch.setattr(
+            "fastmcp.server.auth.oidc_proxy.OIDCProxy.verify_token",
+            AsyncMock(return_value=inner),
+        )
+        assert await provider.verify_token("bearer-token") is None
+
+    async def test_invalid_token_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        monkeypatch.setattr(
+            "fastmcp.server.auth.oidc_proxy.OIDCProxy.verify_token",
+            AsyncMock(return_value=None),
+        )
+        assert await provider.verify_token("bad") is None
+
+    async def test_machine_token_bypasses_oidc_and_gate(self) -> None:
+        from fastmcp.server.auth import AccessToken
+
+        machine = AccessToken(
+            token="pre-shared",
+            client_id="ci-bot",
+            scopes=["user"],
+            expires_at=None,
+            claims={"login": "ci-bot", "machine": True},
+        )
+        provider = _make_provider(allowed_groups=["acme"], machine_tokens=[("pre-shared", machine)])
+        result = await provider.verify_token("pre-shared")
+        assert result is machine
+
+
+# ---------------------------------------------------------------------------
+# build_gitlab_auth
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGitlabAuth:
+    def test_builds_provider_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITLAB_CLIENT_ID", "app-id")
+        monkeypatch.setenv("GITLAB_CLIENT_SECRET", "app-secret")
+        monkeypatch.setenv("DISTILLERY_BASE_URL", "https://distillery.example.com")
+        provider = build_gitlab_auth(_make_config(allowed_groups=["acme"]))
+        assert isinstance(provider, GitLabProvider)
+        assert provider._allowed_groups == ["acme"]
+
+    def test_missing_client_id_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITLAB_CLIENT_ID", raising=False)
+        monkeypatch.setenv("GITLAB_CLIENT_SECRET", "s")
+        monkeypatch.setenv("DISTILLERY_BASE_URL", "https://d.example.com")
+        with pytest.raises(ValueError, match="GITLAB_CLIENT_ID"):
+            build_gitlab_auth(_make_config())
+
+    def test_missing_base_url_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITLAB_CLIENT_ID", "i")
+        monkeypatch.setenv("GITLAB_CLIENT_SECRET", "s")
+        monkeypatch.delenv("DISTILLERY_BASE_URL", raising=False)
+        with pytest.raises(ValueError, match="DISTILLERY_BASE_URL"):
+            build_gitlab_auth(_make_config())
+
+    def test_no_secrets_in_logs(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("GITLAB_CLIENT_ID", "sekrit-id")
+        monkeypatch.setenv("GITLAB_CLIENT_SECRET", "sekrit-value")
+        monkeypatch.setenv("DISTILLERY_BASE_URL", "https://distillery.example.com")
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            build_gitlab_auth(_make_config(allowed_groups=["acme"]))
+        assert "sekrit-value" not in caplog.text
+        assert "sekrit-id" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestGitlabConfigValidation:
+    def test_gitlab_provider_accepted(self) -> None:
+        _validate(_make_config(allowed_groups=["acme"]))
+
+    def test_self_hosted_empty_groups_allowed(self) -> None:
+        _validate(_make_config(instance_url="https://gitlab.example.com"))
+
+    def test_gitlab_com_requires_groups(self) -> None:
+        with pytest.raises(ValueError, match="allowed_groups must be non-empty"):
+            _validate(_make_config(instance_url="https://gitlab.com"))
+
+    def test_gitlab_com_with_groups_ok(self) -> None:
+        _validate(_make_config(instance_url="https://gitlab.com", allowed_groups=["acme"]))
+
+    def test_allowed_groups_requires_gitlab_provider(self) -> None:
+        config = _make_config(provider="github")
+        config.server.auth.allowed_groups = ["acme"]
+        with pytest.raises(ValueError, match="allowed_groups requires"):
+            _validate(config)
+
+    def test_invalid_instance_url_rejected(self) -> None:
+        with pytest.raises(ValueError, match="instance_url"):
+            _validate(_make_config(instance_url="not-a-url"))


### PR DESCRIPTION
Closes #696

## Summary

Adds `server.auth.provider: gitlab` -- GitLab (self-hosted or gitlab.com) as an alternative identity provider for the MCP HTTP transport, using FastMCP's generic `OIDCProxy`. Like the GitHub provider, GitLab is an identity gate only: scopes `openid profile email`, no access to the user's GitLab resources.

## Design

Settled in a design session; the load-bearing decision is recorded in `docs/adr/0001-gitlab-auth-claim-based-group-gating.md`, full spec in `docs/specs/19-spec-gitlab-auth/`.

- **Single provider per deployment** -- `github` | `gitlab` | `none`.
- **OIDC via discovery** -- `OIDCProxy` against `<instance_url>/.well-known/openid-configuration`, with `verify_id_token=True` because GitLab access tokens are opaque (the id_token is JWKS-verified instead).
- **Claim-based group gating (ADR-0001)** -- `allowed_groups` (GitLab group full-paths) is evaluated against the OIDC `groups` claim once, at login, with subtree matching (`acme` admits `acme/dev`, not `acme-corp`). A group-denied login gets no identity claims embedded and `verify_token` fails closed on every request. No per-request GitLab API calls, no GitLab equivalent of `OrgMembershipChecker`. Accepted trade-off: group removal takes effect at token expiry; immediate lockout = block the user in GitLab.
- **gitlab.com guard** -- startup validation requires non-empty `allowed_groups` when `instance_url` is gitlab.com; self-hosted may leave it empty (instance login is the boundary).
- **Single identity namespace** -- GitLab `nickname` maps onto the existing `login` claim; authorship, audit, and machine tokens work unchanged. The machine-token check is extracted into a shared `match_machine_token` helper used by both providers.

## Changes

- `src/distillery/config.py`: `gitlab` provider, `instance_url`, `allowed_groups` + validation
- `src/distillery/mcp/gitlab_auth.py`: `GitLabProvider` + `build_gitlab_auth`
- `src/distillery/mcp/auth.py`: shared `match_machine_token`; `pre_register_claude_code_client` loosened to `OAuthProxy`
- `src/distillery/mcp/__main__.py`: `gitlab` wiring (CIMD patch + Claude Code pre-registration included)
- `docs/team/gitlab-auth.md` (+ nav), deployment/team-setup updates, `/setup` skill references generalized
- `tests/test_gitlab_auth.py`: 27 unit tests

## Testing

- `pytest`: 3206 passed, 101 skipped
- `mypy --strict src/distillery/`: clean
- `ruff check` / `mkdocs build --strict`: clean
- Not exercised: the live OAuth flow against a real GitLab instance -- recommend a smoke test on a deployed server before relying on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitLab as a supported authentication provider alongside existing options.
  * Implemented GitLab OIDC group-based access control during login (including subtree matching and self-hosted vs. hosted rules).
  * Enhanced non-interactive access support via machine tokens.
* **Documentation**
  * Added GitLab authentication setup and specification docs, and expanded the main auth configuration guidance.
  * Updated setup references and environment-variable instructions to cover GitLab credentials.
* **Tests**
  * Added unit tests covering GitLab auth wiring, gating behavior, and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->