### PR TITLE
perf(store): defer FTS rebuild on bulk ingest to fix write-queue stalls

### DIFF
--- a/src/distillery/feeds/github_sync.py
+++ b/src/distillery/feeds/github_sync.py
@@ -403,6 +403,10 @@ class GitHubSyncAdapter:
         project: str | None = None,
     ) -> None:
         self._store = store
+        # Set once any issue/PR is stored or updated with ``defer_index=True``,
+        # so the deferred FTS rebuild + checkpoint is flushed even when a page
+        # errors after committing rows or the sync is cancelled mid-run.
+        self._pending_index_flush = False
         self._owner, self._repo = _parse_github_url(url)
         self._token = token or os.environ.get("GITHUB_TOKEN", "")
         self._author_override = author
@@ -410,6 +414,24 @@ class GitHubSyncAdapter:
         # with entries created via /distill, /bookmark, etc.
         self._project = project if project is not None else self._repo
         self._metadata_key = f"gh_sync_last_{self._owner}/{self._repo}"
+
+    async def _flush_pending_index(self) -> None:
+        """Flush the deferred FTS rebuild + checkpoint if a bulk write is owed.
+
+        Store/update calls during a sync run with ``defer_index=True`` to avoid
+        an O(items × total_rows) rebuild storm; this collapses them to one
+        rebuild + checkpoint. ``shield`` lets it finish even while the sync is
+        being cancelled, so committed rows never linger un-checkpointed. A
+        no-op when nothing was deferred; failure is non-fatal (the rows are
+        committed and vector-searchable, and the next run's flush catches up).
+        """
+        if not self._pending_index_flush:
+            return
+        self._pending_index_flush = False
+        try:
+            await asyncio.shield(self._store.flush_index())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("GitHubSyncAdapter: deferred index flush failed: %s", exc)
 
     @property
     def owner(self) -> str:
@@ -881,13 +903,16 @@ class GitHubSyncAdapter:
                         "tags": entry.tags,
                         "project": entry.project,
                     },
+                    defer_index=True,
                 )
                 entry_id = existing.id
                 updated += 1
+                self._pending_index_flush = True
             else:
                 # Store new entry.
-                entry_id = await self._store.store(entry)
+                entry_id = await self._store.store(entry, defer_index=True)
                 created += 1
+                self._pending_index_flush = True
 
             # Parse cross-references; defer resolution until all items stored.
             all_text = entry.content
@@ -901,6 +926,12 @@ class GitHubSyncAdapter:
             structural_refs = _extract_structural_refs(issue, entry.content)
             if structural_refs:
                 pending_structural.append((entry_id, structural_refs))
+
+        # Flush the deferred FTS rebuild + checkpoint once for the whole batch
+        # (stores/updates above ran with defer_index=True). sync_batched() —
+        # the production path — additionally flushes per page and in a
+        # cancellation-safe finally; this legacy path flushes once here.
+        await self._flush_pending_index()
 
         # Second pass: resolve cross-references now that all items are stored.
         for entry_id, cross_refs in pending_xrefs:
@@ -1028,12 +1059,15 @@ class GitHubSyncAdapter:
                         "tags": entry.tags,
                         "project": entry.project,
                     },
+                    defer_index=True,
                 )
                 entry_id = existing.id
                 updated += 1
+                self._pending_index_flush = True
             else:
-                entry_id = await self._store.store(entry)
+                entry_id = await self._store.store(entry, defer_index=True)
                 created += 1
+                self._pending_index_flush = True
 
             cross_refs = _extract_cross_refs(entry.content)
             cross_refs = [r for r in cross_refs if r != number]
@@ -1104,9 +1138,12 @@ class GitHubSyncAdapter:
                 total_fetched += len(batch)
 
                 try:
-                    created, updated, pending_xrefs, pending_structural = (
-                        await self._process_issue_batch(batch, client=client)
-                    )
+                    (
+                        created,
+                        updated,
+                        pending_xrefs,
+                        pending_structural,
+                    ) = await self._process_issue_batch(batch, client=client)
                     total_created += created
                     total_updated += updated
                     all_pending_xrefs.extend(pending_xrefs)
@@ -1140,6 +1177,13 @@ class GitHubSyncAdapter:
                 except Exception as exc:  # noqa: BLE001
                     errors.append(f"Structural edge resolution failed for {entry_id}: {exc}")
         finally:
