### PR TITLE
feat(webhooks): opt-in ?wait=true to run poll jobs synchronously (autosuspend-safe)

### DIFF
--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -164,6 +164,17 @@ _active_job_by_endpoint: dict[str, str] = {}
 _jobs_lock = asyncio.Lock()
 
 
+def _wants_sync_wait(request: Request) -> bool:
+    """True when the caller asked to block until the async job finishes.
+
+    Opt-in via ``?wait=1|true|yes`` (case-insensitive). Used by schedulers on
+    autosuspend platforms to keep the machine alive for a full poll (see
+    :func:`_dispatch_async`). Absent/other values keep the default 202 async
+    behaviour.
+    """
+    return request.query_params.get("wait", "").strip().lower() in ("1", "true", "yes")
+
+
 def _is_stale(job: _JobStatus, *, now: datetime | None = None) -> bool:
     """Return ``True`` when *job* is non-terminal and older than the TTL.
 
@@ -1531,6 +1542,35 @@ def create_webhook_app(
             _execute_job(job, state, runner, parsed),
             name=f"webhook-{endpoint}-{job.id}",
         )
+
+        # Opt-in synchronous mode (``?wait=true``): hold the HTTP request open
+        # until the job finishes, then return its terminal result instead of a
+        # 202. This exists for platforms that autosuspend idle machines: Fly's
+        # autosuspend fires when no request is in flight and freezes/kills the
+        # detached task mid-run (issue #507 — the stale-job sweep only cleans
+        # up the corpse afterwards). Keeping the request in flight blocks
+        # autosuspend for the duration, so the scheduler's long-lived POST
+        # lets the whole poll — and its deferred end-of-run index flush — run
+        # to completion in one alive window. Autosuspend still fires once this
+        # returns; interactive MCP clients omit the flag and keep the 202
+        # fire-and-forget behaviour.
+        if _wants_sync_wait(request):
+            try:
+                await job.task
+            except Exception:  # noqa: BLE001 — _execute_job records its own error
+                logger.exception("Webhook %s (job=%s): awaited job raised", endpoint, job.id)
+            succeeded = job.state == "succeeded"
+            return JSONResponse(
+                {
+                    "ok": succeeded,
+                    "job_id": job.id,
+                    "state": job.state,
+                    "result": job.result,
+                    "error": job.error,
+                    "status_url": f"{root_path}/jobs/{job.id}",
+                },
+                status_code=200 if succeeded else 500,
+            )
 
         return JSONResponse(
             {

--- a/src/distillery/mcp/webhooks.py
+++ b/src/distillery/mcp/webhooks.py
@@ -143,6 +143,13 @@ _JOBS_MAX = 100
 # never misclassified.
 _ACTIVE_JOB_TTL_SECONDS: int = 1800  # 30 minutes
 
+# Upper bound on how long the opt-in ``?wait=true`` path (see
+# :func:`_dispatch_async`) holds a request open awaiting its job. Tied to the
+# stale-job TTL: a job that runs past this is already considered dead by
+# :func:`_is_stale`, so blocking longer only pins the request slot. On timeout
+# the handler falls back to the 202 contract; the job keeps running (shielded).
+_SYNC_WAIT_MAX_SECONDS: int = _ACTIVE_JOB_TTL_SECONDS
+
 
 @dataclass
 class _JobStatus:
@@ -1556,7 +1563,30 @@ def create_webhook_app(
         # fire-and-forget behaviour.
         if _wants_sync_wait(request):
             try:
-                await job.task
+                # Bounded: a hung job must not pin the request slot forever
+                # (CR #700). ``shield`` keeps the job running when the wait
+                # times out — on timeout we fall back to the 202 contract and
+                # the caller re-attaches via ``status_url`` / the stale sweep
+                # reaps it.
+                await asyncio.wait_for(
+                    asyncio.shield(job.task), timeout=_SYNC_WAIT_MAX_SECONDS
+                )
+            except TimeoutError:
+                logger.warning(
+                    "Webhook %s (job=%s): sync wait exceeded %ds — returning 202",
+                    endpoint,
+                    job.id,
+                    _SYNC_WAIT_MAX_SECONDS,
+                )
+                return JSONResponse(
+                    {
+                        "ok": True,
+                        "job_id": job.id,
+                        "state": job.state,
+                        "status_url": f"{root_path}/jobs/{job.id}",
+                    },
+                    status_code=202,
+                )
             except Exception:  # noqa: BLE001 — _execute_job records its own error
                 logger.exception("Webhook %s (job=%s): awaited job raised", endpoint, job.id)
             succeeded = job.state == "succeeded"

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -173,6 +173,30 @@ async def test_poll_wait_true_blocks_and_returns_terminal_result(
 
 
 @pytest.mark.unit
+async def test_poll_wait_true_bounded_falls_back_to_202_on_timeout(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wait that exceeds the cap must not pin the request forever — it falls
+    back to 202 so the caller re-attaches, while the job keeps running."""
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    # Cap at 0: the just-created job task is not yet complete, so the bounded
+    # wait times out immediately and takes the fallback branch.
+    monkeypatch.setattr("distillery.mcp.webhooks._SYNC_WAIT_MAX_SECONDS", 0)
+    config = _make_config()
+    shared = _make_shared_state(store)
+    app = create_webhook_app(shared, config)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/poll?wait=true", headers=_AUTH_HEADER)
+        assert resp.status_code == 202, f"Expected 202 fallback, got {resp.status_code}"
+        body = resp.json()
+        assert isinstance(body["job_id"], str) and body["job_id"]
+        assert body["status_url"] == f"/jobs/{body['job_id']}"
+        # The job keeps running (shielded) — let it finish for a clean teardown.
+        _wait_for_job(client, body["job_id"])
+
+
+@pytest.mark.unit
 async def test_poll_without_wait_still_returns_202(
     store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -149,6 +149,46 @@ async def test_auth_valid_token_returns_202(
         assert final["state"] == "succeeded"
 
 
+@pytest.mark.unit
+async def test_poll_wait_true_blocks_and_returns_terminal_result(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST /poll?wait=true holds the request open and returns 200 with the
+    terminal job state inline (no 202 / no /jobs polling) — the autosuspend-
+    safe path that keeps the machine alive for the whole poll."""
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+    app = create_webhook_app(shared, config)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/poll?wait=true", headers=_AUTH_HEADER)
+
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["state"] == "succeeded"  # ran to completion within the request
+        assert isinstance(body["job_id"], str) and body["job_id"]
+        assert body["result"] is not None  # terminal poll summary is inline
+
+
+@pytest.mark.unit
+async def test_poll_without_wait_still_returns_202(
+    store: DuckDBStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default behaviour is unchanged: no ``wait`` param → 202 fire-and-forget."""
+    monkeypatch.setenv("DISTILLERY_WEBHOOK_SECRET", _SECRET)
+    config = _make_config()
+    shared = _make_shared_state(store)
+    app = create_webhook_app(shared, config)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/poll?wait=maybe", headers=_AUTH_HEADER)
+        assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+        assert resp.json()["state"] == "queued"
+        _wait_for_job(client, resp.json()["job_id"])
+
+
 def _make_request_with_auth(header_value: str) -> Request:
     """Build a minimal Starlette :class:`Request` carrying *header_value* as Authorization."""
     scope = {


### PR DESCRIPTION
## Problem

The `/poll`, `/rescore`, and `/maintenance` webhooks enqueue a detached `asyncio.create_task` and return `202` immediately. On platforms that autosuspend idle machines (Fly), autosuspend fires when **no request is in flight** and freezes/kills the detached task mid-run — the exact scenario [`_is_stale`](https://github.com/norrietaylor/distillery/blob/main/src/distillery/mcp/webhooks.py) documents for issue #507, where the stale-job sweep only cleans up the corpse afterward.

Observed live 2026-07-07 on the gominimal Fly instance: a poll logged `starting poll cycle` but never completed — the VM autosuspended repeatedly mid-poll, so `FeedPoller.poll()` never reached its `finally`, and the deferred end-of-run FTS index flush ([#699](https://github.com/norrietaylor/distillery/pull/699)) never fired.

## Fix

Add an opt-in **`?wait=true`** (also `1`/`yes`, case-insensitive) to the async webhook dispatch. When set, the handler holds the HTTP request open until the job reaches a terminal state and returns **200** with the job result inline (**500** on failure) instead of 202. An in-flight request blocks autosuspend for the duration, so a scheduler's long-lived POST keeps the machine alive for the whole poll **and** its flush, in one window.

Default behaviour is unchanged: no param (or any other value) → the existing **202** fire-and-forget contract, for interactive MCP clients that can't wait.

## Keeps autosuspend

This doesn't touch any Fly config — autosuspend still fires the moment the request returns. It just ensures the machine stays alive *while actual work is in flight*, which is what autosuspend is supposed to allow.

## Tests

- `?wait=true` → 200 with terminal `state=succeeded` and `result` inline (no /jobs polling).
- No wait / unrecognized value → still 202 `queued` (default contract preserved).
- Existing 74 webhook tests pass.

## Companion change

The gominimal scheduler (`distillery-gominimal`) will POST with `?wait=true` (+ a longer client timeout) to use this — a separate PR in that repo, safe to land in either order (an old server ignores the unknown query param and returns 202 as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in synchronous `wait` mode for webhook POST requests (including `/poll`, `/rescore`, `/maintenance`, and legacy `/hooks/*` aliases) so the response can return the completed result inline instead of only a queued status.
  * When the request is allowed to wait, responses return either a success payload (`ok: true` with the job result) or an error payload (`ok: false` with details).

* **Bug Fixes**
  * Preserved existing async behavior when `wait` is absent or not recognized, continuing to return the queued contract (`202` with job details/status URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->