+            # Flush the whole run's deferred FTS rebuild + checkpoint once
+            # (stores/updates in _process_issue_batch ran with
+            # defer_index=True). In ``finally`` so committed rows are indexed +
+            # checkpointed even when a page errored or the sync was cancelled /
+            # timed out mid-run — one O(total_rows) rebuild instead of one per
+            # issue. No-op when nothing was stored.
+            await self._flush_pending_index()
             if should_close:
                 await client.aclose()
 

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -813,6 +813,18 @@ class FeedPoller:
                     summary.sources_errored += 1
                 # Liveness is already persisted inside ``_poll_source``.
 
+        # Per-entry stores ran with ``defer_index=True`` (skipping the FTS
+        # rebuild + checkpoint), so flush once now to make the whole poll's
+        # new entries BM25-searchable and durably checkpointed — one
+        # O(total_rows) rebuild instead of one per entry. Failure is
+        # non-fatal: the rows are committed and vector-searchable, and the
+        # next poll's flush (or the idle-checkpoint loop) will catch up.
+        if summary.total_stored > 0:
+            try:
+                await self._store.flush_index()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("FeedPoller: deferred index flush failed: %s", exc)
+
         summary.finished_at = datetime.now(tz=UTC)
         return summary
 
@@ -1059,7 +1071,15 @@ class FeedPoller:
                     tags_config=self._tags_config,
                 )
                 entry = Entry(**kwargs)
-                await self._store.store(entry)
+                # Defer the per-write FTS rebuild + checkpoint: with ~79
+                # sources ingesting concurrently, a full O(total_rows) FTS
+                # rebuild after every single insert makes a poll
+                # O(entries × total_rows) and starves reads for minutes
+                # (the write-queue stall). poll() calls flush_index() once
+                # after the gather instead. The row + embedding are still
+                # committed here, so intra-poll dedup (vector similarity)
+                # sees it immediately.
+                await self._store.store(entry, defer_index=True)
                 batch_entry_ids.add(str(entry.id))
                 result.items_stored += 1
                 logger.debug(

--- a/src/distillery/feeds/poller.py
+++ b/src/distillery/feeds/poller.py
@@ -608,6 +608,11 @@ class FeedPoller:
     ) -> None:
         self._store = store
         self._config = config
+        # Set once any source commits a ``defer_index=True`` write, so poll()
+        # flushes the FTS rebuild + checkpoint even when the counted
+        # ``PollResult`` totals miss it — e.g. a source cancelled/errored after
+        # storing, or poll() itself cancelled mid-gather (issue #404).
+        self._pending_index_flush = False
         # Bound the per-cycle fan-out: at most ``max_concurrent_sources`` sources
         # are fetched + scored + stored at once (issue #655).  Values < 1 are
         # clamped to 1 so a misconfiguration can never deadlock the poll.
@@ -775,55 +780,60 @@ class FeedPoller:
                     is_backfill=source.url in first_poll_urls,
                 )
 
-        results = await asyncio.gather(
-            *(_poll_source_bounded(source) for source in sources),
-            return_exceptions=True,
-        )
+        try:
+            results = await asyncio.gather(
+                *(_poll_source_bounded(source) for source in sources),
+                return_exceptions=True,
+            )
 
-        for idx, result in enumerate(results):
-            if isinstance(result, BaseException):
-                # Unexpected exception escaping ``_poll_source`` — its own
-                # ``finally`` clause did not get to run (e.g. raised before
-                # the wrapping ``try``), so record liveness one more time
-                # here so the source isn't left as "never polled".
-                err_result = PollResult(
-                    source_url=sources[idx].url,
-                    source_type=sources[idx].source_type,
-                    errors=[f"Unexpected error: {result}"],
-                )
-                summary.results.append(err_result)
-                summary.sources_polled += 1
-                summary.sources_errored += 1
-                logger.warning(
-                    "FeedPoller: unexpected error polling %s: %s",
-                    sources[idx].url,
-                    result,
-                )
-                await self._persist_poll_status(err_result)
-            else:
-                summary.results.append(result)
-                summary.total_fetched += result.items_fetched
-                summary.total_stored += result.items_stored
-                summary.total_skipped_dedup += result.items_skipped_dedup
-                summary.total_below_threshold += result.items_below_threshold
-                summary.total_items_enriched += result.items_enriched
-                summary.total_enrichment_errors += result.enrichment_errors
-                summary.sources_polled += 1
-                if result.errors:
+            for idx, result in enumerate(results):
+                if isinstance(result, BaseException):
+                    # Unexpected exception escaping ``_poll_source`` — its own
+                    # ``finally`` clause did not get to run (e.g. raised before
+                    # the wrapping ``try``), so record liveness one more time
+                    # here so the source isn't left as "never polled".
+                    err_result = PollResult(
+                        source_url=sources[idx].url,
+                        source_type=sources[idx].source_type,
+                        errors=[f"Unexpected error: {result}"],
+                    )
+                    summary.results.append(err_result)
+                    summary.sources_polled += 1
                     summary.sources_errored += 1
-                # Liveness is already persisted inside ``_poll_source``.
-
-        # Per-entry stores ran with ``defer_index=True`` (skipping the FTS
-        # rebuild + checkpoint), so flush once now to make the whole poll's
-        # new entries BM25-searchable and durably checkpointed — one
-        # O(total_rows) rebuild instead of one per entry. Failure is
-        # non-fatal: the rows are committed and vector-searchable, and the
-        # next poll's flush (or the idle-checkpoint loop) will catch up.
-        if summary.total_stored > 0:
-            try:
-                await self._store.flush_index()
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("FeedPoller: deferred index flush failed: %s", exc)
+                    logger.warning(
+                        "FeedPoller: unexpected error polling %s: %s",
+                        sources[idx].url,
+                        result,
+                    )
+                    await self._persist_poll_status(err_result)
+                else:
+                    summary.results.append(result)
+                    summary.total_fetched += result.items_fetched
+                    summary.total_stored += result.items_stored
+                    summary.total_skipped_dedup += result.items_skipped_dedup
+                    summary.total_below_threshold += result.items_below_threshold
+                    summary.total_items_enriched += result.items_enriched
+                    summary.total_enrichment_errors += result.enrichment_errors
+                    summary.sources_polled += 1
+                    if result.errors:
+                        summary.sources_errored += 1
+                    # Liveness is already persisted inside ``_poll_source``.
+        finally:
+            # Per-entry stores ran with ``defer_index=True`` (skipping the FTS
+            # rebuild + checkpoint), so flush once now — one O(total_rows)
+            # rebuild instead of one per entry. Gate on the commit-point flag,
+            # not ``summary.total_stored``, and run in ``finally`` so committed
+            # rows are still made BM25-searchable + checkpointed when a source
+            # errored after storing, or poll() was cancelled mid-gather (issue
+            # #404). ``shield`` lets the rebuild + checkpoint finish even while
+            # poll() is being cancelled, so rows never linger un-checkpointed
+            # until the next cycle. Failure is non-fatal.
+            if self._pending_index_flush:
+                self._pending_index_flush = False
+                try:
+                    await asyncio.shield(self._store.flush_index())
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("FeedPoller: deferred index flush failed: %s", exc)
 
         summary.finished_at = datetime.now(tz=UTC)
         return summary
@@ -1080,6 +1090,12 @@ class FeedPoller:
                 # committed here, so intra-poll dedup (vector similarity)
                 # sees it immediately.
                 await self._store.store(entry, defer_index=True)
+                # Row is committed but its FTS rebuild + checkpoint are
+                # deferred to poll()'s single end-of-cycle flush. Mark that a
+                # flush is owed now, at the commit point, so it happens even if
+                # this source or the whole poll is cancelled before the counted
+                # totals are assembled (issue #404).
+                self._pending_index_flush = True
                 batch_entry_ids.add(str(entry.id))
                 result.items_stored += 1
                 logger.debug(

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -1916,13 +1916,21 @@ class DuckDBStore:
                 inserted += 1
         return inserted
 
-    def _sync_store(self, entry: Entry, embedding: list[float]) -> str:
+    def _sync_store(
+        self, entry: Entry, embedding: list[float], *, rebuild_index: bool = True
+    ) -> str:
         """Synchronous implementation of store(); called via asyncio.to_thread.
 
         *embedding* is computed by :meth:`store` off-thread *before* the SQL
         lock is acquired (issue #558), so this method only does the SQL
         critical section — keeping ``_conn_lock`` held for milliseconds, not
         the full embedding round-trip.
+
+        When *rebuild_index* is ``False`` the FTS rebuild and post-write
+        checkpoint are skipped — the caller (a bulk writer) is responsible
+        for calling :meth:`flush_index` once after the batch. The insert and
+        embedding are still committed, so vector search sees the row
+        immediately; only BM25 lags until the deferred flush.
         """
         validate_metadata(entry.entry_type.value, entry.metadata)
         conn = self.connection
@@ -1965,19 +1973,25 @@ class DuckDBStore:
         # entry to its embedding-neighbours above threshold so feed-heavy
         # instances stop accumulating graph orphans. No-op when disabled.
         self._auto_link_semantic(conn, entry.id, embedding)
-        # Rebuild FTS index so new content is searchable via BM25.
-        self._rebuild_fts_index(conn)
-        # Flush WAL so the new row survives ungraceful termination.
-        # See :meth:`_checkpoint_after_write` for why this matters (issue #346).
-        self._checkpoint_after_write(conn)
+        if rebuild_index:
+            # Rebuild FTS index so new content is searchable via BM25.
+            self._rebuild_fts_index(conn)
+            # Flush WAL so the new row survives ungraceful termination.
+            # See :meth:`_checkpoint_after_write` for why this matters (issue #346).
+            self._checkpoint_after_write(conn)
         logger.debug("Stored entry id=%s", entry.id)
         return entry.id
 
-    async def store(self, entry: Entry) -> str:
+    async def store(self, entry: Entry, *, defer_index: bool = False) -> str:
         """Persist a new entry and return its ID.
 
         The entry's content is embedded via the configured embedding provider
         before insertion.
+
+        When *defer_index* is ``True`` the per-write FTS rebuild and WAL
+        checkpoint are skipped; the caller must invoke :meth:`flush_index`
+        once after the batch. See the protocol docstring for the rationale
+        (avoids an O(entries × total_rows) rebuild storm on bulk ingest).
 
         Returns:
             The UUID string of the stored entry.
@@ -1986,7 +2000,24 @@ class DuckDBStore:
         # overlap their embedding round-trips instead of serialising on
         # ``_conn_lock`` (issue #558).
         embedding = await asyncio.to_thread(self._embedding_provider.embed, entry.content)
-        return await self._run_sync(self._sync_store, entry, embedding)
+        return await self._run_sync(
+            self._sync_store, entry, embedding, rebuild_index=not defer_index
+        )
+
+    def _sync_flush_index(self) -> None:
+        """Rebuild the FTS index and checkpoint; called via asyncio.to_thread."""
+        conn = self.connection
+        self._rebuild_fts_index(conn)
+        self._checkpoint_after_write(conn)
+
+    async def flush_index(self) -> None:
+        """Rebuild the FTS index and checkpoint the WAL (once, under the lock).
+
+        Pairs with ``store(..., defer_index=True)``. Runs the same
+        rebuild + checkpoint that a non-deferred write does, but once for a
+        whole batch instead of per entry.
+        """
+        await self._run_sync(self._sync_flush_index)
 
     def _sync_store_batch(
         self, entries: Sequence[Entry], embeddings: list[list[float]]

--- a/src/distillery/store/duckdb.py
+++ b/src/distillery/store/duckdb.py
@@ -2187,6 +2187,8 @@ class DuckDBStore:
         entry_id: str,
         updates: dict[str, Any],
         embedding: list[float] | None,
+        *,
+        rebuild_index: bool = True,
     ) -> Entry:
         """
         Apply partial updates to an existing entry and return its updated representation.
@@ -2295,12 +2297,15 @@ class DuckDBStore:
         # forward-only sync mirroring mechanism #1's "additive" semantic.
         if "metadata" in updates and isinstance(updates["metadata"], dict):
             self._fan_out_related_entries(conn, entry_id, updates["metadata"])
-        # Rebuild FTS index when content changes.
-        if "content" in updates:
-            self._rebuild_fts_index(conn)
-        # Flush WAL so the update survives ungraceful termination.
-        # See :meth:`_checkpoint_after_write` for why this matters (issue #346).
-        self._checkpoint_after_write(conn)
+        if rebuild_index:
+            # Rebuild FTS index when content changes.
+            if "content" in updates:
+                self._rebuild_fts_index(conn)
+            # Flush WAL so the update survives ungraceful termination.
+            # See :meth:`_checkpoint_after_write` for why this matters (issue #346).
+            self._checkpoint_after_write(conn)
+        # else: a bulk writer deferred the rebuild + checkpoint and will call
+        # flush_index() once for the batch (see store(..., defer_index=True)).
         logger.debug("Updated entry id=%s", entry_id)
 
         # Re-fetch to return the updated state.
@@ -2314,12 +2319,18 @@ class DuckDBStore:
             raise KeyError(f"Entry disappeared after update: id={entry_id!r}")
         return self._row_to_entry(row, col_names)
 
-    async def update(self, entry_id: str, updates: dict[str, Any]) -> Entry:
+    async def update(
+        self, entry_id: str, updates: dict[str, Any], *, defer_index: bool = False
+    ) -> Entry:
         """Apply a partial update to an existing entry.
 
         Increments ``version`` by 1 and refreshes ``updated_at`` to the
         current UTC time.  Attempts to update ``id``, ``created_at``, or
         ``source`` are rejected with a ``ValueError``.
+
+        When *defer_index* is ``True`` the per-write FTS rebuild and WAL
+        checkpoint are skipped; the caller must invoke :meth:`flush_index`
+        once after the batch (see :meth:`store` for the rationale).
 
         Raises:
             ValueError: If ``updates`` contains any immutable field.
@@ -2334,7 +2345,9 @@ class DuckDBStore:
         embedding: list[float] | None = None
         if "content" in updates:
             embedding = await asyncio.to_thread(self._embedding_provider.embed, updates["content"])
-        return await self._run_sync(self._sync_update, entry_id, updates, embedding)
+        return await self._run_sync(
+            self._sync_update, entry_id, updates, embedding, rebuild_index=not defer_index
+        )
 
     def _sync_delete(self, entry_id: str) -> bool:
         """Synchronous implementation of delete(); called via asyncio.to_thread."""

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -131,7 +131,9 @@ class DistilleryStore(Protocol):
         """
         ...
 
-    async def update(self, entry_id: str, updates: dict[str, Any]) -> Entry:
+    async def update(
+        self, entry_id: str, updates: dict[str, Any], *, defer_index: bool = False
+    ) -> Entry:
         """Apply a partial update to an existing entry.
 
         Increments ``version`` by 1 and refreshes ``updated_at`` to the
@@ -142,6 +144,9 @@ class DistilleryStore(Protocol):
             entry_id: The UUID string of the entry to update.
             updates: A dict of field names to new values.  Only writable
                 fields are accepted.
+            defer_index: When ``True``, skip the per-write FTS rebuild and
+                checkpoint; the caller must invoke :meth:`flush_index` once
+                after the batch. See :meth:`store` for the rationale.
 
         Returns:
             The updated ``Entry`` reflecting all applied changes.

--- a/src/distillery/store/protocol.py
+++ b/src/distillery/store/protocol.py
@@ -69,16 +69,33 @@ class DistilleryStore(Protocol):
         """
         ...
 
-    async def store(self, entry: Entry) -> str:
+    async def store(self, entry: Entry, *, defer_index: bool = False) -> str:
         """Persist a new entry and return its ID.
 
         Args:
             entry: The ``Entry`` instance to persist.  The ``id`` field is
                 used as the primary key; callers should allow ``Entry`` to
                 auto-generate one via ``uuid.uuid4()``.
+            defer_index: When ``True``, skip the per-write full-text index
+                rebuild and WAL checkpoint. The row (and its embedding) are
+                still inserted and immediately visible to vector search, but
+                it is not BM25-searchable until a later :meth:`flush_index`.
+                Bulk writers (the feed poller) set this to avoid an
+                O(entries × total_rows) rebuild storm, then call
+                :meth:`flush_index` once at the end of the batch.
 
         Returns:
             The string representation of the stored entry's UUID.
+        """
+        ...
+
+    async def flush_index(self) -> None:
+        """Rebuild the full-text index and checkpoint the WAL.
+
+        Pairs with ``store(..., defer_index=True)``: bulk writers defer the
+        per-write rebuild/checkpoint and call this once after the batch so
+        the O(total_rows) FTS rebuild runs a single time instead of per
+        entry. A no-op-safe operation to call when nothing was deferred.
         """
         ...
 

--- a/tests/test_duckdb_store.py
+++ b/tests/test_duckdb_store.py
@@ -2604,6 +2604,72 @@ class TestIdleCheckpoint:
 # ---------------------------------------------------------------------------
 
 
+class TestDeferredIndex:
+    """``store(defer_index=True)`` skips the per-write FTS rebuild + checkpoint;
+    ``flush_index()`` performs them once for the batch (perf fix for the
+    O(entries × total_rows) rebuild storm on bulk ingest)."""
+
+    async def test_defer_index_skips_rebuild_and_checkpoint(self, store, monkeypatch) -> None:
+        rebuilds = 0
+        checkpoints = 0
+        real_rebuild = store._rebuild_fts_index
+        real_ckpt = store._checkpoint_after_write
+
+        def _count_rebuild(conn):
+            nonlocal rebuilds
+            rebuilds += 1
+            return real_rebuild(conn)
+
+        def _count_ckpt(conn):
+            nonlocal checkpoints
+            checkpoints += 1
+            return real_ckpt(conn)
+
+        monkeypatch.setattr(store, "_rebuild_fts_index", _count_rebuild)
+        monkeypatch.setattr(store, "_checkpoint_after_write", _count_ckpt)
+
+        await store.store(make_entry(content="deferred one"), defer_index=True)
+        await store.store(make_entry(content="deferred two"), defer_index=True)
+        assert rebuilds == 0
+        assert checkpoints == 0
+
+        # A single flush does exactly one rebuild + one checkpoint for the batch.
+        await store.flush_index()
+        assert rebuilds == 1
+        assert checkpoints == 1
+
+    async def test_default_store_still_rebuilds_per_write(self, store, monkeypatch) -> None:
+        rebuilds = 0
+        real_rebuild = store._rebuild_fts_index
+
+        def _count_rebuild(conn):
+            nonlocal rebuilds
+            rebuilds += 1
+            return real_rebuild(conn)
+
+        monkeypatch.setattr(store, "_rebuild_fts_index", _count_rebuild)
+        await store.store(make_entry(content="eager"))
+        assert rebuilds == 1
+
+    async def test_deferred_entry_is_retrievable_and_searchable_after_flush(self, store) -> None:
+        entry = make_entry(content="deferred but findable")
+        eid = await store.store(entry, defer_index=True)
+
+        # Row + embedding are committed, so it is retrievable and vector-
+        # searchable immediately, before any flush.
+        assert await store.get(eid) is not None
+        results = await store.search("deferred but findable", filters=None, limit=5)
+        assert any(r.entry.id == eid for r in results)
+
+        # Flush makes the deferred write durable/BM25-indexed; retrieval holds.
+        await store.flush_index()
+        assert await store.get(eid) is not None
+
+    async def test_flush_index_is_safe_with_nothing_deferred(self, store) -> None:
+        # Calling flush on a quiescent store must not raise.
+        await store.flush_index()
+
+
 class TestObservabilitySpans:
     """The store funnels emit one ``db {operation}`` span per operation."""
 

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1450,7 +1450,7 @@ class TestPollCycleTopicTagIntegration:
 
         stored_entries: list = []
 
-        async def capture_store(entry: object) -> None:
+        async def capture_store(entry: object, *, defer_index: bool = False) -> None:
             stored_entries.append(entry)
 
         store.store.side_effect = capture_store
@@ -1504,7 +1504,7 @@ class TestPollCycleTopicTagIntegration:
 
         stored_entries: list = []
 
-        async def capture_store(entry: object) -> None:
+        async def capture_store(entry: object, *, defer_index: bool = False) -> None:
             stored_entries.append(entry)
 
         store.store.side_effect = capture_store
@@ -1851,7 +1851,7 @@ class TestPerSourceThresholdOverrides:
 
         stored: list = []
 
-        async def capture_store(entry: object) -> None:
+        async def capture_store(entry: object, *, defer_index: bool = False) -> None:
             stored.append(entry)
 
         store.store.side_effect = capture_store
@@ -1914,7 +1914,7 @@ class TestPerSourceThresholdOverrides:
 
         stored: list = []
 
-        async def capture_store(entry: object) -> None:
+        async def capture_store(entry: object, *, defer_index: bool = False) -> None:
             stored.append(entry)
 
         store.store.side_effect = capture_store

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -365,6 +365,45 @@ class TestGitHubSyncAdapterSync:
         assert "A comment" in entry.content
 
     @pytest.mark.integration
+    async def test_sync_defers_fts_rebuild_to_single_flush(  # type: ignore[no-untyped-def]
+        self, store, httpx_mock, monkeypatch
+    ) -> None:
+        """Bulk sync rebuilds the FTS index once for the batch, not per entry."""
+        httpx_mock.add_response(
+            url=re.compile(r".*/repos/test/repo/issues\?.*"),
+            json=[_mock_issue(number=n, title=f"Issue {n}") for n in (1, 2, 3)],
+        )
+        # One comments fetch per issue (responses are consumed once in this
+        # pytest-httpx version).
+        for _ in range(3):
+            httpx_mock.add_response(
+                url=re.compile(r".*/repos/test/repo/issues/\d+/comments.*"),
+                json=[],
+            )
+
+        rebuilds = 0
+        real_rebuild = store._rebuild_fts_index
+
+        def _count_rebuild(conn):  # type: ignore[no-untyped-def]
+            nonlocal rebuilds
+            rebuilds += 1
+            return real_rebuild(conn)
+
+        monkeypatch.setattr(store, "_rebuild_fts_index", _count_rebuild)
+
+        adapter = GitHubSyncAdapter(store=store, url="test/repo")
+        result = await adapter.sync_batched()
+
+        assert result.created == 3
+        # Three issues stored, but the FTS index is rebuilt exactly once — via
+        # the deferred end-of-run flush — instead of once per issue.
+        assert rebuilds == 1
+        entries = await store.list_entries(
+            filters={"entry_type": "github"}, limit=10, offset=0
+        )
+        assert len(entries) == 3
+
+    @pytest.mark.integration
     async def test_sync_creates_pr_entries(self, store, httpx_mock) -> None:  # type: ignore[no-untyped-def]
         """PRs should have ref_type=pr."""
         httpx_mock.add_response(

--- a/tests/test_radar_published_at_floor.py
+++ b/tests/test_radar_published_at_floor.py
@@ -122,7 +122,7 @@ def _make_store_for_poller(
     store = AsyncMock()
     captured: list[Entry] = stored_entries if stored_entries is not None else []
 
-    async def _capture_store(entry: Entry) -> str:
+    async def _capture_store(entry: Entry, *, defer_index: bool = False) -> str:
         captured.append(entry)
         return str(entry.id)
 

--- a/tests/test_radar_published_at_floor.py
+++ b/tests/test_radar_published_at_floor.py
@@ -230,6 +230,58 @@ class TestPollerBackfillFlag:
         assert "backfill" not in by_url["https://old.com/rss"].metadata
 
 
+class TestDeferredIndexFlushOnPoll:
+    """The poller defers the per-write FTS rebuild and flushes once per cycle.
+
+    The flush must be keyed on the commit-point flag, not the counted
+    ``PollResult`` totals, so committed-but-deferred rows are still indexed +
+    checkpointed when a source errors after storing or the poll is cancelled
+    mid-gather (CR #699, issue #404)."""
+
+    async def test_normal_poll_flushes_index_once(self) -> None:
+        store = _make_store_for_poller([_source_dict(last_polled_at=None)])
+        cfg = _make_poller_config()
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            adapter = MagicMock()
+            adapter.fetch.return_value = [_make_feed_item("a1")]
+            mock_build.return_value = adapter
+            poller = FeedPoller(store=store, config=cfg)
+            summary = await poller.poll()
+        assert summary.total_stored == 1
+        store.flush_index.assert_awaited_once()
+
+    async def test_flush_runs_when_source_errors_after_deferred_store(self, monkeypatch) -> None:
+        # A source commits a deferred write (sets the flag) then raises before
+        # returning a PollResult, so its rows never reach ``total_stored`` —
+        # the flush must still run off the commit-point flag.
+        store = _make_store_for_poller([_source_dict(last_polled_at=None)])
+        cfg = _make_poller_config()
+        poller = FeedPoller(store=store, config=cfg)
+
+        async def _store_then_boom(source: Any, scorer: Any, **_kwargs: Any) -> None:
+            poller._pending_index_flush = True  # simulate a committed deferred store
+            raise RuntimeError("cancelled after store")
+
+        monkeypatch.setattr(poller, "_poll_source", _store_then_boom)
+        with patch("distillery.feeds.poller._build_adapter"):
+            summary = await poller.poll()
+
+        assert summary.total_stored == 0  # the errored source contributed no count
+        store.flush_index.assert_awaited_once()  # but the committed row was flushed
+
+    async def test_no_flush_when_nothing_stored(self) -> None:
+        # Empty fetch → no deferred writes → no wasted full-table FTS rebuild.
+        store = _make_store_for_poller([_source_dict(last_polled_at=None)])
+        cfg = _make_poller_config()
+        with patch("distillery.feeds.poller._build_adapter") as mock_build:
+            adapter = MagicMock()
+            adapter.fetch.return_value = []
+            mock_build.return_value = adapter
+            poller = FeedPoller(store=store, config=cfg)
+            await poller.poll()
+        store.flush_index.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # DuckDBStore: published_after / published_before / exclude_backfill filters
 # ---------------------------------------------------------------------------

--- a/tests/test_store_rollback_on_error.py
+++ b/tests/test_store_rollback_on_error.py
@@ -229,8 +229,10 @@ class TestReadAfterWriteFailure:
         # exception escapes, restoring the connection for subsequent reads.
         original_sync_store = store._sync_store  # type: ignore[attr-defined]
 
-        def failing_sync_store(entry: object, embedding: object) -> str:
-            original_sync_store(entry, embedding)  # do the write, then raise
+        def failing_sync_store(
+            entry: object, embedding: object, *, rebuild_index: bool = True
+        ) -> str:
+            original_sync_store(entry, embedding, rebuild_index=rebuild_index)
             raise RuntimeError("simulated post-write failure")
 
         store._sync_store = failing_sync_store  # type: ignore[attr-defined,method-assign]


### PR DESCRIPTION
## Problem

The hosted `distillery-mcp-gominimal` instance periodically stalled: `distillery_search` up to **1378 s (23 min)**, `distillery_get` 711 s, `distillery_update` 896 s, with clients timing out (`anyio.ClosedResourceError`). Diagnosed live via Logfire using the [#697](https://github.com/norrietaylor/distillery/pull/697) `db {operation}` store spans.

**Root cause:** every `store()` calls `_rebuild_fts_index` → `PRAGMA create_fts_index('entries', 'id', 'content', overwrite=1)`, a full **drop-and-recreate of the entire FTS index over all rows** (O(total_rows)), followed by a `CHECKPOINT` — all inside the exclusive `_conn_lock`. The feed poller ingests ~79 sources' entries **one-by-one**, so a poll is **O(entries × total_rows)**: each insert re-indexes the whole table. This grows without bound as the DB fills, which is exactly the observed onset — at 17:00 UTC the same ops were fast (search 4 s) at high volume, then tipped to minutes by 18:00.

Evidence from the trace of the worst search (1378 s): only ~13 s in `store.search.rank` and ~0.6 s in embed; **~1364 s is untraced waiting** — the read starved for a worker thread + the connection behind the writer. And the forwarded logs captured the compounding failure during a single triggered poll:

> `CHECKPOINT after write failed 3 times in a row — Cannot CHECKPOINT: there are other write transactions active`

The per-write checkpoints fail under the poller's concurrency, so the WAL never flushes and bloats, slowing every subsequent operation further. The idle-checkpoint loop ([#655](https://github.com/norrietaylor/distillery/issues/655)) can't help — it only runs when the writer lock is free, which under sustained polling it never is.

## Fix

Opt-in **index deferral** for bulk writers:

- `store(entry, *, defer_index=False)` — when `True`, skip the per-write FTS rebuild + checkpoint. The row **and its embedding are still committed**, so vector search sees the entry immediately; only BM25 lags until a flush.
- `flush_index()` — runs the same rebuild + checkpoint **once** for a whole batch.
- The poller defers every per-entry store and calls `flush_index()` **once** after the source gather → one O(total_rows) rebuild per poll instead of one per entry, and one checkpoint instead of a per-entry storm.

**Safety:**
- Default behaviour is unchanged (`defer_index=False`) — single-entry writers (MCP `distillery_store`, etc.) still rebuild + checkpoint eagerly, so BM25 freshness and per-write durability are untouched.
- Intra-poll dedup is **vector-based** (`find_similar`/HNSW), which is fed by the synchronously-inserted embedding — so deferring the FTS rebuild does not affect dedup correctness within a poll.
- Deferred entries live in the WAL until the end-of-poll flush; a mid-poll crash leaves them recoverable via WAL replay and re-indexed on the next successful poll. The flush is guarded (non-fatal on failure).

## Tests

- `TestDeferredIndex`: `defer_index=True` performs **0** rebuilds/checkpoints across N stores; `flush_index()` does exactly **1** each; a deferred entry is retrievable and vector-searchable **before** flush and after; `flush_index()` on a quiescent store is safe. Default `store()` still rebuilds once per write.
- Updated the poller/rollback test doubles for the new (backward-compatible) signature.
- Full suite: 3222 passed, 3 skipped. `ruff` + `mypy --strict` clean.

## Follow-ups (not in this PR)

- `github_sync` (the other concurrent writer named in the Fly `[[vm]]` notes — spectacles doc ingest) uses the same per-entry `store()` pattern and should adopt `defer_index`/`flush_index` next.
- Separately, the gominimal Cloud Run otel-collector 404s on `/v1/metrics` (no metrics pipeline configured); metrics to Logfire are unaffected. Infra fix, tracked outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deferred indexing for storage and updates: entries are written immediately for retrieval/search, while full-text index refreshes are postponed.
  * Added a manual index flush action to rebuild full-text search and checkpoint after batched writes.
* **Bug Fixes**
  * Polling now performs a single deferred index flush per cycle when applicable, even if a source fails mid-cycle (with non-fatal warning on flush issues).
  * Sync/sync-batched flows also consolidate deferred flushes to avoid repeated rebuild work.
* **Tests**
  * Added/updated coverage to verify deferred flush behavior and call counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->